### PR TITLE
Update translations for 0.33 and add Dutch

### DIFF
--- a/locales/ca.po
+++ b/locales/ca.po
@@ -28,18 +28,19 @@ msgstr "Explora aquestes dades"
 msgid "Select a database type"
 msgstr "Selecciona un tipus de base de dades"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:75
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:401
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:71
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:182
+#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:410
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:74
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:203
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:180
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:197
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:193
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:171
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:180
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:164
 msgid "Save"
 msgstr "Desa"
@@ -59,7 +60,7 @@ msgid "This is a lightweight process that checks for\n"
 msgstr "Això es un procès simple que busca actualitzacions a l'esquema de la base de dades. En la majoria dels casos ha d'estar bé sincronitzar cada hora."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:184
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
 msgid "Scan"
 msgstr "Escaneja"
 
@@ -74,126 +75,128 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase pot analizar els valors presents a cada camp de la base de dades, per tal d'activar filtres als quadres de comandament i les preguntes. Aquest procés pot ser intensiu, en especial si disposes d'una base de dades gran."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:159
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Amb quina periodicitat Metabase ha d'analitzar i desar en memoria els valors dels camps?"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:164
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
 msgstr "Regularment, basat en horari predefinit."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:195
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
 msgstr "Únicament quan s'afegeix un nou filtre de widget"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:199
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
 msgstr "Quan un usuari afegeix un nou filtre a un quadre de comandament o una consulta SQL, Metabase analitzarà el(s) camp(s) mapejats al filtre per tal de mostrar la llista de valors seleccionables."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:210
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
 msgid "Never, I'll do this manually if I need to"
 msgstr "Mai. Ho faré manualment si ho necessito."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:222
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:222
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:426
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
 msgid "Saving..."
 msgstr "Desant..."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:39
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
 msgid "Server error encountered"
 msgstr "S'ha produït un error al servidor"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:58
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
 msgstr "Eliminar aquesta base de dades?"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
 msgstr "Totes les preguntes, mètriques i segments sobre aquesta base de dades es perdran."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:67
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
 msgstr "Aquesta acció no es pot desfer."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
 msgstr "Si n'estàs segur, si us plau tecleja"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:53
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
 msgstr "Elimar"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:71
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
 msgstr "en aquest camp:"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:82
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:50
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:93
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:58
-#: frontend/src/metabase/admin/permissions/selectors.js:160
-#: frontend/src/metabase/admin/permissions/selectors.js:170
-#: frontend/src/metabase/admin/permissions/selectors.js:185
-#: frontend/src/metabase/admin/permissions/selectors.js:224
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:355
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:181
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:247
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:61
+#: frontend/src/metabase/admin/permissions/selectors.js:163
+#: frontend/src/metabase/admin/permissions/selectors.js:173
+#: frontend/src/metabase/admin/permissions/selectors.js:188
+#: frontend/src/metabase/admin/permissions/selectors.js:227
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:202
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:268
+#: frontend/src/metabase/components/ArchiveModal.jsx:35
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
-#: frontend/src/metabase/components/form/StandardForm.jsx:61
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:196
+#: frontend/src/metabase/components/form/StandardForm.jsx:62
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:198
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:289
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:162
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:153
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:38
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:189
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:24
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:48
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:41
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:92
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:259
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Cancel·lar"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:88
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:121
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:132
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
 msgstr "Eliminar"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:128
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:74
-#: frontend/src/metabase/admin/permissions/selectors.js:320
-#: frontend/src/metabase/admin/permissions/selectors.js:327
-#: frontend/src/metabase/admin/permissions/selectors.js:423
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
+#: frontend/src/metabase/admin/permissions/selectors.js:323
+#: frontend/src/metabase/admin/permissions/selectors.js:330
+#: frontend/src/metabase/admin/permissions/selectors.js:426
 #: frontend/src/metabase/admin/routes.jsx:53
-#: frontend/src/metabase/nav/containers/Navbar.jsx:214
+#: frontend/src/metabase/nav/containers/Navbar.jsx:243
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
 msgstr "Bases de dades"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:129
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
 msgstr "Afegir una base de dades"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
 msgstr "Connexió"
@@ -202,107 +205,107 @@ msgstr "Connexió"
 msgid "Scheduling"
 msgstr "Programació"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:78
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:84
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:26
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:221
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
 msgstr "Desar els canvis"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:185
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:38
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:38
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
 msgstr "Accions"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:193
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
 msgstr "Sincronitzar ara l'esquema de la base de dades"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:194
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:206
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:109
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
 msgstr "Iniciant..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:195
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
 msgstr "Error al sincronitzar"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
 msgstr "Sincronització programada!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:205
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
 msgstr "Torna a analitzar els valors dels camps ara"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:207
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
 msgstr "Error a l'iniciar l'anàlisi"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
 msgstr "Sincronització programada!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:215
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:401
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
 msgstr "Zona de perill"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:221
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
 msgstr "Descartar els valors del camp guardats"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
 msgstr "Elimina base de dades"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:73
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
 msgstr "Afegeix base de dades"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:85
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:36
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:36
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:122
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:32
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:399
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:446
 #: frontend/src/metabase/containers/EntitySearch.jsx:26
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:218
-#: frontend/src/metabase/entities/collections.js:93
-#: frontend/src/metabase/entities/dashboards.js:145
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:461
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:81
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:220
+#: frontend/src/metabase/entities/collections.js:94
+#: frontend/src/metabase/entities/dashboards.js:142
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
 msgstr "Nom"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:86
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
 msgstr "Motor"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:115
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
 msgstr "Esborrant..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:145
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
 msgstr "Carregant..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:161
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
 msgstr "Recuperar la base de dades de prova"
 
@@ -319,9 +322,9 @@ msgid "Successfully saved!"
 msgstr "Desat correctament!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:177
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:197
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
 msgstr "Edita"
@@ -330,86 +333,90 @@ msgstr "Edita"
 msgid "Revision History"
 msgstr "Historial de revisions"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
 msgstr "Retira aquest {0}?"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
 msgstr "Les preguntes guardades i les altres coses que depenen d'aquest {0} continuaran funcionant però aquest {1} ja no es podrà seleccionar des del generador de consultes. "
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
 msgstr "Si esteu segurs de regitar aquest {0}, escriviu una explicació de perquè l'heu retirat:"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
 msgstr "Això es mostrarà al resum d'activitats  amb un correu electrònic que s'enviarà a qualsevol persona del teu equip que hagi creat quelcom que utilitzi aquest {0}."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
 msgstr "Retirar"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
 msgstr "Retirant..."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
 msgstr "Fallit"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
 msgstr "Èxit"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:91
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
+#: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Vista prèvia"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
 msgstr "No hi ha una descripció de la columan"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:135
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
 msgstr "Selecciona la visiblitat del camp"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:210
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
 msgstr "Sense cap tipus especial"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:211
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:148
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
 msgstr "Altres"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:231
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Seleccioneu un tipus especial"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:277
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
 msgstr "Selecciona una referència"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:77
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:89
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:106
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:122
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
 msgstr "Columnes"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Columna"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:121
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:306
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
 msgstr "Visibilitat"
 
@@ -417,53 +424,53 @@ msgstr "Visibilitat"
 msgid "Type"
 msgstr "Tipus"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
 msgstr "Base de dades actual"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
 msgstr "Mostra l'esquema original"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:45
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
 msgstr "Tipus de dades"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
 msgstr "Informació adicional"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
 msgstr "Cerca un esquema"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:51
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "Esquema"
 msgstr[1] "Esquemes"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
 msgstr "Perquè amagar-ho?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
 msgstr "Informació tècnica"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
 msgstr "Irrelevant"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
 msgid "Queryable"
 msgstr "Consultable"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:91
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
 msgstr "Ocult"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
 msgstr "No hi ha cap descripció per la taula"
 
@@ -471,65 +478,67 @@ msgstr "No hi ha cap descripció per la taula"
 msgid "Metadata Strength"
 msgstr "Força metadades"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} taula consultable"
 msgstr[1] "{0} taules consultables"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:96
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} taula amagada"
 msgstr[1] "{0} taules amagades"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
 msgstr "Troba una taula"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
 msgstr "Esquemes"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:24
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:137
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:68
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:56
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:190
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
 msgstr "Mètriques"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
 msgstr "Afegir una mètrica"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:37
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Definició"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Crea mètriques per afegir-les al desplegable \"Veure\" al generador de consultes"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:24
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:930
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:952
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:56
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segments"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
 msgstr "Afegir un segment"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Crea segments per afegir-los al menú de filtres del generador de consultes"
 
@@ -557,53 +566,53 @@ msgstr "editat el"
 msgid "made some changes"
 msgstr "ha fet alguns canvis"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
-#: frontend/src/metabase/home/components/Activity.jsx:80
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:332
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/home/components/Activity.jsx:82
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
 msgstr "Tu"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
 msgstr "Model de dades"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
 msgstr " Historial"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:48
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
 msgstr "Historial de versions per"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:239
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
 msgstr "{0} - Configuració dels camps"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
 msgstr "On es mostrara aquest camp al Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:329
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filtrant per aquest camp"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Quan aquest camp s'utilitza en un filtre, quins valors ha de poder introduir l'usuari?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:453
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "No existeix cap descripció per aquest camp"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:379
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
 msgstr "Valor Original"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:380
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
 msgid "Mapped value"
 msgstr "Valor asignat"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:423
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
 msgstr "Introduïu valor"
 
@@ -620,7 +629,7 @@ msgid "Custom mapping"
 msgstr "Assignació personalitzada"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:155
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
 msgid "Unrecognized mapping type"
 msgstr "Tipus d'assignació no reconeguda"
 
@@ -628,23 +637,23 @@ msgstr "Tipus d'assignació no reconeguda"
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "El camp actual no es una clau forana o fan falten les metadades de la clau forana a la taula de destí"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:187
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
 msgstr "El camp seleccionat no es una clau forana"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:347
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
 msgstr "Mostra valors"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:348
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Escull si vols mostrar el valor original de la base de dades o mostrar informació associada o personalitzada"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:268
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
 msgstr "Tria un camp"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:289
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
 msgstr "Seleccioneu una columna per mosstrar"
 
@@ -652,16 +661,16 @@ msgstr "Seleccioneu una columna per mosstrar"
 msgid "Tip:"
 msgstr "Consell:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Es possible que vulgueu actualitzar el nom del camp per assegurar-t'he que encara tinguin sentit en funció de les opcions d'assignació."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:364
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:102
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
 msgstr "Valors del camp a la memòria cau"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:365
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "El metabase pot escanejar els valors d'aquest camp per habilitar els filtres de casella de verificació pels quadres de comandament i preguntes."
 
@@ -670,167 +679,168 @@ msgid "Re-scan this field"
 msgstr "Torna a escanejar aquest camp"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
 msgstr "Descarteu els valors de la memòria cau"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:118
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
 msgstr "Error al descartar els valors"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard triggered!"
 msgstr "Neteja iniciada!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:105
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Seleccioneu qualsevol taula per veure el seu esquema i afegir o editar les metadades."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:37
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:34
-#: frontend/src/metabase/entities/collections.js:96
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "El nom es obligatori"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:40
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
 msgstr "La descripció es obligatòria"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:44
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:41
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
 msgstr "El missatge de revisió es obligatori"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:50
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
 msgstr "La agrupació es obligatòria"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
 msgstr "Edita la teva mètrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
 msgstr "Crea la teva mètrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:115
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Feu canvis a la vostra mètrica i deixeu un nota explicativa"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Pots crear mètriques i guardar-les com un camp calculat en aquesta taula. Les mètriques guardades inclouen el tipus d'agregat, el camp agregat i opcionalment qualsevol filtre que afegeixis. Per exemple, pots fer servir això per definir la forma oficial de calcular el \"Preu mig\" d'una taula de preus."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
 msgstr "Resultat: "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
 msgstr "Doneu-li un nom a la vostra mètrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
 msgstr "Doneu-li un nom a la vostra mètrica per ajudar als altres a trobar-la."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:162
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
 msgstr "Alguna cosa descriptiva però no massa llarga"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
 msgstr "Descriu la mètrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Doneu-li una descripció a la vostra mètrica per ajudar als altres a entendre de el seu contingut."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Es un bon lloc per ser més específiques sobre les regles de la mètrica no tan evidents. "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:179
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
 msgstr "Motiu dels canvis"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:177
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Deixeu una nota per explicar els canvis que heu fet i per a que són necessaris."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Es mostrarà al historial de revisions de la mètrica per ajudar als altres a entendre perquè han canviat les coses."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
 msgstr "Es requereix com a mínim un filtre"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
 msgstr "Edita el teu segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
 msgstr "Crear el teu segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:121
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Feu canvis al vostre segment i deixeu un nota explicativa"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Seleccioneu i afegiu filtres per crear un nou segment de la taula {0}"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
 msgstr "Doneu-li un nom al vostre segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:162
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
 msgstr "Doneu un nom al vostre segment per ajudar als altres a trobar-lo."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:170
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
 msgstr "Descriu el segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Doneu una descripció al vostre segment per ajudar als altres a saber de que va."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:175
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Aquest es un bon lloc per ser més específics sobre les regles menys obvies del segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:185
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Això apareixerà al historial de versions d'aquest segment per ajudar a tothom a recordar perquè es va realitzar aquest canvi."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:266
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:87
-#: frontend/src/metabase/nav/containers/Navbar.jsx:199
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:269
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:91
+#: frontend/src/metabase/nav/containers/Navbar.jsx:228
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
 msgstr "Configuració"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:103
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "El Metabase pot llegir els valors d'aquesta taula per habilitar filtres de caselles de selecció als quadres de comandament i preguntes"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:108
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
 msgstr "Tornar a escanejar aquesta taula"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:253
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
 msgstr "Afegir"
 
@@ -839,20 +849,22 @@ msgstr "Afegir"
 msgid "Not a valid formatted email address"
 msgstr "El format del correu electrònic no es vàlid"
 
+#: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:100
 msgid "First name"
 msgstr "Nom"
 
+#: frontend/src/metabase/entities/users.js:42
 #: frontend/src/metabase/setup/components/UserStep.jsx:203
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:117
 msgid "Last name"
 msgstr "Cognom"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:77
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:158
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:161
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:470
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:481
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
@@ -866,34 +878,35 @@ msgstr "Grups de permisos"
 msgid "Make this user an admin"
 msgstr "Feu que aquest usuari sigui administrador"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:32
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
 msgstr "Tots els usuaris pertanyen al grup \"{0}\" i no s'hi poden eliminar. Establir permisos per aquest grup es una manera excel·lent per assegurar-vos de que podran veure els nous usuaris del Metabase"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:41
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
 msgstr "Aquest es un grup especial els membres del qual poden veure tota la informació de la instància del Metabase, poden accedir i fer modificacions a la configuració del Panell d'administració, incloïen els permisos d'accés. Afegiu persones amb cautela."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:45
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
 msgstr "Per assegurar que sempre pots accedir al Metabase hi ha d'haver com a mínim un usuari en aquest grup"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
 msgstr "Membres"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:124
-#: frontend/src/metabase/admin/settings/selectors.js:113
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
+#: frontend/src/metabase/admin/settings/selectors.js:110
+#: frontend/src/metabase/entities/users.js:50
 #: frontend/src/metabase/lib/core.js:55
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
 msgstr "Correu electrònic"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:203
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
 msgstr "Un grop només val el que valen els seus membres"
 
@@ -904,8 +917,8 @@ msgid "Admin"
 msgstr "Administrador"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:237
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:290
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
 msgstr "i"
 
@@ -934,13 +947,13 @@ msgid "Are you sure? All members of this group will lose any permissions setting
 msgstr "Esteu segurs? Tots els membres d'aquest grup perdran les configuracions de permisos que tenen gràcies a aquest grup. Això no es pot desfer."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
 msgstr "Si"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
 msgstr "No"
 
@@ -959,10 +972,11 @@ msgstr "Elimina el grup"
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:107
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:327
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:395
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:265
+#: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
 msgstr "Fet"
 
@@ -972,9 +986,9 @@ msgstr "Nom del grup"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:131
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:88
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
 msgstr "Groups"
 
@@ -1003,9 +1017,9 @@ msgid "Deactivate"
 msgstr "Desactiva"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:93
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
-#: frontend/src/metabase/nav/containers/Navbar.jsx:204
+#: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
 msgstr "Gent"
 
@@ -1045,7 +1059,6 @@ msgid "We've re-sent {0}'s invite"
 msgstr "Hem reenviat la invitació del {0}"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
-#: frontend/src/metabase/tutorial/Tutorial.jsx:253
 msgid "Okay"
 msgstr "D'accord"
 
@@ -1077,13 +1090,13 @@ msgstr "Podran tornar a iniciar sessió i se'ls tornarà a col·locar als grups 
 msgid "Reset {0}'s password?"
 msgstr "Restablir la contrasenya del {0}?"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:77
+#: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
 msgstr "Restableix"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:44
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
 msgstr "Esteu segur que voleu realitzar aquesta acció?"
 
@@ -1099,76 +1112,78 @@ msgstr "A continuació podeu trobar una contrasenya temporal que poden fer servi
 msgid "We've sent them an email with instructions for creating a new password."
 msgstr "Els hi hem enviat un correu electrònic amb instruccions per crear una nova contrasenya."
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:101
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
 msgstr "Activar"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:127
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
 msgstr "Desactivat"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:115
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
 msgstr "Afegir algú"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
 msgstr "Últim accés"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:153
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
 msgstr "Accés a mitjançant de Google"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:158
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
 msgstr "Accés a mitjançant de LDAP"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:170
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
 msgstr "Reactivar aquest compte"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:193
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
 msgstr "Mai"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:27
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
 msgstr[0] "{0} taula"
 msgstr[1] "{0} taules"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:45
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
 msgstr " será "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:48
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
 msgstr "s'ha donat accès a"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:53
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
 msgstr " i "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:56
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
 msgstr "denegat l'accés a"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:70
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
 msgstr "j a no podrà "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:71
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
 msgstr " ara serà capaç de "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:79
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
 msgstr " consultes natives de "
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
-#: frontend/src/metabase/nav/containers/Navbar.jsx:219
+#: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
 msgstr "Permisos"
 
@@ -1193,15 +1208,15 @@ msgstr "No es faran canvis als permisos."
 msgid "You've made changes to permissions."
 msgstr "Heu fet canvis als permisos."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:52
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
 msgstr "Permisos d'aquest col·lecció"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
 msgstr "Teniu canvis sense guardar"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:54
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
 msgstr "Esteu segurs d'abandonar la pàgina i descartar els vostres canvis?"
 
@@ -1221,119 +1236,119 @@ msgstr "Tots els usuaris del Metabase pertanyen al grup Tots els Usuaris. Si vol
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
 msgstr "El Metabot es el bot de Slack de Metabase. Aquí pots elegir a que te accés."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:119
+#: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
 msgstr "El grup \"{0}\" pot tenir accés a un conjunt diferent de {1} que aquest grup, lo que pot donar-li accés addicional a algun {2}"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:124
+#: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
 msgstr "El grup \"{0}\" té un major nivell d'accés que aquest cosa que anul·larà aquesta configuració. Has de limitar o revocar el accés del grup \"{1}\" a aquest element."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
 msgstr "Límit"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
 msgstr "Revocar"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:156
+#: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
 msgstr "el accés encara que el grup \"{0}\" té major accés?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:258
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
 msgstr "Limitar accés"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:223
-#: frontend/src/metabase/admin/permissions/selectors.js:266
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:226
+#: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
 msgstr "Revocar el acces"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:168
+#: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
 msgstr "Canviar l'accés a aquesta base de dades a limitat?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:169
+#: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
 msgstr "Canvi"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:182
+#: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
 msgstr "Permetre l'escriptura de consultes directes?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:183
+#: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
 msgstr "Això també canviarà l'accés d'aquest grup a les dades \"Sense restriccions\" per aquesta base de dades."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:184
+#: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
 msgstr "Permetre"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:221
+#: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
 msgstr "Revocar l'accés a totes les taules?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:222
+#: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
 msgstr "Això també revocarà l'accés d'aquest grup a les consultes en pla per aquesta  base de dades."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:251
+#: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
 msgstr "Concedir accés sense restriccions"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:252
+#: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
 msgstr "Accés sense restriccions"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:259
+#: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
 msgstr "Accés limitat"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:267
+#: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
 msgstr "Sense accés"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:273
+#: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
 msgstr "Escriure consultes directes"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:274
+#: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
 msgstr "Pot escriure consultes directes"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:281
+#: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
 msgstr "Mima la col·lecció"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:288
+#: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
 msgstr "Mostrar la col·lecció"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:331
-#: frontend/src/metabase/admin/permissions/selectors.js:427
-#: frontend/src/metabase/admin/permissions/selectors.js:524
+#: frontend/src/metabase/admin/permissions/selectors.js:334
+#: frontend/src/metabase/admin/permissions/selectors.js:430
+#: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
 msgstr "Accedir a les dades"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:492
-#: frontend/src/metabase/admin/permissions/selectors.js:649
-#: frontend/src/metabase/admin/permissions/selectors.js:654
+#: frontend/src/metabase/admin/permissions/selectors.js:495
+#: frontend/src/metabase/admin/permissions/selectors.js:652
+#: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
 msgstr "Mostrar taules"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:590
+#: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
 msgstr "Consultes SQL"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:660
+#: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
 msgstr "Mostrar esquemes"
 
 #: frontend/src/metabase/admin/routes.jsx:59
-#: frontend/src/metabase/nav/containers/Navbar.jsx:209
+#: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
 msgstr "Model de dades"
 
@@ -1342,30 +1357,30 @@ msgstr "Model de dades"
 msgid "Sign in with Google"
 msgstr "Identificar-se amb Google"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:13
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
 msgstr "Permet als usuaris amb una compta de Metabase existent iniciar sessió amb un compte de Google que coincideixi amb la seva direcció de correu electrònic a més de poder accedir amb el seu nom d'usuari i contrasenya."
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:17
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
 msgstr "Configura"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
-#: frontend/src/metabase/admin/settings/selectors.js:207
+#: frontend/src/metabase/admin/settings/selectors.js:204
 msgid "LDAP"
 msgstr "LDAP"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:25
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
 msgstr "Permet als usuaris del teu directori LDAP iniciar sessió a Metabase amb les seves credencials LDAP i permet la assignació automàtica de grups LDAP a grups de metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
-#: frontend/src/metabase/admin/settings/selectors.js:160
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
 msgstr "No es un correu electrònic vàlid"
 
@@ -1403,7 +1418,7 @@ msgstr "Netejar"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:202
+#: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
 msgstr "Autentificació"
 
@@ -1467,21 +1482,21 @@ msgstr "Crea un usuari de Slack BOt pel Metabot"
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Una cop arribats allí, assigna-li un nom i clica a {0}. Desprès copia i pega el token de la API del Bot al camp a continuació. Quan hagis acabat, crea un canal \"metabase_files\" en Slack. Aquest canal es necessita per pujar gràfiques."
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:90
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
 msgstr "Esteu fent servir el Metabase {0} que es la última i millor versió"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:99
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
 msgstr "La versió {0} de Metabase esta disponible. Esteu fent servir la versió {1}"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:112
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
 msgstr "Actualitzat"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:116
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
 msgstr "Que ha cambiat?"
 
@@ -1494,80 +1509,80 @@ msgstr "Afegiu un mapa"
 msgid "URL"
 msgstr "URL"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:199
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
 msgstr "Elimina el mapa personalitzat"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:327
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:40
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:181
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
 msgstr "Elimina"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:226
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:187
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:241
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:246
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
 msgstr "Selecciona..."
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:241
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
 msgstr "Valors de mostra:"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
 msgstr "Afegiu un nou mapa"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
 msgstr "Edita el mapa"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:280
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
 msgstr "Com voleu anomenar aquest mapa?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
 msgstr "p.e: Regne Unit, Brasil, Marg"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:292
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
 msgstr "URL del fitxer GeoJSON que voleu utilitzar"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:298
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
 msgstr "Per exemple https://el-meu-servidor.com/mapes/el-meu-mapa.json"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:33
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
 msgstr "Refresca"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
 msgstr "Carrega"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:315
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
 msgstr "Quina propietat especifica el identificador de la regió?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:324
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
 msgstr "Quina propietat especifica el nom de la regió?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:345
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
 msgstr "Carregeu un fitxer GeoJSOn per veure una mostra"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
 msgstr "Guarda el mapa"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
 msgstr "Afegeix un mapa"
 
@@ -1579,11 +1594,11 @@ msgstr "Utilitzant el incrustat"
 msgid "By enabling embedding you're agreeing to the embedding license located at"
 msgstr "Al habilitar el incrustat acceptes la llicència de incrustat que es troba a"
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:19
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
 msgstr "Amb llenguatge senzill, quan incrustes taules o quadres de comandament del Metabase a la teva pròpia aplicació aquesta aplicació no està subjecte a la llicència AGPL que cobreix la resta del Metabase sempre hi quan que mantenguis el logotips de Metbase y el \"Powered by Metabase\" visible a les incrustacions. No obstant això, has de llegir el text de la llicència ja que l'acabes d'acceptar al habilitar aquesta funcionalitat."
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:32
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
 msgstr "Habilita"
 
@@ -1607,25 +1622,25 @@ msgstr "Compra un token"
 msgid "Enter a token"
 msgstr "Afegiu un token"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:134
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
 msgstr "Editar assignacions"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:140
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
 msgstr "Assignacions de grups"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:147
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
 msgstr "Crea un assignació"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
 msgstr "Les assignacions permeten que el Metabase agregui o elimini automàticament usuaris dels grups segons la informació de la pertinència proporcionada pel servidor de directoris. La pertinència al grup de administració es pot concedir automàticament a través d'assignacions per no s'eliminarà automàticament com una mesura de seguretat. "
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
 msgstr "Nom distingit"
 
@@ -1637,43 +1652,43 @@ msgstr "Enllaç públic"
 msgid "Revoke Link"
 msgstr "Eliminar el enllaç"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:121
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
 msgstr "Desactivar aquest enllaç?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:122
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
 msgstr "Els enllaços ja no funcionaran i no es poden restaurar. No obstant això podeu crear nous enllaços."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
 msgstr "Llista de quadre de comandament públics"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:152
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
 msgstr "Encara no s'ha compartit cap quadre de comandament de forma pública."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:160
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
 msgstr "Llista de targetes públiques"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:163
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
 msgstr "Encara no s'ha pregunta cap quadre de comandament de forma pública."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:172
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
 msgstr "Llista de quadres de comandament incrustats"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
 msgstr "Encara no s'ha incrustat cap quadre de comandament."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:183
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
 msgstr "Llistat de targetes incrustades"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:184
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
 msgstr "Encara no s'ha incrustat cap pregunta."
 
@@ -1694,18 +1709,17 @@ msgid "Generate Key"
 msgstr "Genera la clau"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:78
-#: frontend/src/metabase/admin/settings/selectors.js:87
+#: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
 msgstr "Activat"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:83
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:103
+#: frontend/src/metabase/admin/settings/selectors.js:82
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Desactivat"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:116
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
 msgstr "No es coneix la configuració {0}"
 
@@ -1713,7 +1727,7 @@ msgstr "No es coneix la configuració {0}"
 msgid "Setup"
 msgstr "Configuració"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
 msgstr "General"
@@ -1742,11 +1756,11 @@ msgstr "La base de dades"
 msgid "Select a timezone"
 msgstr "Selecciona una zona horària"
 
-#: frontend/src/metabase/admin/settings/selectors.js:55
+#: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "No totes les bases de dades permeten zones horàries. En aquest cas aquesta configuració no tindrà efecte."
 
-#: frontend/src/metabase/admin/settings/selectors.js:60
+#: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
 msgstr "Idioma"
 
@@ -1754,202 +1768,202 @@ msgstr "Idioma"
 msgid "Select a language"
 msgstr "Seleccioneu un idioma"
 
-#: frontend/src/metabase/admin/settings/selectors.js:70
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
 msgstr "Seguiment anònimc"
 
-#: frontend/src/metabase/admin/settings/selectors.js:75
+#: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
 msgstr "Noms de taules i camps amistosos"
 
-#: frontend/src/metabase/admin/settings/selectors.js:81
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Només es reemplaçaran els guions baixos i els guions per espais"
 
-#: frontend/src/metabase/admin/settings/selectors.js:91
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
 msgstr "Activar consultes anidades"
 
-#: frontend/src/metabase/admin/settings/selectors.js:102
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
 msgstr "Actualitzacions"
 
-#: frontend/src/metabase/admin/settings/selectors.js:107
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
 msgstr "Cerca actualitzacions"
 
-#: frontend/src/metabase/admin/settings/selectors.js:118
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
 msgstr "Servidor SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:126
+#: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
 msgstr "Port SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:130
-#: frontend/src/metabase/admin/settings/selectors.js:230
+#: frontend/src/metabase/admin/settings/selectors.js:127
+#: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
 msgstr "El número de port és invàlid"
 
-#: frontend/src/metabase/admin/settings/selectors.js:134
+#: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
 msgstr "SMTP Segur"
 
-#: frontend/src/metabase/admin/settings/selectors.js:142
+#: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
 msgstr "Usuari SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
 msgstr "Contrasenya SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
 msgstr "Correu electrònic de"
 
-#: frontend/src/metabase/admin/settings/selectors.js:170
+#: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
 msgstr "Token API Slack"
 
-#: frontend/src/metabase/admin/settings/selectors.js:172
+#: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
 msgstr "Introduïu el toquen que heu rebut de Slack"
 
-#: frontend/src/metabase/admin/settings/selectors.js:189
+#: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
 msgstr "Inici de sessió únic"
 
-#: frontend/src/metabase/admin/settings/selectors.js:213
+#: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
 msgstr "Autentificació LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:219
+#: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
 msgstr "Servidor LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:227
+#: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
 msgstr "Port LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:234
+#: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
 msgstr "LDAP segur"
 
-#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
 msgstr "Nom d'usuari o DN"
 
-#: frontend/src/metabase/admin/settings/selectors.js:247
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:188
-#: frontend/src/metabase/user/components/UserSettings.jsx:72
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:191
+#: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
 msgstr "Contrasenya"
 
-#: frontend/src/metabase/admin/settings/selectors.js:252
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "User search base"
 msgstr "Base de cerca d'usuari"
 
-#: frontend/src/metabase/admin/settings/selectors.js:258
+#: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
 msgstr "Filtre d'usuaris"
 
-#: frontend/src/metabase/admin/settings/selectors.js:264
+#: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
 msgstr "Verifiqueu els parèntesis"
 
-#: frontend/src/metabase/admin/settings/selectors.js:270
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
 msgstr "Atribut del correu electrònic"
 
-#: frontend/src/metabase/admin/settings/selectors.js:275
+#: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
 msgstr "Atribut del nom"
 
-#: frontend/src/metabase/admin/settings/selectors.js:280
+#: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
 msgstr "Atribut dels cognoms"
 
-#: frontend/src/metabase/admin/settings/selectors.js:285
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
 msgstr "Sincronitza "
 
-#: frontend/src/metabase/admin/settings/selectors.js:291
+#: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
 msgstr "Base de cerca de grup"
 
-#: frontend/src/metabase/admin/settings/selectors.js:300
+#: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
 msgstr "Mapes"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
 msgstr "URL del servidor de capes de mapes"
 
-#: frontend/src/metabase/admin/settings/selectors.js:306
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "El Metabase fa servir OpenStretMaps per defecte"
 
-#: frontend/src/metabase/admin/settings/selectors.js:311
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
 msgstr "Mapes personalitzats"
 
-#: frontend/src/metabase/admin/settings/selectors.js:312
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Afegeix els teus propis fitxers GeoJSON per habilitar diferents visualitzacions de mapes de regió"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
 msgstr "Compartir públicament"
 
-#: frontend/src/metabase/admin/settings/selectors.js:336
+#: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
 msgstr "Permetre compartir públicament"
 
-#: frontend/src/metabase/admin/settings/selectors.js:341
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
 msgstr "Quadres de comandament compartits"
 
-#: frontend/src/metabase/admin/settings/selectors.js:347
+#: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
 msgstr "Preguntes compartides"
 
-#: frontend/src/metabase/admin/settings/selectors.js:354
+#: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
 msgstr "Incrustar en altres aplicacions"
 
-#: frontend/src/metabase/admin/settings/selectors.js:381
+#: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Habilitar la incrustació del Metabase a altres aplicacions"
 
-#: frontend/src/metabase/admin/settings/selectors.js:391
+#: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
 msgstr "Clau secreta de incrustació"
 
-#: frontend/src/metabase/admin/settings/selectors.js:397
+#: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
 msgstr "Quadres de comandament incrustats"
 
-#: frontend/src/metabase/admin/settings/selectors.js:403
+#: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
 msgstr "Preguntes incrustades"
 
-#: frontend/src/metabase/admin/settings/selectors.js:410
+#: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
 msgstr "Memòria cau"
 
-#: frontend/src/metabase/admin/settings/selectors.js:415
+#: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
 msgstr "Activa la memòria cau"
 
-#: frontend/src/metabase/admin/settings/selectors.js:420
+#: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
 msgstr "Duració mínima de la consulta"
 
-#: frontend/src/metabase/admin/settings/selectors.js:427
+#: frontend/src/metabase/admin/settings/selectors.js:424
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Multiplicador Temps de Vida (TTL) de la memòria cau"
 
-#: frontend/src/metabase/admin/settings/selectors.js:434
+#: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
 msgstr "Mida màxima d'una entrada de la memòria cau"
 
@@ -1965,11 +1979,11 @@ msgstr "La teva alerta ha estat actualitzada."
 msgid "The alert was successfully deleted."
 msgstr "L'alerta s'ha eliminat correctament."
 
-#: frontend/src/metabase/auth/auth.js:33
+#: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
 msgstr "Si us plau, introduïu una direcció de correu electrònic amb el format correcte."
 
-#: frontend/src/metabase/auth/auth.js:116
+#: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
@@ -2011,90 +2025,87 @@ msgstr "Enviar el correu electrònic per recuperar la contrasenya"
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Consulta el teu correu electrònic per obtenir les instruccions sobre com recuperar la teva contrasenya"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:128
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
 msgstr "Iniciar sessió al Metabase"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:138
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
 msgstr "O"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:157
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
 msgstr "Nom d'usuari o direcció de correu electrònic"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:217
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
 msgstr "Accedeix"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:230
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
 msgstr "Sembla que no recordo la meva contrasenya"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
 msgstr "sol·licitar un nou correu electrònic per recuperar la contrasenya"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:120
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
 msgstr "Vaja, aquest enllaç ha caducat"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:122
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
 msgstr "Per raons de seguretat els enllaços per recuperar la contrasenya caduquen al cap d'un temps. Si encara necessites recuperar la teva contrasenya, pots {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:147
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
 msgstr "Nova contrasenya"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:149
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
 msgstr "Per mantenir les teves dades segures les contrasenyes {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:163
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
 msgstr "Crea una nova contraseña"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:170
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:141
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
 msgstr "Han de complir les instruccions anteriors"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:184
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:150
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
 msgstr "Confirma la nova contraseña"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:191
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:159
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
 msgstr "Assegureu-vos que coincideix amb la que acabes d'introduir"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:216
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
 msgstr "La teva contrasenya ha estat restablerta."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:222
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:227
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
 msgstr "Inicia sessió amb la nova contrasenya"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:182
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:251
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "No s'ha pogut guardar"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:183
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:129
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:225
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:252
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
 msgstr "Guardat"
 
@@ -2102,24 +2113,22 @@ msgstr "Guardat"
 msgid "Ok"
 msgstr "D'acord"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:38
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
 msgstr "Arxiva aquesta col·lecció?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:43
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Les"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
-#: frontend/src/metabase/components/CollectionLanding.jsx:624
+#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: frontend/src/metabase/components/CollectionLanding.jsx:620
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:47
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:195
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:200
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:40
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:53
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
 msgstr "Arxiva"
@@ -2128,28 +2137,27 @@ msgstr "Arxiva"
 msgid "This {0} has been archived"
 msgstr "Aquest {0} ha estat arxivat"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:715
+#: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
 msgstr "Mostra l'arxiu"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:43
+#: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
 msgstr "Desarxiva aquest {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:70
-#: frontend/src/metabase/components/BrowseApp.jsx:132
-#: frontend/src/metabase/components/BrowseApp.jsx:225
+#: frontend/src/metabase/components/BrowseApp.jsx:39
+#: frontend/src/metabase/components/BrowseApp.jsx:102
+#: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
 msgstr "Les nostres dades"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:169
+#: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
 msgstr "Aplica rajos-X a aquesta taula"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:183
-#: frontend/src/metabase/containers/Overworld.jsx:246
+#: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
 msgstr "Aprèn sobre aquesta taula"
 
@@ -2167,31 +2175,31 @@ msgstr "Guardat!"
 msgid "Saving failed."
 msgstr "No s'ha pogut guardar"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
 msgstr "dg."
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
 msgstr "dl."
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
 msgstr "dm."
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
 msgstr "dc."
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
 msgstr "dj."
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
 msgstr "dv."
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
 msgstr "ds."
 
@@ -2236,61 +2244,61 @@ msgstr "Els polsos es permeten enviar dades de Metabase en una data planificada 
 msgid "Questions are a saved look at your data."
 msgstr "Les preguntes son visualitzacions guardades de les teves dades."
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:287
+#: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
 msgstr "Contingut fixat"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:341
+#: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
 msgstr "Arrasta coses aquí per fixar-les a dalt"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:737
-#: frontend/src/metabase/components/CollectionLanding.jsx:353
-#: frontend/src/metabase/home/containers/SearchApp.jsx:35
-#: frontend/src/metabase/home/containers/SearchApp.jsx:92
+#: frontend/src/metabase/admin/permissions/selectors.js:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:352
+#: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
 msgstr "Col·leccions"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:432
-#: frontend/src/metabase/components/CollectionLanding.jsx:455
+#: frontend/src/metabase/components/CollectionLanding.jsx:431
+#: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
 msgstr "Arrastra-ho aquí per deixar de fixar-los"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:490
+#: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
 msgstr[0] "{0} element seleccionat"
 msgstr[1] "{0} elements seleccionats"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:522
+#: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
 msgstr "Moure {0} element(s)?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:523
+#: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
 msgstr "Moure \"{0}\"?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:631
+#: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
 msgstr "Moure"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:692
+#: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
 msgstr "Edita aquesta col·lecció"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:700
+#: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
 msgstr "Arxiva aquesta col·lecció"
 
-#: frontend/src/metabase/components/CollectionList.jsx:64
-#: frontend/src/metabase/entities/collections.js:155
+#: frontend/src/metabase/components/CollectionList.jsx:67
+#: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
 msgstr "La meva col·lecció personal"
 
-#: frontend/src/metabase/components/CollectionList.jsx:106
+#: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
 msgstr "Nova col·lecció"
 
@@ -2298,11 +2306,11 @@ msgstr "Nova col·lecció"
 msgid "Copied!"
 msgstr "Copiat!"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:216
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Utilitza un túnel SSH per a les connexions a la base de dades"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
@@ -2310,75 +2318,76 @@ msgstr "Algunes instancies de bases de dades només es poden accedir a través d
 "Aquesta configuració també proporcionarà una cap addicional de seguretat quan no es disposi d'una VPN. \n"
 "Aquest configuració normalment es més lenta que una connexió directa."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:271
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Aquesta es una base de dades gran. Deixem decidir quan el Metabase es sincronitza i escaneja les dades"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:273
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "De forma predeterminada el Metabase realitzar una sincronització lleugera cada hora i un anàlisis diari intensiu dels valors dels camps.\n"
 "Si tens una base de dades gran et recomanem que activis aquesta configuració i que revisis quan i amb quina freqüència s'escanegen els valors del camp."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:289
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0] per generar un ID de client i una clau secreta pel teu projecte"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:291
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:353
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
 msgstr "Cliqueu aquí"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Escul \"Un altre\" com a tipus d'aplicació. Nombra-ho com vulguis."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:316
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
 msgstr "{0} per obtenir un codi d'autentificació"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:328
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
 msgstr "amb permisos de Google Drive"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:348
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Per utilitzar el Metabase amb aquestes dades has d'habilitar el accés a la API a la Consola de Desenvolupadors de Googl"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:351
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} per anar a la consola si encara no ho has fet"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
 msgstr "Com t'agradaria anomenar aquesta base de dades?"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:427
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:237
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:188
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:74
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:194
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:79
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
 msgstr "Següent"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:52
+#: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
 msgstr "Eliminar aquest {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:43
+#: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
 msgstr "Fixa aquest element"
 
-#: frontend/src/metabase/components/EntityItem.jsx:49
+#: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
 msgstr "Mou aquest element"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
 msgstr "Edita aquesta pregunta"
 
@@ -2391,6 +2400,7 @@ msgstr "Tipus d'acció"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
 msgstr "Mostra l'historial de revisions"
 
@@ -2406,8 +2416,7 @@ msgstr "Acció d'arxivar"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:329
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:342
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
 msgstr "Afegir al quadre de comandament"
 
@@ -2431,13 +2440,12 @@ msgstr "Un altre tipus d'acció"
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:449
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:454
 msgid "Get alerts about this"
 msgstr "Rep alertes sobre això"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
 msgstr "Mostra el SQL"
 
@@ -2457,43 +2465,43 @@ msgstr "Aquest es el missatge d'error complert"
 msgid "Hi, Metabot here."
 msgstr "Hola, soc el Metabot"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:95
+#: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
 msgstr "Basat en l'esquema"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:174
+#: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
 msgstr "Una vista als teus"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:234
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
 msgstr "Busca a la llista"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:238
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
 msgstr "Buscar per {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
 msgstr " o introdueix un ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
 msgstr "Introdueix un ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
 msgstr "Introdueix un número"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:248
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
 msgstr "Introdueix un text"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:355
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
 msgstr "No s'han trobat {0} coincidents"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:363
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Incloure totes les opcions al filtre possiblement no servirà de res"
 
@@ -2509,17 +2517,17 @@ msgstr "Em trobat un error. Pots intentar refrescar la pàgina o simplement torn
 #: frontend/src/metabase/components/HeaderBar.jsx:45
 #: frontend/src/metabase/components/ListItem.jsx:37
 #: frontend/src/metabase/reference/components/Detail.jsx:47
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:158
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:213
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:191
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:205
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:209
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:209
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:161
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:216
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:194
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:208
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
 msgstr "Encara sense cap descripció"
 
 #: frontend/src/metabase/components/Header.jsx:112
-#: frontend/src/metabase/entities/containers/EntityForm.jsx:43
+#: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
 msgstr "Nou {0}"
 
@@ -2527,54 +2535,53 @@ msgstr "Nou {0}"
 msgid "Asked by {0}"
 msgstr "Preguntat pel {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:13
+#: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
 msgstr "Avui. "
 
-#: frontend/src/metabase/components/HistoryModal.jsx:15
+#: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
 msgstr "Ahir. "
 
-#: frontend/src/metabase/components/HistoryModal.jsx:68
+#: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
 msgstr "Primera revisió."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:70
+#: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
 msgstr "Revertit a una revisió anterior i {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:82
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:289
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:379
-#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
+#: frontend/src/metabase/components/HistoryModal.jsx:42
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
+#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
 msgstr "Historial de revisións"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:90
+#: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
 msgstr "Quan"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:91
+#: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
 msgstr "Qui"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:92
+#: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
 msgstr "Que"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:113
+#: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
 msgstr "Desfer"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:114
+#: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
 msgstr "Desfent..."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:115
+#: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
 msgstr "No s'ha pogut desfer"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:116
+#: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
 msgstr "Desfet"
 
@@ -2583,26 +2590,24 @@ msgid "Everything"
 msgstr "Tot"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
-#: frontend/src/metabase/home/containers/SearchApp.jsx:69
 msgid "Dashboards"
 msgstr "Quadres de comandament"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
-#: frontend/src/metabase/home/containers/SearchApp.jsx:115
 msgid "Questions"
 msgstr "Preguntes"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:321
+#: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
 msgstr "Polsos"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:103
+#: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
 msgstr "Enrere"
 
-#: frontend/src/metabase/components/ListSearchField.jsx:18
+#: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
 msgstr "Cerca..."
 
@@ -2639,14 +2644,14 @@ msgid "Temporary Password"
 msgstr "Contrasenya temporal"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
 msgstr "Amaga"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:412
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
 msgstr "Mostra"
 
@@ -2711,7 +2716,7 @@ msgstr "15è (punt mitg)"
 msgid "Calendar Day"
 msgstr "Dia del calendari"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:210
+#: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
 msgstr "La zona horària del Metabase"
 
@@ -2740,11 +2745,11 @@ msgid "A component used to make a selection"
 msgstr "Un component utilitzat per a fer una selecció"
 
 #: frontend/src/metabase/components/Select.info.js:20
-#: frontend/src/metabase/components/Select.info.js:28
+#: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
 msgstr "Seleccionat"
 
-#: frontend/src/metabase/components/Select.jsx:297
+#: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
 msgstr "No hi ha res a seleccionar"
 
@@ -2757,7 +2762,7 @@ msgid "Unknown error encountered"
 msgstr "S'ha trobat un error desconegut"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/nav/containers/Navbar.jsx:304
+#: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
 msgstr "Crea"
 
@@ -2766,13 +2771,11 @@ msgid "Create dashboard"
 msgstr "Crea un quadre de comandament"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:331
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:60
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
 msgstr "Taula"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:306
 msgid "Database"
 msgstr "Base de dades"
 
@@ -2780,22 +2783,20 @@ msgstr "Base de dades"
 msgid "Creator"
 msgstr "Creador"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:238
+#: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
 msgstr "No s'han trobat resultats"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:239
+#: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
 msgstr "Intenta ajustar el teu filtre per trobar el que estas buscan"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:258
+#: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
 msgstr "Vist per"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:494
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:84
-#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:69
-#: frontend/src/metabase/tutorial/TutorialModal.jsx:34
+#: frontend/src/metabase/containers/EntitySearch.jsx:495
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
 msgstr "de"
 
@@ -2808,13 +2809,13 @@ msgid "Once you connect your own data, I can show you some automatic exploration
 msgstr "Quan connectes les teves pròpies dades et puc mostrar algunes exploracions automàtiques anomenades rajos-X. Aquí hi ha alguns exemples de mostra."
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
-#: frontend/src/metabase/containers/Overworld.jsx:299
+#: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
 msgstr "Comença aquí"
 
-#: frontend/src/metabase/containers/Overworld.jsx:294
-#: frontend/src/metabase/entities/collections.js:147
+#: frontend/src/metabase/containers/Overworld.jsx:296
+#: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
 msgstr "La nostra analítica"
@@ -2823,53 +2824,53 @@ msgstr "La nostra analítica"
 msgid "Browse all items"
 msgstr "Mostrar tots els elements"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:165
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
 msgstr "Sobreescriure o guardar com una nova pregunta?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:173
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
 msgstr "Sobreescriure la pregunta original: \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:178
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
 msgstr "Guarda com una nova pregunta"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:187
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
 msgstr "Primer guarda la teva pregunta"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:188
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
 msgstr "Guardar la pregunta"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:224
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
 msgstr "Quin es el nom de la teva tarjeta?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:232
-#: frontend/src/metabase/entities/collections.js:101
-#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:234
+#: frontend/src/metabase/entities/collections.js:102
+#: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/lib/core.js:50 frontend/src/metabase/lib/core.js:205
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:156
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:211
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:203
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:207
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:207
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:24
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:159
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:214
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:192
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:206
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:210
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
 msgstr "Descripció"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:238
-#: frontend/src/metabase/entities/dashboards.js:153
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
+#: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
 msgstr "Es opcional, però va tan bé a vegades"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:245
-#: frontend/src/metabase/entities/dashboards.js:157
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
+#: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "A quina col·lecció vols guardar-ho?"
 
@@ -2881,7 +2882,7 @@ msgstr "modificat"
 msgid "item"
 msgstr "element"
 
-#: frontend/src/metabase/containers/UndoListing.jsx:81
+#: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
 msgstr "Desfer"
 
@@ -2905,15 +2906,15 @@ msgstr "No estem segurs si aquesta pregunta es compatible"
 msgid "Archive Dashboard"
 msgstr "Arxiva el quadre de comandament"
 
-#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:20
+#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Asegura't de fer una selecció per a cada sèrie sinó el filtre no funcionarà per aquesta targeta."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:300
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
 msgstr "Sembla que aquest quadre de comandament està buit."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:301
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
 msgstr "Afegeix una pregunta per a que sigui útil"
 
@@ -2933,59 +2934,58 @@ msgstr "Desactiva la pantalla complerta"
 msgid "Enter fullscreen"
 msgstr "Activa la pantalla complerta"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:181
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:183
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Guardant..."
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:216
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
 msgstr "Afegeix una pregunta"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:219
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
 msgstr "Afegiu una pregunta a aquest quadre de comandament."
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:248
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
 msgstr "Afegeix un filtre"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:254
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:78
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Paràmetres"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:275
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
 msgstr "Afegeix una caixa de text"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
 msgstr "Moure el quadre de comandament"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:302
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
 msgstr "Edita el quadre de comandament"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:306
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
 msgstr "Editar la disposició del quadre de comandament"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:369
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
 msgstr "Esteu editant un quadre de comandament"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:374
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
 msgstr "Selecciona el camp que s'ha de filtrar per a cada targeta"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:28
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
 msgstr "Moure el quadre de comandament a..."
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:52
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
 msgstr "El quadre de comandament s'ha mogut a {0}"
 
@@ -3000,7 +3000,7 @@ msgstr "Quin tipus de filtre?"
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:179
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
 msgstr "Desactivat"
 
@@ -3040,174 +3040,174 @@ msgstr "Actualitzant en"
 msgid "Remove this question?"
 msgstr "Eliminar aquesta pregunta?"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:71
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
 msgstr "S'ha guardat el teu quadre de comandament"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:745
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:76
+#: frontend/src/metabase/components/CollectionLanding.jsx:744
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
 msgstr "Veure-ho"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:137
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
 msgstr "Guarda-ho"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:170
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
 msgstr "Mostra més sobre aquest/a"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:140
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
 msgstr "Aquesta targeta no té camps ni paràmetres que coincideixin amb aquest tipus de paràmetre"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:142
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Els valors d'aquest camp no coincideixen amb cap altre camp que hagis escollit"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:186
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
 msgstr "No hi ha camps válid"
 
-#: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
 msgstr "El nom ha de tenir com a màxim 100 caràcters"
 
-#: frontend/src/metabase/entities/collections.js:111
+#: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
 msgstr "El color és obligatori"
 
-#: frontend/src/metabase/entities/dashboards.js:146
+#: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
 msgstr "Quin es el nom del vostre quadre de comandament?"
 
-#: frontend/src/metabase/home/components/Activity.jsx:92
+#: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
 msgstr "He fet algunes coses genials que són difícils de descriure"
 
-#: frontend/src/metabase/home/components/Activity.jsx:101
-#: frontend/src/metabase/home/components/Activity.jsx:116
+#: frontend/src/metabase/home/components/Activity.jsx:103
+#: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
 msgstr "ha creat una alerta sobre - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:126
-#: frontend/src/metabase/home/components/Activity.jsx:141
+#: frontend/src/metabase/home/components/Activity.jsx:128
+#: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
 msgstr "ha eliminat una alerta sobre - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:152
+#: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
 msgstr "ha guardant una pregunta sobre "
 
-#: frontend/src/metabase/home/components/Activity.jsx:165
+#: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
 msgstr "ha guardat una pregunta"
 
-#: frontend/src/metabase/home/components/Activity.jsx:169
+#: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
 msgstr "ha eliminat la pregunta"
 
-#: frontend/src/metabase/home/components/Activity.jsx:172
+#: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
 msgstr "ha creat un quadre de comandament"
 
-#: frontend/src/metabase/home/components/Activity.jsx:175
+#: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
 msgstr "ha eliminat un quadre de comandament"
 
-#: frontend/src/metabase/home/components/Activity.jsx:181
-#: frontend/src/metabase/home/components/Activity.jsx:196
+#: frontend/src/metabase/home/components/Activity.jsx:183
+#: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
 msgstr "ha afegit una pregunta al quadre de comandament - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:206
-#: frontend/src/metabase/home/components/Activity.jsx:221
+#: frontend/src/metabase/home/components/Activity.jsx:208
+#: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
 msgstr "ha eliminat una pregunta al quadre de comandament - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:231
-#: frontend/src/metabase/home/components/Activity.jsx:238
+#: frontend/src/metabase/home/components/Activity.jsx:233
+#: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
 msgstr "ha rebut les ultimes dades de"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:621
-#: frontend/src/metabase/home/components/Activity.jsx:244
+#: frontend/src/metabase-lib/lib/Dimension.js:814
+#: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
 msgstr "Desconegut"
 
-#: frontend/src/metabase/home/components/Activity.jsx:251
+#: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
 msgstr "Hola món!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:252
+#: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
 msgstr "El Metabase està actiu i funcionant."
 
-#: frontend/src/metabase/home/components/Activity.jsx:258
-#: frontend/src/metabase/home/components/Activity.jsx:288
+#: frontend/src/metabase/home/components/Activity.jsx:260
+#: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
 msgstr "ha afegit la mètrica"
 
-#: frontend/src/metabase/home/components/Activity.jsx:272
-#: frontend/src/metabase/home/components/Activity.jsx:362
+#: frontend/src/metabase/home/components/Activity.jsx:274
+#: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
 msgstr " a la "
 
-#: frontend/src/metabase/home/components/Activity.jsx:282
-#: frontend/src/metabase/home/components/Activity.jsx:322
-#: frontend/src/metabase/home/components/Activity.jsx:372
-#: frontend/src/metabase/home/components/Activity.jsx:413
+#: frontend/src/metabase/home/components/Activity.jsx:284
+#: frontend/src/metabase/home/components/Activity.jsx:324
+#: frontend/src/metabase/home/components/Activity.jsx:374
+#: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
 msgstr " taula"
 
-#: frontend/src/metabase/home/components/Activity.jsx:298
-#: frontend/src/metabase/home/components/Activity.jsx:328
+#: frontend/src/metabase/home/components/Activity.jsx:300
+#: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
 msgstr "ha fet canvis a la mètrica "
 
-#: frontend/src/metabase/home/components/Activity.jsx:312
-#: frontend/src/metabase/home/components/Activity.jsx:403
+#: frontend/src/metabase/home/components/Activity.jsx:314
+#: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
 msgstr " en el "
 
-#: frontend/src/metabase/home/components/Activity.jsx:335
+#: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
 msgstr "ha eliminat la mètrica "
 
-#: frontend/src/metabase/home/components/Activity.jsx:338
+#: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
 msgstr "pols creat"
 
-#: frontend/src/metabase/home/components/Activity.jsx:341
+#: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
 msgstr "Pols eliminat"
 
-#: frontend/src/metabase/home/components/Activity.jsx:347
-#: frontend/src/metabase/home/components/Activity.jsx:378
+#: frontend/src/metabase/home/components/Activity.jsx:349
+#: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
 msgstr "ha afegit el fitltre"
 
-#: frontend/src/metabase/home/components/Activity.jsx:388
-#: frontend/src/metabase/home/components/Activity.jsx:419
+#: frontend/src/metabase/home/components/Activity.jsx:390
+#: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
 msgstr "ha fet canvis al filtre"
 
-#: frontend/src/metabase/home/components/Activity.jsx:426
+#: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
 msgstr "ha eliminat el filtre {0}"
 
-#: frontend/src/metabase/home/components/Activity.jsx:429
+#: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
 msgstr "s'ha unit"
 
-#: frontend/src/metabase/home/components/Activity.jsx:529
+#: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
 msgstr "Hmmm, sembla que encara no ha passat res."
 
-#: frontend/src/metabase/home/components/Activity.jsx:532
+#: frontend/src/metabase/home/components/Activity.jsx:534
 msgid "Save a question and get this baby going!"
 msgstr "Guarda una pregunta i fes que això funcioni!"
 
@@ -3255,21 +3255,21 @@ msgstr "Vist recentment"
 msgid "You haven't looked at any dashboards or questions recently"
 msgstr "No has consultat cap quadre de comandament o pregunta recentment"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:99
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
 msgstr "{0} elements seleccionats"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:121
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:172
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
 msgstr "Desarxivar"
 
-#: frontend/src/metabase/home/containers/HomepageApp.jsx:74
-#: frontend/src/metabase/nav/containers/Navbar.jsx:331
+#: frontend/src/metabase/home/containers/HomepageApp.jsx:77
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
 msgstr "Activitat"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:28
+#: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
 msgstr "Resultats de \"{0}\""
 
@@ -3334,6 +3334,7 @@ msgstr "URL del avatar"
 msgid "Common"
 msgstr "Comú"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
@@ -3370,8 +3371,9 @@ msgstr "Latitud"
 msgid "Longitude"
 msgstr "Longitud"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:149
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
 msgstr "Número"
@@ -3468,7 +3470,7 @@ msgstr "Puntuació"
 
 #: frontend/src/metabase/lib/core.js:210
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:17
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
 msgstr "Títol"
 
@@ -3525,8 +3527,9 @@ msgid "Metabase will never retrieve this field. Use this for sensitive or irrele
 msgstr "El Metabase mai obtindrà aquesta camp. Fes-ho servir per informació sensible o irrelevant"
 
 #: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:614
-#: frontend/src/metabase/visualizations/lib/utils.js:126
+#: frontend/src/metabase/lib/query.js:300
+#: frontend/src/metabase/visualizations/lib/utils.js:130
+#: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -3541,7 +3544,7 @@ msgstr "RecompteCumulatiu"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
-#: frontend/src/metabase/visualizations/lib/utils.js:127
+#: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
 msgstr "Suma"
 
@@ -3550,7 +3553,7 @@ msgid "CumulativeSum"
 msgstr "SumaCumulativa"
 
 #: frontend/src/metabase/lib/expressions/config.js:11
-#: frontend/src/metabase/visualizations/lib/utils.js:128
+#: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
 msgstr "Diferent"
 
@@ -3559,35 +3562,35 @@ msgid "StandardDeviation"
 msgstr "DesviacióEstàndard"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/visualizations/lib/utils.js:125
+#: frontend/src/metabase/visualizations/lib/utils.js:129
 msgid "Average"
 msgstr "Mitja"
 
 #: frontend/src/metabase/lib/expressions/config.js:14
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:25
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
 msgstr "Mínim"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
 msgstr "Màxim"
 
-#: frontend/src/metabase/lib/expressions/parser.js:384
+#: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
 msgstr "Trist, molt trista: S'han trobat errors lèxics"
 
-#: frontend/src/metabase/lib/formatting.js:707
+#: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} segon"
 msgstr[1] "{0} segons"
 
-#: frontend/src/metabase/lib/formatting.js:710
+#: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minut"
@@ -3626,222 +3629,224 @@ msgstr "Que tens en ment?"
 msgid "What do you want to find out?"
 msgstr "Sobre que vols buscar?"
 
-#: frontend/src/metabase/lib/query.js:612
-#: frontend/src/metabase/lib/schema_metadata.js:451
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:246
+#: frontend/src/metabase/lib/query.js:298
+#: frontend/src/metabase/lib/schema_metadata.js:458
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
 msgstr "Dades brutes"
 
-#: frontend/src/metabase/lib/query.js:616
+#: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
 msgstr "Recompte cumulatiu"
 
-#: frontend/src/metabase/lib/query.js:619
+#: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
 msgstr "Mtija de"
 
-#: frontend/src/metabase/lib/query.js:624
+#: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
 msgstr "Valors diferents de"
 
-#: frontend/src/metabase/lib/query.js:629
+#: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
 msgstr "Desviació estàndard de "
 
-#: frontend/src/metabase/lib/query.js:634
+#: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
 msgstr "Suma de "
 
-#: frontend/src/metabase/lib/query.js:639
+#: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
 msgstr "Suma acumulativa de"
 
-#: frontend/src/metabase/lib/query.js:644
+#: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
 msgstr "Màxim de"
 
-#: frontend/src/metabase/lib/query.js:649
+#: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
 msgstr "Mínim de"
 
-#: frontend/src/metabase/lib/query.js:663
+#: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
 msgstr "Agrupat per"
 
-#: frontend/src/metabase/lib/query.js:677
+#: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
 msgstr "Filtrar per"
 
-#: frontend/src/metabase/lib/query.js:706
+#: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
 msgstr "Ordenat per"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
 msgstr "Verdader"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
 msgstr "Fals"
 
-#: frontend/src/metabase/lib/schema_metadata.js:305
+#: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
 msgstr "Selecciona la longitud del camp"
 
-#: frontend/src/metabase/lib/schema_metadata.js:306
+#: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
 msgstr "Introdueix la latitud superior"
 
-#: frontend/src/metabase/lib/schema_metadata.js:307
+#: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
 msgstr "Longitud esquerra"
 
-#: frontend/src/metabase/lib/schema_metadata.js:308
+#: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
 msgstr "Longitud inferior"
 
-#: frontend/src/metabase/lib/schema_metadata.js:309
+#: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
 msgstr "Longitud dreta"
 
-#: frontend/src/metabase/lib/schema_metadata.js:345
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase-lib/lib/Dimension.js:505
+#: frontend/src/metabase-lib/lib/Dimension.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:351
+#: frontend/src/metabase/lib/schema_metadata.js:371
 #: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:387
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
 msgstr "És"
 
-#: frontend/src/metabase/lib/schema_metadata.js:346
-#: frontend/src/metabase/lib/schema_metadata.js:366
-#: frontend/src/metabase/lib/schema_metadata.js:376
-#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/lib/schema_metadata.js:352
+#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:396
+#: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
 msgstr "No és"
 
-#: frontend/src/metabase/lib/schema_metadata.js:347
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:369
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:353
+#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
 msgstr "Està buit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:348
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:370
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:402
+#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
 msgstr "No està buit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
 msgstr "Igual a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:355
+#: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
 msgstr "Diferent de"
 
-#: frontend/src/metabase/lib/schema_metadata.js:356
+#: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
 msgstr "Major que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:357
+#: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
 msgstr "Menor que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:358
-#: frontend/src/metabase/lib/schema_metadata.js:384
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:285
+#: frontend/src/metabase/lib/schema_metadata.js:364
+#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Entre"
 
-#: frontend/src/metabase/lib/schema_metadata.js:359
+#: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
 msgstr "Major o igual que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:360
+#: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
 msgstr "Menor o igual que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
 msgstr "Conté"
 
-#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
 msgstr "No conté"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
 msgstr "Comença amb"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
 msgstr "Acaba amb"
 
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:264
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Abans"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:271
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Després"
 
-#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
 msgstr "Dins"
 
-#: frontend/src/metabase/lib/schema_metadata.js:453
+#: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Només una taula amb files a la a resposta. Sense operacions addicionals."
 
-#: frontend/src/metabase/lib/schema_metadata.js:459
+#: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
 msgstr "Nombre de files"
 
-#: frontend/src/metabase/lib/schema_metadata.js:461
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
 msgstr "Nombre total de files a la resposta"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
 msgstr "Suma de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:469
+#: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
 msgstr "Suma tots els valors de una columna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
 msgstr "Mitja de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
 msgstr "Mitja de tots els valors de una columna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
 msgstr "Nombre de valors diferents de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Nombre de valors únics de una columna entre totes les files de la resposta"
 
-#: frontend/src/metabase/lib/schema_metadata.js:491
+#: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
 msgstr "Suma acumulada de ..."
 
@@ -3849,7 +3854,7 @@ msgstr "Suma acumulada de ..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Suma cumulativa de tots els valors de una columan. \\\\n Per exemple: Els ingressos totals al llarg del temps"
 
-#: frontend/src/metabase/lib/schema_metadata.js:499
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
 msgstr "Recompte acumulat de files"
 
@@ -3857,105 +3862,105 @@ msgstr "Recompte acumulat de files"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Recompte acumulat del número de files. \\\\n Per exemple: el nombre total de vendes al llarg del temps"
 
-#: frontend/src/metabase/lib/schema_metadata.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
 msgstr "Desviació estàndard de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:509
+#: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Nombre que expressa com varien els valors de una columna entre totes les files de la resposta"
 
-#: frontend/src/metabase/lib/schema_metadata.js:515
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
 msgstr "Mínim de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:517
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
 msgstr "Valor mínim de una columna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:523
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
 msgstr "Màxim de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:525
+#: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
 msgstr "Valor màxim de una columna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:533
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
 msgstr "Detalla per dimensió"
 
-#: frontend/src/metabase/lib/settings.js:93
+#: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
 msgstr "lletra en minúscules"
 
-#: frontend/src/metabase/lib/settings.js:95
+#: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
 msgstr "lletra en majúscules"
 
-#: frontend/src/metabase/lib/settings.js:97
+#: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "número"
 
-#: frontend/src/metabase/lib/settings.js:99
+#: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
 msgstr "caràcter especials"
 
-#: frontend/src/metabase/lib/settings.js:105
+#: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
 msgstr "ha de ser"
 
-#: frontend/src/metabase/lib/settings.js:105
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:120
+#: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
 msgstr "caràcters"
 
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
 msgstr "Ha de ser"
 
-#: frontend/src/metabase/lib/settings.js:122
+#: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
 msgstr "i incloure"
 
-#: frontend/src/metabase/lib/utils.js:92
+#: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
 msgstr "zero"
 
-#: frontend/src/metabase/lib/utils.js:93
+#: frontend/src/metabase/lib/utils.js:86
 msgid "one"
 msgstr "un"
 
-#: frontend/src/metabase/lib/utils.js:94
+#: frontend/src/metabase/lib/utils.js:87
 msgid "two"
 msgstr "dos"
 
-#: frontend/src/metabase/lib/utils.js:95
+#: frontend/src/metabase/lib/utils.js:88
 msgid "three"
 msgstr "tres"
 
-#: frontend/src/metabase/lib/utils.js:96
+#: frontend/src/metabase/lib/utils.js:89
 msgid "four"
 msgstr "quatre"
 
-#: frontend/src/metabase/lib/utils.js:97
+#: frontend/src/metabase/lib/utils.js:90
 msgid "five"
 msgstr "cinc"
 
-#: frontend/src/metabase/lib/utils.js:98
+#: frontend/src/metabase/lib/utils.js:91
 msgid "six"
 msgstr "sis"
 
-#: frontend/src/metabase/lib/utils.js:99
+#: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
 msgstr "set"
 
-#: frontend/src/metabase/lib/utils.js:100
+#: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
 msgstr "vuit"
 
-#: frontend/src/metabase/lib/utils.js:101
+#: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
 msgstr "nou"
 
@@ -4029,6 +4034,7 @@ msgstr "Temps"
 msgid "Date range, relative date, time of day, etc."
 msgstr "Rang de dates, data relativa, hora del dia, etc."
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
@@ -4051,7 +4057,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Categoria"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
-#: frontend/src/metabase/user/components/UserSettings.jsx:54
+#: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
 msgstr "Configuració del compte"
 
@@ -4063,56 +4069,56 @@ msgstr "Sortir de l'administració"
 msgid "Logs"
 msgstr "Registres"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:64
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
 msgstr "Ajuda"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:67
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
 msgstr "Sobre Metabase"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:73
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
 msgstr "Sortir"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:98
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
 msgstr "Gràcies per utilitzar"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
 msgstr "Esteu utilitzant la versió"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
 msgstr "Construïda el"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:124
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
 msgstr "es una marca registrada de"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:126
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
 msgstr "i s'ha desenvolupat amb amor a San Francisco, California"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:194
+#: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
 msgstr "Administració del Metabase"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:300
+#: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
 msgstr "Fes una pregunta"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:309
+#: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
 msgstr "Afegeix un nou quadre de comandament"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:315
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/nav/containers/Navbar.jsx:361
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
 msgstr "Nou pols"
 
@@ -4120,16 +4126,16 @@ msgstr "Nou pols"
 msgid "Reference"
 msgstr "Referència"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:83
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
 msgstr "Quina mètrica?"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:110
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "La definició de mètriques comunes per al teu equip fa que sigui encara més fàcil crear preguntes"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:113
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
 msgstr "Com crear mètriques"
 
@@ -4141,8 +4147,8 @@ msgstr "Consulta les dades al llarg del temps, com a mapa o en una taula pivotad
 msgid "Custom"
 msgstr "Personalitzat"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:150
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:517
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
 msgstr "Nova pregunta"
 
@@ -4150,22 +4156,22 @@ msgstr "Nova pregunta"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Utilitzeu el generador de preguntes per veure tendències, llistes de coses o les teves pròpies mètriques"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:161
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Consulta nativa"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:162
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Per a preguntes més complicades pots escriure la teva pròpia consulta SQL o nativa."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:240
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
 msgstr "Seleccioneu un valor per defecte"
 
-#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:149
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
 msgstr "Actualitzar el fitlre"
 
@@ -4173,14 +4179,14 @@ msgstr "Actualitzar el fitlre"
 #: frontend/src/metabase/lib/query_time.js:123
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:9
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Today"
 msgstr "Avui"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
 msgstr "Ahir"
 
@@ -4192,7 +4198,7 @@ msgstr "Els últims 7 dies"
 msgid "Past 30 days"
 msgstr "El últims 30 dies"
 
-#: frontend/src/metabase/lib/query_time.js:195
+#: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:29
 #: src/metabase/api/table.clj
@@ -4201,7 +4207,7 @@ msgid_plural "Weeks"
 msgstr[0] "Setmana"
 msgstr[1] "Setmanes"
 
-#: frontend/src/metabase/lib/query_time.js:197
+#: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:30
 #: src/metabase/api/table.clj
@@ -4210,7 +4216,7 @@ msgid_plural "Months"
 msgstr[0] "Mes"
 msgstr[1] "Mesos"
 
-#: frontend/src/metabase/lib/query_time.js:201
+#: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:31
 #: src/metabase/api/table.clj
@@ -4260,6 +4266,7 @@ msgstr "Introduïu un valor"
 msgid "Enter a default value..."
 msgstr "Introduïu un valor predeterminat"
 
+#: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "S'ha produït un error"
@@ -4300,24 +4307,24 @@ msgstr "Publica"
 msgid "Code"
 msgstr "Códi"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:70
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
 msgstr "Estil"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
 msgstr "Quins paràmetres poden utilitzar els usuaris d'aquesta incrustació?"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:83
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
 msgstr "El {0} encara no té cap paràmetre per conigurar"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
 msgstr "Editable"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
 msgstr "Bloquejat"
 
@@ -4325,19 +4332,19 @@ msgstr "Bloquejat"
 msgid "Preview Locked Parameters"
 msgstr "Previsualització dels paràmetres bloquejats"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:115
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
 msgstr "Intenta passar alguns valors al paràmetres bloquejats aquí. El teu servidor haurà de proporcionar els valors reals als token firmat quan s'utilitzi això de debò."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
 msgstr "Zona perillosa"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
 msgstr "Això deshabilitarà la incrustació per aquest {0}"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:128
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
 msgstr "No publicar"
 
@@ -4377,64 +4384,64 @@ msgstr "Més {0}"
 msgid "examples on GitHub"
 msgstr "exemples a GitHub"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:72
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
 msgstr "Habilitar la compartició"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
 msgstr "Deshabilitar aquest enllaç púbic?"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:77
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
 msgstr "Això farà que aquest enllaç deixi de funcionar. Pots tornar-lo a habilitar però quan ho facis aquest serà un enllaç diferent."
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
 msgstr "Enllaç públic"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:118
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
 msgstr "Comparteix aquest {0} amb persones que no tenen una compte de Metabase utilitzant la següent URL:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:158
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
 msgstr "Incrustació púbilca"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:159
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
 msgstr "Incrusta aquest {0} en publicaciós de blocs i pàgines web copiant i pegant aquest fragment:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:176
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
 msgstr "Incrusta aquest {0} en una aplicació"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:177
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
 msgstr "Al integrar-t'he amb un servidor d'aplicacions pots proporcionar estadístiques segures {0} limitades a una usuari, clients o organitzacions específiques."
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
 msgstr "Elimina l'adjunt"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:95
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
 msgstr "Adjunta un fitxer amb els resultats"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
 msgstr "Aquesta pregunta s'afegirà com un fitxer adjunt"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:128
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
 msgstr "Aquesta pregunta no estarà inclosa en el teu Pols."
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:92
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
 msgstr "Aquest pols ja no s'enviarà per correu electrònic a la direcció {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:94
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:376
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
 msgstr[0] "{0} direcció"
@@ -4444,39 +4451,39 @@ msgstr[1] "{0} direccions"
 msgid "Slack channel {0} will no longer get this pulse {1}"
 msgstr "El canal de Slack {0} ja no rebrà aquest pols {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:110
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
 msgstr "El canal {0} ja no rebrà aquest pols {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
 msgstr "Edita un pols"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:131
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
 msgstr "¿Que es un pols?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:141
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
 msgstr "Ho he entès!"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
 msgstr "A on haurien d'anar aquestes dades?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:173
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
 msgstr "Desarxivant..."
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
 msgstr "Ha fallat la recuperació"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
 msgstr "Desarxivat"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
 msgstr "Crea un pols"
 
@@ -4486,7 +4493,7 @@ msgstr "Adjunt"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:673
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
 msgstr "Avis"
 
@@ -4507,6 +4514,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Recomanem mantenir els polsos petits i enfocats per facilitar la seva comprensió i que siguin útils per tot l'equip"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
+#: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
 msgstr "Escull les teves dade"
 
@@ -4522,47 +4530,47 @@ msgstr "Correus electrònics"
 msgid "Slack messages"
 msgstr "Missatges de Slack"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Enviat"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:222
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} s'enviarà a la les"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:224
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Missatges"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Envia el correu electrònic ara"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:241
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Envia a {0} ara"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Enviant..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:244
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "S'ha produït un error al enviar"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "No s'ha enviat el pols perquè no te resultats"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:248
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Pols enviat"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:287
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} ha de ser configurat per un administrador."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:302
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
 msgstr "Slack"
 
@@ -4611,21 +4619,21 @@ msgid "Before {0}"
 msgstr "Abans de {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:295
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Buit"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:301
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "No buit"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:213
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Tot el temps"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:154
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
 msgstr "Aplica"
 
@@ -4691,7 +4699,7 @@ msgstr "Distribució"
 msgid "View details"
 msgstr "Mostra els detalls"
 
-#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:54
+#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
 msgstr "Veure els {1} del {0}"
 
@@ -4715,22 +4723,22 @@ msgstr "Mitja"
 msgid "Distincts"
 msgstr "Diferents"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:32
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Veure aquest {0}"
 msgstr[1] "Veure aquests {0}"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:225
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
 msgstr "Amplia"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:19
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
 msgstr "Expressió personalitzada"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
 msgstr "Mètriques comuns"
 
@@ -4738,7 +4746,7 @@ msgstr "Mètriques comuns"
 msgid "Metabasics"
 msgstr "Metabasics"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
 msgstr "Nom (opcional)"
 
@@ -4750,31 +4758,31 @@ msgstr "Tria un agregat"
 msgid "Set up your own alert"
 msgstr "Configura la teva pròpia alerta"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:140
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
 msgstr "Donant de baixa..."
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:145
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
 msgstr "No s'ha pogut donar de baixa"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:204
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
 msgstr "Donar-se de baixa"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:235
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
 msgstr "Sense canal"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:263
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
 msgstr "D'acord, t'hem donat de baixa"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:335
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
 msgstr "Esteu rebent les alertes de {0}"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
 msgstr "{0} ha configurat una alerta"
 
@@ -4830,147 +4838,147 @@ msgstr "Edita la teva alerta"
 msgid "Edit alert"
 msgstr "Editar alerta"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:374
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
 msgstr "Aquesta alerta ja no s'enviarà per correu electrònica a {0}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:382
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
 msgstr "El canal de Slack {0} ja no rebrà aquesta alerta."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:386
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
 msgstr "El canal {0} ja no rebrà aquesta alerta."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:403
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
 msgstr "Elimina aquesta alerta"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:405
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
 msgstr "Atura l'enviament i elimina aquesta alerta. Vigileu perquè això no es pot desfer."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:413
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
 msgstr "Eliminar aquesta alerta?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:497
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
 msgstr "Avisa'm quan la línia..."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:498
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
 msgstr "Avisa'm quan la barra de progrès"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
 msgstr "Va per damunt de la línia d'objectiu"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
 msgstr "Arriba al objectiu"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
 msgstr "Va per davall de la línia de objectiu"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
 msgstr "Va per davall del objectiu"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:512
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
 msgstr "La primera vegada que es creua o cada vegada?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:513
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
 msgstr "La primera vegada que s'arriba al objectiu o cada vegada?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
 msgstr "La primera vegada"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:516
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
 msgstr "Cada vegada"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:619
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
 msgstr "On vols enviar aquestes alertes?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:630
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
 msgstr "Envia els correus electrònics d'aquesta alerta a:"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:672
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
 msgstr "{0} Les alertes basades en objectius encara no són comptables amb gràfics de més d'una linia de manera que aquesta alerta s'enviara sempre que el gràfic tingui {1}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
 msgstr "resultats"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:679
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
 msgstr "{0} Aquest tipus d'alerta es més útil quan la teva pregunta {1} no retorna cap resultat però vols saber quan ho fa."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:680
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
 msgstr "Consell:"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
 msgstr "generalment"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:57
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
 msgstr "Tria un segment o taula"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
 msgstr "Selecciona una base de dades"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:88
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
 msgstr "Seleccionar.."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:128
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
 msgstr "Selecciona una taula"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:793
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
 msgstr "No s'han trobat taules en aquesta base de dades"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:830
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
 msgstr "Falta una pregunta?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:834
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
 msgstr "Aconsegueix més informació sobre consultes anidades"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:868
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
 msgstr "Camps"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:946
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
 msgstr "No s'han trobat segments"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:969
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
 msgstr "Troba un segment"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:46
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
 msgstr "Mostra menys"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:56
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
 msgstr "Mostra més"
 
@@ -4979,60 +4987,65 @@ msgid "Pick a field to sort by"
 msgstr "Trieu un camp per la ordenació"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
 msgstr "Ordena"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
 msgstr "Límit de files"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:69
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
 msgstr "Camp desconegut"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
 msgstr "camp"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:114
+#: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
 msgstr "Coincidències"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
+#: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Afegeix filtres per perfilar la teva resposta"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:284
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
 msgstr "Afegeix una agrupació"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:322
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:102
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:113
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:152
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:194
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:59
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:68
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:75
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:225
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:231
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:237
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:70
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:75
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:64
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:89
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:131
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:176
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:302
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:308
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:314
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Dades"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:352
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
 msgstr "Filtrat per"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:369
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
 msgstr "Mostra"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:386
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
 msgstr "Agrupat per"
 
@@ -5040,23 +5053,23 @@ msgstr "Agrupat per"
 msgid "None"
 msgstr "Cap"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:345
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
 msgstr "Aquesta pregunta està escrita en {0}"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:353
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
 msgstr "Amaga l'editor"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:354
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
 msgstr "Amaga la consulta"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
 msgstr "Obrir l'editor"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:360
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
 msgstr "Mostra la consulta"
 
@@ -5077,15 +5090,15 @@ msgstr "Baixa aquesta informació"
 msgid "Warning"
 msgstr "Avís"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:52
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
 msgstr "La teva resposta te una gran quantitat de files, podria tarda una estona a descarregar-se"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:53
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
 msgstr "La mida màxima de la baixada es de 1 milió de files"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:232
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
 msgstr "Edita la pregunta"
 
@@ -5101,17 +5114,17 @@ msgstr "CANCEL·LA"
 msgid "Move question"
 msgstr "Moure la pregunta"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:283
+#: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
 msgstr "A quina col·lecció ho hauríem de guardar?"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:313
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:110
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
+#: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
 msgstr "Variables"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:432
+#: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
 msgstr "Coneix les teves dades"
 
@@ -5155,11 +5168,11 @@ msgstr "{0} d'auquesta pregunta"
 msgid "Convert this question to {0}"
 msgstr "Convertir aquesta pregunta a {0}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:122
+#: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
 msgstr "Aquesta pregunta tardarà aproximadament {0} en actualitzar-se"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:131
+#: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
 msgstr "Actualitzat fa {0}"
 
@@ -5177,11 +5190,11 @@ msgstr "Mostrant les primeres {0} {1}"
 msgid "Showing {0} {1}"
 msgstr "Mostrant {0} {1}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:281
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
 msgstr "Fent ciència"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:294
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
 msgstr "Si em dones algunes dades et puc mostrar coses genials. Executa una consulta!"
 
@@ -5189,7 +5202,7 @@ msgstr "Si em dones algunes dades et puc mostrar coses genials. Executa una cons
 msgid "How do I use this thing?"
 msgstr "Com es fa servir aquesta cosa?"
 
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:28
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
 msgstr "Obtenir la resposta"
 
@@ -5217,39 +5230,39 @@ msgstr "Ho sento. Alguna cosa no ha anat bé."
 msgid "Group time by"
 msgstr "Agrupar el temps per"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:46
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
 msgstr "La teva pregunta ha tardat massa temps"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:47
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
 msgstr "No em obtingut una resposta de la base de dades a temps així que em tingut que aturar-ho. Ho pots tornar a intentar en una estona o si el problema continua pots enviar un correu electrònica al administrador per avisar-lo."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:55
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
 msgstr "Estem experimentant problemes al servidor"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:56
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
 msgstr "Intenta actualitzar la pàgina desprès d'esperar una estona. Si el problema continua posa't en contacte amb un un administrador."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:88
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
 msgstr "Hi ha hagut un problema amb la teva pregunta."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:89
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
 msgstr "La majoria de vegades això està causat per una selecció no vàlida o un valor d'entrada incorrecte. Revisa les teves entrades i tornar a executar la consulta."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:60
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
 msgstr "Aquesta pot ser la resposta al que estàs buscant. Si no es així intenta eliminar o canviar els filtres per a que sigui menys específics."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
 msgstr "També pots {0} quan hi hagi alguns resultats."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:68
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
 msgstr "rebre una alterta"
 
@@ -5257,11 +5270,11 @@ msgstr "rebre una alterta"
 msgid "Back to last run"
 msgstr "Tornar a la última execució"
 
-#: frontend/src/metabase/query_builder/components/VisualizationSettings.jsx:100
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
 msgstr "Visualització"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:96
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
 msgstr "Sense descripció"
 
@@ -5273,7 +5286,7 @@ msgstr "Utilitzar per la pregunta actual"
 msgid "Potentially useful questions"
 msgstr "Preguntes potencialment útils"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:166
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
 msgstr "Agrupa per {0}"
 
@@ -5286,14 +5299,14 @@ msgstr "Suma de tots els valors de {0}"
 msgid "All distinct values of {0}"
 msgstr "Tots els valors diferents de {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:187
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
 msgstr "Número de {0} agrupades per {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5309,34 +5322,34 @@ msgstr "Referència de dades"
 msgid "Learn more about your data structure to ask more useful questions"
 msgstr "Aprèn més sobre la teva estructura de dades per fer preguntes més útils"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:58
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:84
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
 msgstr "No s'han pogut trobar les metadades de la taula abans de crear una nova pregunta"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:80
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
 msgstr "Veure {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:94
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
 msgstr "Definició de la mètrica"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:118
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
 msgstr "Filtrar per {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:127
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
 msgstr "Número de {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
 msgstr "Veure tots els {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:148
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
 msgstr "Definició del segment"
 
@@ -5348,7 +5361,7 @@ msgstr "S'ha produït un error al carregar la taula"
 msgid "See the raw data for {0}"
 msgstr "Mostra les dades de {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:180
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
 msgstr "Més"
 
@@ -5360,24 +5373,24 @@ msgstr "Expressió invàlida"
 msgid "unknown error"
 msgstr "error desconegut"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:46
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
 msgstr "Formula del camp"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:57
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Pensa que això es com escriure una fórmula en un full de càlcul: Pots utilitzar números, camps d'aquesta taula, símbols màtemàtics com + i algunes funcions. Pots escriure alguna cosa com: Subtotal - Cost"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
 msgstr "Aprendre'n més"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:66
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
 msgstr "Dona-li un nom"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:72
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
 msgstr "Quelcom agradable i descriptiu"
 
@@ -5429,7 +5442,8 @@ msgstr "verdader"
 msgid "false"
 msgstr "fals"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
 msgstr "Afegir un filtre"
 
@@ -5437,15 +5451,15 @@ msgstr "Afegir un filtre"
 msgid "Item"
 msgstr "Element"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:221
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
 msgstr "Anterior"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:252
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
 msgstr "Actual"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:278
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
@@ -5456,7 +5470,7 @@ msgid "Enter desired number"
 msgstr "Introdueix el nombre desitjat"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:100
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
 msgstr "Buit"
 
@@ -5480,35 +5494,35 @@ msgstr "Pots introduir varis valors separats per comes"
 msgid "Enter desired text"
 msgstr "Introdueix el text desitjat"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
 msgstr "Proba-ho"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
 msgstr "Per a que serveix això?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
 msgstr "Les variables a les consultes natives et permetes substituir dinàmicament els valors a les teves consultes utilitzant elements de filtre o a través de la URL."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
 msgstr "{0} crea una variable en aquesta plantilla SQL anomenada \"nom_variable\". Pots assignar els tipus a les variables al panell lateral cosa que canvia el seu comportament. Tots els tipus de variables que no siguin \"Filtres de camp\" provocaran que es col·loqui un filtre per aquesta pregunta. Amb els filtres de camp, això es opcional. Quan s'estableix el valor d'aquest element al filtre es substitueix la variable a la plantilla SQL."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:121
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
 msgstr "Filtres de camp"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:123
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Donar-li a la variable el tipus \"Filtre de camp\" et permet vincular les targetes SQL amb quadres de comandament amb elements de filtre o utilitzar més tipus d'elements de filtro a la teva pregunta de SQL. Una variable de filtre insereix un SQL similar al que es genera a la UI de generador de consultes quan s'afegeixen filtres amb columnes existents."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:126
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
 msgstr "Al afegir una variable de Filtre de camp l'hauràs d'assignar a un camp especific. A continuació pots mostrar un element de filtre a la teva pregunta, però si no ho fas pots assignar el Filtre de cap a un filtre del quadre de comandament. Els filtres del camp s'ha d'utilitzar dins de la clàusula \"WHERE\"."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:130
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
 msgstr "Clàusules opcionals"
 
@@ -5516,59 +5530,61 @@ msgstr "Clàusules opcionals"
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
 msgstr "Els corxetes al voltant de un {0} creen una clàusula opcional a la plantilla. Si s'estableix la \"variable\" aleshores s'introdueix la clàusula complerta a la plantilla. Si no s'estableix s'ignora tota la clàusula."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:142
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
 msgstr "Pots utilitzar múltiples clàusules opcions, pots incloure almenys una clàusula WEHRE no opcional seguida de clàusules opcionals que comencin per \"AND\""
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
 msgstr "Llegeix la documentació complerta"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:127
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
 msgstr "Filtre d'etiqueta"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:139
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
 msgstr "Tipus de variable"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:143
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
 msgstr "Text"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:150
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:119
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
 msgstr "Data"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
 msgstr "Filtre de camp"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:157
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
 msgstr "Camp per mapejar a"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
 msgstr "Tipus de filtre"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:201
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
 msgstr "Obligatori?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:211
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
 msgstr "Valor per defecte el camp de filtre"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:46
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
 msgstr "Arxivar aquesta pregunta?"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:57
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Aquesta pregunta s'eliminarà dels quadres de comandaments o polsos que la utilitzin."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:136
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
 msgstr "Pregunta"
 
@@ -5585,21 +5601,21 @@ msgstr "Estàs editant aquesta pàgina"
 msgid "See this {0}"
 msgstr "Veure aquest {0}"
 
-#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:120
+#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
 msgstr "Un subconjunt de"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:68
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
 msgstr "Selecciona un tipus de camp"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:57
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
 msgstr "Sense tipus de camp"
 
@@ -5608,16 +5624,16 @@ msgid "by"
 msgstr "per"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
-#: frontend/src/metabase/reference/databases/FieldList.jsx:152
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
+#: frontend/src/metabase/reference/databases/FieldList.jsx:155
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
 msgstr "Tipus de camp"
 
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:72
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
 msgstr "Selecciona una clau forànea"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:53
+#: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
 msgstr "Mostra la formula de {0}"
 
@@ -5634,12 +5650,12 @@ msgid "Nothing important yet"
 msgstr "Res important de moment"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:168
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:233
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:211
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:215
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:219
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:229
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:236
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:214
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
 msgstr "Res interessant de moment"
 
@@ -5648,12 +5664,12 @@ msgid "Things to be aware of about this {0}"
 msgstr "Coses a tenir en compte d'aquest {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:178
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:243
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:221
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:225
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:229
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:239
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:246
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:224
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
 msgstr "No hi ha res que hauries de saber"
 
@@ -5715,15 +5731,15 @@ msgstr "Motiu del canvi"
 msgid "Leave a note to explain what changes you made and why they were required"
 msgstr "Deixa una nota per explicar quins canvis has realitzat i perquè han estat necessaris."
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:166
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
 msgstr "Perquè aquesta base de dades és interessant"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:176
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
 msgstr "Coses a tenir en compte d'aquesta base de dades"
 
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:46
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
 msgstr "Base de dates i taules"
@@ -5731,42 +5747,42 @@ msgstr "Base de dates i taules"
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:41
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:170
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:173
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:34
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:184
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:187
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:30
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:188
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:187
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:191
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:190
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
 msgstr "Detalls"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
-#: frontend/src/metabase/reference/databases/TableList.jsx:111
+#: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
 msgstr "Taules a {0}"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:222
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:200
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:218
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:203
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
 msgstr "Nom real a la base de dades"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:231
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:227
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
 msgstr "Perquè aquest camp es interessant"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:241
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:237
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
 msgstr "Coses a tenir en compte d'aquest camp"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:253
-#: frontend/src/metabase/reference/databases/FieldList.jsx:155
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:249
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
+#: frontend/src/metabase/reference/databases/FieldList.jsx:158
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
 msgstr "Tipus de dada"
 
@@ -5775,13 +5791,13 @@ msgstr "Tipus de dada"
 msgid "Fields in this table will appear here as they're added"
 msgstr "Els camps apareixeran aquí a mesura que es vagin afegint"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:134
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:135
+#: frontend/src/metabase/reference/databases/FieldList.jsx:137
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
 msgstr "Camps a {0}"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:149
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:150
+#: frontend/src/metabase/reference/databases/FieldList.jsx:152
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
 msgstr "Nom del camp"
 
@@ -5805,7 +5821,10 @@ msgstr "Les bases de dades apareixeran aquí una vegada que els administradors l
 msgid "Connect a database"
 msgstr "Connecta una base de dades"
 
+#. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
+#. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
+#: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
 msgstr "Recompte de {0}"
 
@@ -5813,11 +5832,11 @@ msgstr "Recompte de {0}"
 msgid "See raw data for {0}"
 msgstr "Mostra les dades de {0}"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:209
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
 msgstr "Perquè aquesta taula es interesant"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:219
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
 msgstr "Coses a tenir en compte sobre aquesta taule"
 
@@ -5829,16 +5848,16 @@ msgstr "Les taules d'aquesta base de dades es mostraran aquí una vegades afegei
 msgid "Questions about this table will appear here as they're added"
 msgstr "Les preguntes d'aquesta taula es mostraran aquí una vegades afegeixes"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:71
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:75
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:74
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
 msgstr "Preguntes sobre {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
 msgstr "Creat fa {0} per {1}"
 
@@ -5850,151 +5869,152 @@ msgstr "Camps en aquesta taula"
 msgid "Questions about this table"
 msgstr "Preguntes sobre aquesta taula"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:157
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
 msgstr "Ajuda al teu equip a començar amb les teves dades"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:159
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
 msgstr "Mostra al teu equip el que es més important per elegir els quadres de comandament, les mètriques i els segments principals."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:165
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
 msgstr "Comença"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:173
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
 msgstr "El nostre quadre de comandament més important"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:188
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
 msgstr "El números als que hem de tenir en compte"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:213
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
 msgstr "Les mètriques son números destacats que li importen a la teva empresa. Normalment representen un indicador central de com està funcionant el negoci. "
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:221
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
 msgstr "Mostra totes les mètriques"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:235
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
 msgstr "Segments i taules"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
+#: frontend/src/metabase/home/containers/SearchApp.jsx:83
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
 msgstr "Taules"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:262
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
 msgstr "Els segments i les taules son components bàsics de les dades de la teva empresa. Les taules són col·leccions d'informació sense format mentre que els segments son bocins acotats amb un significat específic, cóm {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:267
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
 msgstr "Les taules son els components bàsics de les dades de la teva empresa"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:277
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
 msgstr "Mostra tots els segments"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:293
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
 msgstr "Mostra totes les taules"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:301
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
 msgstr "Altres coses que has de saber sobre les nostres dades"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
 msgstr "Descobreix més"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:307
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
 msgstr "Una bona forma de conèixer les teves dades es dedicar una mica de temps a explorar les teves taules i l'altra informació disponible. Pots tardar una mica però començaràs a conèixer noms i significats a través del temps. "
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:313
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
 msgstr "Explorar les nostres dades"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:321
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
 msgstr "Tens una pregunta?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:326
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
 msgstr "Contacta amb {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:248
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
 msgstr "Ajuda als nous usuaris del Metabase a descobrir com funciona"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:251
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
 msgstr "La guia d'introducció destaca el quadre de comandaments, les mètriques, els segments i les taules que més importen. També informa als usuaris sobre coses importants que haurien de saber abans de profunditzar en les seves dades."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:258
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
 msgstr "Hi ha alguna quadre de comandament important pel teu equip?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:260
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
 msgstr "Creeu un quadre de comandament ara"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:266
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
 msgstr "Quin es el quadre de comandament més important?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:285
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
 msgstr "Tens alguna mètrica que de la que se'n faci referència sovint?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:287
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
 msgstr "Aprèn a definir una mètrica"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:300
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
 msgstr "Quines son les 3-5 mètriques que s'utilitzen més sovint?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:344
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
 msgstr "Afegeix una altra mètrica"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:357
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
 msgstr "Tens algun segment o taula que es referencii sovint?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:359
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
 msgstr "Aprèn a crear un segment"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:372
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
 msgstr "Quins son els 3-5 segments o taules referenciades de forma comuna que serien útils per aquesta audiència?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:418
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
 msgstr "Afegeix un altre segment o taula"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:427
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
 msgstr "Hi ha alguna cosa que han de saber o entendre els usuaris abans d'accedir a les dades?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:433
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
 msgstr "Que ha de saber el usuari sobre aquestes dades abans d'accedir-hi?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:437
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
 msgstr "Per exemple, les expectatives sobre la privacitat i els us de les dades, perills comuns, informació sobre el rendiment del servidor, avisos legals, etc."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
 msgstr "Hi ha algú que els teus usuaris poden contactar en cas de que tinguin dubtes amb aquesta guia?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:457
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
 msgstr "Amb quin han de contactar els usuaris per obtenir ajuda si tenen dubtes sobre aquesta informació?"
 
@@ -6003,39 +6023,39 @@ msgstr "Amb quin han de contactar els usuaris per obtenir ajuda si tenen dubtes 
 msgid "Please enter a revision message"
 msgstr "Si us plau afegeix un missatge de revisió"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:213
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
 msgstr "Perquè aquesta mètrica és interessant"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:223
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
 msgstr "Coses a tenir en compte d'aquesta mètrica"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:233
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
 msgstr "Com es calcula aquesta metrica"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:235
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
 msgstr "Encara no sabem com s'han calculat"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:293
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
 msgstr "Altres camps pels que es pot agrupar aquesta mètrica"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:294
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
 msgstr "Camps pels que es pot agrupar aquesta mètrica"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:23
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Les mètriques són nombres oficials pels que el teu equip es preocupa"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Les mètriques apareixeran aquí una vegada que els teus administradors n'hagin creat alguna. "
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
 msgstr "Aprèn com crear mètriques"
 
@@ -6047,9 +6067,9 @@ msgstr "Les preguntes sobre aquesta mètrica apareixeran aquí quan es creïn."
 msgid "There are no revisions for this metric"
 msgstr "No hi ha revisions per aquesta mètrica"
 
-#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:88
-#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
-#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:88
+#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
+#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
+#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
 msgstr "Historial de revisions de {0}"
 
@@ -6057,27 +6077,27 @@ msgstr "Historial de revisions de {0}"
 msgid "X-ray this metric"
 msgstr "Aplica rajos-X a aquesta mètrica"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:217
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
 msgstr "Perquè aquest segment es interessant"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:227
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
 msgstr "Coses a tenir en compte d'aquest segment"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
 msgstr "Els segments son subconjunts interessants de taules"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "La definició de segments comuns pel teu equip fa que encara sigui més fàcil fer preguntes"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
 msgstr "Els segments apareixeran aquí una vegada que els administradors els hagin creat"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
 msgstr "Aprèn a crear segments"
 
@@ -6105,7 +6125,7 @@ msgstr "Aplica rajos-X a aquest segment"
 msgid "Login"
 msgstr "Inicia sessió"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:130
+#: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
 msgstr "Cerca"
@@ -6122,99 +6142,99 @@ msgstr "Nova pregunta"
 msgid "Select the type of Database you use"
 msgstr "Selecciona el tipus de base de dades que utilitzes"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:141
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
 msgstr "Afegeix les teves dades"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:145
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
 msgstr "Afegiré les meves dades més tard"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
 msgstr "Connectant amb {0}"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:165
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
 msgstr "Et farà falta la informació de la teva base de dades: el nom d'usuari i la contrasenya. Si no tens aquesta informació ara mateix el Metabase conté un conjunt de dades de mostra amb els que pots començar."
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:196
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
 msgstr "Afegiré les meves dades més tard"
 
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:41
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
 msgstr "Controla els escanejos automàtics"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:53
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
 msgstr "Preferències d'utilització de dades"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
 msgstr "Gràcies per ajudar-nos a millorar"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:57
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
 msgstr "No recopilarem cap esdeveniment d'ús."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:76
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Per ajudar-nos a millorar el Metabase ens agradaria recollir informació sobre el seu us a través de Google Analytics."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
 msgstr "Aquí hi ha una llista complerta de tota la informació que recollirem i perquè."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:98
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Permetre que el Metabase reculli esdeveniments d'ús de forma anònima"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} recull informació sobre les teves dades o els resultats de les preguntes"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:106
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
 msgstr "mai"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
 msgstr "Tota la informació obtinguda es totalment anònima"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "La recopilació es pot desactivar en qualsevol moment des de la pàgina de configuració."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:45
+#: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
 msgstr "Si et sents abrumant"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:52
+#: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
 msgstr "la nostra guia d'iniciació"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:53
+#: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
 msgstr "està a un sol click"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:95
+#: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
 msgstr "Benvingut/da al Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:96
+#: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Sembla que tot està funcionant. Ara anem a coneixe't, connectar amb les teves dades i començar a donar respostes a les teves preguntes."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:100
+#: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
 msgstr "Començem"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:145
+#: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
 msgstr "Ja està tot llest!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:156
+#: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
 msgstr "Portam al Metabase"
 
@@ -6231,7 +6251,7 @@ msgid "Create a password"
 msgstr "Crea una contrasenya"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:116
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
 msgstr "Shhht..."
 
@@ -6424,11 +6444,11 @@ msgstr "Inicia sessió amb la direcció de correu electrònic de Googl"
 msgid "User Details"
 msgstr "Detalls del usuari"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:275
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
 msgstr "Restablir els valors predeterminats"
 
-#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:133
+#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
 msgstr "mapa desconegut"
 
@@ -6440,24 +6460,24 @@ msgstr "El mapa de quadrícula necessita que la longitud i la latitud estigui ag
 msgid "more"
 msgstr "més"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:101
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
 msgstr "Quins camps vols fer servir pels eixos X i Y?"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:103
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:60
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
 msgstr "Escull els camps"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:204
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
 msgstr "Guarda com a vista per defecte"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
 msgstr "Dibuixa una caixa per filtrar"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
 msgstr "Cancel·la el filtre"
 
@@ -6465,7 +6485,7 @@ msgstr "Cancel·la el filtre"
 msgid "Pin Map"
 msgstr "Mapa de pin"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:303
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
 msgstr "Desmarcar"
 
@@ -6473,31 +6493,31 @@ msgstr "Desmarcar"
 msgid "Rows {0}-{1} of {2}"
 msgstr "Files {0}-{1} de {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:189
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
 msgstr "Les dades s'han truncat a {0} files."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:364
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
 msgstr "No s'ha pogut trobar la visualització"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:371
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
 msgstr "No s'ha pogut mostrar el gràfic amb aquesta informació."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:469
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
 msgstr "Sense resultats"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:490
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
 msgstr "Esperant..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:493
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
 msgstr "Normalment tarda una mitja de {0}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:499
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
 msgstr "(es una mica llarg per a un quadre de comandament)"
 
@@ -6513,11 +6533,11 @@ msgstr "Selecciona un camp"
 msgid "error"
 msgstr "erro"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:126
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
 msgstr "Clica i arrastra per canviar l'ordre"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:139
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
 msgstr "Afegeix camps de la llista inferior"
 
@@ -6607,7 +6627,7 @@ msgid "Highlight the whole row"
 msgstr "Ressalta tota la fila"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:98
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Colors"
 
@@ -6672,20 +6692,20 @@ msgstr "Ja s'ha registrat una visualització amb aquesta identificació:"
 msgid "No visualization for {0}"
 msgstr "No hi ha visualitzacions per {0}"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:75
+#: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
 msgstr "El camp \"{0}\" no es un agregat: si hi ha més d'un valor en un punt del eix X els valors es sumaran."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:91
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
 msgstr "Aquest tipus de gràfic requereix com a mínim dos columnes"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:96
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
 msgstr "Aquest tipus de gràfic no permet més de {0} sèries de dades."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:51
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:297
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
 msgstr "Objectiu"
 
@@ -6725,25 +6745,25 @@ msgstr "Editar configuració"
 msgid "xValues missing!"
 msgstr "Falten valors per les x!"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:114
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "Eix-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:140
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
 msgstr "Afegeix un desglòs de series..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:153
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Eix-Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:178
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
 msgstr "Afegeix una altra sèrie..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:195
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
 msgstr "Mida de la bombolla"
 
@@ -6757,7 +6777,7 @@ msgid "Curve"
 msgstr "Curva"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:69
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
 msgstr "Pas"
 
@@ -6765,27 +6785,27 @@ msgstr "Pas"
 msgid "Show point markers on lines"
 msgstr "Mostra un marcador de punts a les línies"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:235
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
 msgstr "Apilat"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:239
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
 msgstr "Sense apilar"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:240
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
 msgstr "Apilar"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:241
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
 msgstr "Apilat - 100%"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:300
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
 msgstr "Mostrar objectiu"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:306
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
 msgstr "Valor del objectiu"
 
@@ -6805,126 +6825,126 @@ msgstr "Res"
 msgid "Linear Interpolated"
 msgstr "Interpolació lineal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:371
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
 msgstr "Escala Eix-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
 msgstr "Series de temps"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:391
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:409
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:381
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
 msgstr "Lineal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:410
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:383
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
 msgstr "Exponencial"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:384
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
 msgstr "Logarítimc"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:396
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
 msgstr "Histograma"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:398
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
 msgstr "Ordinal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:404
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
 msgstr "Escala Eix-Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:417
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
 msgstr "Mostra lńia i marca del Eix-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:423
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
 msgstr "Compacte"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:424
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
 msgstr "Girar 45º"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
 msgstr "Girar 90º"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
 msgstr "Mostra ínia i marques del Eix-Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
 msgstr "Rang del Eix-Y automàtic"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
 msgstr "Utilitza un Eix-Y dividit quan sigui necesàri"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
 msgstr "Mostra etiqueta en l'Eix-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:501
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
 msgstr "Etiqueta Eix-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:510
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
 msgstr "Mostra etiqueta en l'Eix-Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:516
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
 msgstr "Etiqueta Eix-Y"
 
-#: frontend/src/metabase/visualizations/lib/utils.js:129
+#: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
 msgstr "Desviació Estàndard"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:275
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:17
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:256
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
 msgstr "Àrea"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
 msgstr "Gràfic de àrea"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:276
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:16
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:257
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
 msgstr "Barra"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
 msgstr "Gràfic de barres"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
 msgstr "Quins camps vols utilitzar?"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
 msgstr "Embut"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:76
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:76
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Mesura"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
 msgstr "Tipus d'embut"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:88
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
 msgstr "Gràfic de barres"
 
@@ -6932,141 +6952,141 @@ msgstr "Gràfic de barres"
 msgid "line chart"
 msgstr "Gràfic de línies"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:224
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Selecciona les columnes de longitud i latitud a la configuració del gràfic."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
 msgstr "Si us plau, selecciona un mapa de la regió"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Selecciona les columnes de regió i mètriques a la configuració del gràfic."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:38
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:53
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
 msgstr "Tipus de mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:57
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:149
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
 msgstr "Mapa de la regió"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
 msgstr "Mapa de pin"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
 msgstr "Tipus de pin"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
 msgstr "Rajoles"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
 msgstr "Marcados"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
 msgstr "Camp latitud"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
 msgstr "Camp longitud"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:142
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:168
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
 msgstr "Camp mètrica"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
 msgstr "Camp regió"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
 msgstr "Radi"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:198
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
 msgstr "Difuminar"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
 msgstr "Opacitat mínima"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
 msgstr "Zoom Maxim"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:175
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
 msgstr "No s'han trobat relacions"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:213
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:290
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
 msgstr "Està {0} està connectada a:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:47
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
 msgstr "Detall del objecte"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
 msgstr "objecte"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
 msgstr "Total"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Quines columnes vols fer servir?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:44
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Pastís"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Dimesió"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:81
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Mostra la llegenda"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:86
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Mostra percentatges a la llegenda"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:92
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Percentatge mínim de la porció"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:146
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
 msgstr "Objectiu aconseguit"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:148
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
 msgstr "Objectiu superat"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
 msgstr "Objectiu {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
 msgstr "La visualització del progrès requereix un nombre"
 
@@ -7074,9 +7094,9 @@ msgstr "La visualització del progrès requereix un nombre"
 msgid "Progress"
 msgstr "Progrès"
 
-#: frontend/src/metabase/entities/collections.js:108
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:176
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:57
+#: frontend/src/metabase/entities/collections.js:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Color"
 
@@ -7088,7 +7108,7 @@ msgstr "Gràfic de files"
 msgid "row chart"
 msgstr "gràfic de files"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:357
+#: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
 msgstr "Estil del separador"
 
@@ -7096,15 +7116,15 @@ msgstr "Estil del separador"
 msgid "Number of decimal places"
 msgstr "Nombre de decimals"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:381
+#: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
 msgstr "Afegeix un prefix"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:385
+#: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
 msgstr "Afegeix un sufix"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:374
+#: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
 msgstr "Multiplica per un nombre"
 
@@ -7116,7 +7136,7 @@ msgstr "Dispersió"
 msgid "scatter plot"
 msgstr "gràfic de dispersió"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:78
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
 msgstr "Pivota la taula"
 
@@ -7125,7 +7145,8 @@ msgid "Visible fields"
 msgstr "Camps visibles"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-msgid "Write here, and use Markdown if you''d like"
+#, fuzzy
+msgid "Write here, and use Markdown if you'd like"
 msgstr "Escriu aquí. Pots fer servir Markdown si ho desiges"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
@@ -7166,13 +7187,13 @@ msgstr "Dreta"
 msgid "Show background"
 msgstr "Mostrar el fons"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:553
+#: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} agrupació"
 msgstr[1] "{0} agrupacions"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:559
+#: frontend/src/metabase-lib/lib/Dimension.js:731
 msgid "Auto binned"
 msgstr "Agrupació automàtica"
 
@@ -7440,26 +7461,26 @@ msgstr "Agrupació automàtica"
 msgid "Don''t bin"
 msgstr "Sense agrupació"
 
-#: frontend/src/metabase/lib/query_time.js:193 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Dia"
 msgstr[1] "Dies"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
-#: frontend/src/metabase/lib/query_time.js:189 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minut"
 msgstr[1] "Minuts"
 
-#: frontend/src/metabase/lib/query_time.js:191 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Hora"
 msgstr[1] "Hores"
 
-#: frontend/src/metabase/lib/query_time.js:199 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
 msgstr[0] "Trimestre"
@@ -7526,7 +7547,7 @@ msgid "Bin every 20 degrees"
 msgstr "Agrupa cada 20 graus"
 
 #. returns `true` if successful -- see JavaDoc
-#: src/metabase/api/tiles.clj src/metabase/pulse/render.clj
+#: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
 msgstr "No s'ha trobat un generador d'imatges apropiat!"
 
@@ -7598,10 +7619,12 @@ msgstr "suma acumulativa"
 msgid "{0} and {1}"
 msgstr "{0} i {1}"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} de {1}"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
 msgstr "{0} per {1}"
@@ -7614,9 +7637,12 @@ msgstr "{0} al segment {1}"
 msgid "{0} segment"
 msgstr "{0} segment"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
-msgstr "{0} mètrica"
+msgid_plural "{0} metrics"
+msgstr[0] "{0} mètrica"
+msgstr[1] "{0} metricas"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
@@ -8197,6 +8223,7 @@ msgid "Cannot save Question: source query has circular references."
 msgstr "No s'ha pogut guardar la pregunta degut a referències circulars"
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
+#: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
 msgstr "No existeix la targeta {0}"
@@ -8598,7 +8625,7 @@ msgstr "El tipus de canal {0} es desconegut"
 msgid "Error sending notification!"
 msgstr "Error enviant la notificació."
 
-#: src/metabase/pulse/color.clj
+#: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
 msgstr "No s'ha pogut encontrar el selector JS a \"{0}\""
 
@@ -8905,43 +8932,43 @@ msgstr "Permís d'accés a les dade"
 msgid "Collection permissions"
 msgstr "Permisos d'accés a les col·leccions"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:56
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
 msgstr "Veure tots els permisos de les col·leccions"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:25
+#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
 msgstr "Canviar també les sub-col·leccions"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:282
+#: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
 msgstr "Pot editar aquesta col·lecció i els seus continguts"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:289
+#: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
 msgstr "Pot veure el contingut d'aquesta col·lecció"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:749
+#: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
 msgstr "Accés a la col·lecció"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:825
+#: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Aquest grup té permisos per veure com a mínim una sub-col·lecció d'aquesta col·lecció"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:830
+#: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Aquest grup té permisos per editar com a mínim una sub-col·lecció d'aquesta col·lecció"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
 msgstr "Mostra sub col·leccíó"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:211
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
 msgstr "Recorda'm"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:95
+#: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
 msgstr "Aplica rajos-X a aquest esquema"
 
@@ -8973,31 +9000,32 @@ msgstr "Guardar els quadres de comandament, preguntes i col·leccions a \"{0}\""
 msgid "Access dashboards, questions, and collections in \"{0}\""
 msgstr "Accedir als quadres de comandament, preguntes i col·leccions de \"{0}\""
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:221
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
 msgstr "Compara"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:229
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
 msgstr "Allunya"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:233
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
 msgstr "Relacionat"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:293
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
 msgstr "Més rajos-X"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:46
+#: frontend/src/metabase/home/containers/SearchApp.jsx:40
+#: src/metabase/pulse/render/body.clj
 msgid "No results"
 msgstr "No hi ha resultats"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:47
+#: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
 msgstr "El Metabase no ha pogut trobar cap resultat per la seva cerca."
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:111
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
 msgstr "No s'ha trobat cap mètrica"
 
@@ -9039,7 +9067,7 @@ msgstr "Error al concedir permisos: {0}"
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
 msgstr "No s'ha pogut desencriptar el text encriptat. Heu canviat o us no heu establer el valor de MB_ENCRYPTION_SECRET_KEY?"
 
-#: frontend/src/metabase/entities/collections.js:164
+#: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
 msgstr "Totes les col·leccions personals"
 
@@ -9203,18 +9231,18 @@ msgstr "N/A"
 msgid "Windows domain"
 msgstr "Domini de Windows"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:509
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:515
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:490
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:499
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
 msgstr "Etiquetes"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:329
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
 msgstr "Afegir membres"
 
-#: frontend/src/metabase/entities/collections.js:115
+#: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
 msgstr "Col·lecció que es guarda a"
 
@@ -9235,39 +9263,39 @@ msgid "Sharing"
 msgstr "Compartir"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:234
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:270
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:299
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:305
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:313
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:321
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:218
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:251
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:280
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:286
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:294
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:302
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:80
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:85
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:91
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:97
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:50
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:56
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
 msgstr "Visualitza"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:370
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:416
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:431
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:487
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:358
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:406
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:447
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
 msgstr "Eixos"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:222
-#: frontend/src/metabase/admin/settings/selectors.js:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
+#: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
@@ -9301,20 +9329,20 @@ msgstr "Aplica rajos-X"
 msgid "Compare to the rest"
 msgstr "Compara amb a resta"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:244
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Utilitza la zona horària de la màquina virtual de Java (JVM)"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
 msgstr "Et suggerim que desactivis això excepte si estàs forçant manualment la zona horària a la majoria de consultes d'aquestes dades"
 
-#: frontend/src/metabase/containers/Overworld.jsx:310
+#: frontend/src/metabase/containers/Overworld.jsx:312
 msgid "Your team's most important dashboards go here"
 msgstr "Els quadres de comandament més importants van aquí"
 
-#: frontend/src/metabase/containers/Overworld.jsx:311
+#: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
 msgstr "Fixeu els quadres de comandament a {0] per a que es mostrin en aquest espai per a tots"
 
@@ -9330,32 +9358,32 @@ msgstr "Utilitza la zona horària de la màquina virtual de Java (JVM)"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Estem analitzant les taules i els camps per ajudar-te a explorar les teves dades"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
 msgstr "Consell: "
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:258
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
 msgstr "Selecciona un tipus de moneda"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:318
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
 msgstr "Tipo de camp"
 
 #: frontend/src/metabase/admin/routes.jsx:109
-#: frontend/src/metabase/nav/containers/Navbar.jsx:224
+#: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
 msgstr "Solució de problemes"
 
-#: frontend/src/metabase/admin/settings/selectors.js:96
+#: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
 msgstr "Habilita les característiques de rajos-X"
 
-#: frontend/src/metabase/admin/settings/selectors.js:323
+#: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
 msgstr "Opcions de format"
 
-#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:19
+#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
 msgstr "Detalls de la tasca"
 
@@ -9395,7 +9423,7 @@ msgstr "Modena"
 msgid "Pick a user or channel..."
 msgstr "Escull un usuari o canal"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
+#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
 msgstr "Sense configuració de format"
 
@@ -9503,31 +9531,31 @@ msgstr "HH:MM:SS.MS"
 msgid "Time style"
 msgstr "Format de l'hora"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:299
+#: frontend/src/metabase/visualizations/lib/settings/column.js:300
 msgid "Unit of currency"
 msgstr "Unitat de moneda"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:319
+#: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
 msgstr "Format de l'etiqueta de moneda"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:337
+#: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
 msgstr "On mostrar l'unitat de la moneda"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:370
+#: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
 msgstr "Nombre mínim de decimals"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:271
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
 msgstr "Tipus de gràfic apilat"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:314
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
 msgstr "Etiqueta de l'objectiu"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:322
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
 msgstr "Mostra la línia de tendència"
 
@@ -9556,7 +9584,7 @@ msgstr "Línia + Barra"
 msgid "line and bar chart"
 msgstr "Gràfic de línia i barra"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:72
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
 msgstr "La visualització del comptador requereix un nombre"
 
@@ -9564,75 +9592,75 @@ msgstr "La visualització del comptador requereix un nombre"
 msgid "Gauge"
 msgstr "Comptador"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
 msgstr "Rangs del comptador"
 
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
 msgstr "Camp a mostrar"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
 msgstr "últim {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:185
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
 msgstr "{0} era {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:52
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Agrupa per un cap temporal per veure com ha canviat al llarg del temps."
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
 msgstr "Mostrar colors positius/negatius"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
 msgstr "Columna pivot"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:107
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
 msgstr "Columna celda"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:123
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
 msgstr "Columnes visibles"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:143
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
 msgstr "Format condicional"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
 msgstr "Títol de la columna"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
 msgstr "Mostra una gràfica de barres en minuatura"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:183
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
 msgstr "Enllaç"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:187
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
 msgstr "Enllaç de correu electrònic"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
 msgstr "Imatge"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:195
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
 msgstr "Automàtic"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:200
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
 msgstr "Mostra com un enllaç o una imatge"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
 msgstr "Text el enllaç"
 
@@ -9896,7 +9924,7 @@ msgstr "Error processant la consulta"
 msgid "No native form returned."
 msgstr "No s'ha obtingut un formulari natiu."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
 msgstr "Resposta invàlida del controlador de base de dades. No ha retornat cap estat."
 
@@ -11262,7 +11290,7 @@ msgstr "No s'ha pogut establir `query-caching-max-kb` a {0}"
 msgid "Values greater than {1} are not allowed."
 msgstr "No es permeten valors superiors a {1}"
 
-#: src/metabase/query_processor/middleware/resolve_database.clj
+#: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
 msgstr "La base de dades {0} no existeix"
 
@@ -11311,7 +11339,7 @@ msgstr "Disparadors"
 msgid "View triggers"
 msgstr "Veure disparadors"
 
-#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:82
+#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
 msgstr "Informació sobre la programació"
 
@@ -11343,7 +11371,7 @@ msgstr "Hora última ejecució"
 msgid "May Fire Again?"
 msgstr "Es pot tornar a executar?"
 
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:75
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
 msgstr "Disparadors per {0}"
 
@@ -11355,19 +11383,19 @@ msgstr "Tasques"
 msgid "Jobs"
 msgstr "Treballs"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
 msgstr "S'ha duplicat {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:55
+#: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
 msgstr "Duplica aquest ítem"
 
-#: frontend/src/metabase/components/EntityItem.jsx:61
+#: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
 msgstr "Arxiva aquest ítem"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:330
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
 msgstr "Duplica el quadre de comandaments"
 
@@ -11417,63 +11445,64 @@ msgstr "fa {0} {1}"
 msgid "{0} {1} from now"
 msgstr "{0} {1} desde ara"
 
-#: frontend/src/metabase/lib/query_time.js:187
+#: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
 msgstr[0] "Període per defecte"
 msgstr[1] "Períodes per defecte"
 
-#: frontend/src/metabase/lib/query_time.js:203
+#: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
 msgstr[0] "Minut de la hora"
 msgstr[1] "Minuts de la hora"
 
-#: frontend/src/metabase/lib/query_time.js:205
+#: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
 msgstr[0] "Hora del dia"
 msgstr[1] "Hores del dia"
 
-#: frontend/src/metabase/lib/query_time.js:207
+#: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
 msgstr[0] "Dia de la setmana"
 msgstr[1] "Dies de la setmana"
 
-#: frontend/src/metabase/lib/query_time.js:209
+#: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
 msgstr[0] "Dia del mes"
 msgstr[1] "Dies del mes"
 
-#: frontend/src/metabase/lib/query_time.js:211
+#: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
 msgstr[0] "Dia de l'any"
 msgstr[1] "Dies de l'any"
 
-#: frontend/src/metabase/lib/query_time.js:213
+#: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
 msgstr[0] "Setmana de l'any"
 msgstr[1] "Setmanes de l'any"
 
-#: frontend/src/metabase/lib/query_time.js:215
+#: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
 msgstr[0] "Mes del any"
 msgstr[1] "Mesos de l'any"
 
-#: frontend/src/metabase/lib/query_time.js:217
+#: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "Trimestre del any"
 msgstr[1] "Trimestres de l'any"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:79
+#: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} seleccionat"
@@ -11487,20 +11516,20 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "Aquest"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:64
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
 msgstr "Invàlid"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:147
+#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
 msgstr "Afegeix una hora"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:170
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
 msgstr "Res que comprar amb el {0} anterior."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:517
+#: frontend/src/metabase-lib/lib/Dimension.js:678
 msgid "by {0}"
 msgstr "per {0}."
 
@@ -11794,35 +11823,35 @@ msgstr "Registrant el controlador de càrrega mandrosa {0} ..."
 msgid "Error running query for Card {0}"
 msgstr "Error al executar la consulta per la targeta {0}"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
 msgstr "La setmana pasada"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This week"
 msgstr "Aquesta setmana"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
 msgstr "El mes pasat"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This month"
 msgstr "Aquest mes"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
 msgstr "El trimestre pasat"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
 msgstr "Aquest trimestre"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
 msgstr "L'any passat"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This year"
 msgstr "Aquest any"
 
@@ -12069,7 +12098,7 @@ msgid "[[CreateDate]] by quarter of the year"
 msgstr "[[CreateDate]] per trimestre del any"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:200
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
 msgstr "Editar usuari"
 
@@ -12077,12 +12106,12 @@ msgstr "Editar usuari"
 msgid "New user"
 msgstr "Nou usuari"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
 msgstr "Restablir contrasenya"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:209
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
 msgstr "Desactivar usuari"
 
@@ -12094,40 +12123,40 @@ msgstr "Reactivar {0}?"
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
 msgstr "No s'ha pogut enviar la invitació per correu electrònic. Asegura't de dir-los-hi que el seu nom d'usuari es {0} i que facin servir la contrasenya temporal que em generat per ells:"
 
-#: frontend/src/metabase/entities/collections.js:21
+#: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
 msgstr "col·lecció"
 
-#: frontend/src/metabase/entities/collections.js:22
+#: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
 msgstr "col·leccions"
 
-#: frontend/src/metabase/entities/dashboards.js:29
+#: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
 msgstr "quadre de comandament"
 
-#: frontend/src/metabase/entities/dashboards.js:30
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
 msgstr "quadres de comandament"
 
-#: frontend/src/metabase/entities/users.js:125
+#: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
 msgstr "El nom es obligatori"
 
-#: frontend/src/metabase/entities/users.js:126
-#: frontend/src/metabase/entities/users.js:133
+#: frontend/src/metabase/entities/users.js:38
+#: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
 msgstr "Ha de tenir 100 caràcters com a màxim"
 
-#: frontend/src/metabase/entities/users.js:132
+#: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
 msgstr "El cognom es obligatori"
 
-#: frontend/src/metabase/entities/users.js:138
+#: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
 msgstr "El correu electrònic es obligatori"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:90
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
 msgstr "Els ítems que arxivis es mostraran aquí"
 
@@ -12135,11 +12164,11 @@ msgstr "Els ítems que arxivis es mostraran aquí"
 msgid "No description"
 msgstr "Sense descripció"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:175
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
 msgstr "Suma de tots els valors"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:183
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
 msgstr "Mostra tots els valors diferents"
 
@@ -12339,15 +12368,778 @@ msgstr "Afegint l'usuari {0} al grup de tots els usuaris..."
 msgid "Adding User {0} to Admin permissions group..."
 msgstr "Afegint l'usuari {0} al grup de permisos d'administració..."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
 msgstr "La consulta ha fallat"
 
-#: src/metabase/query_processor/async.clj
+#: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
 msgstr "Nombre màxim de consultes simultànies que es permeten per a cada base de dades."
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
 msgstr "Temps de finalització desprès de {0} mil·lisegons"
+
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
+msgid "Misfire Instruction"
+msgstr "Instruccions de fallada"
+
+#: frontend/src/metabase/components/ArchiveModal.jsx:31
+msgid "Archive this?"
+msgstr "Arxivar això?"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:244
+msgid "Learn about our data"
+msgstr "Apren de les teves dades"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
+msgid "Use DNS SRV when connecting"
+msgstr "Utilitza el DNS SRV quan et conectis"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
+msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
+"an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
+"leave this disabled."
+msgstr "Aquesta opció requereis que el host sigui FQDN. Si es conecta a un clúster Atlar es possibleu que necessiteu habilitar aquesta opció. Si no sabeu el que significa deixa-ho deshbilitat."
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
+msgid "Automatically run queries when doing simple filtering and summarizing"
+msgstr "Executa les consultes automàticament quan es realitze un sumari o un filtre simple."
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr "Quan axxò esta actiu el Metabase executarà automaticament les consultes quan els usuaris duen a terme exploracions simples amb els botons de Resumiri filtrar quan es mostra una taula o grafica. Podeu desactivar-ho si les consultes a la base de dades son lesntes. Aquesta configuració no afecta la otenció de detalls o les consultes SQL."
+
+#: frontend/src/metabase/containers/Overworld.jsx:247
+msgid "Learn about this database"
+msgstr "Apren d'aquesta base de dades"
+
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+msgid "Archive this dashboard?"
+msgstr "Arxivar aquest quadr de comandament?"
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:113
+msgid "All results"
+msgstr "Tots els resultats"
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:180
+msgid "Our Analytics"
+msgstr "Les nostres analítiques"
+
+#: frontend/src/metabase/lib/schema_metadata.js:500
+msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
+msgstr "Suma aditiva de tots els valors d'una columna.\\n P.e: Ingresos totals al llarg dels temps."
+
+#: frontend/src/metabase/lib/schema_metadata.js:508
+msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
+msgstr "Recompte aditiu del nombre de files.\\n P.e: Nombre total de vendes en el temps"
+
+#: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
+msgid "Filter"
+msgstr "Filtre"
+
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+msgid "record"
+msgid_plural "records"
+msgstr[0] "registre"
+msgstr[1] "registres"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:346
+msgid "Browse Data"
+msgstr "Navegar"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:376
+msgid "Write SQL"
+msgstr "Escriu SQL"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
+msgid "Simple question"
+msgstr "Pregunta simple"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
+msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
+msgstr "Tria algunes dades, visualitza'ls i filtra'ls, resumeix-los i analitza'ls de forma senzilla."
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
+msgid "Custom question"
+msgstr "Pregunta personalitzada"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
+msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
+msgstr "Utilitza l'editor avançat per unir dades, crear columnes personalitzades, fer cálculs matemàtics i més."
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+msgid "Basic Metrics"
+msgstr "Mètriques bàsiques"
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+msgid "Custom…"
+msgstr "Personalitzada..."
+
+#: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
+msgid "Add grouping"
+msgstr "Afegeix una agrupació"
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
+msgid "Pick a limit"
+msgstr "Trieu un limit"
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
+msgid "Show maximum"
+msgstr "Mostra el màxi"
+
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
+msgid "Get Preview"
+msgstr "Mostra una previsualització"
+
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
+msgid "Back to previous results"
+msgstr "Torna als resultat anterior"
+
+#: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
+msgid "Sample values"
+msgstr "Valors de mostra"
+
+#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
+msgstr "Navega pel contingut de les teves bases de dades, taules i columnes.\n"
+"Escull una base de dades per començar."
+
+#: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
+msgid "Visualize"
+msgstr "Visualitza"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
+msgid "Join data"
+msgstr "Uneix dades"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
+msgid "Custom column"
+msgstr "Columna personalitzada"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
+msgid "Summarize"
+msgstr "Resumeix"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
+msgid "Aggregate"
+msgstr "Agregar"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
+msgid "Breakout"
+msgstr "Desglosar"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
+msgid "Pick the metric you want to see"
+msgstr "Trieu la mètrica que voleu veure"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
+#: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
+msgid "Pick a column to group by"
+msgstr "Trieu la columna per la qual agrupar"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
+msgid "Pick your starting data"
+msgstr "Trieu les dades inicials"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select None"
+msgstr "Seleccionar cap"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select All"
+msgstr "Selecciona'ls tots"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
+msgid "Pick a table..."
+msgstr "Trieu una taula..."
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
+msgid "Enter a limit"
+msgstr "Afegiu un límit"
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
+msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
+msgstr "Els corxetes al envoltant un {0} creen una clásula opcional a la plantilla. Si s'estableix aquesta variable la clausula complerta es coloca a la plantilla. Sinó s'ignora tota la cláusula."
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
+msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
+msgstr "Quan s'utilitza un filtre de camp, el nombre de la columna no s'ha d'incluir a la consulta SQL. Al seu lloc, la variable s'ha d'asignar a un camp del panell lateral."
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
+msgid "View the native query"
+msgstr "Veure la consulta nativa"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
+msgid "Native query for this question"
+msgstr "Consulta nativa per aquesta pregunta"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
+msgid "Convert this question to a native query"
+msgstr "Convertir aquesta pregunta a una consulta nativa"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
+msgid "SQL for this question"
+msgstr "SQL d'aquesta pregunta"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
+msgid "Convert this question to SQL"
+msgstr "Converteix aquesta pregunta a SQL"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
+msgid "Get alerts"
+msgstr "Obté alertes"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
+msgid "{0} breakout"
+msgid_plural "{0} breakouts"
+msgstr[0] "desglos de {0}"
+msgstr[1] "desglossos de {0}º"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
+msgid "Hide filters"
+msgstr "Amaga el filtres"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
+msgid "Show filters"
+msgstr "Mostra els filtres"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
+msgid "Started from"
+msgstr "Iniciat des de"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
+msgid "{0} row"
+msgid_plural "{0} rows"
+msgstr[0] "{0} fila"
+msgstr[1] "{0} files"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
+msgid "Show all rows"
+msgstr "Mostra tota les files"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
+msgid "Show {0}"
+msgstr "Mostra {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
+msgid "Showing first {0}"
+msgstr "Mostra les {0} primeres"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
+msgid "Showing {0}"
+msgstr "Mostrant {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
+msgid "Summarized"
+msgstr "Resumit"
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Hide editor"
+msgstr "Amaga l'editor"
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Show editor"
+msgstr "Mostra l'editor"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
+msgid "Pick the metric you'd like to see"
+msgstr "Trieu la mètrica que voleu veure"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
+msgid "{0} options"
+msgstr "{0} opcions"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
+msgid "Choose a visualization"
+msgstr "Esculliu una visualització"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
+msgid "Filter by"
+msgstr "Filtra per"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+msgid "Summarize by"
+msgstr "Resumit per"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+msgid "Group by"
+msgstr "Agrupa per"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+msgid "Add a metric"
+msgstr "Afegeix una mètrica"
+
+#: frontend/src/metabase/user/components/UserSettings.jsx:57
+msgid "Profile"
+msgstr "Perfil"
+
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:548
+msgid "This is usually pretty fast but seems to be taking a while right now."
+msgstr "Això normalment es batant ràpid pero sembla que aquesta vegada esta tardant una mica."
+
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
+msgid "Combo"
+msgstr "Combo"
+
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
+msgid "Row"
+msgstr "Fila"
+
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
+msgid "Trend"
+msgstr "Tendència"
+
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:129
+msgid "Boolean"
+msgstr "Boleà"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+msgid "Unknown Segment"
+msgstr "Segment desconegut"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+msgid "Unknown Filter"
+msgstr "Filtre desconegut"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
+msgid "Left outer join"
+msgstr "Unió externa per l'esquerra"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
+msgid "Right outer join"
+msgstr "Unió externa per la dreta"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
+msgid "Inner join"
+msgstr "Unió interna"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
+msgid "Full outer join"
+msgstr "Unió externa complerta"
+
+#: src/metabase/api/card.clj
+msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
+msgstr "Falten les metadades de resultats de la targeta a la API. Executant la consulta per obtenir les metadades correctes."
+
+#: src/metabase/api/session.clj
+msgid "Problem connecting to LDAP server, will fall back to local authentication"
+msgstr "Problema amb la conexió al servidor LDAP, es fa servir la autentificació local"
+
+#: src/metabase/api/setup.clj
+msgid "Cannot create Database: cannot find driver {0}."
+msgstr "No es pot crear la base de dades: no s'ha trobat el driver {0}"
+
+#: src/metabase/api/tiles.clj
+msgid "Query failed"
+msgstr "Ha fallat la consulta"
+
+#: src/metabase/async/util.clj
+msgid "Warning: {0} returned `nil`"
+msgstr "Avis: {0} ha tornat `nul`"
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing result to output channel: already closed"
+msgstr "Error inesperat al escriure el resultat al canal de sortida: Ja està tancat."
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing exception to output channel: already closed"
+msgstr "Error inesperat al escriure l'excepció al canal de sortida: Ja està tancat."
+
+#: src/metabase/async/util.clj
+msgid "Request canceled, canceling future."
+msgstr "Sol·licitud cancel·lada, cancelant el futur."
+
+#: src/metabase/cmd/load_from_h2.clj
+msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
+msgstr "El metabase només pot transferir dades de H2 a Postgres or MySQL/MariaDB"
+
+#: src/metabase/db.clj
+msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
+msgstr "ATENCIÓ: No es recomana utilizar el Metabase amb una base de dades H\" per a entorns de producció"
+
+#: src/metabase/db.clj
+msgid "Application database setup"
+msgstr "Configuració de la base de dades de l'aplicació"
+
+#: src/metabase/driver.clj
+msgid "Could not find {0} driver."
+msgstr "No s'ha trobar el driver {0}"
+
+#: src/metabase/driver.clj
+msgid "Abstract drivers cannot derive from concrete parent drivers."
+msgstr "Els controladors abstractes no poden derivar de controladors concrets"
+
+#: src/metabase/driver/mysql.clj
+msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
+msgstr "Es posible que hagis d'afegir 'trustServerCertificate=true' a les opcions de conexió adicionals per conectarte amb SSL."
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifer."
+msgstr "No se com fer un alías de {0}, esperava un identificador."
+
+#: src/metabase/driver/sql_jdbc/execute.clj
+msgid "Client closed connection, canceling query"
+msgstr "El client ha tancat la conexió, cancel·lant la consulta"
+
+#: src/metabase/integrations/ldap.clj
+msgid "{0} is not a valid DN."
+msgstr "{0} no és un DN válid."
+
+#: src/metabase/middleware/log.clj
+msgid "Error logging API request"
+msgstr "Error al registrar la sol·licitud de la API"
+
+#: src/metabase/middleware/misc.clj
+msgid "Failed to set site-url"
+msgstr "No s'ha pogut establir la URL de lloc"
+
+#: src/metabase/models/database.clj
+msgid "Error destroying thread pool for DB."
+msgstr "Error al destruir el pool de threads the la BBDD."
+
+#: src/metabase/models/humanization.clj
+msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
+msgstr "Actualitzant el nom a mostrar de {0} \"{1}\": \"{2\"} -> \"{3}\""
+
+#: src/metabase/models/humanization.clj
+msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
+msgstr "L'estratègia d'humanització \"{0}\" no es vàlida. Les estratègies vàlides son: {1}"
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr "Cambian l'estratègia d'humanització de noms de taules i camps de \"{0}\" a \"{1}\"."
+
+#: src/metabase/models/task_history.clj src/metabase/sync/util.clj
+msgid "Error saving task history"
+msgstr "Error al guardar el històric de la tasca"
+
+#: src/metabase/plugins.clj
+msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
+msgstr "A partir del Metabas 0.32.0+ ja no es necesita el spark-deps.jar. El podeu eliminar del directori de plugins"
+
+#: src/metabase/plugins/classloader.clj
+msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
+msgstr "Utilitzant la clase NEWLY CREATE com a carregardor de classes de context compartit: {0}"
+
+#: src/metabase/plugins/files.clj
+msgid "Failed to copy file"
+msgstr "No s'ha pogut copia el fitxer"
+
+#: src/metabase/public_settings.clj
+msgid "Invalid site URL: {0}"
+msgstr "Url invàlida: {0}"
+
+#: src/metabase/public_settings.clj
+msgid "site-url is invalid; returning nil for now. Will be reset on next request."
+msgstr "La url de destí no es vàlida retorant null de moment. Es restableixerà a la pròxima sol·licitud."
+
+#: src/metabase/pulse/render/body.clj
+msgid "More results have been included as a file attachment"
+msgstr "S'han inclos més ressultas en el fitxer adjunt."
+
+#: src/metabase/pulse/render/body.clj
+msgid "This question has been included as a file attachment"
+msgstr "Aquesta pregunta s'ha inclos com un fitxer adjunt"
+
+#: src/metabase/pulse/render/body.clj
+msgid "We were unable to display this Pulse."
+msgstr "No s'ha pogut mostrar aquest Pols."
+
+#: src/metabase/pulse/render/body.clj
+msgid "Please view this card in Metabase."
+msgstr "Si us plau visualitzeu aquesta targeta al Metabase."
+
+#: src/metabase/pulse/render/body.clj
+msgid "An error occurred while displaying this card."
+msgstr "S'ha produït un error al mostrar aquesta targeta."
+
+#: src/metabase/query_processor.clj
+msgid "Can only determine expected columns for MBQL queries."
+msgstr "Només es poden determianr les colunnes esperades per les consultes MBQL."
+
+#: src/metabase/query_processor.clj
+msgid "No columns returned."
+msgstr "No s'han retornat columnes."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr "Avis: No es poden determinar els camps per una `source-query` explícita a menos que també inclogui `source-metadata`."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
+msgstr "No es pot resoldre {0}: el camp no existeix o la seva taula pertany a una base de dades diferent."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
+msgstr "No es pot resoldre :field-literal dins de :fk-> am menys que sigui una unió interna amb :alias expllicit."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot find Table ID for {0}"
+msgstr "No s'ha pogut trobar el ID de la Taula {0}"
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "No matching info found."
+msgstr "No s'ha trobat cap informació coincident."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Could not resolve {0}"
+msgstr "No s'ha pogut resoldre {0}"
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Invalid fk-> clause: nowhere to add corresponding join."
+msgstr "fk-> invàlid: no es pot agregar el join corresponent."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "{0} driver does not support foreign keys."
+msgstr "El driver {0} no soporta les claus forànes"
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
+msgstr "No es pot inferir `:source-metadata`per la consulta d'orígen amb una consulta d'origen nativa sense metadades d'origen."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Query processor error: number of columns returned by driver does not match results."
+msgstr "Error del procesador de consultes: El nombre de columnes retornades no coincideix amb els resultats."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Expected {0} columns, but first row of resuls has {1} columns."
+msgstr "S'esperaven {0} columnes, pero la primera fila de resultats té {1} columnes."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "No expression named {0} found. Found: {1}"
+msgstr "No he trobat l'expresió anomenada {0}. He trobat: {1}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Distinct values of {0}"
+msgstr "Valors únics de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Average of {0}"
+msgstr "Mitja de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0}"
+msgstr "Suma de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "SD of {0}"
+msgstr "DS de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Min of {0}"
+msgstr "Mínim de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Max of {0}"
+msgstr "Màxim de {0}"
+
+#. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0} matching condition"
+msgstr "Suma de {0} amb condició"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Share of rows matching condition"
+msgstr "Nombre de files amb la condició"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Count of rows matching condition"
+msgstr "Número de files conicidents amb la condició"
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Request already canceled, will not run synchronous QP code."
+msgstr "La sol·licitud ja ha estat cancel·lada, no s'ejecutara el codi QP síncron."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unexpectedly got `nil` Query Processor response."
+msgstr "S'ha rebut la resposta inesperada `nil` del processador de consultes."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Got InterruptedException. Canceling query."
+msgstr "S'ha obtingunt un excepció d'interrupció. Cancel·lant la consulta."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
+msgstr "Excepció no controlada, s'esperava un middleware `catch-exceptions` que se n'encarregui."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Query timed out after %s"
+msgstr "S'ha esgotat el temps d'espera desprès de %s"
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Creating new query thread pool for Database {0}"
+msgstr "Creant un nou grup de subprocessos de consulta per la base de dades {0}"
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Destroying query thread pool for Database {0}"
+msgstr "Eliminant el grup de subprocessos de consulta per la base de dades {0}"
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Request canceled, canceling pending query"
+msgstr "Sol·licitud cancelada, cancel·lant la consulta pendent"
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: query is missing source-metadata"
+msgstr "No es pot actualitzar el camp agrupat: falten les metadades en la consulta"
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
+msgstr "No es pot actualtizar el camp agrupat: No s'han trobat metadades conicidents per al camp \"{0}\""
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Using query processor cache backend: {0}"
+msgstr "Utiltizant la cache del processador de consultes: {0}"
+
+#: src/metabase/query_processor/middleware/expand_macros.clj
+msgid "Invalid metric: {0} reason: {1}"
+msgstr "Métrica invàlida: {0} raó: {1}"
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unknown error"
+msgstr "Error desconegut"
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unexpected nil response from query processor."
+msgstr "Responsta nula inesperada del procesador de consultes"
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Query canceled"
+msgstr "Consulta cancelada"
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
+msgstr "No es pot resoldre la consulta: EL ID de `:database` falta o es invàlid."
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: Database {0} does not exist."
+msgstr "No es pot resoldre la consulta: la base de dades {0} no existeix."
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr "No es pot fer servir :fields :all en una fusió controla la consulta d'orígen si no té :source-metadata"
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
+msgstr "El la clausla de fusió :joined-field amb alias \"{0}\" no existeis. S'ha trobat: {1}"
+
+#: src/metabase/query_processor/middleware/resolve_source_table.clj
+msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
+msgstr "La taula {0} es invalida: ja s'hauria d'haver resolter per un ID de la taula."
+
+#: src/metabase/query_processor/store.clj
+msgid "Cannot store Tables or Fields before Database is stored."
+msgstr "No es poden guardar taules o camps sense guardar la base de dades."
+
+#: src/metabase/query_processor/store.clj
+msgid "Attempting to fetch second Database. Queries can only reference one Database."
+msgstr "Intentant recuperar la segona base de dades. Les consultes només poden referenciar una base de dades."
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
+msgstr "Error al recuperar la Taula {0}: no existeix aquesta taula o pertany a una base de dades diferent."
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
+msgstr "Error al recuperar el Camp {0}: no existeix aquest camp o pertany a una base de dades diferent."
+
+#: src/metabase/routes/index.clj
+msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
+msgstr "Error al carregar la plantilla \"{0}\". ¿Us heu enrecordar de construir la interfície de Metabase?"
+
+#: src/metabase/sample_data.clj
+msgid "Sample dataset DB file ''{0}'' cannot be found."
+msgstr "No s'ha pogut trobar el fitxer \"{0}\" de la base de dades de mostra."
+
+#: src/metabase/sample_data.clj
+msgid "Loading sample dataset..."
+msgstr "Carregant dades de mostra..."
+
+#: src/metabase/sample_data.clj
+msgid "Failed to load sample dataset"
+msgstr "No s'ha pogut carregar les dades de mostra"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Found new tables:"
+msgstr "S'han trobat noves taules:"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Marking tables as inactive:"
+msgstr "Marcant taules com inactives:"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Updating description for tables:"
+msgstr "Actualtizant la descripció de les taules:"
+
+#: src/metabase/task.clj
+msgid "Rescheduling job {0}"
+msgstr "Reprogramant el treball {0}"
+
+#: src/metabase/task.clj
+msgid "Error rescheduling job"
+msgstr "Error al reprogramar el treball"
+
+#: src/metabase/task/send_pulses.clj
+msgid "Starting Pulse Execution: {0}"
+msgstr "Iniciant la execució del Pols: {0}"
+
+#: src/metabase/task/send_pulses.clj
+msgid "Finished Pulse Execution: {0}"
+msgstr "Ha finalitazat la execució del Pols: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Failed to schedule tasks for Database {0}"
+msgstr "Error al programar tasques per la base de dades {0}"
+
+#: src/metabase/util/schema.clj
+msgid "All elements must be distinct."
+msgstr "Tots els elements han de ser diferents"
+
+#: 
+msgctxt "Modal for selecting columns in source data or when doing a join."
+msgid "Pick the columns you want to include"
+msgstr "Esculleix les columnes que vols incloure"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr "Al activar aquesta opció Metabase executarà automàticamente les consultes quan els usuaris realitzin exploracions simples amb els botóns Resumir i Filtra de taules i gràfiques. Pots desactivar aquesta opció si les consultes a la base de dades son lentes. Aquesta configuració no afecta als detalls ni a les consultes SQL."
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
+msgid "Change join type"
+msgstr "Canviar el tipus d'unió"
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifier."
+msgstr "No se com obtenir un alies de {0}, esperava un identificador"
+
+#: src/metabase/integrations/common.clj
+msgid "Error adding User {0} to Group {1}"
+msgstr "Error afegint el usuari {0} al grup {1}"
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr "Canviat l'estratègia d'humanització de noms de taules i camps de \"{0} a \"{1}\""
+
+#: src/metabase/query_processor.clj
+msgid "Infinite loop detected: recursively preprocessed query {0} times."
+msgstr "S'ha detectat un bucle infinit: consulta preposcessada recursivamente {0} vegades"
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr "Avís: No es poden determinar els camps per un `source-query` explicit sinó s'inclou també el `source-metadata`."
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Error determining expected columns for query"
+msgstr "Error al determinar les columnes esperades de la consulta"
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
+msgstr "Excepció no controlada, s'espera un middleware `catch-exceptions` que la controli"
 

--- a/locales/de.po
+++ b/locales/de.po
@@ -28,18 +28,19 @@ msgstr "Erkunde diese Daten"
 msgid "Select a database type"
 msgstr "Wähle einen Datenbanktyp"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:75
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:401
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:71
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:182
+#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:410
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:74
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:203
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:180
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:197
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:193
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:171
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:180
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:164
 msgid "Save"
 msgstr "Speichern"
@@ -59,7 +60,7 @@ msgid "This is a lightweight process that checks for\n"
 msgstr "Dieser Prozess prüft regelmäßig auf Updates der Schemata. Zumeist kannst du die voreingestellte, stündliche Synchronisierung belassen."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:184
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
 msgid "Scan"
 msgstr "Scannen"
 
@@ -74,126 +75,128 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase kann Werte eines jeden Feldes der Datenbank prüfen, um Checkboxen in Dashboards und Fragen zu ermöglichen. Dies kann insbesondere für größere Datenbank ein ressourenintensiver Prozess sein."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:159
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Wann soll Metabase Felder automatisch prüfen und Werte puffern?"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:164
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
 msgstr "Regelmäßig, nach einem Zeitplan"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:195
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
 msgstr "Nur beim Hinzufügen eines neuen Filter-Widgets"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:199
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
 msgstr "Sobald ein Benutzer einen neuen Filter oder eine SQL Abfrage zu einem Dashboard hinzufügt, wird Metabase die entsprechenden Felder der Datenbank untersuchen, um eine Liste adäquater Werte anzuzeigen."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:210
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
 msgid "Never, I'll do this manually if I need to"
 msgstr "Niemals, ich werde das manuell machen, falls nötig"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:222
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:222
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:426
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
 msgid "Saving..."
 msgstr "Speichere..."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:39
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
 msgid "Server error encountered"
 msgstr "Server-Fehler aufgetreten"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:58
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
 msgstr "Diese Datenbank löschen?"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
 msgstr "Alle gespeicherten Fragen, Metriken und Segmente dieser Datenbank gehen verloren."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:67
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
 msgstr "Dies kann nicht rückgängig gemacht werden."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
 msgstr "Wenn du sicher bist, schreibe"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:53
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
 msgstr "LÖSCHEN"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:71
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
 msgstr "in dieses Eingabefeld:"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:82
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:50
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:93
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:58
-#: frontend/src/metabase/admin/permissions/selectors.js:160
-#: frontend/src/metabase/admin/permissions/selectors.js:170
-#: frontend/src/metabase/admin/permissions/selectors.js:185
-#: frontend/src/metabase/admin/permissions/selectors.js:224
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:355
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:181
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:247
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:61
+#: frontend/src/metabase/admin/permissions/selectors.js:163
+#: frontend/src/metabase/admin/permissions/selectors.js:173
+#: frontend/src/metabase/admin/permissions/selectors.js:188
+#: frontend/src/metabase/admin/permissions/selectors.js:227
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:202
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:268
+#: frontend/src/metabase/components/ArchiveModal.jsx:35
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
-#: frontend/src/metabase/components/form/StandardForm.jsx:61
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:196
+#: frontend/src/metabase/components/form/StandardForm.jsx:62
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:198
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:289
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:162
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:153
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:38
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:189
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:24
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:48
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:41
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:92
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:259
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:88
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:121
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:132
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
 msgstr "Löschen"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:128
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:74
-#: frontend/src/metabase/admin/permissions/selectors.js:320
-#: frontend/src/metabase/admin/permissions/selectors.js:327
-#: frontend/src/metabase/admin/permissions/selectors.js:423
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
+#: frontend/src/metabase/admin/permissions/selectors.js:323
+#: frontend/src/metabase/admin/permissions/selectors.js:330
+#: frontend/src/metabase/admin/permissions/selectors.js:426
 #: frontend/src/metabase/admin/routes.jsx:53
-#: frontend/src/metabase/nav/containers/Navbar.jsx:214
+#: frontend/src/metabase/nav/containers/Navbar.jsx:243
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
 msgstr "Datenbanken"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:129
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
 msgstr "Datenbank hinzufügen"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
 msgstr "Verbindung"
@@ -202,108 +205,108 @@ msgstr "Verbindung"
 msgid "Scheduling"
 msgstr "Planung"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:78
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:84
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:26
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:221
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:185
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:38
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:38
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
 msgstr "Aktionen"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:193
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
 msgstr "Datenbankschema synchronisieren"
 
 #. Starte...
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:194
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:206
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:109
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
 msgstr "Starten…"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:195
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
 msgstr "Synchronisierung fehlgeschlagen"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
 msgstr "Synchronisierung gestartet!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:205
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
 msgstr "Prüfe Feldwerte erneut"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:207
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
 msgstr "Scan konnte nicht gestartet werden"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
 msgstr "Scan gestartet!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:215
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:401
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
 msgstr "Gefahrenzone"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:221
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
 msgstr "Verwerfen gespeicherter Werte"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
 msgstr "Diese Datenbank löschen"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:73
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
 msgstr "Datenbank hinzufügen"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:85
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:36
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:36
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:122
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:32
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:399
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:446
 #: frontend/src/metabase/containers/EntitySearch.jsx:26
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:218
-#: frontend/src/metabase/entities/collections.js:93
-#: frontend/src/metabase/entities/dashboards.js:145
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:461
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:81
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:220
+#: frontend/src/metabase/entities/collections.js:94
+#: frontend/src/metabase/entities/dashboards.js:142
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
 msgstr "Name"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:86
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
 msgstr "Maschine"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:115
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
 msgstr "Löschen..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:145
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
 msgstr "Laden..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:161
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
 msgstr "Wiederherstellen der Beispieldaten"
 
@@ -320,9 +323,9 @@ msgid "Successfully saved!"
 msgstr "Erfolgreich gespeichert!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:177
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:197
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
 msgstr "Bearbeiten"
@@ -331,86 +334,90 @@ msgstr "Bearbeiten"
 msgid "Revision History"
 msgstr "Revisionshistorie"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
 msgstr "Zurückziehen {0}?"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
 msgstr "Gespeicherte Fragen und andere Dinge, die von dieser {0} abhängen, funktionieren weiter, aber diese {1} sind nicht mehr aus dem Abfragengenerator auswählbar."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
 msgstr "Wenn du sicher bist, dass du diese {0} zurückziehen möchtest, schreibe bitte eine kurze Erklärung, warum es zurückgezogen wird:"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
 msgstr "Dies wird im Aktivitäts-Feed und in einer E-Mail angezeigt, die an jedes Teammitglied gesendet wird, der etwas erstellt hat, das diese {0}."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
 msgstr "Verwerfen"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
 msgstr "Verwerfe…"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
 msgstr "Erfolgreich"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:91
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
+#: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Vorschau"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
 msgstr "Keine Spaltenbeschreibung"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:135
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
 msgstr "Wähle die Sichtbarkeit des Feldes"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:210
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
 msgstr "Kein spezieller Typ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:211
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:148
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
 msgstr "Andere"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:231
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Wähle ein speziellen Typ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:277
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
 msgstr "Wähle ein Ziel"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:77
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:89
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:106
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:122
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
 msgstr "Spalten"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Spalte"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:121
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:306
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
 msgstr "Sichtbarkeit"
 
@@ -418,53 +425,53 @@ msgstr "Sichtbarkeit"
 msgid "Type"
 msgstr "Typ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
 msgstr "Aktuelle Datenbank:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
 msgstr "Originalschema anzeigen"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:45
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
 msgstr "Datentyp"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
 msgstr "Zusatzinformationen"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
 msgstr "Schema suchen"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:51
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "{0} Schema"
 msgstr[1] "{0} Schemen"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
 msgstr "Warum verbergen?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
 msgstr "Technische Daten"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
 msgstr "Irrelevant"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
 msgid "Queryable"
 msgstr "Abfragbar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:91
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
 msgstr "Versteckt"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
 msgstr "Keine Tabellenbeschreibung"
 
@@ -472,65 +479,67 @@ msgstr "Keine Tabellenbeschreibung"
 msgid "Metadata Strength"
 msgstr "Metadatenstärke"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} Abfragbare Tabelle"
 msgstr[1] "{0} Abfragbare Tabellen"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:96
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} Verborgene Tabelle"
 msgstr[1] "{0} Verborgene Tabellen"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
 msgstr "Finde eine Tabelle"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
 msgstr "Schemata"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:24
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:137
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:68
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:56
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:190
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
 msgstr "Metrik"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
 msgstr "Hinzufügen einer Metrik"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:37
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Definition"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Erstelle Metriken, um diese einer Liste in der Ansicht des Abfragengenerators hinzuzufügen"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:24
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:930
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:952
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:56
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segmente"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
 msgstr "Hinzufügen eines Segments"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Erstelle Segmente, um diese einer Liste in der Ansicht des Abfragengenerators hinzuzufügen"
 
@@ -558,53 +567,53 @@ msgstr "Bearbeitete "
 msgid "made some changes"
 msgstr "einige Änderungen vorgenommen"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
-#: frontend/src/metabase/home/components/Activity.jsx:80
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:332
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/home/components/Activity.jsx:82
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
 msgstr "Du"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
 msgstr "Datenmodell"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
 msgstr " Geschichte"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:48
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
 msgstr "Revisionshistorie für"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:239
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
 msgstr "{0} - Feldeinstellungen"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
 msgstr "Wo dieses Feld in Metabase erscheint"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:329
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filtern des Feldes"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Welche Eingaben sollen Benutzer tätigen, wenn sie das Feld filtern möchten?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:453
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Keine Beschreibung für dieses Feld"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:379
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
 msgstr "Originalwert"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:380
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
 msgid "Mapped value"
 msgstr "Zugeordneter Wert"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:423
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
 msgstr "Wert eingeben"
 
@@ -621,7 +630,7 @@ msgid "Custom mapping"
 msgstr "Eigene Zuordnung"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:155
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
 msgid "Unrecognized mapping type"
 msgstr "Unbestimmter Zuordnungstyp"
 
@@ -629,23 +638,23 @@ msgstr "Unbestimmter Zuordnungstyp"
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Aktuelles Feld ist kein Fremdschlüssel oder es fehlen Metadaten der Fremdschlüssel-Zieltabellen"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:187
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
 msgstr "Das ausgewählte Feld ist kein Fremdschlüssel"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:347
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
 msgstr "Anzeigewerte"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:348
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Wähle diese Option, um den ursprünglichen Wert aus der Datenbank anzuzeigen, oder lasse dir die zugehörigen oder benutzerdefinierten Informationen in diesem Feld anzeigen."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:268
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
 msgstr "Wähle ein Feld"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:289
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
 msgstr "Bitte wähle eine anzuzeigende Spalte."
 
@@ -653,16 +662,16 @@ msgstr "Bitte wähle eine anzuzeigende Spalte."
 msgid "Tip:"
 msgstr "Hinweis:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Möglicherweise möchtest du den Feldnamen aktualisieren, um sicherzustellen, dass er auf der Grundlage deiner Umstellungen noch sinnvoll ist."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:364
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:102
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
 msgstr "Gepufferte Feldwerte"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:365
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase kann die Werte für dieses Feld prüfen, um Listenfitler für Dashboards und Fragen zu aktivieren."
 
@@ -671,167 +680,168 @@ msgid "Re-scan this field"
 msgstr "Dieses Feld erneut scannen"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
 msgstr "Verwerfen von zwischengespeicherten Feldwerten"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:118
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
 msgstr "Werte konnten nicht verworfen werden"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard triggered!"
 msgstr "Verwerfen gestartet!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:105
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Wähle eine beliebige Tabelle aus, um ihr Schema anzuzeigen und Metadaten hinzuzufügen oder zu bearbeiten."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:37
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:34
-#: frontend/src/metabase/entities/collections.js:96
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "Name ist erforderlich"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:40
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
 msgstr "Beschreibung ist erforderlich"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:44
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:41
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
 msgstr "Änderungstext ist erforderlich"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:50
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
 msgstr "Aggregation ist erforderlich"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
 msgstr "Editieren Deiner Metrik"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
 msgstr "Erstellen Deiner Metrik"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:115
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Nimm Änderungen an deiner Metrik vor und hinterlasse eine Erläuterung."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Du kannst gespeicherte Metriken erstellen, um dieser Tabelle eine benannte Metrikoption hinzuzufügen. Gespeicherte Metriken umfassen den Aggregationstyp, das aggregierte Feld und optional jeden von dir hinzugefügten Filter. Als Beispiel kannst du damit so etwas wie die offizielle Art der Berechnung des \"Durchschnittspreises\" für eine Bestell-Tabelle erstellen."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
 msgstr "Ergebnis: "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
 msgstr "Benenne Deine Metrik"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
 msgstr "Benenne Deine Metrik, um anderen zu helfen, sie zu finden."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:162
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
 msgstr "Eine Beschreibung, aber nicht zu lang"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
 msgstr "Beschreibe Deine Metrik"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Gib deiner Metrik eine Beschreibung, damit andere verstehen, worum es geht."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Dies ist ein guter Ort, um genauer auf weniger offensichtliche metrische Regeln einzugehen"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:179
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
 msgstr "Grund der Änderung"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:177
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Hinterlasse eine Notiz, um zu erklären, welche Änderungen du vorgenommen hast und warum sie erforderlich waren."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Dies wird in der Revisionshistorie für diese Metrik angezeigt, damit sich jeder daran erinnern kann, warum sich die Dinge geändert haben"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
 msgstr "Mindestens ein Filter ist erforderlich"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
 msgstr "Abschnitt bearbeiten"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
 msgstr "Abschnitt erstellen"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:121
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Nimm Änderungen an deinem Segment vor und hinterlasse eine Erläuterung."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Um ein neues Segment für die {0} Tabelle zu erstellen, wähle einen Filter und füge diesen hinzu"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
 msgstr "Abschnitt benennen"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:162
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
 msgstr "Benenne Dein Segment, um anderen zu helfen, sie zu finden."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:170
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
 msgstr "Abschnitt beschreiben"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Gib deinem Segment eine Beschreibung, damit andere verstehen, worum es geht."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:175
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Dies ist ein guter Ort, um etwas genauer auf weniger offensichtliche Segmentregeln einzugehen"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:185
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Dies wird in der Revisionshistorie für dieses Segment angezeigt, damit sich jeder daran erinnern kann, warum sich die Dinge geändert haben"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:266
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:87
-#: frontend/src/metabase/nav/containers/Navbar.jsx:199
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:269
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:91
+#: frontend/src/metabase/nav/containers/Navbar.jsx:228
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:103
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase kann die Werte in dieser Tabelle scannen, um Listenfilter in Dashboards und Fragen zu aktivieren."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:108
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
 msgstr "Diese Tabelle erneut scannen"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:253
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
 msgstr "Hinzufügen"
 
@@ -840,20 +850,22 @@ msgstr "Hinzufügen"
 msgid "Not a valid formatted email address"
 msgstr "Keine gültige formatierte E-Mail-Adresse"
 
+#: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:100
 msgid "First name"
 msgstr "Vorname"
 
+#: frontend/src/metabase/entities/users.js:42
 #: frontend/src/metabase/setup/components/UserStep.jsx:203
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:117
 msgid "Last name"
 msgstr "Nachname"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:77
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:158
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:161
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:470
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:481
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
@@ -867,35 +879,36 @@ msgstr "Berechtigungsgruppen"
 msgid "Make this user an admin"
 msgstr "Diesen Benutzer zum Administrator machen"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:32
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
 msgstr "Alle Benutzer gehören zur Gruppe {0} und können nicht entfernt werden. Das Setzen von Berechtigungen für diese Gruppe ist eine großartige Möglichkeit, um\n"
 "festzulegen, was neue Metabase-Benutzer sehen dürfen."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:41
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
 msgstr "Dies ist eine spezielle Gruppe, deren Mitglieder alles in der Metabase-Instanz sehen können und auf administrative Einstellungen zugreifen und Änderungen an diesen vornehmen können. Dies beinhaltet auch das Ändern von Berechtigungen! Also vergewissere dich, wen du hinzufügst."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:45
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
 msgstr "Um sicherzustellen, dass du nicht aus Metabase ausgeschlossen wirst, muss es immer mindestens einen Benutzer in dieser Gruppe geben."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
 msgstr "Mitglieder"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:124
-#: frontend/src/metabase/admin/settings/selectors.js:113
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
+#: frontend/src/metabase/admin/settings/selectors.js:110
+#: frontend/src/metabase/entities/users.js:50
 #: frontend/src/metabase/lib/core.js:55
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
 msgstr "E-Mail"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:203
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
 msgstr "Eine Gruppe ist nur so gut wie ihre Mitglieder."
 
@@ -906,8 +919,8 @@ msgid "Admin"
 msgstr "Administrator"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:237
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:290
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
 msgstr "Und"
 
@@ -937,13 +950,13 @@ msgstr "Bist du sicher? Alle Mitglieder dieser Gruppe verlieren alle Berechtigun
 "Das kann nicht rückgängig gemacht werden."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
 msgstr "Ja"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
 msgstr "Nein"
 
@@ -962,10 +975,11 @@ msgstr "Gruppe löschen"
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:107
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:327
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:395
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:265
+#: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
 msgstr "Fertig"
 
@@ -975,9 +989,9 @@ msgstr "Gruppenname"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:131
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:88
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
 msgstr "Gruppen"
 
@@ -1006,9 +1020,9 @@ msgid "Deactivate"
 msgstr "Deaktivieren"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:93
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
-#: frontend/src/metabase/nav/containers/Navbar.jsx:204
+#: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
 msgstr "Mitglieder"
 
@@ -1048,7 +1062,6 @@ msgid "We've re-sent {0}'s invite"
 msgstr "Wir haben die Einladung von {0} erneut gesendet"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
-#: frontend/src/metabase/tutorial/Tutorial.jsx:253
 msgid "Okay"
 msgstr "In Ordnung"
 
@@ -1080,13 +1093,13 @@ msgstr "Sie können sich wieder einloggen und starten mit den Gruppen, in denen 
 msgid "Reset {0}'s password?"
 msgstr "{0}s Passwort zurücksetzen?"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:77
+#: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
 msgstr "Zurücksetzen"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:44
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
 msgstr "Bist du sicher, dass du es tun möchtest?"
 
@@ -1102,76 +1115,78 @@ msgstr "Hier ist ein temporäres Passwort, mit dem sie sich einloggen und dann i
 msgid "We've sent them an email with instructions for creating a new password."
 msgstr "Wir haben ihnen eine E-Mail mit Anweisungen zum Erstellen eines neuen Passworts geschickt."
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:101
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
 msgstr "Aktivieren"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:127
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
 msgstr "Deaktivieren"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:115
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
 msgstr "Jemanden hinzufügen"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
 msgstr "Letzte Anmeldung"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:153
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
 msgstr "Anmeldung über Google"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:158
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
 msgstr "Anmeldung über LDAP"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:170
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
 msgstr "Reaktivieren des Accounts"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:193
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
 msgstr "Nie"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:27
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
 msgstr[0] "{0} Tabelle"
 msgstr[1] "{0} Tabellen"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:45
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
 msgstr " wird sein "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:48
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
 msgstr "Zugriff geben auf"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:53
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
 msgstr " und "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:56
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
 msgstr "Zugriff verweigern für"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:70
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
 msgstr " wird nicht länger in der Lage sein "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:71
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
 msgstr " wird nun in der Lage sein "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:79
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
 msgstr " native Abfragen für "
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
-#: frontend/src/metabase/nav/containers/Navbar.jsx:219
+#: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
 msgstr "Berechtigungen"
 
@@ -1196,15 +1211,15 @@ msgstr "Es werden keine Änderungen an Berechtigungen vorgenommen."
 msgid "You've made changes to permissions."
 msgstr "Du hast Änderungen an Berechtigungen vorgenommen."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:52
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
 msgstr "Berechtigungen dieser Sammlung"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
 msgstr "Du hast ungespeicherte Änderungen"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:54
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
 msgstr "Möchtest du die Änderungen verwerfen und die Seite verlassen?"
 
@@ -1224,119 +1239,119 @@ msgstr "Jeder Benutzer von Metabase gehört zur Gruppe \"Alle Benutzer\". Wenn d
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
 msgstr "MetaBot ist der Slack-Bot von Metabase. Du kannst hier auswählen, auf was er Zugriff hat."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:119
+#: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
 msgstr "Die Gruppe \"{0}\" hat anderen Zugriff auf {1} als diese Gruppe, was dieser Gruppe somit weiteren Zugriff auf {2} gibt."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:124
+#: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
 msgstr "Die Gruppe \"{0}\" hat höheren Zugriff als diese, was wiederum ein Überschreiben dieser Einstellung mit sich bringt. Du solltest den Zugriff der Gruppe \"{1}\" auf das Element beschränken oder revidieren."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
 msgstr "Begrenzung"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
 msgstr "Widerrufen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:156
+#: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
 msgstr "Zugriff, obwohl \"{0}\" einen größeren Zugriff hat?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:258
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
 msgstr "Zugriff beschränken"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:223
-#: frontend/src/metabase/admin/permissions/selectors.js:266
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:226
+#: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
 msgstr "Zugriff widerrufen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:168
+#: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
 msgstr "Soll der Zugriff dieser Datenbank auf beschränkt geändert werden?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:169
+#: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
 msgstr "Änderung"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:182
+#: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
 msgstr "Schreiben von SQL-Abfragen zulassen?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:183
+#: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
 msgstr "Dadurch bekommt diese Gruppe unbeschränkten Zugriff auf die Datensätze dieser Datenbank."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:184
+#: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
 msgstr "Erlauben"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:221
+#: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
 msgstr "Zugriff auf alle Tabellen widerrufen?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:222
+#: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
 msgstr "Dadurch wird der Datenzugriff dieser Gruppe  auf die Datensätze der Datenbank widerrufen."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:251
+#: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
 msgstr "Unbeschränkten Zugriff gewähren"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:252
+#: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
 msgstr "Unbeschränkter Zugriff"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:259
+#: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
 msgstr "Eingeschränkter Zugriff"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:267
+#: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
 msgstr "Kein Zugriff"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:273
+#: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
 msgstr "Native Abfragen schreiben"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:274
+#: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
 msgstr "Kann native Abfragen schreiben"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:281
+#: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
 msgstr "Sammlung organisieren"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:288
+#: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
 msgstr "Sammlung ansehen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:331
-#: frontend/src/metabase/admin/permissions/selectors.js:427
-#: frontend/src/metabase/admin/permissions/selectors.js:524
+#: frontend/src/metabase/admin/permissions/selectors.js:334
+#: frontend/src/metabase/admin/permissions/selectors.js:430
+#: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
 msgstr "Datenzugriff"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:492
-#: frontend/src/metabase/admin/permissions/selectors.js:649
-#: frontend/src/metabase/admin/permissions/selectors.js:654
+#: frontend/src/metabase/admin/permissions/selectors.js:495
+#: frontend/src/metabase/admin/permissions/selectors.js:652
+#: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
 msgstr "Tabellen ansehen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:590
+#: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
 msgstr "SQL Queries"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:660
+#: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
 msgstr "Schemas ansehen"
 
 #: frontend/src/metabase/admin/routes.jsx:59
-#: frontend/src/metabase/nav/containers/Navbar.jsx:209
+#: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
 msgstr "Datenmodell"
 
@@ -1345,30 +1360,30 @@ msgstr "Datenmodell"
 msgid "Sign in with Google"
 msgstr "Anmeldung über Google"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:13
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
 msgstr "Ermöglicht es bestehenden Benutzerkonten, sich, neben ihren Metabase Benutzernamen und Passwort, mit einem Google-Konto anzumelden, das ihrer E-Mail-Adresse entspricht."
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:17
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
 msgstr "Konfigurieren"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
-#: frontend/src/metabase/admin/settings/selectors.js:207
+#: frontend/src/metabase/admin/settings/selectors.js:204
 msgid "LDAP"
 msgstr "LDAP"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:25
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
 msgstr "Ermöglicht Benutzern innerhalb deines LDAP-Verzeichnisses, sich mit ihren LDAP-Anmeldeinformationen bei Metabase anzumelden und ein automatisches Zuordnen von LDAP- zu Metabase-Gruppen vorzunehmen."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
-#: frontend/src/metabase/admin/settings/selectors.js:160
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
 msgstr "Dies ist keine valide E-Mail-Adresse"
 
@@ -1406,7 +1421,7 @@ msgstr "Löschen"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:202
+#: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
 msgstr "Authentifizierung"
 
@@ -1470,21 +1485,21 @@ msgstr "Erstelle einen Slack Bot Benutzer für MetaBot"
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Sobald du angekommen bist, gib ihm einen Namen und klicke auf {0}. Kopiere alsdann den Bot-API-Token und füge diesen in das Feld unten ein. Sobald du fertig bist, erstelle einen \"metabase_files\"-Kanal in Slack. Metabase benötigt diesen, um Grafiken hochzuladen."
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:90
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
 msgstr "Du verwendest Metabase {0}, dass die aktuellste und beste Version ist!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:99
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0} ist verfügbar. Du verwendest Version {1}"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:112
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
 msgstr "Update"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:116
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
 msgstr "Was sich geändert hat:"
 
@@ -1497,80 +1512,80 @@ msgstr "Karte hinzufügen"
 msgid "URL"
 msgstr "URL"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:199
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
 msgstr "Lösche individuelle Karte"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:327
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:40
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:181
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
 msgstr "Löschen"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:226
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:187
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:241
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:246
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
 msgstr "Wähle…"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:241
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
 msgstr "Beispielwert:"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
 msgstr "Füge eine neue Karte hinzu"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
 msgstr "Ändere Karte"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:280
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
 msgstr "Wie möchtest du diese Kare nennen?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
 msgstr "z.B. Großbritannien, Brasilien, Mars"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:292
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
 msgstr "URL der GeoJSON Datei, die du nutzen möchtest"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:298
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
 msgstr "Wie https://my-mb-server.com/maps/my-map.json"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:33
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
 msgstr "Aktualisieren"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
 msgstr "Laden"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:315
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
 msgstr "Welche Eigenschaft spezifiziert die Region eindeutig?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:324
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
 msgstr "Welche Eigenschaft spezifiziert den Anzeigename der Region?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:345
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
 msgstr "Lade eine GeoJSON Datei, um eine Vorschau zu sehen"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
 msgstr "Karte speichern"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
 msgstr "Karte hinzufügen"
 
@@ -1582,11 +1597,11 @@ msgstr "Einbettung verwenden"
 msgid "By enabling embedding you're agreeing to the embedding license located at"
 msgstr "Indem du die Einbettung aktivierst, stimmst du der Einbettungslizenz zu, die sich auf der Seite"
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:19
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
 msgstr "Wenn du Diagramme oder Dashboards von Metabase in deine eigene Anwendung einbetten möchtest, unterliegt diese nicht der Affero General Public License, die den Rest von Metabase abdeckt, sodass du das Metabase-Logo und das \"Powered by Metabase\" auf diesen Einbettungen sichtbar machen musst. Du solltest jedoch den oben verlinkten Lizenztext lesen, da dies die eigentliche Lizenz ist, der du durch Aktivierung dieser Funktion zustimmst."
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:32
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
 msgstr "Aktivieren"
 
@@ -1610,26 +1625,26 @@ msgstr "Token kaufen"
 msgid "Enter a token"
 msgstr "Token eingeben"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:134
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
 msgstr "Editiere Zuordnungen"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:140
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
 msgstr "Gruppenzuordnung"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:147
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
 msgstr "Erstelle eine Zuordnung"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
 msgstr "Mappings ermöglichen Metabase das automatische Hinzufügen und Entfernen von Benutzern aus Gruppen, basierend auf den Mitgliedschaftsinformationen des\n"
 "Verzeichnisservers. Die Mitgliedschaft in der Admin-Gruppe kann über Mappings gewährt werden, wird aber nicht automatisch entfernt, um Ausfällen vorzubeugen."
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
 msgstr "Distinguished Name"
 
@@ -1641,43 +1656,43 @@ msgstr "Öffentlicher Link"
 msgid "Revoke Link"
 msgstr "Widerrufe Link"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:121
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
 msgstr "Diesen Link deaktivieren?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:122
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
 msgstr "Sie funktionieren nicht mehr und können nicht wiederhergestellt werden, aber du kannst neue Links erstellen."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
 msgstr "Öffentliches Dashboard-Auflistung"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:152
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
 msgstr "Aktuell wurde noch kein Dashboard veröffentlicht."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:160
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
 msgstr "Öffentliche Kartenauflistung"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:163
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
 msgstr "Es wurden noch keine Fragen veröffentlicht."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:172
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
 msgstr "Eingebettete Dashboard-Auflistung"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
 msgstr "Es wurden aktuell noch keine Dashboards eingebettet."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:183
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
 msgstr "Eingebettete Karten-Auflistung"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:184
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
 msgstr "Es wurden aktuell noch keine Fragen eingebettet."
 
@@ -1698,18 +1713,17 @@ msgid "Generate Key"
 msgstr "Generiere Schlüssel"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:78
-#: frontend/src/metabase/admin/settings/selectors.js:87
+#: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
 msgstr "Aktiviert"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:83
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:103
+#: frontend/src/metabase/admin/settings/selectors.js:82
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Deaktiviert"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:116
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
 msgstr "Unbekannte Einstellung {0}"
 
@@ -1717,7 +1731,7 @@ msgstr "Unbekannte Einstellung {0}"
 msgid "Setup"
 msgstr "Einstellungen"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
 msgstr "Allgemein"
@@ -1746,11 +1760,11 @@ msgstr "Datenbank Standard"
 msgid "Select a timezone"
 msgstr "Wähle eine Zeitzone"
 
-#: frontend/src/metabase/admin/settings/selectors.js:55
+#: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Nicht alle Datenbanken unterstützen Zeitzonen. In diesem Fall wird diese Einstellung nicht wirksam."
 
-#: frontend/src/metabase/admin/settings/selectors.js:60
+#: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
 msgstr "Sprache"
 
@@ -1758,202 +1772,202 @@ msgstr "Sprache"
 msgid "Select a language"
 msgstr "Wähle eine Sprache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:70
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
 msgstr "Anonymes Tracking"
 
-#: frontend/src/metabase/admin/settings/selectors.js:75
+#: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
 msgstr "Sprechende Tabellen- und Feldnamen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:81
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Ersetze nur Unterstriche und Bindestriche durch Leerzeichen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:91
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
 msgstr "Aktiviere verschachtelte Abfragen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:102
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
 msgstr "Updates"
 
-#: frontend/src/metabase/admin/settings/selectors.js:107
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
 msgstr "Auf Updates prüfen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:118
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
 msgstr "SMTP Host"
 
-#: frontend/src/metabase/admin/settings/selectors.js:126
+#: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
 msgstr "SMTP Port"
 
-#: frontend/src/metabase/admin/settings/selectors.js:130
-#: frontend/src/metabase/admin/settings/selectors.js:230
+#: frontend/src/metabase/admin/settings/selectors.js:127
+#: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
 msgstr "Dies ist keine valide Portnummer"
 
-#: frontend/src/metabase/admin/settings/selectors.js:134
+#: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
 msgstr "SMTP Sicherheit"
 
-#: frontend/src/metabase/admin/settings/selectors.js:142
+#: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
 msgstr "SMTP Benutzername"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
 msgstr "SMTP Passwort"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
 msgstr "Absenderadresse"
 
-#: frontend/src/metabase/admin/settings/selectors.js:170
+#: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
 msgstr "Slack API Token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:172
+#: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
 msgstr "Gebe den Token ein, den du von Slack erhalten hast"
 
-#: frontend/src/metabase/admin/settings/selectors.js:189
+#: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
 msgstr "Single Sign-On"
 
-#: frontend/src/metabase/admin/settings/selectors.js:213
+#: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
 msgstr "LDAP Authentifizierung"
 
-#: frontend/src/metabase/admin/settings/selectors.js:219
+#: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
 msgstr "LDAP Host"
 
-#: frontend/src/metabase/admin/settings/selectors.js:227
+#: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
 msgstr "LDAP Port"
 
-#: frontend/src/metabase/admin/settings/selectors.js:234
+#: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
 msgstr "LDAP Sicherheit"
 
-#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
 msgstr "Benutzername oder DN"
 
-#: frontend/src/metabase/admin/settings/selectors.js:247
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:188
-#: frontend/src/metabase/user/components/UserSettings.jsx:72
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:191
+#: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
 msgstr "Passwort"
 
-#: frontend/src/metabase/admin/settings/selectors.js:252
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "User search base"
 msgstr "Benutzer-Suchbasis"
 
-#: frontend/src/metabase/admin/settings/selectors.js:258
+#: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
 msgstr "Benutzerfilter"
 
-#: frontend/src/metabase/admin/settings/selectors.js:264
+#: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
 msgstr "Überprüfe deine Klammern"
 
-#: frontend/src/metabase/admin/settings/selectors.js:270
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
 msgstr "E-Mail-Attribute"
 
-#: frontend/src/metabase/admin/settings/selectors.js:275
+#: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
 msgstr "Vornamen-Attribut"
 
-#: frontend/src/metabase/admin/settings/selectors.js:280
+#: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
 msgstr "Nachnamen-Attribut"
 
-#: frontend/src/metabase/admin/settings/selectors.js:285
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
 msgstr "Synchronisiere Gruppen-Mitgliedschaften"
 
-#: frontend/src/metabase/admin/settings/selectors.js:291
+#: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
 msgstr "Gruppen-Suchbasis"
 
-#: frontend/src/metabase/admin/settings/selectors.js:300
+#: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
 msgstr "Karten"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
 msgstr "Karten-Server-URL"
 
-#: frontend/src/metabase/admin/settings/selectors.js:306
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase nutzt standardmäßig OpenStreetMaps."
 
-#: frontend/src/metabase/admin/settings/selectors.js:311
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
 msgstr "Eigene Karten"
 
-#: frontend/src/metabase/admin/settings/selectors.js:312
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Füge deine eigene GeoJSON Datei hinzu, um verschiedene Kartenvisualisierungen zu aktivieren"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
 msgstr "Öffentliches Teilen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:336
+#: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
 msgstr "Aktiviere Öffentliches Teilen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:341
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
 msgstr "Geteilte Dashboards"
 
-#: frontend/src/metabase/admin/settings/selectors.js:347
+#: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
 msgstr "Geteilte Fragen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:354
+#: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
 msgstr "Einbettung in andere Applikationen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:381
+#: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Aktivieren die Einbettung von Metabase in andere Applikationen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:391
+#: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
 msgstr "Einbetten des geheimen Schlüssels"
 
-#: frontend/src/metabase/admin/settings/selectors.js:397
+#: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
 msgstr "Eingebettete Dashboards"
 
-#: frontend/src/metabase/admin/settings/selectors.js:403
+#: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
 msgstr "Eingebettete Fragen"
 
-#: frontend/src/metabase/admin/settings/selectors.js:410
+#: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
 msgstr "Caching"
 
-#: frontend/src/metabase/admin/settings/selectors.js:415
+#: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
 msgstr "Aktiviere Caching"
 
-#: frontend/src/metabase/admin/settings/selectors.js:420
+#: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
 msgstr "Minimale Abfragedauer"
 
-#: frontend/src/metabase/admin/settings/selectors.js:427
+#: frontend/src/metabase/admin/settings/selectors.js:424
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Cache Time-To-Live (TTL) Multiplikator"
 
-#: frontend/src/metabase/admin/settings/selectors.js:434
+#: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
 msgstr "Max Cache Anfangsgröße"
 
@@ -1969,11 +1983,11 @@ msgstr "Dein Alarm wurde aktualisiert."
 msgid "The alert was successfully deleted."
 msgstr "Dein Alarm wurde erfolgreich gelöscht."
 
-#: frontend/src/metabase/auth/auth.js:33
+#: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
 msgstr "Gib bitte eine valide E-Mail-Adresse an."
 
-#: frontend/src/metabase/auth/auth.js:116
+#: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
@@ -2015,90 +2029,87 @@ msgstr "Sende E-Mail zur Kennwortzurücksetzung"
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Prüfe deine E-Mails, um weitere Informationen zur Kennwortzurücksetzung zu erhalten."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:128
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
 msgstr "Bei Metabase anmelden"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:138
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
 msgstr "Oder"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:157
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
 msgstr "Benutzername oder E-Mail-Adresse"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:217
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
 msgstr "Anmelden"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:230
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
 msgstr "Ich habe mein Passwort vermeintlich vergessen"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
 msgstr "beantrage eine neue E-Mail zur Kennwortzurücksetzung"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:120
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
 msgstr "Ups, das ist ein abgelaufener Link"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:122
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
 msgstr "Aus Sicherheitsgründen laufen E-Mails zur Kennwortzurücksetzung nach einer gewissen Weile ab. Solltest du dein Passwort weiterhin zurücksetzen wollen, kannst du {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:147
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
 msgstr "Neues Passwort"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:149
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
 msgstr "Um die Daten sicher zu halten, Passwörter {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:163
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
 msgstr "Erstelle ein neues Passwort"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:170
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:141
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
 msgstr "Versichere dich, dass es den oben benannten Sicherheitsanforderungen entspricht"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:184
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:150
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
 msgstr "Bestätige neues Passwort"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:191
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:159
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
 msgstr "Stelle sicher, dass es dem bereits Eingegebenen entspricht"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:216
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
 msgstr "Dein Passwort wurde zurückgesetzt."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:222
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:227
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
 msgstr "Melde dich mit deinem neuen Passwort an"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:182
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:251
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Speichern fehlgeschlagen"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:183
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:129
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:225
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:252
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
 msgstr "Gespeichert"
 
@@ -2106,24 +2117,22 @@ msgstr "Gespeichert"
 msgid "Ok"
 msgstr "Ok"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:38
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
 msgstr "Möchtest du die Sammlung archivieren?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:43
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Alle Dashboards, Sammlungen und Pulses in dieser Sammlung werden auch archiviert."
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
-#: frontend/src/metabase/components/CollectionLanding.jsx:624
+#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: frontend/src/metabase/components/CollectionLanding.jsx:620
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:47
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:195
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:200
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:40
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:53
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
 msgstr "Archiv"
@@ -2132,28 +2141,27 @@ msgstr "Archiv"
 msgid "This {0} has been archived"
 msgstr "Dieses {0} wurde archiviert"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:715
+#: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
 msgstr "Sieh dir das Archiv an"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:43
+#: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
 msgstr "Stelle Archiv {0} wieder her"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:70
-#: frontend/src/metabase/components/BrowseApp.jsx:132
-#: frontend/src/metabase/components/BrowseApp.jsx:225
+#: frontend/src/metabase/components/BrowseApp.jsx:39
+#: frontend/src/metabase/components/BrowseApp.jsx:102
+#: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
 msgstr "Unsere Daten"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:169
+#: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
 msgstr "X-Ray für diese Tabelle"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:183
-#: frontend/src/metabase/containers/Overworld.jsx:246
+#: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
 msgstr "Lerne etwas über diese Tabelle"
 
@@ -2171,31 +2179,31 @@ msgstr "Gespeichert!"
 msgid "Saving failed."
 msgstr "Speichern fehlgeschlagen."
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
 msgstr "So"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
 msgstr "Mo"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
 msgstr "Di"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
 msgstr "Mi"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
 msgstr "Do"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
 msgstr "Fr"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
 msgstr "Sa"
 
@@ -2240,61 +2248,61 @@ msgstr "Mit Pulses kannst du die aktuellsten Daten zeitlich geplant an dein Team
 msgid "Questions are a saved look at your data."
 msgstr "Fragen sind ein gespeichertes Abbild deiner Daten."
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:287
+#: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
 msgstr "Pins"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:341
+#: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
 msgstr "Ziehe etwas hierher, um es oben anzupinnen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:737
-#: frontend/src/metabase/components/CollectionLanding.jsx:353
-#: frontend/src/metabase/home/containers/SearchApp.jsx:35
-#: frontend/src/metabase/home/containers/SearchApp.jsx:92
+#: frontend/src/metabase/admin/permissions/selectors.js:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:352
+#: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
 msgstr "Sammlungen"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:432
-#: frontend/src/metabase/components/CollectionLanding.jsx:455
+#: frontend/src/metabase/components/CollectionLanding.jsx:431
+#: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
 msgstr "Ziehe es hierher, um es das Anpinnen zu entfernen"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:490
+#: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
 msgstr[0] "{0} Element ausgewählt"
 msgstr[1] "{0} Elemente ausgewählt"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:522
+#: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
 msgstr "Bewege {0} Elemente?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:523
+#: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
 msgstr "Bewege \"{0}\"?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:631
+#: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
 msgstr "Verschieben"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:692
+#: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
 msgstr "Ändere diese Sammlung"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:700
+#: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
 msgstr "Archiviere diese Sammlung"
 
-#: frontend/src/metabase/components/CollectionList.jsx:64
-#: frontend/src/metabase/entities/collections.js:155
+#: frontend/src/metabase/components/CollectionList.jsx:67
+#: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
 msgstr "Meine persönliche Sammlung"
 
-#: frontend/src/metabase/components/CollectionList.jsx:106
+#: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
 msgstr "Neue Sammlung"
 
@@ -2302,86 +2310,87 @@ msgstr "Neue Sammlung"
 msgid "Copied!"
 msgstr "Kopiert!"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:216
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Benutze einen SSH-Tunnel für Datenbankverbindungen"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
 msgstr "Auf einige Datenbanken können nur mittels SSH Bastion Host zugegriffen werden. Diese Option integriert gleichfalls eine höhere Ebenen an Sicherheit, sobald das VPN nicht erreichbar ist. Im Normalfall ist die Verbindung langsamer als eine Direktanbindung."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:271
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Dies ist eine große Datenbank. Lasst mich also selbst entscheiden, wann Metabase synchronisiert und prüft"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:273
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Standardmäßig führt Metabase eine stündliche Synchronisation und einen intensiven täglichen Scan der Feldwerte durch.\n"
 "Wenn du eine große Datenbank besitzt, empfehlen wir, diese Option zu aktivieren, um die Intervalle selbst einzustellen."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:289
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0}, um eine Client-ID und ein Client-Secret für dein Projekt zu generieren."
 
 #. Hier klicken
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:291
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:353
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
 msgstr "Hier klicken"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Wähle \"Andere\" als Applikationstyp. Benenne es wie du willst."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:316
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
 msgstr "{0}, um einen Authentifizierungscode"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:328
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
 msgstr "mit Google Drive Berechtigungen"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:348
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Um Metabase mit diesen Daten verwenden zu können, musst du den API-Zugriff in der Google Developers Console aktivieren."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:351
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0}, um zur Konsole zu gelangen, insofern du das noch nicht getan hast."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
 msgstr "Wie würdest du gerne auf diese Datenbank referenzieren?"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:427
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:237
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:188
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:74
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:194
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:79
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
 msgstr "Nächste"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:52
+#: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
 msgstr "Lösche {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:43
+#: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
 msgstr "Fixiere dieses Element"
 
-#: frontend/src/metabase/components/EntityItem.jsx:49
+#: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
 msgstr "Bewege dieses Element"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
 msgstr "Ändere dieses Element"
 
@@ -2394,6 +2403,7 @@ msgstr "Aktiontyp"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
 msgstr "Betrachte die Revisionshistorie"
 
@@ -2409,8 +2419,7 @@ msgstr "Archivierungsaktion"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:329
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:342
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
 msgstr "Zu Dashboard hinzufügen"
 
@@ -2434,13 +2443,12 @@ msgstr "Anderer Aktionstyp"
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:449
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:454
 msgid "Get alerts about this"
 msgstr "Alarme hierzu erhalten"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
 msgstr "SQL anzeigen"
 
@@ -2460,43 +2468,43 @@ msgstr "Hier ist die ganze Fehlermeldung"
 msgid "Hi, Metabot here."
 msgstr "Hi, Metabot hier."
 
-#: frontend/src/metabase/components/ExplorePane.jsx:95
+#: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
 msgstr "Basierend auf dem Schema"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:174
+#: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
 msgstr "Ein Blick auf"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:234
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
 msgstr "Liste durchsuchen"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:238
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
 msgstr "Suche nach {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
 msgstr " oder gibt eine ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
 msgstr "ID eingeben"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
 msgstr "Nummer eingeben"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:248
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
 msgstr "Text eingeben"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:355
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
 msgstr "Keine Treffer für {0} gefunden."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:363
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Jede Option in deinem Filter zu verwenden wird wahrscheinlich nicht viel bewirken…"
 
@@ -2512,17 +2520,17 @@ msgstr "Wir sind auf einen Fehler gestoßen. Du kannst versuchen, die Seite zu a
 #: frontend/src/metabase/components/HeaderBar.jsx:45
 #: frontend/src/metabase/components/ListItem.jsx:37
 #: frontend/src/metabase/reference/components/Detail.jsx:47
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:158
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:213
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:191
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:205
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:209
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:209
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:161
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:216
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:194
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:208
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
 msgstr "Noch keine Beschreibung"
 
 #: frontend/src/metabase/components/Header.jsx:112
-#: frontend/src/metabase/entities/containers/EntityForm.jsx:43
+#: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
 msgstr "Neue {0}"
 
@@ -2530,54 +2538,53 @@ msgstr "Neue {0}"
 msgid "Asked by {0}"
 msgstr "Gefragt durch {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:13
+#: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
 msgstr "Heute, "
 
-#: frontend/src/metabase/components/HistoryModal.jsx:15
+#: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
 msgstr "Gestern, "
 
-#: frontend/src/metabase/components/HistoryModal.jsx:68
+#: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
 msgstr "Erste Revision."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:70
+#: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
 msgstr "Wiederhergestellt zu einer früheren Version und {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:82
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:289
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:379
-#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
+#: frontend/src/metabase/components/HistoryModal.jsx:42
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
+#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
 msgstr "Revisionshistorie"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:90
+#: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
 msgstr "Wann"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:91
+#: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
 msgstr "Wer"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:92
+#: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
 msgstr "Was"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:113
+#: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
 msgstr "Zurückkehren"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:114
+#: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
 msgstr "Wiederherstellen…"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:115
+#: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
 msgstr "Rückkehr fehlgeschlagen"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:116
+#: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
 msgstr "Zurückgekehrt"
 
@@ -2586,26 +2593,24 @@ msgid "Everything"
 msgstr "Alles"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
-#: frontend/src/metabase/home/containers/SearchApp.jsx:69
 msgid "Dashboards"
 msgstr "Übersicht"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
-#: frontend/src/metabase/home/containers/SearchApp.jsx:115
 msgid "Questions"
 msgstr "Fragen"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:321
+#: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
 msgstr "Pulses"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:103
+#: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
 msgstr "Zurück"
 
-#: frontend/src/metabase/components/ListSearchField.jsx:18
+#: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
 msgstr "Finden..."
 
@@ -2642,14 +2647,14 @@ msgid "Temporary Password"
 msgstr "Temporäres Passwort"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
 msgstr "Verstecken"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:412
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
 msgstr "Anzeigen"
 
@@ -2714,7 +2719,7 @@ msgstr "15. (Mittelpunkt)"
 msgid "Calendar Day"
 msgstr "Kalender Tag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:210
+#: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
 msgstr "deine Metabase Zeitzone"
 
@@ -2743,11 +2748,11 @@ msgid "A component used to make a selection"
 msgstr "Eine Komponente, die für eine Auswahl verwendet wird"
 
 #: frontend/src/metabase/components/Select.info.js:20
-#: frontend/src/metabase/components/Select.info.js:28
+#: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
 msgstr "Ausgewählt"
 
-#: frontend/src/metabase/components/Select.jsx:297
+#: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
 msgstr "Nichts zu wählen"
 
@@ -2760,7 +2765,7 @@ msgid "Unknown error encountered"
 msgstr "Unbekannter Fehler aufgetreten"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/nav/containers/Navbar.jsx:304
+#: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
 msgstr "Erstellen"
 
@@ -2769,13 +2774,11 @@ msgid "Create dashboard"
 msgstr "Dashboard erstellen"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:331
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:60
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
 msgstr "Tabelle"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:306
 msgid "Database"
 msgstr "Datenbank"
 
@@ -2783,22 +2786,20 @@ msgstr "Datenbank"
 msgid "Creator"
 msgstr "Ersteller"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:238
+#: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
 msgstr "Keine Ergebnisse gefunden"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:239
+#: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
 msgstr "Versuche, deinen Filter anzupassen, um das zu finden, wonach du suchst."
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:258
+#: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
 msgstr "Ansicht nach"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:494
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:84
-#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:69
-#: frontend/src/metabase/tutorial/TutorialModal.jsx:34
+#: frontend/src/metabase/containers/EntitySearch.jsx:495
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
 msgstr "von"
 
@@ -2811,13 +2812,13 @@ msgid "Once you connect your own data, I can show you some automatic exploration
 msgstr "Sobald du deine eigenen Daten verbunden hast, kann ich dir einige automatische Analysen zeigen, die X-Ray genannt werden. Anbei einige Beispieldaten."
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
-#: frontend/src/metabase/containers/Overworld.jsx:299
+#: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
 msgstr "Beginne hier"
 
-#: frontend/src/metabase/containers/Overworld.jsx:294
-#: frontend/src/metabase/entities/collections.js:147
+#: frontend/src/metabase/containers/Overworld.jsx:296
+#: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
 msgstr "Unsere Analysen"
@@ -2826,53 +2827,53 @@ msgstr "Unsere Analysen"
 msgid "Browse all items"
 msgstr "Durchsuche alle Elemente"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:165
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
 msgstr "Überschreibe oder speichere als neu?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:173
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
 msgstr "Überschreibe originale Frage, \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:178
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
 msgstr "Speichere als neue Frage"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:187
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
 msgstr "Speichere zuerst deine Frage"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:188
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
 msgstr "Speichere Frage"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:224
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
 msgstr "Wie lautet der Name deiner Karte?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:232
-#: frontend/src/metabase/entities/collections.js:101
-#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:234
+#: frontend/src/metabase/entities/collections.js:102
+#: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/lib/core.js:50 frontend/src/metabase/lib/core.js:205
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:156
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:211
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:203
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:207
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:207
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:24
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:159
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:214
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:192
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:206
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:210
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
 msgstr "Beschreibung"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:238
-#: frontend/src/metabase/entities/dashboards.js:153
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
+#: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
 msgstr "Es ist optional, aber sehr hilfreich"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:245
-#: frontend/src/metabase/entities/dashboards.js:157
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
+#: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "In welche Sammlung soll es gehen?"
 
@@ -2884,7 +2885,7 @@ msgstr "geändert"
 msgid "item"
 msgstr "Objekt"
 
-#: frontend/src/metabase/containers/UndoListing.jsx:81
+#: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
 msgstr "Rückgängig"
 
@@ -2908,15 +2909,15 @@ msgstr "Wir sind uns nicht sicher, ob die Frage kompatibel ist"
 msgid "Archive Dashboard"
 msgstr "Dashboard archivieren"
 
-#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:20
+#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Stelle sicher, dass du für jede Serie eine Auswahl triffst, sonst funktioniert der Filter auf dieser Karte nicht."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:300
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
 msgstr "Dieses Dashboard sieht leer aus."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:301
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
 msgstr "Füge eine Frage hinzu, um es nützlicher zu machen!"
 
@@ -2936,59 +2937,58 @@ msgstr "Vollbild beenden"
 msgid "Enter fullscreen"
 msgstr "Vollbild anzeigen"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:181
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:183
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Speichern…"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:216
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
 msgstr "Füge eine Frage hinzu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:219
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
 msgstr "Füge eine Frage zu diesem Dashboard hinzu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:248
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
 msgstr "Füge einen Filter hinzu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:254
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:78
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Parameter"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:275
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
 msgstr "Füge ein Textfeld hinzu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
 msgstr "Bewege das Dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:302
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
 msgstr "Ändere das Dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:306
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
 msgstr "Ändere das Dashboard-Layout"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:369
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
 msgstr "Du editierst ein Dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:374
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
 msgstr "Wähle das Feld aus, welches auf jeder Karte gefiltert werden soll"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:28
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
 msgstr "Bewege das Dashboard nach..."
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:52
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
 msgstr "Dashboard wurde nach {0} verschoben"
 
@@ -3003,7 +3003,7 @@ msgstr "Welche Art von Filter?"
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:179
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
 msgstr "Aus"
 
@@ -3043,174 +3043,174 @@ msgstr "Aktualisiere in"
 msgid "Remove this question?"
 msgstr "Diese frage löschen?"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:71
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
 msgstr "Dein Dashboard wurde gespeichert"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:745
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:76
+#: frontend/src/metabase/components/CollectionLanding.jsx:744
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
 msgstr "Sieh es dir an"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:137
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
 msgstr "Speichere dies"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:170
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
 msgstr "Zeige mehr über das"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:140
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
 msgstr "Diese Karte hat keine Felder oder Parameter, die auf diesen Parametertyp zugeordnet werden können."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:142
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Die Werte in diesem Feld überschneiden sich nicht mit den Werten anderer Felder, die du ausgewählt hast."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:186
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
 msgstr "Keine validen Felder"
 
-#: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
 msgstr "Name darf maximal 100 Zeichen lang sein"
 
-#: frontend/src/metabase/entities/collections.js:111
+#: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
 msgstr "Farbe ist notwendig"
 
-#: frontend/src/metabase/entities/dashboards.js:146
+#: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
 msgstr "Wie lautet der Name deines Dashboards?"
 
-#: frontend/src/metabase/home/components/Activity.jsx:92
+#: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
 msgstr "habe etwas Unglaubliches gemacht, was schwer zu erklären ist"
 
-#: frontend/src/metabase/home/components/Activity.jsx:101
-#: frontend/src/metabase/home/components/Activity.jsx:116
+#: frontend/src/metabase/home/components/Activity.jsx:103
+#: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
 msgstr "erstellte eine Alarm über - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:126
-#: frontend/src/metabase/home/components/Activity.jsx:141
+#: frontend/src/metabase/home/components/Activity.jsx:128
+#: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
 msgstr "löschte einen Alarm über - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:152
+#: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
 msgstr "Speicherte eine Frage über "
 
-#: frontend/src/metabase/home/components/Activity.jsx:165
+#: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
 msgstr "Frage gespeichert"
 
-#: frontend/src/metabase/home/components/Activity.jsx:169
+#: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
 msgstr "Frage gelöscht"
 
-#: frontend/src/metabase/home/components/Activity.jsx:172
+#: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
 msgstr "Dashboard erstellt"
 
-#: frontend/src/metabase/home/components/Activity.jsx:175
+#: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
 msgstr "Dashboard gelöscht"
 
-#: frontend/src/metabase/home/components/Activity.jsx:181
-#: frontend/src/metabase/home/components/Activity.jsx:196
+#: frontend/src/metabase/home/components/Activity.jsx:183
+#: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
 msgstr "fügte eine Frage zum Dashboard hinzu - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:206
-#: frontend/src/metabase/home/components/Activity.jsx:221
+#: frontend/src/metabase/home/components/Activity.jsx:208
+#: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
 msgstr "Löschte eine Frage vom Dashboard - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:231
-#: frontend/src/metabase/home/components/Activity.jsx:238
+#: frontend/src/metabase/home/components/Activity.jsx:233
+#: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
 msgstr "erhielt aktuellste Daten von"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:621
-#: frontend/src/metabase/home/components/Activity.jsx:244
+#: frontend/src/metabase-lib/lib/Dimension.js:814
+#: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: frontend/src/metabase/home/components/Activity.jsx:251
+#: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
 msgstr "Hallo Welt!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:252
+#: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
 msgstr "Metabase ist in Betrieb."
 
-#: frontend/src/metabase/home/components/Activity.jsx:258
-#: frontend/src/metabase/home/components/Activity.jsx:288
+#: frontend/src/metabase/home/components/Activity.jsx:260
+#: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
 msgstr "fügte eine Metrik hinzu "
 
-#: frontend/src/metabase/home/components/Activity.jsx:272
-#: frontend/src/metabase/home/components/Activity.jsx:362
+#: frontend/src/metabase/home/components/Activity.jsx:274
+#: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
 msgstr " zum "
 
-#: frontend/src/metabase/home/components/Activity.jsx:282
-#: frontend/src/metabase/home/components/Activity.jsx:322
-#: frontend/src/metabase/home/components/Activity.jsx:372
-#: frontend/src/metabase/home/components/Activity.jsx:413
+#: frontend/src/metabase/home/components/Activity.jsx:284
+#: frontend/src/metabase/home/components/Activity.jsx:324
+#: frontend/src/metabase/home/components/Activity.jsx:374
+#: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
 msgstr " Tabelle"
 
-#: frontend/src/metabase/home/components/Activity.jsx:298
-#: frontend/src/metabase/home/components/Activity.jsx:328
+#: frontend/src/metabase/home/components/Activity.jsx:300
+#: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
 msgstr "tätigte Änderungen an der Metrik "
 
-#: frontend/src/metabase/home/components/Activity.jsx:312
-#: frontend/src/metabase/home/components/Activity.jsx:403
+#: frontend/src/metabase/home/components/Activity.jsx:314
+#: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
 msgstr " in dem "
 
-#: frontend/src/metabase/home/components/Activity.jsx:335
+#: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
 msgstr "löschte die Metrik "
 
-#: frontend/src/metabase/home/components/Activity.jsx:338
+#: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
 msgstr "erstellte einen Pulse"
 
-#: frontend/src/metabase/home/components/Activity.jsx:341
+#: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
 msgstr "löschte einen Pulse"
 
-#: frontend/src/metabase/home/components/Activity.jsx:347
-#: frontend/src/metabase/home/components/Activity.jsx:378
+#: frontend/src/metabase/home/components/Activity.jsx:349
+#: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
 msgstr "Filter hinzugefügt"
 
-#: frontend/src/metabase/home/components/Activity.jsx:388
-#: frontend/src/metabase/home/components/Activity.jsx:419
+#: frontend/src/metabase/home/components/Activity.jsx:390
+#: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
 msgstr "machte Änderungen am Filter"
 
-#: frontend/src/metabase/home/components/Activity.jsx:426
+#: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
 msgstr "Löschte den Filter {0}"
 
-#: frontend/src/metabase/home/components/Activity.jsx:429
+#: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
 msgstr "beigetreten!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:529
+#: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
 msgstr "Hmm, sieht so aus als wäre bis jetzt nichts passiert."
 
-#: frontend/src/metabase/home/components/Activity.jsx:532
+#: frontend/src/metabase/home/components/Activity.jsx:534
 msgid "Save a question and get this baby going!"
 msgstr "Speichere eine Frage und bringe damit das Baby zum Laufen!"
 
@@ -3258,21 +3258,21 @@ msgstr "Vor Kurzem Anzeige"
 msgid "You haven't looked at any dashboards or questions recently"
 msgstr "Du hast dir in letzter Zeit keine Dashboards oder Fragen angeschaut"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:99
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
 msgstr "{0} Elemente ausgewählt"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:121
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:172
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
 msgstr "Stelle aus dem Archiv wieder her"
 
-#: frontend/src/metabase/home/containers/HomepageApp.jsx:74
-#: frontend/src/metabase/nav/containers/Navbar.jsx:331
+#: frontend/src/metabase/home/containers/HomepageApp.jsx:77
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
 msgstr "Aktivitäten"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:28
+#: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
 msgstr "Ergebnisse für \"{0}\""
 
@@ -3337,6 +3337,7 @@ msgstr "Avatar Bild-URL"
 msgid "Common"
 msgstr "Gemeinsam"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
@@ -3373,8 +3374,9 @@ msgstr "Breite"
 msgid "Longitude"
 msgstr "Länge"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:149
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
 msgstr "Nummer"
@@ -3472,7 +3474,7 @@ msgstr "Ergebnis"
 
 #: frontend/src/metabase/lib/core.js:210
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:17
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
 msgstr "Titel"
 
@@ -3529,8 +3531,9 @@ msgid "Metabase will never retrieve this field. Use this for sensitive or irrele
 msgstr "Metabase wird dieses Feld nie abrufen. Benutze dies für vertrauliche oder irrelevante Daten."
 
 #: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:614
-#: frontend/src/metabase/visualizations/lib/utils.js:126
+#: frontend/src/metabase/lib/query.js:300
+#: frontend/src/metabase/visualizations/lib/utils.js:130
+#: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -3545,7 +3548,7 @@ msgstr "Kumulative Zählung"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
-#: frontend/src/metabase/visualizations/lib/utils.js:127
+#: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
 msgstr "Summe"
 
@@ -3554,7 +3557,7 @@ msgid "CumulativeSum"
 msgstr "Kumulative Summe"
 
 #: frontend/src/metabase/lib/expressions/config.js:11
-#: frontend/src/metabase/visualizations/lib/utils.js:128
+#: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
 msgstr "Eindeutig"
 
@@ -3563,35 +3566,35 @@ msgid "StandardDeviation"
 msgstr "Standardabweichung"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/visualizations/lib/utils.js:125
+#: frontend/src/metabase/visualizations/lib/utils.js:129
 msgid "Average"
 msgstr "Durchschnitt"
 
 #: frontend/src/metabase/lib/expressions/config.js:14
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:25
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
 msgstr "Min"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
 msgstr "Max"
 
-#: frontend/src/metabase/lib/expressions/parser.js:384
+#: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
 msgstr "trauriger trauriger Panda, Lexing-Fehler entdeckt"
 
-#: frontend/src/metabase/lib/formatting.js:707
+#: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} Sekunde"
 msgstr[1] "{0} Sekunden"
 
-#: frontend/src/metabase/lib/formatting.js:710
+#: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} Minute"
@@ -3630,222 +3633,224 @@ msgstr "Was hast du auf dem Herzen?"
 msgid "What do you want to find out?"
 msgstr "Was möchtest du herausfinden?"
 
-#: frontend/src/metabase/lib/query.js:612
-#: frontend/src/metabase/lib/schema_metadata.js:451
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:246
+#: frontend/src/metabase/lib/query.js:298
+#: frontend/src/metabase/lib/schema_metadata.js:458
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
 msgstr "Rohdaten"
 
-#: frontend/src/metabase/lib/query.js:616
+#: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
 msgstr "Kumulative Zählung"
 
-#: frontend/src/metabase/lib/query.js:619
+#: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
 msgstr "Durchschnitt von "
 
-#: frontend/src/metabase/lib/query.js:624
+#: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
 msgstr "Eindeutiger Wert von "
 
-#: frontend/src/metabase/lib/query.js:629
+#: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
 msgstr "Standardabweichung von "
 
-#: frontend/src/metabase/lib/query.js:634
+#: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
 msgstr "Summe von "
 
-#: frontend/src/metabase/lib/query.js:639
+#: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
 msgstr "Kumulative Summe von "
 
-#: frontend/src/metabase/lib/query.js:644
+#: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
 msgstr "Maximum von "
 
-#: frontend/src/metabase/lib/query.js:649
+#: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
 msgstr "Minimum von "
 
-#: frontend/src/metabase/lib/query.js:663
+#: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
 msgstr "Gruppieren nach "
 
-#: frontend/src/metabase/lib/query.js:677
+#: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
 msgstr "Filtern nach "
 
-#: frontend/src/metabase/lib/query.js:706
+#: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
 msgstr "Sortieren nach "
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
-msgstr "Richtig"
+msgstr "Wahr"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
 msgstr "Falsch"
 
-#: frontend/src/metabase/lib/schema_metadata.js:305
+#: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
 msgstr "Wähle limitierendes Feld aus"
 
-#: frontend/src/metabase/lib/schema_metadata.js:306
+#: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
 msgstr "Setze oberes Limit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:307
+#: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
 msgstr "Setze linkes Limit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:308
+#: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
 msgstr "Setze unteres Limit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:309
+#: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
 msgstr "Setze rechtes Limit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:345
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase-lib/lib/Dimension.js:505
+#: frontend/src/metabase-lib/lib/Dimension.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:351
+#: frontend/src/metabase/lib/schema_metadata.js:371
 #: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:387
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
 msgstr "Ist"
 
-#: frontend/src/metabase/lib/schema_metadata.js:346
-#: frontend/src/metabase/lib/schema_metadata.js:366
-#: frontend/src/metabase/lib/schema_metadata.js:376
-#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/lib/schema_metadata.js:352
+#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:396
+#: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
 msgstr "Ist nicht"
 
-#: frontend/src/metabase/lib/schema_metadata.js:347
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:369
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:353
+#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
 msgstr "Ist leer"
 
-#: frontend/src/metabase/lib/schema_metadata.js:348
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:370
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:402
+#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
 msgstr "Nicht leer"
 
-#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
 msgstr "Gleich zu"
 
-#: frontend/src/metabase/lib/schema_metadata.js:355
+#: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
 msgstr "Nicht gleich zu"
 
-#: frontend/src/metabase/lib/schema_metadata.js:356
+#: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
 msgstr "Größer als"
 
-#: frontend/src/metabase/lib/schema_metadata.js:357
+#: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
 msgstr "Kleiner als"
 
-#: frontend/src/metabase/lib/schema_metadata.js:358
-#: frontend/src/metabase/lib/schema_metadata.js:384
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:285
+#: frontend/src/metabase/lib/schema_metadata.js:364
+#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Zwischen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:359
+#: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
 msgstr "Größer oder gleich als"
 
-#: frontend/src/metabase/lib/schema_metadata.js:360
+#: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
 msgstr "Kleiner oder gleich als"
 
-#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
 msgstr "Enthält"
 
-#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
 msgstr "Enthält nicht"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
 msgstr "Startet mit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
 msgstr "Endet mit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:264
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Vor"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:271
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Nach"
 
-#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
 msgstr "Intern"
 
-#: frontend/src/metabase/lib/schema_metadata.js:453
+#: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Nur eine Tabelle mit den Zeilen in der Antwort ohne zusätzlichen Operationen."
 
-#: frontend/src/metabase/lib/schema_metadata.js:459
+#: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
 msgstr "Zählen der Zeilen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:461
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
 msgstr "Gesamtanzahl der Zeilen einer Antwort."
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
 msgstr "Summe von..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:469
+#: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
 msgstr "Summe aller Werte einer Spalte."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
 msgstr "Durchschnitt von..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
 msgstr "Durchschnitt aller Werte einer Spalte"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
 msgstr "Anzahl eindeutiger Werte von..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Anzahl eindeutiger Werte einer Spalte für die Zeilen einer Antwort."
 
-#: frontend/src/metabase/lib/schema_metadata.js:491
+#: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
 msgstr "Kumulative Summe von..."
 
@@ -3853,7 +3858,7 @@ msgstr "Kumulative Summe von..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Additive Summe aller Werte einer Spalte.\\\\ne.x. Gesamtumsatz über die Zeit."
 
-#: frontend/src/metabase/lib/schema_metadata.js:499
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
 msgstr "Kumulative Zählung von Zeilen"
 
@@ -3861,105 +3866,105 @@ msgstr "Kumulative Zählung von Zeilen"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Additive Zählung von Reihen.\\\\ne.x. Gesamtanzahl vom Verkauf über die Zeit."
 
-#: frontend/src/metabase/lib/schema_metadata.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
 msgstr "Standardabweichung von..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:509
+#: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Zahl, die angibt, wie stark die Werte einer Spalte zwischen allen Zeilen der Antwort variieren."
 
-#: frontend/src/metabase/lib/schema_metadata.js:515
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
 msgstr "Minimum von ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:517
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
 msgstr "Minimalwert einer Spalte"
 
-#: frontend/src/metabase/lib/schema_metadata.js:523
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
 msgstr "Maximum von ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:525
+#: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
 msgstr "Maximalwert einer Spalte"
 
-#: frontend/src/metabase/lib/schema_metadata.js:533
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
 msgstr "Abweichung nach Dimension"
 
-#: frontend/src/metabase/lib/settings.js:93
+#: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
 msgstr "Kleinbuchstabe"
 
-#: frontend/src/metabase/lib/settings.js:95
+#: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
 msgstr "Grossbuchstabe"
 
-#: frontend/src/metabase/lib/settings.js:97
+#: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "Nummer"
 
-#: frontend/src/metabase/lib/settings.js:99
+#: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
 msgstr "Sonderzeichen"
 
-#: frontend/src/metabase/lib/settings.js:105
+#: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
 msgstr "muss"
 
-#: frontend/src/metabase/lib/settings.js:105
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:120
+#: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
 msgstr "Zeichen lang"
 
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
 msgstr "Muss"
 
-#: frontend/src/metabase/lib/settings.js:122
+#: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
 msgstr "und inkludiere"
 
-#: frontend/src/metabase/lib/utils.js:92
+#: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
 msgstr "null"
 
-#: frontend/src/metabase/lib/utils.js:93
+#: frontend/src/metabase/lib/utils.js:86
 msgid "one"
 msgstr "eins"
 
-#: frontend/src/metabase/lib/utils.js:94
+#: frontend/src/metabase/lib/utils.js:87
 msgid "two"
 msgstr "zwei"
 
-#: frontend/src/metabase/lib/utils.js:95
+#: frontend/src/metabase/lib/utils.js:88
 msgid "three"
 msgstr "drei"
 
-#: frontend/src/metabase/lib/utils.js:96
+#: frontend/src/metabase/lib/utils.js:89
 msgid "four"
 msgstr "vier"
 
-#: frontend/src/metabase/lib/utils.js:97
+#: frontend/src/metabase/lib/utils.js:90
 msgid "five"
 msgstr "fünf"
 
-#: frontend/src/metabase/lib/utils.js:98
+#: frontend/src/metabase/lib/utils.js:91
 msgid "six"
 msgstr "sechs"
 
-#: frontend/src/metabase/lib/utils.js:99
+#: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
 msgstr "sieben"
 
-#: frontend/src/metabase/lib/utils.js:100
+#: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
 msgstr "acht"
 
-#: frontend/src/metabase/lib/utils.js:101
+#: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
 msgstr "neun"
 
@@ -4033,6 +4038,7 @@ msgstr "Zeit"
 msgid "Date range, relative date, time of day, etc."
 msgstr "Zeitspanne, relatives Datum, Zeitpunkt eines Tages, usw."
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
@@ -4055,7 +4061,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Kategorie, Typ, Modell, Bewertung, usw."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
-#: frontend/src/metabase/user/components/UserSettings.jsx:54
+#: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
 msgstr "Kontoeinstellungen"
 
@@ -4067,56 +4073,56 @@ msgstr "Verlasse Administration"
 msgid "Logs"
 msgstr "Protokolle"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:64
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
 msgstr "Hilfe"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:67
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
 msgstr "Über Metabase"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:73
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
 msgstr "Abmelden"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:98
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
 msgstr "Danke für die Nutzung"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
 msgstr "Du nutzt Version"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
 msgstr "Aufgebaut auf"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:124
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
 msgstr "ist ein Warenzeichen von"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:126
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
 msgstr "und wird mit Sorgfalt in San Francisco, CA gebaut"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:194
+#: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
 msgstr "Metabase Administrator"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:300
+#: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
 msgstr "Stelle eine Frage"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:309
+#: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
 msgstr "Neues Dashboard"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:315
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/nav/containers/Navbar.jsx:361
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
 msgstr "Neuer Pulse"
 
@@ -4124,16 +4130,16 @@ msgstr "Neuer Pulse"
 msgid "Reference"
 msgstr "Referenz"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:83
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
 msgstr "Welchen Kennwert?"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:110
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Die Definition gemeinsamer Metriken für dein Team macht es noch einfacher, Fragen zu stellen"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:113
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
 msgstr "Wie du Metriken erstellst"
 
@@ -4145,8 +4151,8 @@ msgstr "Betrachte Daten über die Zeit, als Kartendiagramm oder als Pivot, um Tr
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:150
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:517
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
 msgstr "Neue Frage"
 
@@ -4154,22 +4160,22 @@ msgstr "Neue Frage"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Verwende den einfachen Fragen-Builder, um Trends und Listen zu betrachten oder eigene Metriken zu erstellen."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:161
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Native Abfrage"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:162
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Für kompliziertere Fragen kannst du deine eigenen SQL- bzw. native Abfragen schreiben."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:240
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
 msgstr "Wähle einen Standardwert…"
 
-#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:149
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
 msgstr "Filter anpassen"
 
@@ -4177,14 +4183,14 @@ msgstr "Filter anpassen"
 #: frontend/src/metabase/lib/query_time.js:123
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:9
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Today"
 msgstr "Heute"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
 msgstr "Gestern"
 
@@ -4196,7 +4202,7 @@ msgstr "Vergangenen 7 Tage"
 msgid "Past 30 days"
 msgstr "Vergangenen 30 Tagen"
 
-#: frontend/src/metabase/lib/query_time.js:195
+#: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:29
 #: src/metabase/api/table.clj
@@ -4205,7 +4211,7 @@ msgid_plural "Weeks"
 msgstr[0] "Woche"
 msgstr[1] "Wochen"
 
-#: frontend/src/metabase/lib/query_time.js:197
+#: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:30
 #: src/metabase/api/table.clj
@@ -4214,7 +4220,7 @@ msgid_plural "Months"
 msgstr[0] "Monat"
 msgstr[1] "Monate"
 
-#: frontend/src/metabase/lib/query_time.js:201
+#: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:31
 #: src/metabase/api/table.clj
@@ -4264,6 +4270,7 @@ msgstr "Gib einen Wert ein..."
 msgid "Enter a default value..."
 msgstr "Trage einen Standardwert ein..."
 
+#: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Ein Fehler ist aufgetaucht"
@@ -4304,24 +4311,24 @@ msgstr "Veröffentlichen"
 msgid "Code"
 msgstr "Code"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:70
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
 msgstr "Stil"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
 msgstr "Welche Parameter können Benutzer verwenden?"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:83
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
 msgstr "Dieses {0} hat noch keine konfigurierbaren Parameter."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
 msgstr "Bearbeitbar"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
 msgstr "Gesperrt"
 
@@ -4329,19 +4336,19 @@ msgstr "Gesperrt"
 msgid "Preview Locked Parameters"
 msgstr "Vorschau zu gesperrten Parametern"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:115
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
 msgstr "Versuche hier einige Werte an deine gesperrten Parameter zu übergeben. Dein Server muss die tatsächlichen Werte im signierten Token angeben, wenn du dieses für reale Zwecke verwendest."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
 msgstr "Gefahrenbereich"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
 msgstr "Dies wird das Einbetten für {0} deaktivieren."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:128
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
 msgstr "Veröffentlichung zurückziehen"
 
@@ -4381,64 +4388,64 @@ msgstr "Mehr {0}"
 msgid "examples on GitHub"
 msgstr "Beispiele auf GitHub"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:72
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
 msgstr "Aktiviere Teilen"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
 msgstr "Soll der öffentliche Link deaktiviert werden?"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:77
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
 msgstr "Dies führt dazu, dass die bestehende Links nicht mehr funktioniert. Du kannst es wieder aktivieren, jedoch wird ein neuer Link generiert."
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
 msgstr "Öffentlicher Link"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:118
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
 msgstr "Teile {0}, unter Nutzung folgender URL, mit Personen, welche keinen Metabase Account haben:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:158
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
 msgstr "Öffentliches eingebettet"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:159
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
 msgstr "Bette {0} in Blog Artikel oder Webseiten ein, indem du folgenden Schnipsel kopierst und einfügst:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:176
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
 msgstr "Bette {0} in eine Applikation ein"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:177
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
 msgstr "Durch die Integration mit deinem Applikationsserver-Code kannst du eine sichere Statistik {0} erstellen, die auf bestimmte Benutzer, Kunden, Organisationen usw. beschränkt ist."
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
 msgstr "Entferne Anhang"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:95
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
 msgstr "Füge Anhang mit Ergebnissen hinzu"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
 msgstr "Diese Frage wird als Dateianhang der Frage angefügt"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:128
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
 msgstr "Diese Frage wird nicht in dein Pulse integriert"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:92
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
 msgstr "Dieser Pulse wird nicht länger als E-Mail an {0} {1} versendet"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:94
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:376
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
 msgstr[0] "{0} Adresse"
@@ -4448,40 +4455,40 @@ msgstr[1] "{0} Adressen"
 msgid "Slack channel {0} will no longer get this pulse {1}"
 msgstr "Der Slack Kanal {0} wird nicht länger den Pulse {1} erhalten"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:110
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
 msgstr "Der Kanal {0} wird nicht länger den Pulse {1} erhalten"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
 msgstr "Ändere den Pulse"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:131
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
 msgstr "Was ist ein Pulse?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:141
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
 msgstr "Kapiert"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
 msgstr "Wo sollen Daten landen?"
 
 #. Aus dem Archiv wird wiederhergestellt ...
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:173
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
 msgstr "Wird aus dem Archiv wiederhergestellt ..."
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
 msgstr "Wiederherstellung aus Archiv fehlgeschlagen"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
 msgstr "Wiederhergestellt aus Archiv"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
 msgstr "Erstelle Pulse"
 
@@ -4491,7 +4498,7 @@ msgstr "Anhang"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:673
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
 msgstr "Vorwarnung"
 
@@ -4512,6 +4519,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Wir empfehlen, die Pulse klein und essentiell zu halten, damit diese für das Team verständlich bleiben."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
+#: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
 msgstr "Wähle deine Daten"
 
@@ -4527,48 +4535,48 @@ msgstr "E-Mails"
 msgid "Slack messages"
 msgstr "Slack-Nachrichten"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Versendet"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:222
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} wird gesendet an"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:224
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "E-Mail jetzt versenden"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:241
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Jetzt an {0} versenden"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Senden…"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:244
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Senden fehlgeschlagen"
 
 #. How to translate "Pulse"? Is it like Pulse / Heartbeat or the name of the untranslated metabase feature?
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Wurde nicht versandt, da der Pulse nichts beinhaltet."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:248
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Pulse gesendet"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:287
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} muss von einem Administrator eingerichtet werden."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:302
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
 msgstr "Slack"
 
@@ -4617,21 +4625,21 @@ msgid "Before {0}"
 msgstr "Vor {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:295
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Ist leer"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:301
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Nicht leer"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:213
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Allzeit"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:154
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
 msgstr "Anwenden"
 
@@ -4654,7 +4662,7 @@ msgstr "Anzahl der Zeilen nach Zeit"
 #. eher "aufschlüsseln" oder "herunterbrechen"?
 #: frontend/src/metabase/modes/components/actions/PivotByAction.jsx:52
 msgid "Break out by {0}"
-msgstr "Abbruch nach {0}"
+msgstr "Aufschlüsseln nach {0}"
 
 #. Summarize heisst m.E. (hier) "zusammenfassen"
 #: frontend/src/metabase/modes/components/actions/SummarizeBySegmentMetricAction.jsx:31
@@ -4699,7 +4707,7 @@ msgstr "Beschreibung"
 msgid "View details"
 msgstr "Details anzeigen"
 
-#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:54
+#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
 msgstr "Sieh dieses {0}s {1}"
 
@@ -4723,22 +4731,22 @@ msgstr "Mittel"
 msgid "Distincts"
 msgstr "Besonderheiten"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:32
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Siehe dieses {0}"
 msgstr[1] "Siehe diese {0}"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:225
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
 msgstr "Heranzoomen"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:19
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
 msgstr "Benutzerdefinierter Ausdruck"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
 msgstr "Allgemeine Metriken"
 
@@ -4746,7 +4754,7 @@ msgstr "Allgemeine Metriken"
 msgid "Metabasics"
 msgstr "Metabasics"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
 msgstr "Name (optional)"
 
@@ -4758,31 +4766,31 @@ msgstr "Wähle eine Aggregierung"
 msgid "Set up your own alert"
 msgstr "Setze deinen eigenen Alarm auf"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:140
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
 msgstr "Abmelden..."
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:145
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
 msgstr "Abmeldung fehlgeschlagen"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:204
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
 msgstr "Abmelden"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:235
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
 msgstr "Kein Kanal"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:263
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
 msgstr "Ok, du bist abgemeldet"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:335
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
 msgstr "Du erhältst {0}s Alarme"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
 msgstr "{0} hat einen Alarm aufgesetzt"
 
@@ -4838,147 +4846,147 @@ msgstr "Ändere deinen Alarm"
 msgid "Edit alert"
 msgstr "Ändere Alarm"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:374
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
 msgstr "Dieser Alarm wird nicht länger via E-Mail verteilt an {0}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:382
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
 msgstr "Der Slack Kanal {0} wird diesen Alarm nicht länger erhalten."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:386
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
 msgstr "Kanal {0} wird nicht länger diesen Alarm erhalten."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:403
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
 msgstr "Lösche den Alarm"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:405
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
 msgstr "Stoppe die Zustellung und lösche diesen Alarm. Es gibt keine Wiederherstellung, also sei vorsichtig."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:413
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
 msgstr "Löschen dieses Alarms?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:497
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
 msgstr "Alarmiere mich, wenn die Linie…"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:498
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
 msgstr "Alarmiere mich, wenn die Fortschrittsanzeige…"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
 msgstr "Übertritt die Zielllinie"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
 msgstr "Erreicht das Ziel"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
 msgstr "Unterschreitet die Ziellinie"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
 msgstr "Unterschreitet das Ziel"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:512
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
 msgstr "Das erste Mal, wenn es überschneidet oder dauerhaft?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:513
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
 msgstr "Das erste Mal, sobald das Ziel erreicht wird oder dauerhaft?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
 msgstr "Das erste Mal"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:516
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
 msgstr "Dauerhaft"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:619
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
 msgstr "An wen möchtest du die Alarme senden?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:630
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
 msgstr "E-Mail Alarme zu:"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:672
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
 msgstr "{0} zielbasierte Alarme werden für Diagramme mit mehr als einer Zeile noch nicht unterstützt, daher wird dieser Alarm immer dann gesendet, wenn das Diagramm {1} hat."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
 msgstr "Ergebnis"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:679
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
 msgstr "{0} Diese Art der Warnung ist am nützlichsten, wenn deine gespeicherte Frage {1} keine Ergebnisse liefert, du aber wissen möchtest, wann sie es tut."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:680
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
 msgstr "Tipp"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
 msgstr "normalerweise"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:57
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
 msgstr "Wähle ein Abschnitt oder eine Tabelle"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
 msgstr "Wähle eine Datenbank"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:88
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
 msgstr "Wähle..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:128
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
 msgstr "Wähle eine Tabelle"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:793
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
 msgstr "Es wurde keine Tabelle in der Datenbank gefunden."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:830
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
 msgstr "Fehlt hier eine Frage?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:834
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
 msgstr "Lerne mehr über verschachtelte Abfragen"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:868
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
 msgstr "Felder"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:946
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
 msgstr "Es wurden keine Abschnitte gefunden."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:969
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
 msgstr "Finde ein Segment"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:46
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
 msgstr "Weniger anzeigen"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:56
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
 msgstr "Mehr anzeigen"
 
@@ -4987,60 +4995,65 @@ msgid "Pick a field to sort by"
 msgstr "Wähle ein Feld, nach dem sortiert werden soll"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
 msgstr "Sortieren"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
 msgstr "Zeilenlimit"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:69
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
 msgstr "Unbekanntes Feld"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
 msgstr "Feld"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:114
+#: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
 msgstr "Stimmt überein"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
+#: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Füge Filter hinzu, um deine Antwort einzugrenzen"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:284
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
 msgstr "Füge eine Gruppierung hinzu"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:322
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:102
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:113
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:152
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:194
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:59
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:68
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:75
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:225
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:231
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:237
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:70
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:75
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:64
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:89
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:131
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:176
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:302
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:308
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:314
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Daten"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:352
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
 msgstr "Gefiltert nach"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:369
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
 msgstr "Ansicht"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:386
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
 msgstr "Gruppiert nach"
 
@@ -5048,23 +5061,23 @@ msgstr "Gruppiert nach"
 msgid "None"
 msgstr "Nichts"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:345
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
 msgstr "Diese Frage wurde in {0} geschrieben."
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:353
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
 msgstr "Verberge Editor"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:354
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
 msgstr "Verberge Abfrage"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
 msgstr "Öffne Editor"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:360
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
 msgstr "Zeige Abfrage"
 
@@ -5085,15 +5098,15 @@ msgstr "Lade Daten herunter"
 msgid "Warning"
 msgstr "Warnung"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:52
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
 msgstr "Deine Antwort hat eine große Anzahl von Zeilen, so dass es eine Weile dauern kann, sie herunterzuladen."
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:53
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
 msgstr "Die maximale Größe für einen Download beträgt 1 Millionen Zeilen."
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:232
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
 msgstr "Ändere Frage"
 
@@ -5109,17 +5122,17 @@ msgstr "ABBRECHEN"
 msgid "Move question"
 msgstr "Verschiebe Frage"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:283
+#: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
 msgstr "In welcher Sammlung sollte dies sein?"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:313
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:110
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
+#: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
 msgstr "Variablen"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:432
+#: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
 msgstr "Lerne etwas über deine Daten"
 
@@ -5163,11 +5176,11 @@ msgstr "{0} für diese Frage"
 msgid "Convert this question to {0}"
 msgstr "Konvertiere diese Frage zu {0}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:122
+#: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
 msgstr "Diese Frage wird ungefähr {0} zum aktualisieren benötigen"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:131
+#: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
 msgstr "{0} aktualisiert"
 
@@ -5186,11 +5199,11 @@ msgstr "Zeige erste {0} {1}"
 msgid "Showing {0} {1}"
 msgstr "Zeige {0} {1}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:281
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
 msgstr "Betreibe Wissenschaft"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:294
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
 msgstr "Wenn du mir ein paar Daten gibst, kann ich dir etwas Aufregendes zeigen. Führe  eine Abfrage durch!"
 
@@ -5198,9 +5211,9 @@ msgstr "Wenn du mir ein paar Daten gibst, kann ich dir etwas Aufregendes zeigen.
 msgid "How do I use this thing?"
 msgstr "Wie benutze ich das?"
 
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:28
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
-msgstr "Bekomme Antworten"
+msgstr "Antwort bekommen"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:12
 msgid "It's okay to play around with saved questions"
@@ -5226,39 +5239,39 @@ msgstr "Entschuldigung. Etwas ist schief gelaufen."
 msgid "Group time by"
 msgstr "Gruppiere Zeit nach"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:46
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
 msgstr "Deine Frage dauert zu lange"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:47
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
 msgstr "Wir haben nicht rechtzeitig eine Antwort von der Datenbank erhalten, also mussten wir den Vorgang stoppen. Du kannst es in einer Minute noch einmal versuchen. Sollte das Problem weiterhin besteht, kannst du einen Admin per E-Mail benachrichtigen."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:55
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
 msgstr "Es liegen Server-Probleme vor"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:56
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
 msgstr "Versuche, die Seite nach ein oder zwei Minuten zu aktualisieren. Wenn das Problem weiterhin besteht, empfehlen wir dir, einen Admin zu kontaktieren."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:88
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
 msgstr "Es gab Probleme mit deiner Frage"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:89
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
 msgstr "Meistens wird dies durch eine ungültige Auswahl oder einen falschen Eingabewert verursacht. Überprüfen deine Eingaben und versuche es erneut."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:60
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
 msgstr "Das könnte die Antwort sein, nach der du suchst. Wenn nicht, versuche, deine Filter zu entfernen oder zu ändern, um sie weniger spezifisch zu machen."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
 msgstr "Du kannst auch {0}, wenn es einige Ergebnisse gibt."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:68
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
 msgstr "bekomme einen Alarm"
 
@@ -5266,11 +5279,11 @@ msgstr "bekomme einen Alarm"
 msgid "Back to last run"
 msgstr "Zurück zur vorherigen Ausführung"
 
-#: frontend/src/metabase/query_builder/components/VisualizationSettings.jsx:100
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
 msgstr "Visualisierung"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:96
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
 msgstr "Keine Beschreibung hinterlegt."
 
@@ -5282,7 +5295,7 @@ msgstr "Benutze es für die aktuelle Frage"
 msgid "Potentially useful questions"
 msgstr "Potentiell nützliche Frage"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:166
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
 msgstr "Gruppiert nach {0}"
 
@@ -5295,14 +5308,14 @@ msgstr "Summe aller Werte von {0}"
 msgid "All distinct values of {0}"
 msgstr "Alle eindeutigen Werte von {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:187
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
 msgstr "Anzahl von {0}, gruppiert nach {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5318,34 +5331,34 @@ msgstr "Daten Referenz"
 msgid "Learn more about your data structure to ask more useful questions"
 msgstr "Erfahre mehr über deine Datenstruktur, um weitere nützliche Fragen zu stellen"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:58
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:84
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
 msgstr "Die Metadaten der Tabelle konnten vor dem Erstellen einer neuen Frage nicht gefunden werden"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:80
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
 msgstr "Siehe {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:94
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
 msgstr "Metrik-Definition"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:118
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
 msgstr "Gefiltert nach {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:127
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
 msgstr "Anzahl von {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
 msgstr "Betrachte all {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:148
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
 msgstr "Abschnitts-Definition"
 
@@ -5357,7 +5370,7 @@ msgstr "Beim Laden der Tabelle ist ein Fehler aufgetreten"
 msgid "See the raw data for {0}"
 msgstr "Siehe die Rohdaten für {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:180
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
 msgstr "Mehr"
 
@@ -5369,24 +5382,24 @@ msgstr "Ungültiger Ausdruck"
 msgid "unknown error"
 msgstr "unbekannter Fehler"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:46
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
 msgstr "Feld-Formel"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:57
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Stelle es dir wie das Schreiben einer Formel in einem Tabellenkalkulationsprogramm vor: du kannst Zahlen, Felder und mathematische Symbole wie + und weitere Funktionen für Tabellen verwenden. Du kannst also so etwas wie Zwischensumme eingeben."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
 msgstr "Mehr erfahren"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:66
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
 msgstr "Benenne es"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:72
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
 msgstr "Etwas genau Beschreibendes"
 
@@ -5438,7 +5451,8 @@ msgstr "wahr"
 msgid "false"
 msgstr "falsch"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
 msgstr "Füge einen Filter hinzu"
 
@@ -5446,15 +5460,15 @@ msgstr "Füge einen Filter hinzu"
 msgid "Item"
 msgstr "Element"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:221
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
 msgstr "Letzte"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:252
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
 msgstr "Aktuell"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:278
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
@@ -5465,7 +5479,7 @@ msgid "Enter desired number"
 msgstr "Gib die gewünschte Zahl ein"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:100
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
 msgstr "Leer"
 
@@ -5489,35 +5503,35 @@ msgstr "Du kannst mehrere Werte durch Kommas getrennt eingeben"
 msgid "Enter desired text"
 msgstr "Gewünschten Text eingeben"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
 msgstr "Versuche es"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
 msgstr "Wofür steht es?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
 msgstr "Mit Variablen kannst du Werte in deinen Abfragen dynamisch durch Filter-Widgets oder über die URL ersetzen."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
 msgstr "{0} erzeugt in diesem SQL-Template eine Variable namens \"variable_name\". Variablen können im Seitenmenü mit Typen versehen werden, die ihr Verhalten verändern. Bei allen  Variablentypen, außer dem \"Feldfilter\", wird automatisch ein Filter-Widget auf diese Frage gesetzt; bei Feldfiltern ist dies optional. Wenn dieses Filter-Widget ausgefüllt ist, ersetzt dieser Wert die Variable in der SQL-Vorlage."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:121
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
 msgstr "Feldfilter"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:123
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Wenn du einer Variablen den Typ \"Feldfilter\" zuweist, kannst du SQL-Karten mit Dashboard-Filter-Widgets verknüpfen oder mehrere Arten von Filter-Widgets für deine SQL-Frage verwenden. Eine Feldfiltervariable fügt ähnliche SQL Abfragen wie die Oberfläche des Abfragengenerators ein, sobald ein Filter auf eine Spalte gelegt wird."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:126
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
 msgstr "Wenn du eine Feldfiltervariable hinzufügst, musst du sie einem bestimmten Feld zuordnen. Du kannst dann wählen, ob du ein Filter-Widget für deine Frage anzeigen möchtest. Aber selbst wenn du es nicht möchtest, kannst du jetzt deine Feldfilter-Variable einem Dashboard-Filter zuordnen. Feldfilter sollten innerhalb einer \"WHERE\"-Klausel verwendet werden."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:130
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
 msgstr "Optionale Klausel"
 
@@ -5525,59 +5539,61 @@ msgstr "Optionale Klausel"
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
 msgstr "Klammern um eine {0} erzeugen in der Vorlage eine optionale Klausel. Wenn \"Variable\" gesetzt ist, dann wird die gesamte Klausel in die Vorlage eingefügt. Wenn nicht, dann wird die gesamte Klausel ignoriert."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:142
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
 msgstr "Um mehrere optionale Klauseln zu verwenden, kannst du mindestens eine nicht-optionale WHERE-Klausel einfügen, gefolgt von optionalen Klauseln, die mit \"AND\" beginnen."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
 msgstr "Lies die Dokumentation"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:127
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
 msgstr "Filterbezeichnung"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:139
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
 msgstr "Variablentyp"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:143
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
 msgstr "Text"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:150
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:119
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
 msgstr "Datum"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
 msgstr "Feldfilter"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:157
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
 msgstr "Feld soll Folgendes verknüpft werden"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
 msgstr "Feld-Widget-Typ"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:201
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
 msgstr "Wird benötigt?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:211
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
 msgstr "Standard Filter-Widget-Wert"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:46
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
 msgstr "Archivieren dieser Frage?"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:57
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Diese Frage wird von allen Dashboards oder Pulse, die sie verwenden, entfernt."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:136
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
 msgstr "Frage"
 
@@ -5594,21 +5610,21 @@ msgstr "Du editierst diese Seite"
 msgid "See this {0}"
 msgstr "Betrachte dies {0}"
 
-#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:120
+#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
 msgstr "Ein Subset von"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:68
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
 msgstr "Wähle einen Feldtyp"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:57
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
 msgstr "Kein Feldtyp"
 
@@ -5617,16 +5633,16 @@ msgid "by"
 msgstr "nach"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
-#: frontend/src/metabase/reference/databases/FieldList.jsx:152
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
+#: frontend/src/metabase/reference/databases/FieldList.jsx:155
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
 msgstr "Feldtyp"
 
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:72
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
 msgstr "Wähle einen Fremdschlüssel"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:53
+#: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
 msgstr "Betrachte die  {0} Formel"
 
@@ -5643,12 +5659,12 @@ msgid "Nothing important yet"
 msgstr "Nichts Interessantes momentan"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:168
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:233
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:211
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:215
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:219
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:229
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:236
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:214
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
 msgstr "Nichts Interessantes bisher"
 
@@ -5657,12 +5673,12 @@ msgid "Things to be aware of about this {0}"
 msgstr "Dinge, die man darüber wissen sollte {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:178
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:243
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:221
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:225
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:229
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:239
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:246
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:224
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
 msgstr "Noch nichts zu beachten"
 
@@ -5724,15 +5740,15 @@ msgstr "Grund der Änderung"
 msgid "Leave a note to explain what changes you made and why they were required"
 msgstr "Hinterlasse eine Notiz, um zu erklären, welche Änderungen du vorgenommen hast und warum sie erforderlich waren"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:166
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
 msgstr "Warum ist diese Datenbank interessant"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:176
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
 msgstr "Dinge über die Datenbank, auf die man achten sollte"
 
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:46
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
 msgstr "Datenbanken und Tabellen"
@@ -5740,42 +5756,42 @@ msgstr "Datenbanken und Tabellen"
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:41
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:170
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:173
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:34
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:184
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:187
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:30
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:188
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:187
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:191
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:190
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
 msgstr "Details"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
-#: frontend/src/metabase/reference/databases/TableList.jsx:111
+#: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
 msgstr "Tabellen in {0}"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:222
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:200
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:218
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:203
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
 msgstr "Tatsächlicher Name in der Datenbank"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:231
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:227
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
 msgstr "Warum ist dieses Feld interessant"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:241
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:237
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
 msgstr "Dinge, die man bei diesem Feld beachten sollte"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:253
-#: frontend/src/metabase/reference/databases/FieldList.jsx:155
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:249
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
+#: frontend/src/metabase/reference/databases/FieldList.jsx:158
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
 msgstr "Datentyp"
 
@@ -5784,13 +5800,13 @@ msgstr "Datentyp"
 msgid "Fields in this table will appear here as they're added"
 msgstr "Felder in dieser Tabelle erscheinen hier, wenn sie hinzugefügt werden"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:134
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:135
+#: frontend/src/metabase/reference/databases/FieldList.jsx:137
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
 msgstr "Felder in {0}"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:149
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:150
+#: frontend/src/metabase/reference/databases/FieldList.jsx:152
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
 msgstr "Feldname"
 
@@ -5815,7 +5831,10 @@ msgstr "Datenbanken werden hier erscheinen, sobald Deine Administratoren einige 
 msgid "Connect a database"
 msgstr "Eine Datenbank verbinden"
 
+#. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
+#. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
+#: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
 msgstr "Anzahl von {0}"
 
@@ -5823,11 +5842,11 @@ msgstr "Anzahl von {0}"
 msgid "See raw data for {0}"
 msgstr "Siehe Rohdaten für {0}"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:209
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
 msgstr "Warum ist diese Tabelle interessant"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:219
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
 msgstr "Dinge, auf die man bei dieser Tabelle achten sollte"
 
@@ -5839,16 +5858,16 @@ msgstr "Tabellen dieser Datenbank werden hier erscheinen, sobald sie hinzugefüg
 msgid "Questions about this table will appear here as they're added"
 msgstr "Fragen über diese Tabelle werden hier erscheinen, sobald sie hinzugefügt sind"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:71
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:75
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:74
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
 msgstr "Fragen zum {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
 msgstr "Erstellt {0} von {1}"
 
@@ -5860,151 +5879,152 @@ msgstr "Felder dieser Tabelle"
 msgid "Questions about this table"
 msgstr "Fragen über diese Tabelle"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:157
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
 msgstr "Hilf deinem Team mit deinen Daten loszulegen."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:159
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
 msgstr "Zeige Deinem Team die wichtigsten Informationen, indem du dein bestes Dashboard, sowie deine besten Metriken und Segmente auswählst."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:165
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
 msgstr "Loslegen"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:173
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
 msgstr "Unser wichtigstes Dashboard"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:188
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
 msgstr "Zahlen, denen wir Aufmerksamkeit schenken"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:213
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
 msgstr "Metriken sind wichtige Zahlen, um die sich dein Unternehmen kümmert. Sie stellen oft einen zentralen Indikator für die Geschäftsentwicklung dar."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:221
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
 msgstr "Alle Metriken ansehen"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:235
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
 msgstr "Segmente und Tabellen"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
+#: frontend/src/metabase/home/containers/SearchApp.jsx:83
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
 msgstr "Tabellen"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:262
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
 msgstr "Segmente und Tabellen sind die Bausteine der Daten deines Unternehmens. Tabellen sind Sammlungen von rohen Informationen während Segmente spezifische Ausschnitte mit spezifischer Bedeutung sind. Siehe {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:267
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
 msgstr "Tabellen sind die Bausteine deiner Unternehmensdaten."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:277
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
 msgstr "Alle Segmente ansehen"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:293
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
 msgstr "Alle Tabellen anzeigen"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:301
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
 msgstr "Was du sonst noch über unsere Daten wissen sollten"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
 msgstr "Erfahre mehr"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:307
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
 msgstr "Ein guter Weg um deine Daten kennenzulernen ist es Zeit damit zu verbringen die verschiedenen Tabellen und andere Informationen die dir zur Verfügung stehen zu erkunden. Es wird eine Weile dauern, aber du wirst dir Namen und Bedeutungen über die Zeit merken können."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:313
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
 msgstr "Entdecke deine Daten"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:321
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
 msgstr "Hast Du Fragen?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:326
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
 msgstr "Kontakt {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:248
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
 msgstr "Helfe neuen Metabase Nutzern sich zurecht zu finden."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:251
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
 msgstr "Der Getting-Started-Guide hebt das Dashboard, die Metriken, die Segmente und Tabellen hervor, die am wichtigsten sind, und informiert deine Nutzer über wichtige Dinge, die sie wissen sollten, bevor sie sich in die Daten eingraben."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:258
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
 msgstr "Existiert ein für das Team wichtiges Dashboard?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:260
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
 msgstr "Erstelle jetzt ein Dashboard"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:266
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
 msgstr "Welches ist das wichtigste Dashboard?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:285
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
 msgstr "Hast du häufig referenzierte Metriken?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:287
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
 msgstr "Lerne wie man eine Metrik definiert"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:300
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
 msgstr "Was sind deine 3-5 am häufigsten referenzierten Metriken?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:344
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
 msgstr "Füge eine andere Metrik hinzu"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:357
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
 msgstr "Hast du häufig referenzierte Segmente oder Tabellen?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:359
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
 msgstr "Lerne ein Segment zu erstellen"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:372
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
 msgstr "Was sind deine 3-5 am häufigsten referenzierten Segmente oder Tabellen, die für die Benutzer nützlich sind?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:418
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
 msgstr "Ein weiteres Segment oder weitere Tabelle hinzufügen"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:427
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
 msgstr "Gibt es irgendetwas, was deine Benutzer verstehen oder wissen sollten, bevor sie auf die Daten zugreifen?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:433
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
 msgstr "Was sollte ein Benutzer dieser Daten wissen bevor auf sie zugegriffen wird?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:437
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
 msgstr "Zum Beispiel Erwartungen rund um den Datenschutz und die Nutzung, häufige Fallstricke oder Missverständnisse, Informationen über die Leistung von einem Data Warehouse, rechtliche Hinweise, etc."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
 msgstr "Gibt es jemanden den deine Nutzer zur Unterstützung kontaktieren sollten wenn Ihnen diese Anleitung nicht weiterhilft?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:457
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
 msgstr "Wen sollten Nutzer kontaktieren wenn sie Unterstützung zu diesen Daten benötigen?"
 
@@ -6013,39 +6033,39 @@ msgstr "Wen sollten Nutzer kontaktieren wenn sie Unterstützung zu diesen Daten 
 msgid "Please enter a revision message"
 msgstr "Bitte gib eine Änderungsnachricht ein"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:213
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
 msgstr "Weshalb diese Metrik interessant ist"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:223
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
 msgstr "Dinge, auf die man bei der Metrik achten sollte"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:233
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
 msgstr "Wie diese Metrik kalkuliert wird"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:235
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
 msgstr "Keine Information, wie es kalkuliert wurde"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:293
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
 msgstr "Andere Felder, nach denen die Metrik gruppiert werden kann"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:294
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
 msgstr "Felder, nach denen die Metrik gruppiert werden kann"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:23
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Metriken sind die offiziellen Zahlen, um die sich dein Team kümmert"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Metriken werden hier erscheinen, sobald die Administratoren sie erstellen"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
 msgstr "Lerne Metriken zu erstellen"
 
@@ -6057,9 +6077,9 @@ msgstr "Fragen zu dieser Metrik erscheinen hier, wenn sie hinzugefügt werden"
 msgid "There are no revisions for this metric"
 msgstr "Es gibt keine Revisionen dieser Metrik"
 
-#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:88
-#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
-#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:88
+#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
+#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
+#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
 msgstr "Revisionshistorie für {0}"
 
@@ -6067,27 +6087,27 @@ msgstr "Revisionshistorie für {0}"
 msgid "X-ray this metric"
 msgstr "X-Ray für diese Metrik"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:217
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
 msgstr "Weshalb dieser Abschnitt interessant ist"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:227
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
 msgstr "Wissenswertes über diesen Abschnitt"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
 msgstr "Abschnitte sind interessante Teilmengen von Tabellen"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Die Definition gemeinsamer Abschnitte für Dein Team macht es noch einfacher, Fragen zu stellen"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
 msgstr "Abschnitte erscheinen hier, sobald dein Administrator welche erstellt hat"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
 msgstr "Lerne wie man Abschnitte erstellt"
 
@@ -6115,7 +6135,7 @@ msgstr "X-Ray für diesen Abschnitt"
 msgid "Login"
 msgstr "Anmeldung"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:130
+#: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
 msgstr "Suche"
@@ -6132,99 +6152,99 @@ msgstr "Neue Frage"
 msgid "Select the type of Database you use"
 msgstr "Wähle den Datenbanktyp"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:141
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
 msgstr "Füge deine Daten hinzu"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:145
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
 msgstr "Ich füge meine eigenen Daten später hinzu"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
 msgstr "Stelle Verbindung zu {0} her"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:165
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
 msgstr "Du benötigst Informationen wie Benutzername oder das Passwort für die Datenbank. Wenn Du das im Moment nicht hast, kann Metabase zu Beginn auch Beispieldaten bereitstellen."
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:196
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
 msgstr "Ich füge meine Daten später hinzu"
 
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:41
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
 msgstr "Administriere automatische Überprüfungen"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:53
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
 msgstr "Einstellungen zu Benutzungsdaten"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
 msgstr "Danke, dass sie uns bei der Verbesserung helfen"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:57
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
 msgstr "Wir sammeln keine Benutzerereignisse"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:76
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Um uns bei der Verbesserung von Metabase zu helfen, möchten wir bestimmte Daten über die Nutzung durch Google Analytics sammeln."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
 msgstr "Hier ist eine vollständige Liste von allem, was wir verfolgen und weshalb."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:98
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Erlaube Metabase das anonyme Sammeln von Ereignisinformationen"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} sammelt alles über deine Daten oder Frageergebnisse."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:106
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
 msgstr "niemals"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
 msgstr "Die gesamte Sammlung ist völlig anonym."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Die Sammlung kann an jeder beliebigen Stelle in den administrativen Einstellungen deaktiviert werden."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:45
+#: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
 msgstr "Wenn du feststeckst"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:52
+#: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
 msgstr "unsere Startanleitung"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:53
+#: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
 msgstr "ist nur einen Klick entfernt."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:95
+#: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
 msgstr "Willkommen bei Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:96
+#: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Sieht so aus, als ob alles funktioniert. Lass uns gemeinsam kennenlernen, deine Daten verbinden und anfangen, ein paar Antworten für dich zu finden!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:100
+#: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
 msgstr "Lass uns loslegen"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:145
+#: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
 msgstr "Es ist alles eingerichtet!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:156
+#: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
 msgstr "Führe mich zu Metabase"
 
@@ -6241,7 +6261,7 @@ msgid "Create a password"
 msgstr "Erstelle ein Passwort"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:116
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
 msgstr "Pssst..."
 
@@ -6434,11 +6454,11 @@ msgstr "Mit Google E-Mail Adresse einloggen"
 msgid "User Details"
 msgstr "Benutzerdetails"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:275
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
 msgstr "Auf Standard zurücksetzen"
 
-#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:133
+#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
 msgstr "Unbekannte Karte"
 
@@ -6450,24 +6470,24 @@ msgstr "Die Grid-Map benötigt klassifizierte Längen- und Breitengrade. "
 msgid "more"
 msgstr "mehr"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:101
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
 msgstr "Welche Felder möchtest du für die X- und Y-Achse verwenden?"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:103
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:60
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
 msgstr "Felder auswählen"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:204
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
 msgstr "Als Standard-Ansicht speichern"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
 msgstr "Zeichne eine Box um zu filtern "
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
 msgstr "Filter abbrechen"
 
@@ -6475,7 +6495,7 @@ msgstr "Filter abbrechen"
 msgid "Pin Map"
 msgstr "Pin-Karte"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:303
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
 msgstr "Nicht gesetzt"
 
@@ -6484,31 +6504,31 @@ msgid "Rows {0}-{1} of {2}"
 msgstr "Zeilen {0}-{1} von {2}"
 
 #. Daten auf {0} Zeilen gekürzt.
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:189
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
 msgstr "Daten auf {0} Zeilen gekürzt."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:364
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
 msgstr "Konnte keine Visualisierung finden"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:371
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
 msgstr "Konnte das Diagramm mit diesen Daten nicht anzeigen."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:469
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
 msgstr "Keine Ergebnisse!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:490
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
 msgstr "Warte weiterhin..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:493
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
 msgstr "Das dauert gewöhnlich durchschnittlich {0}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:499
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Das ist ein wenig lange für ein Dashboard)"
 
@@ -6524,11 +6544,11 @@ msgstr "Wähle ein Feld"
 msgid "error"
 msgstr "Fehler"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:126
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
 msgstr "Klicke und ziehe um deren Reihenfolge zu ändern"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:139
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
 msgstr "Füge Felder von der folgenden Liste hinzu"
 
@@ -6618,7 +6638,7 @@ msgid "Highlight the whole row"
 msgstr "Die gesamte Zeile hervorheben"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:98
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Farben"
 
@@ -6683,20 +6703,20 @@ msgstr "Die Visualisierung mit dieser Kennung ist bereits registriert: "
 msgid "No visualization for {0}"
 msgstr "Keine Visualisierung für {0}"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:75
+#: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
 msgstr "\"{0}\" ist ein unaggregiertes Feld: Wenn es mehr als einen Wert an einem Punkt auf der x-Achse hat, werden die Werte zusammengefasst."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:91
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
 msgstr "Dieser Diagramm-Typ benötigt mindestens 2 Spalten."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:96
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
 msgstr "Dieser Diagramm-Typ unterstützt nicht mehr als {0} Datenreihen."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:51
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:297
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
 msgstr "Ziel"
 
@@ -6736,26 +6756,26 @@ msgstr "Einstellungen anpassen"
 msgid "xValues missing!"
 msgstr "x-Werte fehlen!"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:114
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "X-Achse"
 
 #. Weitere Achse hinzufügen
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:140
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
 msgstr "Sekundärachse hinzufügen"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:153
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Y-Achse"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:178
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
 msgstr "Eine weitere Serie hinzufügen..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:195
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
 msgstr "Blasengröße"
 
@@ -6769,7 +6789,7 @@ msgid "Curve"
 msgstr "Kurve"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:69
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
 msgstr "Schritt"
 
@@ -6777,27 +6797,27 @@ msgstr "Schritt"
 msgid "Show point markers on lines"
 msgstr "Zeige Datenpunkte auf Linien"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:235
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
 msgstr "Stapeln"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:239
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
 msgstr "Nicht stapeln"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:240
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
 msgstr "Stapel"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:241
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
 msgstr "Stapel - 100%"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:300
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
 msgstr "Ziel anzeigen"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:306
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
 msgstr "Zielwert"
 
@@ -6817,126 +6837,126 @@ msgstr "Nichts"
 msgid "Linear Interpolated"
 msgstr "Linear interpoliert"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:371
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
 msgstr "X-Achsen Skala"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
 msgstr "Zeitreihe"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:391
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:409
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:381
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
 msgstr "Linear"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:410
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:383
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
 msgstr "Potenz"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:384
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
 msgstr "Logarithmus"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:396
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
 msgstr "Histogramm"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:398
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
 msgstr "Ordnungszahl"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:404
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
 msgstr "Y-Achsen-Skala"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:417
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
 msgstr "Zeige Linie und Markierungen der X-Achse"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:423
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
 msgstr "Kompakt"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:424
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
 msgstr "Drehen 45°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
 msgstr "Drehen 90°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
 msgstr "Zeige Linie und Markierungen der Y-Achse"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
 msgstr "Automatische Y-Achsen-Skalierung"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
 msgstr "Verwende bei Bedarf eine geteilte y-Achse"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
 msgstr "Beschriftung auf der X-Achse anzeigen"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:501
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
 msgstr "Beschriftung X-Achse"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:510
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
 msgstr "Beschriftung auf der Y-Achse anzeigen"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:516
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
 msgstr "Beschriftung Y-Achse"
 
-#: frontend/src/metabase/visualizations/lib/utils.js:129
+#: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
 msgstr "Standardabweichung"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:275
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:17
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:256
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
 msgstr "Fläche"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
 msgstr "Flächendiagramm"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:276
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:16
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:257
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
 msgstr "Balken"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
 msgstr "Balkendiagramm"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
 msgstr "Welche Felder möchtest du nutzen?"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
 msgstr "Trichter"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:76
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:76
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Messen"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
 msgstr "Trichter-Typ"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:88
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
 msgstr "Balkendiagramm"
 
@@ -6944,141 +6964,141 @@ msgstr "Balkendiagramm"
 msgid "line chart"
 msgstr "Liniendiagramm"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:224
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Bitte wähle die Längen- und Breitengrad-Spalten in den Diagramm-Einstellungen."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
 msgstr "Bitte wähle eine Region-Karte."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Bitte wähle eine Region sowie die metrischen Spalten in den Diagramm-Einstellungen."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:38
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Karte"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:53
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
 msgstr "Kartentyp"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:57
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:149
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
 msgstr "Region-Karte"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
 msgstr "Pin-Karte"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
 msgstr "Pin-Typ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
 msgstr "Kacheln"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
 msgstr "Markierungen"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
 msgstr "Breitengrad-Feld"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
 msgstr "Längengrad-Feld"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:142
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:168
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
 msgstr "Metrisches Feld"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
 msgstr "Region-Feld"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
 msgstr "Radius"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:198
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
 msgstr "Unschärfe"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
 msgstr "Min. Transparenz"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
 msgstr "Max. Zoom"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:175
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
 msgstr "Keine Beziehungen gefunden."
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:213
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:290
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
 msgstr "{0} ist verbunden mit:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:47
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
 msgstr "Objekt Detail"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
 msgstr "Objekt"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
 msgstr "Gesamt"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Welche Spalten möchtest du verwenden?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:44
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Torte"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Dimension"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:81
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Legende anzeigen"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:86
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Zeige Prozentangaben in der Legende"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:92
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Mindestanteil"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:146
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
 msgstr "Ziel erreicht"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:148
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
 msgstr "Ziel übertroffen"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
 msgstr "Ziel {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
 msgstr "Fortschrittsanzeige benötigt eine Zahl."
 
@@ -7086,9 +7106,9 @@ msgstr "Fortschrittsanzeige benötigt eine Zahl."
 msgid "Progress"
 msgstr "Fortschritt"
 
-#: frontend/src/metabase/entities/collections.js:108
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:176
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:57
+#: frontend/src/metabase/entities/collections.js:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Farbe"
 
@@ -7100,7 +7120,7 @@ msgstr "Balkendiagramm"
 msgid "row chart"
 msgstr "Balkendiagramm"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:357
+#: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
 msgstr "Trennzeichen-Stil"
 
@@ -7108,15 +7128,15 @@ msgstr "Trennzeichen-Stil"
 msgid "Number of decimal places"
 msgstr "Anzahl der Dezimalstellen"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:381
+#: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
 msgstr "Ein Präfix hinzufügen"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:385
+#: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
 msgstr "Ein Suffix hinzufügen"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:374
+#: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
 msgstr "Multiplizieren mit einer Zahl"
 
@@ -7128,7 +7148,7 @@ msgstr "Verstreuen"
 msgid "scatter plot"
 msgstr "Punktdiagramm"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:78
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
 msgstr "Pivottabelle erzeugen"
 
@@ -7137,7 +7157,8 @@ msgid "Visible fields"
 msgstr "Sichtbare Felder"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-msgid "Write here, and use Markdown if you''d like"
+#, fuzzy
+msgid "Write here, and use Markdown if you'd like"
 msgstr "Schreibe hier und verwende Markdown, wenn du möchtest"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
@@ -7178,13 +7199,13 @@ msgstr "Rechts"
 msgid "Show background"
 msgstr "Hintergrund anzeigen"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:553
+#: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "Klasse"
 msgstr[1] "Klassen"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:559
+#: frontend/src/metabase-lib/lib/Dimension.js:731
 #, fuzzy
 msgid "Auto binned"
 msgstr "Automatische Klassifizierung"
@@ -7457,26 +7478,26 @@ msgstr "Automatische Klasseneinteilung"
 msgid "Don''t bin"
 msgstr "Keine Klasseneinteilung"
 
-#: frontend/src/metabase/lib/query_time.js:193 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Tag"
 msgstr[1] "Tage"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
-#: frontend/src/metabase/lib/query_time.js:189 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minute"
 msgstr[1] "Minuten"
 
-#: frontend/src/metabase/lib/query_time.js:191 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Stunde"
 msgstr[1] "Stunden"
 
-#: frontend/src/metabase/lib/query_time.js:199 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
 msgstr[0] "Quartal"
@@ -7547,7 +7568,7 @@ msgid "Bin every 20 degrees"
 msgstr "Eine Klasse pro 20 Grad"
 
 #. returns `true` if successful -- see JavaDoc
-#: src/metabase/api/tiles.clj src/metabase/pulse/render.clj
+#: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 #, fuzzy
 msgid "No appropriate image writer found!"
 msgstr "Kein geeigneter Bildschreiber gefunden!"
@@ -7620,10 +7641,12 @@ msgstr "kumulierte Summe"
 msgid "{0} and {1}"
 msgstr "{0} und {1}"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} of {1}"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
 msgstr "{0} durch {1} "
@@ -7636,9 +7659,12 @@ msgstr "{0} im {1} Segment"
 msgid "{0} segment"
 msgstr "{0} Segment"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
-msgstr "{0} Metrik"
+msgid_plural "{0} metrics"
+msgstr[0] "{0} Metrik"
+msgstr[1] "{0} Metriken"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
@@ -8235,6 +8261,7 @@ msgid "Cannot save Question: source query has circular references."
 msgstr "Kann diese Frage nicht speichern: Quell-Abfrage hat zirkulare Referenzen."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
+#: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
 msgstr "Karte {0} existiert nicht."
@@ -8645,7 +8672,7 @@ msgstr "Unerkannter Kanaltyp {0}"
 msgid "Error sending notification!"
 msgstr "Fehler beim Versenden einer Benachrichtigung!"
 
-#: src/metabase/pulse/color.clj
+#: src/metabase/pulse/render/color.clj
 #, fuzzy
 msgid "Can't find JS color selector at ''{0}''"
 msgstr "Kann JS Farbwähler bei \"{0}\" nicht finden"
@@ -8962,43 +8989,43 @@ msgstr "Datenberechtigungen"
 msgid "Collection permissions"
 msgstr "Sammlungsberechtigungen"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:56
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
 msgstr "Alle Sammlungsberechtigungen sehen"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:25
+#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
 msgstr "Auch Untersammlungen ändern"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:282
+#: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
 msgstr "Kann diese Sammlung und ihre Inhalte editieren"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:289
+#: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
 msgstr "Kann Objekte in dieser Sammlung sehen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:749
+#: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
 msgstr "Sammlungszugriff"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:825
+#: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Diese Gruppe hat die Erlaubnis, mindestens eine Untersammlung dieser Sammlung zu sehen."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:830
+#: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Diese Gruppe hat die Erlaubnis, mindestens eine Untersammlung dieser Sammlung zu bearbeiten."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
 msgstr "Untersammlungen anzeigen"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:211
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
 msgstr "Angemeldet bleiben"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:95
+#: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
 msgstr "Dieses Schema durchleuchten"
 
@@ -9030,31 +9057,32 @@ msgstr "Speichere Dashboards, Fragen und Sammlungen in \"{0}\""
 msgid "Access dashboards, questions, and collections in \"{0}\""
 msgstr "Öffne Dashboards, Fragen und Sammlungen in \"{0}\""
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:221
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
 msgstr "Vergleichen"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:229
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
 msgstr "Verkleinern"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:233
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
 msgstr "Ähnlich"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:293
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
 msgstr "Mehr X-Rays"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:46
+#: frontend/src/metabase/home/containers/SearchApp.jsx:40
+#: src/metabase/pulse/render/body.clj
 msgid "No results"
 msgstr "Keine Ergebnisse"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:47
+#: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
 msgstr "Metabase konnte keine Ergebnisse für deine Suche finden."
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:111
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
 msgstr "Keine Metriken"
 
@@ -9097,7 +9125,7 @@ msgstr "Fehler beim Zuweisen der Berechtigungen: {0}"
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
 msgstr "Konnte verschlüsselte Strings nicht entschlüsseln. Hast du vergessen MB_ENCRYPTION_SECRET_KEY zu setzen oder den Wert geändert?"
 
-#: frontend/src/metabase/entities/collections.js:164
+#: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
 msgstr "Alle persönlichen Sammlungen"
 
@@ -9262,18 +9290,18 @@ msgstr "N/A"
 msgid "Windows domain"
 msgstr "Windows Domain"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:509
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:515
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:490
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:499
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
 msgstr "Beschriftungen"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:329
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
 msgstr "Mitglieder hinzufügen"
 
-#: frontend/src/metabase/entities/collections.js:115
+#: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
 msgstr "Sammlung in der es gespeichert ist"
 
@@ -9294,39 +9322,39 @@ msgid "Sharing"
 msgstr "Teilen"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:234
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:270
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:299
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:305
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:313
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:321
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:218
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:251
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:280
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:286
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:294
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:302
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:80
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:85
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:91
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:97
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:50
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:56
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
 msgstr "Anzeige"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:370
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:416
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:431
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:487
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:358
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:406
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:447
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
 msgstr "Achsen"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:222
-#: frontend/src/metabase/admin/settings/selectors.js:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
+#: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
@@ -9360,20 +9388,20 @@ msgstr "X-Ray"
 msgid "Compare to the rest"
 msgstr "Vergleiche mit dem Rest"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:244
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Verwende die Java Virtual Machine (JVM) Zeitzone"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
 msgstr "Wir empfehlen dir diesen Wert zu belassen, es sei denn, du machst manuelle Zeitzone-Castings in vielen oder den meisten deiner Abfragen mit diesen Daten."
 
-#: frontend/src/metabase/containers/Overworld.jsx:310
+#: frontend/src/metabase/containers/Overworld.jsx:312
 msgid "Your team's most important dashboards go here"
 msgstr "Die wichtigsten Dashboards deines Teams kommen hier hin"
 
-#: frontend/src/metabase/containers/Overworld.jsx:311
+#: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
 msgstr "Fixiere Dashboards in {0} damit sie für jeden an dieser Stelle erscheinen"
 
@@ -9391,32 +9419,32 @@ msgstr "Verwende JVM Zeitzone"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Wir analysieren gerade die Tabellen und Felder, um dir bei der Untersuchung der Daten helfen zu können."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
 msgstr "Tipp: "
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:258
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
 msgstr "Wähle einen Währungstypen"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:318
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
 msgstr "Feld-Typ"
 
 #: frontend/src/metabase/admin/routes.jsx:109
-#: frontend/src/metabase/nav/containers/Navbar.jsx:224
+#: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
 msgstr "Fehlerbehebung"
 
-#: frontend/src/metabase/admin/settings/selectors.js:96
+#: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
 msgstr "X-Ray-Funktionen aktivieren"
 
-#: frontend/src/metabase/admin/settings/selectors.js:323
+#: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
 msgstr "Formatierungsoptionen"
 
-#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:19
+#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
 msgstr "Aufgaben-Details"
 
@@ -9456,7 +9484,7 @@ msgstr "Währung"
 msgid "Pick a user or channel..."
 msgstr "Wähle einen Benutzer oder einen Kanal"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
+#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
 msgstr "Keine Format-Einstellungen"
 
@@ -9564,32 +9592,32 @@ msgstr "HH:MM:SS.MS"
 msgid "Time style"
 msgstr "Zeit-Format "
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:299
+#: frontend/src/metabase/visualizations/lib/settings/column.js:300
 #, fuzzy
 msgid "Unit of currency"
 msgstr "Währung"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:319
+#: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
 msgstr "Style des Währungs-Labels"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:337
+#: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
 msgstr "Wo soll die Währungseinheit angezeigt werden? "
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:370
+#: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
 msgstr "Mindestanzahl an Dezimalstellen"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:271
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
 msgstr "Stapeldiagrammtyp"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:314
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
 msgstr "Ziel-Beschriftung"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:322
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
 msgstr "Trendlinie anzeigen"
 
@@ -9618,7 +9646,7 @@ msgstr "Linie + Balken"
 msgid "line and bar chart"
 msgstr "Line- und Bar-Chart"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:72
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
 msgstr "Manometerdiagramme benötigen Nummern."
 
@@ -9626,75 +9654,75 @@ msgstr "Manometerdiagramme benötigen Nummern."
 msgid "Gauge"
 msgstr "Tacho"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
 msgstr "Messbereich"
 
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
 msgstr "Feld zum Anzeigen"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
 msgstr "Letzte {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:185
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
 msgstr "{0} war {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:52
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Gruppiere nach einem Zeit-Feld, um die Entwicklung über die Zeit zu sehen"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
 msgstr "Möchtest du die positiven / negativen Farben wechseln?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
 msgstr "Spalte pivotieren"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:107
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
 msgstr "Zellspalte"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:123
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
 msgstr "Sichtbare Spalten"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:143
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
 msgstr "Bedingte Formatierung"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
 msgstr "Spalten-Überschrift"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
 msgstr "Zeige ein kleines Balkendiagramm"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:183
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
 msgstr "Link"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:187
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
 msgstr "E-Mail-Link"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
 msgstr "Bild"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:195
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:200
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
 msgstr "Betrachte es als Link oder Bild"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
 msgstr "Link-Text"
 
@@ -9959,7 +9987,7 @@ msgstr "Fehler bei der Vorverarbeitung der Abfrage"
 msgid "No native form returned."
 msgstr "Es wurde kein natives Formular zurückgegeben."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
 msgstr "Ungültige Antwort des Datenbanktreibers. No :status zur Verfügung gestellt."
 
@@ -11326,7 +11354,7 @@ msgstr "Fehlgeschlagene Einstellung `query-caching-max-kb` auf {0}."
 msgid "Values greater than {1} are not allowed."
 msgstr "Werte größer als {1} sind nicht erlaubt."
 
-#: src/metabase/query_processor/middleware/resolve_database.clj
+#: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
 msgstr "Die Datenbank {0} existiert nicht."
 
@@ -11375,7 +11403,7 @@ msgstr "Auslöser"
 msgid "View triggers"
 msgstr "Auslöser anzeigen"
 
-#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:82
+#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
 msgstr "Planer-Info"
 
@@ -11407,7 +11435,7 @@ msgstr "Finale Ausführungszeit"
 msgid "May Fire Again?"
 msgstr "Erneut ausführen?"
 
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:75
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
 msgstr "Auslöser für {0}"
 
@@ -11419,19 +11447,19 @@ msgstr "Aufgaben"
 msgid "Jobs"
 msgstr "Jobs"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
 msgstr "Doppelte {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:55
+#: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
 msgstr "Eintrag duplizieren"
 
-#: frontend/src/metabase/components/EntityItem.jsx:61
+#: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
 msgstr "Eintrag archivieren"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:330
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
 msgstr "Dashboard duplizieren"
 
@@ -11481,63 +11509,64 @@ msgstr "vor {0} {1}"
 msgid "{0} {1} from now"
 msgstr "{0} {1} ab heute"
 
-#: frontend/src/metabase/lib/query_time.js:187
+#: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
 msgstr[0] "Standard Zeitraum"
 msgstr[1] "Standard Zeiträume"
 
-#: frontend/src/metabase/lib/query_time.js:203
+#: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
 msgstr[0] "Minute einer Stunde"
 msgstr[1] "Minuten einer Stunde"
 
-#: frontend/src/metabase/lib/query_time.js:205
+#: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
 msgstr[0] "Stunde am Tag"
 msgstr[1] "Stunden am Tag"
 
-#: frontend/src/metabase/lib/query_time.js:207
+#: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
 msgstr[0] "Tag in der Woche"
 msgstr[1] "Tage in der Woche"
 
-#: frontend/src/metabase/lib/query_time.js:209
+#: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
 msgstr[0] "Tag im Monat"
 msgstr[1] "Tage im Monat"
 
-#: frontend/src/metabase/lib/query_time.js:211
+#: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
 msgstr[0] "Tag im Jahr"
 msgstr[1] "Tage im Jahr"
 
-#: frontend/src/metabase/lib/query_time.js:213
+#: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
 msgstr[0] "Woche im Jahr"
 msgstr[1] "Wochen im Jahr"
 
-#: frontend/src/metabase/lib/query_time.js:215
+#: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
 msgstr[0] "Monat im Jahr"
 msgstr[1] "Monate im Jahr"
 
-#: frontend/src/metabase/lib/query_time.js:217
+#: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "Quartal im Jahr"
 msgstr[1] "Quartale im Jahr"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:79
+#: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} Auswahl"
@@ -11551,20 +11580,20 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "Dieses"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:64
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
 msgstr "Ungültig"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:147
+#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
 msgstr "Zeit hinzufügen"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:170
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
 msgstr "Es gibt nichts zum vorigen {0} zu vergleichen."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:517
+#: frontend/src/metabase-lib/lib/Dimension.js:678
 msgid "by {0}"
 msgstr "von {0}"
 
@@ -11634,7 +11663,7 @@ msgstr "Treiber nach dem Laden nicht registriert: {0}"
 
 #: src/metabase/driver.clj
 msgid "Error: attempting to change {0} property `:abstract?` from {1} to {2}."
-msgstr ""
+msgstr "Fehler: Die Eigenschaft {0} zu ändern `:abstract?` von {1} nach {2}"
 
 #: src/metabase/driver.clj
 msgid "Registered abstract driver {0}"
@@ -11686,11 +11715,11 @@ msgstr "Fehler beim Synchronisieren der Datenbank {0}"
 
 #: src/metabase/events/sync_database.clj
 msgid "Failed to process sync-database event."
-msgstr ""
+msgstr "Sync-Datenbank-Ereignis konnte nicht verarbeitet werden."
 
 #: src/metabase/mbql/util.clj
 msgid "Bad nested-query-level: query does not have a source query"
-msgstr ""
+msgstr "Ungültige Query-Verschachtelung: Abfrage hat keine Quelle"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know how to `{0}`."
@@ -11758,11 +11787,11 @@ msgstr "Lade plugins in {0}..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using Clojure base loader as shared context classloader: {0}"
-msgstr ""
+msgstr "Verwende Clojure-Base-Loader als geteilten Context-Classloader: {0}"
 
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to shared classloader {0}..."
-msgstr ""
+msgstr "Setze Classloader aus aktuellem Thread-Kontext als geteilten Classloader {0}..."
 
 #. it's important that we deref the promise again here instead of using the one we just created because it is
 #. possible thru a race condition that somebody else delivered the promise before we did; in that case,
@@ -11770,7 +11799,7 @@ msgstr ""
 #. value of it rather than one that ends up getting discarded
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to NEWLY CREATED classloader {0}..."
-msgstr ""
+msgstr "Setze Classloader aus aktuellem Thread-Kontext als NEU ERSTELLTEN Classloader {0}..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Added URL {0} to classpath"
@@ -11782,7 +11811,7 @@ msgstr "Plugin {0} gibt eine Abhängigkeit an, die Metabase nicht versteht: {1}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Refer to the plugin manifest reference for a complete list of valid plugin dependencies:"
-msgstr ""
+msgstr "In der Referenz zum Plugin-Manifest findest du eine Liste der gültigen Plugin-Abhängigkeiten:"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Metabase cannot initialize plugin {0} due to required dependencies."
@@ -11839,7 +11868,7 @@ msgstr "Ungültiger Verbindungs-Parameter {0}: Kein String oder Map."
 #. ok, do the init steps listed in the plugin mainfest
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Load lazy loading driver {0}"
-msgstr ""
+msgstr "Lade langsam ladenden Traiber {0}"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Cannot initialize plugin: missing required property `driver-name`"
@@ -11852,47 +11881,47 @@ msgstr "Warnung: Plugin-Manifest für {0} enthält keine Verbindungs-Parameter"
 #. finally, register the Metabase driver
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Registering lazy loading driver {0}..."
-msgstr ""
+msgstr "Registriere langsam ladenden Treiber {0}..."
 
 #: src/metabase/pulse.clj
 msgid "Error running query for Card {0}"
 msgstr "Fehler in der Abfrage für Karte {0}"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
 msgstr "Letzte Woche"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This week"
 msgstr "Diese Woche"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
 msgstr "Letzer Monat"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This month"
 msgstr "Dieser Monat"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
 msgstr "Letztes Quartal"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
 msgstr "Dieses Quartal"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
 msgstr "Letztes Jahr"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This year"
 msgstr "Dieses Jahr"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "*driver* is unbound."
-msgstr ""
+msgstr "*driver* hat keinen Wert zugeordnet."
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Error syncing Fields for Table ''{0}''"
@@ -11900,7 +11929,7 @@ msgstr "Fehler beim Synchronisieren der Felder für Tabelle \"{0}\""
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Hash of {0} matches stored hash, skipping Fields sync"
-msgstr ""
+msgstr "Hashen von {0} stimmt mit gespeicherten Hash überein - überspringe Feldsynchronisation"
 
 #: src/metabase/sync/sync_metadata/fields/common.clj
 msgid "Field"
@@ -11958,7 +11987,7 @@ msgstr "Fehler beim Initialisieren der Aufgabe {0}"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Problem sending abandonment email"
-msgstr ""
+msgstr "Problem beim Verschicken der Email zur Nichtnutzung"
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Sending anonymous usage stats."
@@ -11974,7 +12003,7 @@ msgstr "Fehler beim Senden des Pulse {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Sending scheduled pulses..."
-msgstr ""
+msgstr "Versende geplante Pulse..."
 
 #: src/metabase/task/send_pulses.clj
 msgid "SendPulses task failed"
@@ -12012,7 +12041,7 @@ msgstr "Maximal für die JVM verfügbarer Speicher: {0}"
 #. Whithout any context, it is almost impossible to get the real meaning of this.
 #: src/metabase/util.clj
 msgid "Not something with an ID: {0}"
-msgstr ""
+msgstr "Ist bzw. hat keine ID: {0}"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by month of the year"
@@ -12135,7 +12164,7 @@ msgid "[[CreateDate]] by quarter of the year"
 msgstr "[[CreateDate]] pro Quartal eines Jahres"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:200
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
 msgstr "Benutzer bearbeiten"
 
@@ -12143,12 +12172,12 @@ msgstr "Benutzer bearbeiten"
 msgid "New user"
 msgstr "Neuer Benutzer"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
 msgstr "Passwort zurücksetzen"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:209
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
 msgstr "Benutzer deaktivieren"
 
@@ -12160,52 +12189,52 @@ msgstr "{0} wieder aktivieren?"
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
 msgstr "Wir konnten ihnen keine Einladung per E-Mail schicken, also bitte sie auf anderem Wege, sich als {0} einzuloggen. Das Kennwort lautet:"
 
-#: frontend/src/metabase/entities/collections.js:21
+#: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
 msgstr "Sammlung"
 
-#: frontend/src/metabase/entities/collections.js:22
+#: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
 msgstr "Sammlungen"
 
-#: frontend/src/metabase/entities/dashboards.js:29
+#: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
 msgstr "dashboard"
 
-#: frontend/src/metabase/entities/dashboards.js:30
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
 msgstr "dashboards"
 
-#: frontend/src/metabase/entities/users.js:125
+#: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
 msgstr "Vorname muss angegeben werden"
 
-#: frontend/src/metabase/entities/users.js:126
-#: frontend/src/metabase/entities/users.js:133
+#: frontend/src/metabase/entities/users.js:38
+#: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
 msgstr "100 Zeichen oder weniger"
 
-#: frontend/src/metabase/entities/users.js:132
+#: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
 msgstr "Nachname muss angegeben werden"
 
-#: frontend/src/metabase/entities/users.js:138
+#: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
 msgstr "Email muss angegeben werden"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:90
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
-msgstr ""
+msgstr "Archivierte Elemente werden hier angezeigt werden."
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:16
 msgid "No description"
 msgstr "Kein Beschreibung"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:175
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
 msgstr "Summe aller Werte"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:183
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
 msgstr "Alle unterschiedlichen Werte ansehen"
 
@@ -12231,23 +12260,23 @@ msgstr "{0} wurde automatisch korrigiert zu {1}"
 
 #: src/metabase/api/metric.clj
 msgid "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id."
-msgstr ""
+msgstr "DELETE /api/metric/:id ist abgekündigt. Ändere stattdessen den archivierten Wert mit PUT /api/metric/:id."
 
 #: src/metabase/api/segment.clj
 msgid "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id."
-msgstr ""
+msgstr "DELETE /api/segment/:id ist abgekündigt. Ändere stattdessen den archivierten Wert mit PUT /api/segment/:id."
 
 #: src/metabase/api/user.clj
 msgid "Value of is_superuser must correspond to presence of Admin group ID in group_ids."
-msgstr ""
+msgstr "Der Wert von is_superuser muss dem Vorhandensein der Admin-Gruppen-ID in group_ids entsprechen."
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected error writing keepalive characters"
-msgstr ""
+msgstr "Unerwarteter Fehler beim Schreiben der Keepalive Werte"
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected output in async API response"
-msgstr ""
+msgstr "Unerwarteter Inhalt in asynchoner API-Antwort"
 
 #: src/metabase/async/api_response.clj
 msgid "starting streaming response"
@@ -12271,23 +12300,23 @@ msgstr "Der Eingabekanal wurde unerwartet geschlossen."
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "f finished, permit will be returned"
-msgstr ""
+msgstr "f beendet, Erlaubnis wird zurückgesetzt"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "request canceled, permit will be returned"
-msgstr ""
+msgstr "Die Anfrage wurde abgebrochen. Erlaubnis wird zurückgenommen"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Unexpected error attempting to run function after obtaining permit"
-msgstr ""
+msgstr "Unerwarteter Fehler beim Versuch, die Funktion nach Erhalt der Genehmigung auszuführen."
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Not running pending function call: output channel already closed."
-msgstr ""
+msgstr "Führe wartenden Funktionsaufruf nicht aus: Ausgangskanal bereits geschlossen."
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Current thread already has a permit for {0}, will not wait to acquire another"
-msgstr ""
+msgstr "Aktueller Thread hat die Erlaubnis für {0}, wird nicht warten einen anderen zu erhalten"
 
 #: src/metabase/async/util.clj
 msgid "Output channel closed, will skip running {0}."
@@ -12303,7 +12332,7 @@ msgstr "Fehler abgefangen in {0}"
 
 #: src/metabase/async/util.clj
 msgid "Request canceled, canceling future"
-msgstr ""
+msgstr "Anfrage abgebrochen, breche folgende ab"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing old connection pool for database {0} ..."
@@ -12343,27 +12372,27 @@ msgstr "Setze Metabase-URL auf {0}"
 
 #: src/metabase/models/database.clj
 msgid "Error scheduling tasks for DB"
-msgstr ""
+msgstr "Fehler beim Planen von Aufgaben für die DB"
 
 #: src/metabase/models/database.clj
 msgid "Error unscheduling tasks for DB."
-msgstr ""
+msgstr "Fehler beim Deaktivieren von Aufgaben für die DB."
 
 #: src/metabase/models/database.clj
 msgid "{0} Database ''{1}'' sync/analyze schedules have changed!"
-msgstr ""
+msgstr "{0} Datenbank \"{1}\" Synchronisierungs- / Analyse-Zeitpläne wurden geändert!"
 
 #: src/metabase/models/database.clj
 msgid "Sync metadata was: ''{0}'' is now: ''{1}''"
-msgstr ""
+msgstr "Synchronisierte Metadaten hatten: \"{0}\", nun: \"{1}\""
 
 #: src/metabase/models/database.clj
 msgid "Cache FieldValues was: ''{0}'', is now: ''{1}''"
-msgstr ""
+msgstr "Zwischengespeicherte Feldwerte hatten: \"{0}\", nun: \"{1}\""
 
 #: src/metabase/models/metric.clj
 msgid "You cannot update the creator_id of a Metric."
-msgstr ""
+msgstr "Du kannst die creator_id einer Metrik nicht ändern."
 
 #: src/metabase/models/permissions.clj
 msgid "MetaBot can only have Collection permissions."
@@ -12387,11 +12416,11 @@ msgstr "AN:"
 
 #: src/metabase/models/segment.clj
 msgid "You cannot update the creator_id of a Segment."
-msgstr ""
+msgstr "Du kannst die creator_id eines Segments nicht ändern."
 
 #: src/metabase/models/setting.clj
 msgid "Attempted to set Setting {0} to obfuscated value. Ignoring change."
-msgstr ""
+msgstr "Es wurde versucht, die Einstellung {0} auf den verschleierten Wert zu setzen. Veränderungen wird ignoriert."
 
 #: src/metabase/models/setting.clj
 msgid "Using value of env var {0}"
@@ -12405,15 +12434,779 @@ msgstr "Füge Benutzer {0} zur \"Alle Benutzer\" Gruppe hinzu..."
 msgid "Adding User {0} to Admin permissions group..."
 msgstr "Füge Benutzer {0} zur \"Administrator\" Gruppe hinzu..."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
 msgstr "Abfrage fehlgeschlagen"
 
-#: src/metabase/query_processor/async.clj
+#: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
-msgstr ""
+msgstr "Maximale Anzahl gleichzeitiger Anfragen je verbundener Datenbank."
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
 msgstr "Zeitüberschreitung nach {0} Millisekunden."
+
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
+msgid "Misfire Instruction"
+msgstr "Fehlzündungsanweisung"
+
+#: frontend/src/metabase/components/ArchiveModal.jsx:31
+msgid "Archive this?"
+msgstr "Archivieren?"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:244
+msgid "Learn about our data"
+msgstr "Erfahre mehr über deine Daten"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
+msgid "Use DNS SRV when connecting"
+msgstr "Verwende DNS SRV zum Verbinden"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
+msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
+"an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
+"leave this disabled."
+msgstr "Die Verwendung dieser Option setzt voraus, dass der angegebene Host ein FQDN ist. Wenn du dich mit \n"
+"einen Atlas-Cluster verbinden, musst du diese Option möglicherweise aktivieren. Wenn du nicht weißt, was das bedeutet,\n"
+"lasse es deaktiviert."
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
+msgid "Automatically run queries when doing simple filtering and summarizing"
+msgstr "Führe Abfragen bei einechem Filtern und Zusammenfassen automatisch aus"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr "Wenn dies aktiviert ist, führt Metabase automatisch Abfragen aus, wenn Benutzer einfache Erkundungen mit den Schaltflächen Zusammenfassen und Filtern, während sie Tabellen oder ein Diagramm anzeigen. Du kannst dies ausschalten, wenn die Abfrage dieser Datenbank langsam ist. Diese Einstellung hat keinen Einfluss auf Drill-Throughs oder SQL-Abfragen."
+
+#: frontend/src/metabase/containers/Overworld.jsx:247
+msgid "Learn about this database"
+msgstr "Lerne etwas über diese Datenbank"
+
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+msgid "Archive this dashboard?"
+msgstr "Dieses Dashboard archivieren?"
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:113
+msgid "All results"
+msgstr "Alle Ergebnisse"
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:180
+msgid "Our Analytics"
+msgstr "Unsere Analysen"
+
+#: frontend/src/metabase/lib/schema_metadata.js:500
+msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
+msgstr ""
+
+#: frontend/src/metabase/lib/schema_metadata.js:508
+msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
+msgstr ""
+
+#: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
+msgid "Filter"
+msgstr "Filter"
+
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+msgid "record"
+msgid_plural "records"
+msgstr[0] "Eintrag"
+msgstr[1] "Einträge"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:346
+msgid "Browse Data"
+msgstr ""
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:376
+msgid "Write SQL"
+msgstr "Sql schreiben"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
+msgid "Simple question"
+msgstr "Einfache Frage"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
+msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
+msgid "Custom question"
+msgstr "Benutzerdefinierte Frage"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
+msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+msgid "Basic Metrics"
+msgstr "Einfache Metriken"
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+msgid "Custom…"
+msgstr "Benutzerdefiniert..."
+
+#: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
+msgid "Add grouping"
+msgstr "Gruppierung hinzufügen"
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
+msgid "Pick a limit"
+msgstr "Wähle ein Limit"
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
+msgid "Show maximum"
+msgstr "Maximum anzeigen"
+
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
+msgid "Get Preview"
+msgstr "Vorschau anzeigen"
+
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
+msgid "Back to previous results"
+msgstr "Zum voherigen Ergebnis"
+
+#: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
+msgid "Sample values"
+msgstr "Beispielwerte"
+
+#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
+msgstr "Durchsuche den Inhalt der Datenbanken, Tabellen und Spalten. Wähle eine Datenbank um zu beginnen."
+
+#: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
+msgid "Visualize"
+msgstr "Darstellen"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
+msgid "Join data"
+msgstr "Daten verknüpfen"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
+msgid "Custom column"
+msgstr "Benutzerdefinierte Spalte"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
+msgid "Summarize"
+msgstr "Zusammenfassen"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
+msgid "Aggregate"
+msgstr "Aggregieren"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
+msgid "Breakout"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
+msgid "Pick the metric you want to see"
+msgstr "Wähle eine Metrik"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
+#: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
+msgid "Pick a column to group by"
+msgstr "Wähle eine Spalte für die Gruppierung"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
+msgid "Pick your starting data"
+msgstr "Wähle deine Start-Daten"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select None"
+msgstr "Nichts auswählen"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select All"
+msgstr "Alles auswählen"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
+msgid "Pick a table..."
+msgstr "Wähle eine Tabelle..."
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
+msgid "Enter a limit"
+msgstr "Gib ein Limit an"
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
+msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
+msgstr "Klammern um eine {0} erschaffen einen optionalen Abschnitt im Template. Wenn die Variable gesetzt ist, wird der gesamt Abschnitt sichtbar. Falls nicht, wird der Abschnitt ausgeblendet."
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
+msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
+msgstr "Wenn ein Feldfilter genutzt wird, sollte dessen Spaltenname nicht im SQL enthalten sein. Stattdessen sollte die Variable in der Seitenleiste mit einem Feld verknüpft werden."
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
+msgid "View the native query"
+msgstr "Zeigt den nativen Query an"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
+msgid "Native query for this question"
+msgstr "Query für diese Frage"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
+msgid "Convert this question to a native query"
+msgstr "Konvertiere diese Frage in einen Query"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
+msgid "SQL for this question"
+msgstr "SQL für diese Frage"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
+msgid "Convert this question to SQL"
+msgstr "Konvertiere diese Frage in SQL"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
+msgid "Get alerts"
+msgstr "Alarme"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
+msgid "{0} breakout"
+msgid_plural "{0} breakouts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
+msgid "Hide filters"
+msgstr "Filter verstecken"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
+msgid "Show filters"
+msgstr "Filter anzeigen"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
+msgid "Started from"
+msgstr "Gestarten von"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
+msgid "{0} row"
+msgid_plural "{0} rows"
+msgstr[0] "{0} Zeile"
+msgstr[1] "{0} Zeilen"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
+msgid "Show all rows"
+msgstr "Alle Zeilen anzeigen"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
+msgid "Show {0}"
+msgstr "{0} anzeigen"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
+msgid "Showing first {0}"
+msgstr "Zeige die ersten {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
+msgid "Showing {0}"
+msgstr "Zeige {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
+msgid "Summarized"
+msgstr "Summiert"
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Hide editor"
+msgstr "Editor verstecken"
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Show editor"
+msgstr "Editor anzeigen"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
+msgid "Pick the metric you'd like to see"
+msgstr "Wähle die Metrik, die du sehen möchtest"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
+msgid "{0} options"
+msgstr "{0} Optionen"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
+msgid "Choose a visualization"
+msgstr "Wähle eine Darstellung"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
+msgid "Filter by"
+msgstr "Filtern nach"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+msgid "Summarize by"
+msgstr "Summiere"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+msgid "Group by"
+msgstr "Gruppieren nach"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+msgid "Add a metric"
+msgstr "Metrik hinzufügen"
+
+#: frontend/src/metabase/user/components/UserSettings.jsx:57
+msgid "Profile"
+msgstr "Profil"
+
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:548
+msgid "This is usually pretty fast but seems to be taking a while right now."
+msgstr "Das geht normalerweise zeimlich schnell aber scheint gerade sehr lange zu dauern."
+
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
+msgid "Combo"
+msgstr "Combo"
+
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
+msgid "Row"
+msgstr "Zeile"
+
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
+msgid "Trend"
+msgstr "Trend"
+
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:129
+msgid "Boolean"
+msgstr "Boolean"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+msgid "Unknown Segment"
+msgstr "Unbekanntes Segment"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+msgid "Unknown Filter"
+msgstr "Unbekannter Filter"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
+msgid "Left outer join"
+msgstr "Left outer join"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
+msgid "Right outer join"
+msgstr "Right outer join"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
+msgid "Inner join"
+msgstr "Inner join"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
+msgid "Full outer join"
+msgstr "Full outer join"
+
+#: src/metabase/api/card.clj
+msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
+msgstr ""
+
+#: src/metabase/api/session.clj
+msgid "Problem connecting to LDAP server, will fall back to local authentication"
+msgstr ""
+
+#: src/metabase/api/setup.clj
+msgid "Cannot create Database: cannot find driver {0}."
+msgstr ""
+
+#: src/metabase/api/tiles.clj
+msgid "Query failed"
+msgstr "Abfrage fehlgeschlagen"
+
+#: src/metabase/async/util.clj
+msgid "Warning: {0} returned `nil`"
+msgstr "Warnung: {0} hat `nil` zurückgegeben"
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing result to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing exception to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Request canceled, canceling future."
+msgstr ""
+
+#: src/metabase/cmd/load_from_h2.clj
+msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "Application database setup"
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Could not find {0} driver."
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Abstract drivers cannot derive from concrete parent drivers."
+msgstr ""
+
+#: src/metabase/driver/mysql.clj
+msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifer."
+msgstr ""
+
+#: src/metabase/driver/sql_jdbc/execute.clj
+msgid "Client closed connection, canceling query"
+msgstr ""
+
+#: src/metabase/integrations/ldap.clj
+msgid "{0} is not a valid DN."
+msgstr ""
+
+#: src/metabase/middleware/log.clj
+msgid "Error logging API request"
+msgstr ""
+
+#: src/metabase/middleware/misc.clj
+msgid "Failed to set site-url"
+msgstr ""
+
+#: src/metabase/models/database.clj
+msgid "Error destroying thread pool for DB."
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/models/task_history.clj src/metabase/sync/util.clj
+msgid "Error saving task history"
+msgstr ""
+
+#: src/metabase/plugins.clj
+msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
+msgstr ""
+
+#: src/metabase/plugins/classloader.clj
+msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
+msgstr ""
+
+#: src/metabase/plugins/files.clj
+msgid "Failed to copy file"
+msgstr ""
+
+#: src/metabase/public_settings.clj
+msgid "Invalid site URL: {0}"
+msgstr ""
+
+#: src/metabase/public_settings.clj
+msgid "site-url is invalid; returning nil for now. Will be reset on next request."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "More results have been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "This question has been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "We were unable to display this Pulse."
+msgstr "Der Puls kann nicht angezeigt werden."
+
+#: src/metabase/pulse/render/body.clj
+msgid "Please view this card in Metabase."
+msgstr "Sieh dir diese Karte in Metabase an."
+
+#: src/metabase/pulse/render/body.clj
+msgid "An error occurred while displaying this card."
+msgstr "Beim Anzeigen der Karte ist ein Fehler aufgetreten."
+
+#: src/metabase/query_processor.clj
+msgid "Can only determine expected columns for MBQL queries."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "No columns returned."
+msgstr "Keine Spalten zurückgegeben."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot find Table ID for {0}"
+msgstr "Kann die ID der Tabelle {0} nicht finden"
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "No matching info found."
+msgstr "Keine passende Info gefunden."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Could not resolve {0}"
+msgstr "Konnte {0} nicht auflösen"
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Invalid fk-> clause: nowhere to add corresponding join."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "{0} driver does not support foreign keys."
+msgstr "Der Treiber für {0} unterstützt keine Fremdschlüssel."
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Query processor error: number of columns returned by driver does not match results."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Expected {0} columns, but first row of resuls has {1} columns."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "No expression named {0} found. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Distinct values of {0}"
+msgstr "Eindeutige Werte von {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Average of {0}"
+msgstr "Durchschnitt von {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0}"
+msgstr "Summe von {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "SD of {0}"
+msgstr "Standardabweichung von {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Min of {0}"
+msgstr "Minimum von {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Max of {0}"
+msgstr "Maximum von {0}"
+
+#. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0} matching condition"
+msgstr "Summe von {0} Bedingung erfüllend"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Share of rows matching condition"
+msgstr "Anteil an Zeilen, die Bedingung erfüllend"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Count of rows matching condition"
+msgstr "Anzahl an Zeilen, die Bedingung erfüllend"
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Request already canceled, will not run synchronous QP code."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unexpectedly got `nil` Query Processor response."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Got InterruptedException. Canceling query."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Query timed out after %s"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Creating new query thread pool for Database {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Destroying query thread pool for Database {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Request canceled, canceling pending query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: query is missing source-metadata"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Using query processor cache backend: {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/expand_macros.clj
+msgid "Invalid metric: {0} reason: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unknown error"
+msgstr "Unbekannter Fehler"
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unexpected nil response from query processor."
+msgstr "Unerwartete Null-Antwort vom Query-Prozessor."
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Query canceled"
+msgstr "Query abgebrochen"
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: Database {0} does not exist."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_source_table.clj
+msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Cannot store Tables or Fields before Database is stored."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Attempting to fetch second Database. Queries can only reference one Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
+msgstr ""
+
+#: src/metabase/routes/index.clj
+msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Sample dataset DB file ''{0}'' cannot be found."
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Loading sample dataset..."
+msgstr "Lade Beispieldaten..."
+
+#: src/metabase/sample_data.clj
+msgid "Failed to load sample dataset"
+msgstr "Fehler beim Laden der Beispieldaten"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Found new tables:"
+msgstr "Neue Tabellen gefunden:"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Marking tables as inactive:"
+msgstr "Markiere Tabellen als inaktiv:"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Updating description for tables:"
+msgstr "Aktualisiere Beschreibung für Tabellen:"
+
+#: src/metabase/task.clj
+msgid "Rescheduling job {0}"
+msgstr "Aufgabe {0} wird neu geplant"
+
+#: src/metabase/task.clj
+msgid "Error rescheduling job"
+msgstr "Fehler beim Neuplanen der Aufgabe"
+
+#: src/metabase/task/send_pulses.clj
+msgid "Starting Pulse Execution: {0}"
+msgstr "Ausführung des Puls gestartet: {0}"
+
+#: src/metabase/task/send_pulses.clj
+msgid "Finished Pulse Execution: {0}"
+msgstr "Ausführung des Puls beendet: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Failed to schedule tasks for Database {0}"
+msgstr "Fehler beim Planen der Aufgaben für Datenbank {0}"
+
+#: src/metabase/util/schema.clj
+msgid "All elements must be distinct."
+msgstr "Jedes Element muss eindeutig sein."
+
+#: 
+msgctxt "Modal for selecting columns in source data or when doing a join."
+msgid "Pick the columns you want to include"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
+msgid "Change join type"
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifier."
+msgstr ""
+
+#: src/metabase/integrations/common.clj
+msgid "Error adding User {0} to Group {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Infinite loop detected: recursively preprocessed query {0} times."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Error determining expected columns for query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
+msgstr ""
 

--- a/locales/es.po
+++ b/locales/es.po
@@ -28,18 +28,19 @@ msgstr "Explora estos datos"
 msgid "Select a database type"
 msgstr "Selecciona un tipo de base de datos"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:75
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:401
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:71
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:182
+#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:410
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:74
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:203
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:180
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:197
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:193
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:171
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:180
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:164
 msgid "Save"
 msgstr "Guardar"
@@ -61,7 +62,7 @@ msgstr "Este es un proceso rápido que busca \n"
 "configurado para sincronizar cada hora."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:184
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
 msgid "Scan"
 msgstr "Explorar"
 
@@ -79,126 +80,128 @@ msgstr "Metabase puede escanear los valores presentes en cada \n"
 "puede ser un proceso que consume muchos recursos, particularmente si tienes una \n"
 "base de datos grande."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:159
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "¿Cuándo debería Metabase escanear y almacenar automáticamente los valores de campo?"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:164
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
 msgstr "Regularmente, siguiendo un horario"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:195
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
 msgstr "Solo cuando se añade un nuevo elemento de filtro"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:199
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
 msgstr "Cuando un usuario añade un nuevo filtro o una pregunta SQL al Dashboard, Metabase escaneará los campos asignados a ese filtro para mostrar la lista de valores seleccionables."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:210
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
 msgid "Never, I'll do this manually if I need to"
 msgstr "Nunca, lo haré manualmente si lo necesito"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:222
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:222
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:426
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
 msgid "Saving..."
 msgstr "Guardando..."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:39
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
 msgid "Server error encountered"
 msgstr "Se ha encontrado un error en el servidor"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:58
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
 msgstr "¿Eliminar esta base de datos?"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
 msgstr "Todas las preguntas, métricas y segmentos guardados que dependen de esta base de datosse perderán."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:67
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
 msgstr "Esta acción no se puede deshacer."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
 msgstr "Si estás seguro, por favor teclea:"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:53
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
 msgstr "ELIMINAR"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:71
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
 msgstr "en esta casilla:"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:82
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:50
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:93
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:58
-#: frontend/src/metabase/admin/permissions/selectors.js:160
-#: frontend/src/metabase/admin/permissions/selectors.js:170
-#: frontend/src/metabase/admin/permissions/selectors.js:185
-#: frontend/src/metabase/admin/permissions/selectors.js:224
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:355
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:181
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:247
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:61
+#: frontend/src/metabase/admin/permissions/selectors.js:163
+#: frontend/src/metabase/admin/permissions/selectors.js:173
+#: frontend/src/metabase/admin/permissions/selectors.js:188
+#: frontend/src/metabase/admin/permissions/selectors.js:227
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:202
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:268
+#: frontend/src/metabase/components/ArchiveModal.jsx:35
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
-#: frontend/src/metabase/components/form/StandardForm.jsx:61
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:196
+#: frontend/src/metabase/components/form/StandardForm.jsx:62
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:198
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:289
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:162
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:153
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:38
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:189
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:24
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:48
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:41
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:92
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:259
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:88
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:121
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:132
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
 msgstr "Eliminar"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:128
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:74
-#: frontend/src/metabase/admin/permissions/selectors.js:320
-#: frontend/src/metabase/admin/permissions/selectors.js:327
-#: frontend/src/metabase/admin/permissions/selectors.js:423
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
+#: frontend/src/metabase/admin/permissions/selectors.js:323
+#: frontend/src/metabase/admin/permissions/selectors.js:330
+#: frontend/src/metabase/admin/permissions/selectors.js:426
 #: frontend/src/metabase/admin/routes.jsx:53
-#: frontend/src/metabase/nav/containers/Navbar.jsx:214
+#: frontend/src/metabase/nav/containers/Navbar.jsx:243
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
 msgstr "Bases de Datos"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:129
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
 msgstr "Añadir Base de Datos"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
 msgstr "Conexión"
@@ -207,107 +210,107 @@ msgstr "Conexión"
 msgid "Scheduling"
 msgstr "Programación"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:78
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:84
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:26
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:221
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
 msgstr "Guardar cambios"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:185
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:38
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:38
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
 msgstr "Acciones"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:193
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
 msgstr "Sincronizar el esquema de la base de datos ahora"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:194
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:206
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:109
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
 msgstr "Empezando…"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:195
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
 msgstr "No se ha podido sincronizar"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
 msgstr "Sincronización iniciada!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:205
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
 msgstr "Vuelva a escanear los valores de campo ahora"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:207
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
 msgstr "No se ha podido iniciar la exploración"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
 msgstr "Exploración iniciada!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:215
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:401
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
 msgstr "Zona Peligrosa"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:221
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
 msgstr "Descartar valores de campos guardados"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
 msgstr "Eliminar esta base de datos"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:73
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
 msgstr "Añadir base de datos"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:85
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:36
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:36
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:122
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:32
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:399
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:446
 #: frontend/src/metabase/containers/EntitySearch.jsx:26
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:218
-#: frontend/src/metabase/entities/collections.js:93
-#: frontend/src/metabase/entities/dashboards.js:145
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:461
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:81
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:220
+#: frontend/src/metabase/entities/collections.js:94
+#: frontend/src/metabase/entities/dashboards.js:142
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
 msgstr "Nombre"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:86
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
 msgstr "Motor"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:115
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
 msgstr "Eliminando..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:145
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
 msgstr "Cargando..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:161
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
 msgstr "Recuperar la base de datos de prueba"
 
@@ -325,9 +328,9 @@ msgstr "¡Guardado con éxito!"
 
 #. Editar
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:177
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:197
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
 msgstr "Editar"
@@ -336,87 +339,91 @@ msgstr "Editar"
 msgid "Revision History"
 msgstr "Historial de Revisiones"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
 msgstr "¿Retirar este {0}?"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
 msgstr "Las preguntas guardadas y otras cosas que dependen de este {0} continuarán funcionando, pero este {1} ya no se podrá seleccionar desde el generador de consultas."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
 msgstr "Si estás seguro de querer retirar este {0}, escribe una explicación de por qué está siendo retirado:"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
 msgstr "Esto se mostrará en el resumen de actividades y en un correo electrónico que se enviará a cualquier persona de tu equipo que haya creado algo que use este {0}."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
 msgstr "Retirar"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
 msgstr "Retirando…"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
 msgstr "Ha fallado"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
 msgstr "Éxito"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:91
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
+#: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Vista Preliminar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
 msgstr "No hay una descripción de la columna"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:135
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
 msgstr "Selecciona una visibilidad de campo"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:210
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
 msgstr "Sin tipo especial"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:211
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:148
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
 msgstr "Otro"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:231
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Selección un tipo especial"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:277
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
 msgstr "Seleccione un objetivo"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:77
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:89
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:106
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:122
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
 msgstr "Columnas"
 
 #. Campo
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Campo"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:121
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:306
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
 msgstr "Visibilidad"
 
@@ -424,54 +431,54 @@ msgstr "Visibilidad"
 msgid "Type"
 msgstr "Tipo"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
 msgstr "Base de Datos actual:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
 msgstr "Mostrar Esquema Original"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:45
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
 msgstr "Tipo de Dato"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
 msgstr "Información Adicional"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
 msgstr "Encontrar un esquema"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:51
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "Ver esquema"
 msgstr[1] "Ver esquemas"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
 msgstr "¿Por qué esconderlo?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
 msgstr "Datos Técnicos"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
 msgstr "Irrelevante"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
 msgid "Queryable"
 msgstr "Consultable"
 
 #. Oculto
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:91
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
 msgstr "Oculto"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
 msgstr "No hay una descripción de la tabla"
 
@@ -479,65 +486,67 @@ msgstr "No hay una descripción de la tabla"
 msgid "Metadata Strength"
 msgstr "Alcance Metadatos"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0] Tabla Consultable"
 msgstr[1] "{0] Tablas Consultables"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:96
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0] Tabla Escondida"
 msgstr[1] "{0] Tablas Escondidas"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
 msgstr "Encontrar una tabla"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
 msgstr "Esquemas"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:24
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:137
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:68
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:56
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:190
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
 msgstr "Métricas"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
 msgstr "Añadir una Métrica"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:37
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Definición"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Crea métricas para añadirlas al menú Ver en el generador de consultas"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:24
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:930
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:952
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:56
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segmentos"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
 msgstr "Añadir un Segmento"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Crea segmentos para añadirlos al menú Filtro en el generador de consultas"
 
@@ -565,53 +574,53 @@ msgstr "editado el"
 msgid "made some changes"
 msgstr "he hecho algunos cambios"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
-#: frontend/src/metabase/home/components/Activity.jsx:80
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:332
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/home/components/Activity.jsx:82
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
 msgstr "Tu"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
 msgstr "Modelo de datos"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
 msgstr "Historia"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:48
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
 msgstr "Historial de Revisiones para"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:239
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
 msgstr "{0} – Configuración de campos"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
 msgstr "Donde aparecerá este campo en Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:329
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filtrando sobre este campo"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Cuando este campo se usa en un filtro, ¿qué valores debería aceptar?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:453
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "No hay descripción para este campo todavía"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:379
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
 msgstr "Valor original"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:380
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
 msgid "Mapped value"
 msgstr "Valor asignado"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:423
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
 msgstr "Introduce un valor"
 
@@ -628,7 +637,7 @@ msgid "Custom mapping"
 msgstr "Mapeo personalizado"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:155
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
 msgid "Unrecognized mapping type"
 msgstr "Tipo de mapeo no reconocido"
 
@@ -636,23 +645,23 @@ msgstr "Tipo de mapeo no reconocido"
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "El campo actual no es una clave foránea o faltan los metadatos de clave foránea en la tabla de destino"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:187
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
 msgstr "El campo seleccionado no es una clave foránea"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:347
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
 msgstr "Valores mostrados"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:348
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Elige si quieres mostrar el valor original de la base de datos, o mostrar información asociada o personalizada."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:268
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
 msgstr "Elige un campo"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:289
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
 msgstr "Selecciona una columna para mostrar."
 
@@ -660,16 +669,16 @@ msgstr "Selecciona una columna para mostrar."
 msgid "Tip:"
 msgstr "Consejo:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Es posible que quieras actualizar el nombre del campo para asegurarte de que todavía tenga sentidoen función de las opciones de asignación."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:364
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:102
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
 msgstr "Valores de campo en caché"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:365
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase puede escanear los valores de este campo para habilitar los filtros de casilla de verificación en cuadros de mando y preguntas."
 
@@ -678,167 +687,168 @@ msgid "Re-scan this field"
 msgstr "Vuelve a escanear este campo"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
 msgstr "Descartar valores de campo en caché"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:118
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
 msgstr "Error al descartar valores"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard triggered!"
 msgstr "Limpieza iniciada!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:105
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Selecciona cualquier tabla para ver su esquema y añadir o editar metadatos."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:37
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:34
-#: frontend/src/metabase/entities/collections.js:96
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "Nombre es obligatorio"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:40
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
 msgstr "Descripción es obligatorio"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:44
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:41
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
 msgstr "Mensaje de la revisión es obligatorio"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:50
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
 msgstr "Agregación es obligatoria"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
 msgstr "Edita tu Métrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
 msgstr "Crea tu Métrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:115
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Haz cambios en tu métrica y deja una nota explicativa."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Puedes crear métricas y guardarlas como campo calculado en esta tabla.Las métricas guardadas incluyen el tipo de agregación, el campo agregado y, opcionalmente, cualquier filtro que añadas.Por ejemplo, puedes usar esto para definir la forma oficial de calcular el \"Precio promedio\" para una tabla de Pedidos."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
 msgstr "Resultado:"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
 msgstr "Ponle nombre a tu Métrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
 msgstr "Dale un nombre a tu métrica para ayudar a otros a encontrarla."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:162
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
 msgstr "Algo descriptivo pero no demasiado largo"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
 msgstr "Describe tu Métrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Dale una descripción a tu métrica para ayudar a otros a entender de qué se trata."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Este es un buen lugar para ser más específico sobre las reglas métricas menos obvias"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:179
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
 msgstr "Motivo de los cambios"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:177
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Deja una nota para explicar qué cambios has hecho y por qué fueron necesarios."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Esto aparecerá en el historial de revisiones de esta métrica para ayudar a todos a recordar por qué se realizó el cambio"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
 msgstr "Se requiere al menos un filtro"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
 msgstr "Edita tu Segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
 msgstr "Crea tu Segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:121
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Haz cambios en tu segmento y deja una nota explicativa."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Selecciona y añade filtros para crear un nuevo segmento para la tabla {0}"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
 msgstr "Ponle nombre a tu segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:162
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
 msgstr "Dale un nombre a tu segmento para ayudar a otros a encontrarla."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:170
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
 msgstr "Describe tu Segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Dale una descripción a tu segmento para ayudar a otros a entender de qué se trata."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:175
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Este es un buen lugar para ser más específico sobre las reglas de segmentación menos obvias"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:185
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Esto aparecerá en el historial de revisiones de este segmento para ayudar a todos a recordar por qué se realizó el cambio"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:266
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:87
-#: frontend/src/metabase/nav/containers/Navbar.jsx:199
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:269
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:91
+#: frontend/src/metabase/nav/containers/Navbar.jsx:228
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
 msgstr "Configuración"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:103
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase puede leer los valores en esta tabla para habilitar filtros de casillas de verificación en cuadros de mandos y preguntas."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:108
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
 msgstr "Re-Leer esta tabla"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:253
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
 msgstr "Añadir"
 
@@ -847,20 +857,22 @@ msgstr "Añadir"
 msgid "Not a valid formatted email address"
 msgstr "Formato de Email incorrecto"
 
+#: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:100
 msgid "First name"
 msgstr "Nombre"
 
+#: frontend/src/metabase/entities/users.js:42
 #: frontend/src/metabase/setup/components/UserStep.jsx:203
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:117
 msgid "Last name"
 msgstr "Apellidos"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:77
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:158
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:161
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:470
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:481
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
@@ -874,34 +886,35 @@ msgstr "Grupos de Permisos"
 msgid "Make this user an admin"
 msgstr "Convertir a este usuario en administrador"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:32
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
 msgstr "Todos los usuarios pertenecen al grupo {0} no se pueden eliminar. Establecer permisos para este grupo es una excelente manera de asegurarte qué podrán ver los nuevos usuarios de Metabase."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:41
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
 msgstr "Este es un grupo especial cuyos miembros pueden ver todo en la instancia de Metabase, y quienes pueden acceder y realizar cambios en la configuración en el Panel de administración, ¡incluyendo el cambio de permisos!Así que añade personas a este grupo con cuidado."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:45
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
 msgstr "Para asegurarte de no quedar sin acceso a Metabase, siempre debe haber al menos un usuario en este grupo."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
 msgstr "Miembros"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:124
-#: frontend/src/metabase/admin/settings/selectors.js:113
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
+#: frontend/src/metabase/admin/settings/selectors.js:110
+#: frontend/src/metabase/entities/users.js:50
 #: frontend/src/metabase/lib/core.js:55
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
 msgstr "Email"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:203
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
 msgstr "Un grupo solo vale lo que valen sus miembros."
 
@@ -912,8 +925,8 @@ msgid "Admin"
 msgstr "Admin"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:237
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:290
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
 msgstr "y"
 
@@ -921,8 +934,8 @@ msgstr "y"
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:31
 msgid "{0} other group"
 msgid_plural "{0} other groups"
-msgstr[0] "[0] grupo más"
-msgstr[1] "[0] grupos más"
+msgstr[0] "{0} grupo más"
+msgstr[1] "{0} grupos más"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:37
 msgid "Default"
@@ -943,13 +956,13 @@ msgstr "¿Estás seguro? Todos los miembros de este grupo perderán las configur
 "Esto no puede deshacerse."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
 msgstr "Sí"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
 msgstr "No"
 
@@ -968,10 +981,11 @@ msgstr "Borrar Grupo"
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:107
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:327
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:395
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:265
+#: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
 msgstr "Hecho"
 
@@ -981,9 +995,9 @@ msgstr "Nombre Grupo"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:131
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:88
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
 msgstr "Grupos"
 
@@ -1012,9 +1026,9 @@ msgid "Deactivate"
 msgstr "Desactivar"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:93
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
-#: frontend/src/metabase/nav/containers/Navbar.jsx:204
+#: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
 msgstr "Personas"
 
@@ -1054,7 +1068,6 @@ msgid "We've re-sent {0}'s invite"
 msgstr "Hemos vuelto a enviar la invitación de {0}"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
-#: frontend/src/metabase/tutorial/Tutorial.jsx:253
 msgid "Okay"
 msgstr "Vale"
 
@@ -1086,13 +1099,13 @@ msgstr "Podrán volver a iniciar sesión y se les volverá a colocar en los grup
 msgid "Reset {0}'s password?"
 msgstr "¿Restablecer la contraseña de {0}?"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:77
+#: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
 msgstr "Reiniciar"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:44
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
 msgstr "¿Seguro que quieres hacer esto?"
 
@@ -1108,76 +1121,78 @@ msgstr "Aquí hay una contraseña temporal que pueden usar para iniciar sesión 
 msgid "We've sent them an email with instructions for creating a new password."
 msgstr "Les hemos enviado un correo electrónico con instrucciones para crear una nueva contraseña."
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:101
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
 msgstr "Activo"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:127
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
 msgstr "Desactivado"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:115
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
 msgstr "Añadir alguien"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
 msgstr "Ultimo acceso"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:153
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
 msgstr "Acceso via Google"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:158
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
 msgstr "Acceso via LDAP"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:170
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
 msgstr "Activar esta cuenta"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:193
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
 msgstr "Nunca"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:27
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
 msgstr[0] "{0} tabla"
 msgstr[1] "{0} tablas"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:45
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
 msgstr "será"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:48
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
 msgstr "dado el acceso a"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:53
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
 msgstr " y "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:56
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
 msgstr "denegado el acceso a"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:70
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
 msgstr "ya no podrá"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:71
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
 msgstr "ahora será capaz de"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:79
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
 msgstr "consultas nativas para"
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
-#: frontend/src/metabase/nav/containers/Navbar.jsx:219
+#: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
 msgstr "Permisos"
 
@@ -1202,15 +1217,15 @@ msgstr "No se realizarán cambios en los permisos."
 msgid "You've made changes to permissions."
 msgstr "Has realizado cambios en los permisos."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:52
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
 msgstr "Permisos de esta colección"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
 msgstr "Tiene cambios sin guardar"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:54
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
 msgstr "¿Quieres abandonar esta página y descartar tus cambios?"
 
@@ -1230,119 +1245,119 @@ msgstr "Todos los usuarios de Metabase pertenecen al grupo All Users. Si quieres
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
 msgstr "MetaBot es el bot de Slack de Metabase. Puedes elegir a qué tiene acceso aquí."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:119
+#: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
 msgstr "El grupo \"{0}\" puede tener acceso a un conjunto diferente de {1} que este grupo, lo que puede darle a este grupo acceso adicional a algún {2}."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:124
+#: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
 msgstr "El grupo \"{0}\" tiene un mayor nivel de acceso que este, lo que anulará esta configuración. Debes limitar o revocar el acceso del grupo \"{1}\" a este elemento."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
 msgstr "¿Limitar"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
 msgstr "¿Revocar"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:156
+#: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
 msgstr "el acceso a pesar de que el grupo \"{0}\" tiene mayor acceso?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:258
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
 msgstr "Limita el acceso"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:223
-#: frontend/src/metabase/admin/permissions/selectors.js:266
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:226
+#: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
 msgstr "Revocar el acceso"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:168
+#: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
 msgstr "¿Cambiar el acceso a esta base de datos a limitado?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:169
+#: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
 msgstr "Cambiar"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:182
+#: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
 msgstr "Permitir escritura de consultas directas"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:183
+#: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
 msgstr "Esto también cambiará el acceso de datos de este grupo a Sin restricciones para esta base de datos."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:184
+#: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
 msgstr "Permitir"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:221
+#: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
 msgstr "¿Revoca el acceso a todas las tablas?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:222
+#: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
 msgstr "Esto también revocará el acceso de este grupo a consultas sin formato para esta base de datos."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:251
+#: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
 msgstr "Conceder acceso sin restricciones"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:252
+#: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
 msgstr "Acceso no restingido"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:259
+#: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
 msgstr "Acceso limitado"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:267
+#: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
 msgstr "Sin acceso"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:273
+#: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
 msgstr "Escribir consultas directas"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:274
+#: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
 msgstr "Puede escribir consultas directas"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:281
+#: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
 msgstr "Mima la colección"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:288
+#: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
 msgstr "Ver colección"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:331
-#: frontend/src/metabase/admin/permissions/selectors.js:427
-#: frontend/src/metabase/admin/permissions/selectors.js:524
+#: frontend/src/metabase/admin/permissions/selectors.js:334
+#: frontend/src/metabase/admin/permissions/selectors.js:430
+#: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
 msgstr "Acceso a Datos"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:492
-#: frontend/src/metabase/admin/permissions/selectors.js:649
-#: frontend/src/metabase/admin/permissions/selectors.js:654
+#: frontend/src/metabase/admin/permissions/selectors.js:495
+#: frontend/src/metabase/admin/permissions/selectors.js:652
+#: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
 msgstr "Ver tablas"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:590
+#: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
 msgstr "Consultas SQL"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:660
+#: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
 msgstr "Ver esquemas"
 
 #: frontend/src/metabase/admin/routes.jsx:59
-#: frontend/src/metabase/nav/containers/Navbar.jsx:209
+#: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
 msgstr "Modelo de Datos"
 
@@ -1351,30 +1366,30 @@ msgstr "Modelo de Datos"
 msgid "Sign in with Google"
 msgstr "Accede con Google"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:13
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
 msgstr "Permite a los usuarios con cuentas Metabase existentes iniciar sesión con una cuenta de Google que coincida con su dirección de correo electrónico además de su nombre de usuario y contraseña de Metabase."
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:17
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
 msgstr "Configura"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
-#: frontend/src/metabase/admin/settings/selectors.js:207
+#: frontend/src/metabase/admin/settings/selectors.js:204
 msgid "LDAP"
 msgstr "LDAP"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:25
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
 msgstr "Permite a los usuarios de tu directorio LDAP iniciar sesión en la Metabase con sus credenciales LDAP, y permite la asignación automática de grupos LDAP a grupos de metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
-#: frontend/src/metabase/admin/settings/selectors.js:160
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
 msgstr "Esa no es una dirección de correo electrónico válida"
 
@@ -1412,7 +1427,7 @@ msgstr "Limpiar"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:202
+#: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
 msgstr "Autenticación"
 
@@ -1476,21 +1491,21 @@ msgstr "Crear un usuario de Slack Bot para MetaBot"
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Una vez que estés allí, asígnele un nombre y haz clic en {0}. Luego, copia y pega el API Token del Bot en el campo a continuación. En cuanto hayas terminado, crea un canal \"metabase_files\" en Slack. Metabase necesita ese para subir gráficos."
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:90
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
 msgstr "¡Estás ejecutando Metabase {0} que es lo último y lo mejor!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:99
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0} está disponible.  Estás ejecutando {1}"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:112
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
 msgstr "Actualiza"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:116
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
 msgstr "Qué ha cambiado:"
 
@@ -1503,80 +1518,80 @@ msgstr "Añade un mapa"
 msgid "URL"
 msgstr "URL"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:199
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
 msgstr "Elimina mapa personalizado"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:327
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:40
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:181
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
 msgstr "Borrar"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:226
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:187
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:241
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:246
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
 msgstr "Selecciona…"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:241
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
 msgstr "Valores de muestra:"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
 msgstr "Añade un nuevo mapa"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
 msgstr "Editar mapa"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:280
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
 msgstr "¿Cómo quieres llamar a este mapa?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
 msgstr "e.g. United Kingdom, Brazil, Mars"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:292
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
 msgstr "URL para el archivo GeoJSON que quieres usar"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:298
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
 msgstr "Como https://my-mb-server.com/maps/my-map.json"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:33
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
 msgstr "Actualizar"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
 msgstr "Carga"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:315
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
 msgstr "¿Qué propiedad especifica el identificador de la región?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:324
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
 msgstr "¿Qué propiedad especifica el nombre de la región?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:345
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
 msgstr "Carga un archivo GeoJSON para ver una vista previa"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
 msgstr "Guardar mapa"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
 msgstr "Añadir mapa"
 
@@ -1588,11 +1603,11 @@ msgstr "Utilizando embebido"
 msgid "By enabling embedding you're agreeing to the embedding license located at"
 msgstr "Al habilitar el embebido, aceptas la licencia de incorporación ubicada en"
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:19
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
 msgstr "En lenguaje sencillo, cuando insertas tablas o cuadros de mando de Metabase en tu propia aplicación, esa aplicación no está sujeta a la Licencia AGPL que cubre el resto de Metabase, siempre que mantengas el logotipo de Metabase y el \"Powered by Metabase\" visible en esas incrustaciones. Sin embargo, debes leer el texto de licencia, ya que esa es la licencia real que aceptas al habilitar esta función."
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:32
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
 msgstr "Habilitar"
 
@@ -1616,25 +1631,25 @@ msgstr "Comprar un token"
 msgid "Enter a token"
 msgstr "Introducir un token"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:134
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
 msgstr "Editar Asignaciones"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:140
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
 msgstr "Asignaciones de Grupo"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:147
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
 msgstr "Crear una asignación"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
 msgstr "Las asignaciones permiten que Metabase agregue y elimine automáticamente usuarios de grupos según la información de membresía proporcionada por el servidor de directorios. La membresía al grupo de administración se puede otorgar a través de asignaciones, pero no se eliminará automáticamente como una medida a prueba de fallas."
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
 msgstr "Nombre Distinguido"
 
@@ -1646,43 +1661,43 @@ msgstr "Enlace Público"
 msgid "Revoke Link"
 msgstr "Eliminar Enlace"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:121
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
 msgstr "¿Deshabilitar este enlace?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:122
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
 msgstr "Ya no funcionarán y no se pueden restaurar, pero puedes crear nuevos enlaces."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
 msgstr "Listado de Cuadros de Mando Públicos"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:152
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
 msgstr "Aún no se ha compartido públicamente ningún cuadro de mando."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:160
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
 msgstr "Listado de tarjetas públicas"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:163
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
 msgstr "Aún no se ha compartido públicamente ninguna pregunta."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:172
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
 msgstr "Listado de cuadros de mando embebidos"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
 msgstr "No se han incrustado cuadros de mando todavía."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:183
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
 msgstr "Listado de tarjetas embebidas"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:184
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
 msgstr "No se han incrustado preguntas todavía."
 
@@ -1703,18 +1718,17 @@ msgid "Generate Key"
 msgstr "Generar clave"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:78
-#: frontend/src/metabase/admin/settings/selectors.js:87
+#: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
 msgstr "Habilitado"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:83
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:103
+#: frontend/src/metabase/admin/settings/selectors.js:82
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Deshabilitado"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:116
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
 msgstr "La directiva de configuración {0} es desconocida"
 
@@ -1722,7 +1736,7 @@ msgstr "La directiva de configuración {0} es desconocida"
 msgid "Setup"
 msgstr "Configura"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
 msgstr "General"
@@ -1751,11 +1765,11 @@ msgstr "La de la base de datos"
 msgid "Select a timezone"
 msgstr "Selecciona una zona horaria"
 
-#: frontend/src/metabase/admin/settings/selectors.js:55
+#: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "No todas las bases de datos admiten zonas horarias, en cuyo caso esta configuración no tendrá efecto."
 
-#: frontend/src/metabase/admin/settings/selectors.js:60
+#: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
 msgstr "Idioma"
 
@@ -1763,202 +1777,202 @@ msgstr "Idioma"
 msgid "Select a language"
 msgstr "Selecciona un idioma"
 
-#: frontend/src/metabase/admin/settings/selectors.js:70
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
 msgstr "Seguimiento anónimo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:75
+#: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
 msgstr "Nombres de tablas y campos amistosos"
 
-#: frontend/src/metabase/admin/settings/selectors.js:81
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Solo reemplaza los guiones bajos y guiones por espacios"
 
-#: frontend/src/metabase/admin/settings/selectors.js:91
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
 msgstr "Habilitar consultas anidadas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:102
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
 msgstr "Actualizaciones"
 
-#: frontend/src/metabase/admin/settings/selectors.js:107
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
 msgstr "Buscar actualizaciones"
 
-#: frontend/src/metabase/admin/settings/selectors.js:118
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
 msgstr "Servidor SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:126
+#: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
 msgstr "Puerto SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:130
-#: frontend/src/metabase/admin/settings/selectors.js:230
+#: frontend/src/metabase/admin/settings/selectors.js:127
+#: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
 msgstr "Ese no es un número de puerto válido"
 
-#: frontend/src/metabase/admin/settings/selectors.js:134
+#: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
 msgstr "Seguridad SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:142
+#: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
 msgstr "Usuario SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
 msgstr "Contraseña SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
 msgstr "Email De"
 
-#: frontend/src/metabase/admin/settings/selectors.js:170
+#: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
 msgstr "Slack API Token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:172
+#: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
 msgstr "Introduce el token que has recibido de Slack"
 
-#: frontend/src/metabase/admin/settings/selectors.js:189
+#: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
 msgstr "Inicio de sesión único"
 
-#: frontend/src/metabase/admin/settings/selectors.js:213
+#: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
 msgstr "Autentificación LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:219
+#: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
 msgstr "Servidor LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:227
+#: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
 msgstr "Puerto LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:234
+#: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
 msgstr "Seguridad LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
 msgstr "Nombre de Usuario o DN"
 
-#: frontend/src/metabase/admin/settings/selectors.js:247
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:188
-#: frontend/src/metabase/user/components/UserSettings.jsx:72
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:191
+#: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
 msgstr "Contraseña"
 
-#: frontend/src/metabase/admin/settings/selectors.js:252
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "User search base"
 msgstr "Base de búsqueda de usuario"
 
-#: frontend/src/metabase/admin/settings/selectors.js:258
+#: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
 msgstr "Filtro de usuario"
 
-#: frontend/src/metabase/admin/settings/selectors.js:264
+#: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
 msgstr "Verifica los paréntesis"
 
-#: frontend/src/metabase/admin/settings/selectors.js:270
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
 msgstr "Atributo de Email"
 
-#: frontend/src/metabase/admin/settings/selectors.js:275
+#: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
 msgstr "Atributo de Nombre"
 
-#: frontend/src/metabase/admin/settings/selectors.js:280
+#: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
 msgstr "Atributo de Apellidos"
 
-#: frontend/src/metabase/admin/settings/selectors.js:285
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
 msgstr "Sincronizar membresías de grupo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:291
+#: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
 msgstr "Base de búsqueda para Grupo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:300
+#: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
 msgstr "Mapas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
 msgstr "URL del servidor de capas de mapa"
 
-#: frontend/src/metabase/admin/settings/selectors.js:306
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase usa OpenStreetMaps por defecto."
 
-#: frontend/src/metabase/admin/settings/selectors.js:311
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
 msgstr "Mapas Personalizados"
 
-#: frontend/src/metabase/admin/settings/selectors.js:312
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Añade tus propios archivos GeoJSON para habilitar diferentes visualizaciones de mapas de región"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
 msgstr "Uso compartido público"
 
-#: frontend/src/metabase/admin/settings/selectors.js:336
+#: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
 msgstr "Habilitar el intercambio público"
 
-#: frontend/src/metabase/admin/settings/selectors.js:341
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
 msgstr "Cuadros de Mando compartidos"
 
-#: frontend/src/metabase/admin/settings/selectors.js:347
+#: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
 msgstr "Preguntas compartidas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:354
+#: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
 msgstr "Incrustar en otras aplicaciones"
 
-#: frontend/src/metabase/admin/settings/selectors.js:381
+#: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Habilitar incrustación de Metabase en otras aplicaciones"
 
-#: frontend/src/metabase/admin/settings/selectors.js:391
+#: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
 msgstr "Clave secreta de incrustación"
 
-#: frontend/src/metabase/admin/settings/selectors.js:397
+#: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
 msgstr "Cuadros de Mando embebidos"
 
-#: frontend/src/metabase/admin/settings/selectors.js:403
+#: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
 msgstr "Preguntas embebidas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:410
+#: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
 msgstr "Almacenamiento en caché"
 
-#: frontend/src/metabase/admin/settings/selectors.js:415
+#: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
 msgstr "Habilitar caché"
 
-#: frontend/src/metabase/admin/settings/selectors.js:420
+#: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
 msgstr "Duración mínima de la consulta"
 
-#: frontend/src/metabase/admin/settings/selectors.js:427
+#: frontend/src/metabase/admin/settings/selectors.js:424
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Multiplicador Time-to-Live (TTL) de caché"
 
-#: frontend/src/metabase/admin/settings/selectors.js:434
+#: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
 msgstr "Tamaño máximo de entrada de caché"
 
@@ -1974,11 +1988,11 @@ msgstr "Tu alerta fue actualizada."
 msgid "The alert was successfully deleted."
 msgstr "La alerta fue eliminada correctamente."
 
-#: frontend/src/metabase/auth/auth.js:33
+#: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
 msgstr "Por favor introduce una dirección de correo electrónico con formato válido."
 
-#: frontend/src/metabase/auth/auth.js:116
+#: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
@@ -2020,91 +2034,88 @@ msgstr "Enviar correo electrónico de restablecimiento de contraseña"
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Consulta tu correo electrónico para obtener instrucciones sobre cómo restablecer tu contraseña."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:128
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
 msgstr "Iniciar sesión en Metabase"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:138
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
 msgstr "O"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:157
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
 msgstr "Nombre de usuario o dirección de correo electrónico"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:217
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
 msgstr "Acceder"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:230
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
 msgstr "Parece que olvidé mi contraseña"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
 msgstr "solicitar un nuevo correo electrónico de reinicio"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:120
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
 msgstr "Vaya, ese es un enlace caducado"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:122
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
 msgstr "Por razones de seguridad, los enlaces de restablecimiento de contraseña caducan después de un tiempo.\n"
 "Si aún necesita restablecer tu contraseña, puedes {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:147
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
 msgstr "Nueva contraseña"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:149
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
 msgstr "Para mantener tus datos seguros, las contraseñas {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:163
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
 msgstr "Crear una nueva contraseña"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:170
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:141
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
 msgstr "Ha de cumplir las instrucciones anteriores"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:184
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:150
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
 msgstr "Confirmar nueva contraseña"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:191
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:159
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
 msgstr "Tiene que coincidir con la que acabas de poner"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:216
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
 msgstr "Tu contraseña ha sido restablecida."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:222
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:227
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
 msgstr "Inicia sesión con tu nueva contraseña"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:182
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:251
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Ha fallado"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:183
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:129
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:225
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:252
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
 msgstr "Guardado"
 
@@ -2112,24 +2123,22 @@ msgstr "Guardado"
 msgid "Ok"
 msgstr "Vale"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:38
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
 msgstr "¿Archivar esta colección?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:43
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Los cuadros de mando, colecciones y pulsos guardados en esta colección también se archivarán."
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
-#: frontend/src/metabase/components/CollectionLanding.jsx:624
+#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: frontend/src/metabase/components/CollectionLanding.jsx:620
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:47
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:195
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:200
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:40
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:53
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
 msgstr "Archivar"
@@ -2138,28 +2147,27 @@ msgstr "Archivar"
 msgid "This {0} has been archived"
 msgstr "Este {0} ha sido archivado"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:715
+#: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
 msgstr "Ver el archivo"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:43
+#: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
 msgstr "Desarchive este {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:70
-#: frontend/src/metabase/components/BrowseApp.jsx:132
-#: frontend/src/metabase/components/BrowseApp.jsx:225
+#: frontend/src/metabase/components/BrowseApp.jsx:39
+#: frontend/src/metabase/components/BrowseApp.jsx:102
+#: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
 msgstr "Nuestros datos"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:169
+#: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
 msgstr "Aplica rayos-X a esta tabla"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:183
-#: frontend/src/metabase/containers/Overworld.jsx:246
+#: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
 msgstr "Aprende sobre esta tabla"
 
@@ -2177,31 +2185,31 @@ msgstr "Guardado!"
 msgid "Saving failed."
 msgstr "No se ha podido guardar."
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
 msgstr "D"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
 msgstr "L"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
 msgstr "M"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
 msgstr "X"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
 msgstr "J"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
 msgstr "V"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
 msgstr "S"
 
@@ -2246,61 +2254,61 @@ msgstr "Los pulsos te permiten enviar datos de Metabase a correo electrónico o 
 msgid "Questions are a saved look at your data."
 msgstr "Las preguntas son vistas guardadas de tus datos."
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:287
+#: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
 msgstr "Pins"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:341
+#: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
 msgstr "Arrastra algo aquí para pegarlo arriba"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:737
-#: frontend/src/metabase/components/CollectionLanding.jsx:353
-#: frontend/src/metabase/home/containers/SearchApp.jsx:35
-#: frontend/src/metabase/home/containers/SearchApp.jsx:92
+#: frontend/src/metabase/admin/permissions/selectors.js:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:352
+#: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
 msgstr "Colecciones"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:432
-#: frontend/src/metabase/components/CollectionLanding.jsx:455
+#: frontend/src/metabase/components/CollectionLanding.jsx:431
+#: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
 msgstr "Arrastra aquí para despegarlo"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:490
+#: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
 msgstr[0] "{0} elemento seleccionado"
 msgstr[1] "{0} elementos seleccionados"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:522
+#: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
 msgstr "¿Mover {1} elemento(s)?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:523
+#: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
 msgstr "¿Mover \"{0}\"?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:631
+#: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
 msgstr "Mover"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:692
+#: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
 msgstr "Edita esta colección"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:700
+#: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
 msgstr "Archivar esta colección"
 
-#: frontend/src/metabase/components/CollectionList.jsx:64
-#: frontend/src/metabase/entities/collections.js:155
+#: frontend/src/metabase/components/CollectionList.jsx:67
+#: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
 msgstr "Mi colección personal"
 
-#: frontend/src/metabase/components/CollectionList.jsx:106
+#: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
 msgstr "Nueva colección"
 
@@ -2308,11 +2316,11 @@ msgstr "Nueva colección"
 msgid "Copied!"
 msgstr "Copiado!"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:216
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Utiliza un túnel SSH para las conexiones a la base de datos"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
@@ -2320,75 +2328,76 @@ msgstr "Algunas instalaciones de bases de datos solo se pueden acceder conectán
 "Esta opción también proporciona una capa adicional de seguridad cuando no dispones de una VPN.\n"
 "Esto suele ser más lento que una conexión directa."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:271
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Esta es una base de datos grande, así que déjame elegir cuándo Metabase sincroniza y escanea"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:273
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "De forma predeterminada, Metabase realiza una sincronización ligera cada hora y un análisis diario intensivo de los valores de campo.\n"
 "Si tienes una base de datos grande, te recomendamos activarla y revisar cuándo y con qué frecuencia ocurren los escaneos de valores de campo."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:289
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} para generar un ID y clave secreta de cliente para tu proyecto."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:291
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:353
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
 msgstr "Haz clic aquí"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Elige \"Otro\" como tipo de aplicación. Llámalo como quieras"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:316
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
 msgstr "{0} para obtener un código de autenticación"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:328
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
 msgstr "con permisos de Google Drive"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:348
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Para usar Metabase con estos datos, debes habilitar el acceso a la API en Google Developers Console."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:351
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} para ir a la consola si aún no lo has hecho."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
 msgstr "¿Cómo te gustaría llamar esta base de datos?"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:427
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:237
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:188
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:74
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:194
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:79
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
 msgstr "Siguiente"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:52
+#: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
 msgstr "Elimina este {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:43
+#: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
 msgstr "Fija este elemento"
 
-#: frontend/src/metabase/components/EntityItem.jsx:49
+#: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
 msgstr "Mueve este elemento"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
 msgstr "Editar esta pregunta"
 
@@ -2401,6 +2410,7 @@ msgstr "Tipo acción"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
 msgstr "Ver el historial de revisiones"
 
@@ -2416,8 +2426,7 @@ msgstr "Acción de archivar"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:329
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:342
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
 msgstr "Añadir a Cuadro de Mando"
 
@@ -2441,13 +2450,12 @@ msgstr "Otro tipo de acción"
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:449
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:454
 msgid "Get alerts about this"
 msgstr "Recibe alertas sobre esto"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
 msgstr "Ver el SQL"
 
@@ -2467,43 +2475,43 @@ msgstr "Este es el mensaje de error completo"
 msgid "Hi, Metabot here."
 msgstr "Hola, soy Metabot"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:95
+#: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
 msgstr "Basado en el esquema"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:174
+#: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
 msgstr "Una vista a tus"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:234
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
 msgstr "Busca la lista"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:238
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
 msgstr "Buscar por {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
 msgstr "o introduce un ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
 msgstr "Introduce un ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
 msgstr "Introduce un número"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:248
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
 msgstr "Introduce un texto"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:355
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
 msgstr "No se encontraron {0} coincidentes."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:363
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Incluir cada opción en tu filtro probablemente no hará mucho…"
 
@@ -2519,17 +2527,17 @@ msgstr "Nos encontramos con un error. Puedes intentar refrescar la página, o si
 #: frontend/src/metabase/components/HeaderBar.jsx:45
 #: frontend/src/metabase/components/ListItem.jsx:37
 #: frontend/src/metabase/reference/components/Detail.jsx:47
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:158
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:213
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:191
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:205
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:209
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:209
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:161
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:216
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:194
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:208
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
 msgstr "Sin descripción todavía"
 
 #: frontend/src/metabase/components/Header.jsx:112
-#: frontend/src/metabase/entities/containers/EntityForm.jsx:43
+#: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
 msgstr "Nuevo {0}"
 
@@ -2537,54 +2545,53 @@ msgstr "Nuevo {0}"
 msgid "Asked by {0}"
 msgstr "Preguntado por {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:13
+#: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
 msgstr "Hoy."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:15
+#: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
 msgstr "Ayer."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:68
+#: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
 msgstr "Primera revisión."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:70
+#: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
 msgstr "Revertido a una revisión anterior y {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:82
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:289
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:379
-#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
+#: frontend/src/metabase/components/HistoryModal.jsx:42
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
+#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
 msgstr "Historial de Revisiones"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:90
+#: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
 msgstr "Cuando"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:91
+#: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
 msgstr "Quien"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:92
+#: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
 msgstr "Que"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:113
+#: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
 msgstr "Revertir"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:114
+#: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
 msgstr "Revertiendo…"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:115
+#: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
 msgstr "Falló la reversión"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:116
+#: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
 msgstr "Revertido"
 
@@ -2593,26 +2600,24 @@ msgid "Everything"
 msgstr "Todo"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
-#: frontend/src/metabase/home/containers/SearchApp.jsx:69
 msgid "Dashboards"
 msgstr "Cuadros de Mando"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
-#: frontend/src/metabase/home/containers/SearchApp.jsx:115
 msgid "Questions"
 msgstr "Preguntas"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:321
+#: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
 msgstr "Pulsos"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:103
+#: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
 msgstr "Atrás"
 
-#: frontend/src/metabase/components/ListSearchField.jsx:18
+#: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
 msgstr "Encontrar..."
 
@@ -2649,14 +2654,14 @@ msgid "Temporary Password"
 msgstr "Contraseña Temporal"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
 msgstr "Esconder"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:412
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
 msgstr "Mostrar"
 
@@ -2721,7 +2726,7 @@ msgstr "15to (punto medio)"
 msgid "Calendar Day"
 msgstr "Día Calendario"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:210
+#: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
 msgstr "tu zona horaria en Metabase"
 
@@ -2750,11 +2755,11 @@ msgid "A component used to make a selection"
 msgstr "Un componente utilizado para hacer una selección"
 
 #: frontend/src/metabase/components/Select.info.js:20
-#: frontend/src/metabase/components/Select.info.js:28
+#: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
 msgstr "Seleccionado"
 
-#: frontend/src/metabase/components/Select.jsx:297
+#: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
 msgstr "Nada para seleccionar"
 
@@ -2767,7 +2772,7 @@ msgid "Unknown error encountered"
 msgstr "Error desconocido encontrado"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/nav/containers/Navbar.jsx:304
+#: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
 msgstr "Crea"
 
@@ -2776,13 +2781,11 @@ msgid "Create dashboard"
 msgstr "Crea un Cuadro de Mando"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:331
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:60
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
 msgstr "Tabla"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:306
 msgid "Database"
 msgstr "Base de Datos"
 
@@ -2790,22 +2793,20 @@ msgstr "Base de Datos"
 msgid "Creator"
 msgstr "Creador"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:238
+#: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
 msgstr "No se han encontrado resultados"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:239
+#: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
 msgstr "Intenta ajustar tu filtro para encontrar lo que estás buscando."
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:258
+#: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
 msgstr "Ver por"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:494
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:84
-#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:69
-#: frontend/src/metabase/tutorial/TutorialModal.jsx:34
+#: frontend/src/metabase/containers/EntitySearch.jsx:495
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
 msgstr "de"
 
@@ -2818,13 +2819,13 @@ msgid "Once you connect your own data, I can show you some automatic exploration
 msgstr "En cuanto conectas tus propios datos, puedo mostrarte algunas exploraciones automáticas llamadas rayos-X. Aquí hay algunos ejemplos con datos de muestra."
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
-#: frontend/src/metabase/containers/Overworld.jsx:299
+#: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
 msgstr "Empieza aquí"
 
-#: frontend/src/metabase/containers/Overworld.jsx:294
-#: frontend/src/metabase/entities/collections.js:147
+#: frontend/src/metabase/containers/Overworld.jsx:296
+#: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
 msgstr "Nuestra Analítica"
@@ -2833,53 +2834,53 @@ msgstr "Nuestra Analítica"
 msgid "Browse all items"
 msgstr "Ver todos los elementos"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:165
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
 msgstr "¿Reemplazar o guardar como nuevo?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:173
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
 msgstr "Reemplazar la pregunta original, \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:178
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
 msgstr "Guardar como nueva pregunta"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:187
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
 msgstr "Primero, guarda tu pregunta"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:188
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
 msgstr "Guardar pregunta"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:224
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
 msgstr "¿Cuál es el nombre de tu tarjeta?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:232
-#: frontend/src/metabase/entities/collections.js:101
-#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:234
+#: frontend/src/metabase/entities/collections.js:102
+#: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/lib/core.js:50 frontend/src/metabase/lib/core.js:205
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:156
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:211
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:203
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:207
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:207
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:24
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:159
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:214
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:192
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:206
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:210
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
 msgstr "Descripción"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:238
-#: frontend/src/metabase/entities/dashboards.js:153
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
+#: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
 msgstr "Es opcional pero, tan útil"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:245
-#: frontend/src/metabase/entities/dashboards.js:157
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
+#: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "¿En qué colección debería ir esto?"
 
@@ -2891,7 +2892,7 @@ msgstr "modificado"
 msgid "item"
 msgstr "elemento"
 
-#: frontend/src/metabase/containers/UndoListing.jsx:81
+#: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
 msgstr "Deshacer"
 
@@ -2915,15 +2916,15 @@ msgstr "No estamos seguros si esta pregunta es compatible"
 msgid "Archive Dashboard"
 msgstr "Archivar Cuadro de Mando"
 
-#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:20
+#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Asegúrate de hacer una selección para cada serie, o el filtro no funcionará en esta tarjeta."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:300
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
 msgstr "Este cuadro de mando parece estar vacío."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:301
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
 msgstr "¡Añade una pregunta para hacerlo útil!"
 
@@ -2943,59 +2944,58 @@ msgstr "Desactivar Pantalla Completa"
 msgid "Enter fullscreen"
 msgstr "Activar Pantalla Completa"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:181
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:183
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Guardando…"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:216
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
 msgstr "Añade una pregunta"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:219
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
 msgstr "Añade una pregunta a este cuadro de mando"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:248
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
 msgstr "Añadir filtro"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:254
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:78
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Parámetros"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:275
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
 msgstr "Añade una caja de texto"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
 msgstr "Mover cuadro de mando"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:302
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
 msgstr "Editar Cuadro de Mando"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:306
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
 msgstr "Editar Disposición del Cuadro de Mando"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:369
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
 msgstr "Estás editando un cuadro de mando"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:374
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
 msgstr "Selecciona el campo que debe filtrarse para cada tarjeta"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:28
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
 msgstr "Mover cuadro de mando a..."
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:52
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
 msgstr "Cuadro de Mando movido a {0}"
 
@@ -3010,7 +3010,7 @@ msgstr "¿Qué tipo de filtro?"
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:179
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
 msgstr "Apagado"
 
@@ -3050,174 +3050,174 @@ msgstr "Actualizando en"
 msgid "Remove this question?"
 msgstr "¿Eliminar esta pregunta?"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:71
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
 msgstr "Se ha guardado tu cuadro de mando."
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:745
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:76
+#: frontend/src/metabase/components/CollectionLanding.jsx:744
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
 msgstr "Verlo"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:137
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
 msgstr "Guardalo"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:170
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
 msgstr "Mostrar más sobre este/a"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:140
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
 msgstr "Esta tarjeta no tiene campos ni parámetros que coincidan con este tipo de parámetro."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:142
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Los valores en este campo no coinciden con los valores de ningún otro campo que hayas elegido."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:186
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
 msgstr "No hay campos válidos"
 
-#: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
 msgstr "El nombre debe tener 100 caracteres o menos"
 
-#: frontend/src/metabase/entities/collections.js:111
+#: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
 msgstr "Color es obligatorio"
 
-#: frontend/src/metabase/entities/dashboards.js:146
+#: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
 msgstr "¿Cuál es el nombre de tu cuadro de mando?"
 
-#: frontend/src/metabase/home/components/Activity.jsx:92
+#: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
 msgstr "he hecho algunas cosas geniales que son difíciles de describir"
 
-#: frontend/src/metabase/home/components/Activity.jsx:101
-#: frontend/src/metabase/home/components/Activity.jsx:116
+#: frontend/src/metabase/home/components/Activity.jsx:103
+#: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
 msgstr "creado una alerta sobre - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:126
-#: frontend/src/metabase/home/components/Activity.jsx:141
+#: frontend/src/metabase/home/components/Activity.jsx:128
+#: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
 msgstr "eliminado una alerta sobre - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:152
+#: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
 msgstr "guardado una pregunta sobre"
 
-#: frontend/src/metabase/home/components/Activity.jsx:165
+#: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
 msgstr "guardado una pregunta"
 
-#: frontend/src/metabase/home/components/Activity.jsx:169
+#: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
 msgstr "eliminado una pregunta"
 
-#: frontend/src/metabase/home/components/Activity.jsx:172
+#: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
 msgstr "creado un cuadro de mando"
 
-#: frontend/src/metabase/home/components/Activity.jsx:175
+#: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
 msgstr "eliminado un cuadro de mando"
 
-#: frontend/src/metabase/home/components/Activity.jsx:181
-#: frontend/src/metabase/home/components/Activity.jsx:196
+#: frontend/src/metabase/home/components/Activity.jsx:183
+#: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
 msgstr "añadido una pregunta al cuadro de mando - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:206
-#: frontend/src/metabase/home/components/Activity.jsx:221
+#: frontend/src/metabase/home/components/Activity.jsx:208
+#: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
 msgstr "eliminado una pregunta del cuadro de mando - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:231
-#: frontend/src/metabase/home/components/Activity.jsx:238
+#: frontend/src/metabase/home/components/Activity.jsx:233
+#: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
 msgstr "recibido los últimos datos de"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:621
-#: frontend/src/metabase/home/components/Activity.jsx:244
+#: frontend/src/metabase-lib/lib/Dimension.js:814
+#: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: frontend/src/metabase/home/components/Activity.jsx:251
+#: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
 msgstr "Hola Mundo!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:252
+#: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
 msgstr "Metabase está funcionando."
 
-#: frontend/src/metabase/home/components/Activity.jsx:258
-#: frontend/src/metabase/home/components/Activity.jsx:288
+#: frontend/src/metabase/home/components/Activity.jsx:260
+#: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
 msgstr "añadido la métrica"
 
-#: frontend/src/metabase/home/components/Activity.jsx:272
-#: frontend/src/metabase/home/components/Activity.jsx:362
+#: frontend/src/metabase/home/components/Activity.jsx:274
+#: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
 msgstr "a la"
 
-#: frontend/src/metabase/home/components/Activity.jsx:282
-#: frontend/src/metabase/home/components/Activity.jsx:322
-#: frontend/src/metabase/home/components/Activity.jsx:372
-#: frontend/src/metabase/home/components/Activity.jsx:413
+#: frontend/src/metabase/home/components/Activity.jsx:284
+#: frontend/src/metabase/home/components/Activity.jsx:324
+#: frontend/src/metabase/home/components/Activity.jsx:374
+#: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
 msgstr "tabla"
 
-#: frontend/src/metabase/home/components/Activity.jsx:298
-#: frontend/src/metabase/home/components/Activity.jsx:328
+#: frontend/src/metabase/home/components/Activity.jsx:300
+#: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
 msgstr "ha hecho cambios a la métrica"
 
-#: frontend/src/metabase/home/components/Activity.jsx:312
-#: frontend/src/metabase/home/components/Activity.jsx:403
+#: frontend/src/metabase/home/components/Activity.jsx:314
+#: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
 msgstr "en el"
 
-#: frontend/src/metabase/home/components/Activity.jsx:335
+#: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
 msgstr "eliminado la métrica"
 
-#: frontend/src/metabase/home/components/Activity.jsx:338
+#: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
 msgstr "pulso creado"
 
-#: frontend/src/metabase/home/components/Activity.jsx:341
+#: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
 msgstr "pulso eliminado"
 
-#: frontend/src/metabase/home/components/Activity.jsx:347
-#: frontend/src/metabase/home/components/Activity.jsx:378
+#: frontend/src/metabase/home/components/Activity.jsx:349
+#: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
 msgstr "filtro añadido"
 
-#: frontend/src/metabase/home/components/Activity.jsx:388
-#: frontend/src/metabase/home/components/Activity.jsx:419
+#: frontend/src/metabase/home/components/Activity.jsx:390
+#: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
 msgstr "ha hecho cambios al filtro"
 
-#: frontend/src/metabase/home/components/Activity.jsx:426
+#: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
 msgstr "eliminado el filtro {0}"
 
-#: frontend/src/metabase/home/components/Activity.jsx:429
+#: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
 msgstr "se ha unido!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:529
+#: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
 msgstr "Hmmm, parece que nada ha pasado aún."
 
-#: frontend/src/metabase/home/components/Activity.jsx:532
+#: frontend/src/metabase/home/components/Activity.jsx:534
 msgid "Save a question and get this baby going!"
 msgstr "¡Guarda una pregunta y haz que esto funcione!"
 
@@ -3265,21 +3265,21 @@ msgstr "Visto Recientemente"
 msgid "You haven't looked at any dashboards or questions recently"
 msgstr "No has consultado ningún cuadro de mando o pregunta recientemente"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:99
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
 msgstr "{0} elemento(s) seleccionado(s)"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:121
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:172
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
 msgstr "Desarchivar"
 
-#: frontend/src/metabase/home/containers/HomepageApp.jsx:74
-#: frontend/src/metabase/nav/containers/Navbar.jsx:331
+#: frontend/src/metabase/home/containers/HomepageApp.jsx:77
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
 msgstr "Actividad"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:28
+#: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
 msgstr "Resultados de \"{0}\""
 
@@ -3344,6 +3344,7 @@ msgstr "URL Avatar"
 msgid "Common"
 msgstr "Común"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
@@ -3380,8 +3381,9 @@ msgstr "Latitud"
 msgid "Longitude"
 msgstr "Longitud"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:149
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
 msgstr "Número"
@@ -3479,7 +3481,7 @@ msgstr "Puntuación"
 
 #: frontend/src/metabase/lib/core.js:210
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:17
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
 msgstr "Título"
 
@@ -3536,8 +3538,9 @@ msgid "Metabase will never retrieve this field. Use this for sensitive or irrele
 msgstr "Metabase nunca recuperará este campo. Úsalo para información sensible o irrelevante."
 
 #: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:614
-#: frontend/src/metabase/visualizations/lib/utils.js:126
+#: frontend/src/metabase/lib/query.js:300
+#: frontend/src/metabase/visualizations/lib/utils.js:130
+#: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -3552,7 +3555,7 @@ msgstr "RecuentoAcumulativo"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
-#: frontend/src/metabase/visualizations/lib/utils.js:127
+#: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
 msgstr "Suma"
 
@@ -3561,7 +3564,7 @@ msgid "CumulativeSum"
 msgstr "SumaAcumulativa"
 
 #: frontend/src/metabase/lib/expressions/config.js:11
-#: frontend/src/metabase/visualizations/lib/utils.js:128
+#: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
 msgstr "Distinto"
 
@@ -3571,35 +3574,35 @@ msgid "StandardDeviation"
 msgstr "DesviacionEstandar"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/visualizations/lib/utils.js:125
+#: frontend/src/metabase/visualizations/lib/utils.js:129
 msgid "Average"
 msgstr "Media"
 
 #: frontend/src/metabase/lib/expressions/config.js:14
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:25
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
 msgstr "Mín"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
 msgstr "Máx"
 
-#: frontend/src/metabase/lib/expressions/parser.js:384
+#: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
 msgstr "triste panda triste, errores léxicos detectados"
 
-#: frontend/src/metabase/lib/formatting.js:707
+#: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} segundo"
 msgstr[1] "{0} segundos"
 
-#: frontend/src/metabase/lib/formatting.js:710
+#: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuto"
@@ -3638,222 +3641,224 @@ msgstr "¿Qué tienes en mente?"
 msgid "What do you want to find out?"
 msgstr "¿Qué quieres saber?"
 
-#: frontend/src/metabase/lib/query.js:612
-#: frontend/src/metabase/lib/schema_metadata.js:451
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:246
+#: frontend/src/metabase/lib/query.js:298
+#: frontend/src/metabase/lib/schema_metadata.js:458
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
 msgstr "Datos brutos"
 
-#: frontend/src/metabase/lib/query.js:616
+#: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
 msgstr "Recuento acumulativo"
 
-#: frontend/src/metabase/lib/query.js:619
+#: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
 msgstr "Media de"
 
-#: frontend/src/metabase/lib/query.js:624
+#: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
 msgstr "Valores distintos de"
 
-#: frontend/src/metabase/lib/query.js:629
+#: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
 msgstr "Desviación estándar de"
 
-#: frontend/src/metabase/lib/query.js:634
+#: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
 msgstr "Suma de"
 
-#: frontend/src/metabase/lib/query.js:639
+#: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
 msgstr "Suma acumulativa de"
 
-#: frontend/src/metabase/lib/query.js:644
+#: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
 msgstr "Máximo de"
 
-#: frontend/src/metabase/lib/query.js:649
+#: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
 msgstr "Mínimo de"
 
-#: frontend/src/metabase/lib/query.js:663
+#: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
 msgstr "Agrupado por"
 
-#: frontend/src/metabase/lib/query.js:677
+#: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
 msgstr "Filtrado por"
 
-#: frontend/src/metabase/lib/query.js:706
+#: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
 msgstr "Ordenado por"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
 msgstr "Verdadero"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
 msgstr "Falso"
 
-#: frontend/src/metabase/lib/schema_metadata.js:305
+#: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
 msgstr "Selecciona el campo de longitud"
 
-#: frontend/src/metabase/lib/schema_metadata.js:306
+#: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
 msgstr "Latitud Superior"
 
-#: frontend/src/metabase/lib/schema_metadata.js:307
+#: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
 msgstr "Longitud Izquierda"
 
-#: frontend/src/metabase/lib/schema_metadata.js:308
+#: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
 msgstr "Latitud Inferior"
 
-#: frontend/src/metabase/lib/schema_metadata.js:309
+#: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
 msgstr "Longitud Derecha"
 
-#: frontend/src/metabase/lib/schema_metadata.js:345
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase-lib/lib/Dimension.js:505
+#: frontend/src/metabase-lib/lib/Dimension.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:351
+#: frontend/src/metabase/lib/schema_metadata.js:371
 #: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:387
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
 msgstr "Es"
 
-#: frontend/src/metabase/lib/schema_metadata.js:346
-#: frontend/src/metabase/lib/schema_metadata.js:366
-#: frontend/src/metabase/lib/schema_metadata.js:376
-#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/lib/schema_metadata.js:352
+#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:396
+#: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
 msgstr "No es"
 
-#: frontend/src/metabase/lib/schema_metadata.js:347
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:369
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:353
+#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
 msgstr "Vacío"
 
-#: frontend/src/metabase/lib/schema_metadata.js:348
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:370
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:402
+#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
 msgstr "No Vacío"
 
-#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
 msgstr "Igual a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:355
+#: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
 msgstr "Distinto a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:356
+#: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
 msgstr "Mayor que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:357
+#: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
 msgstr "Menor que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:358
-#: frontend/src/metabase/lib/schema_metadata.js:384
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:285
+#: frontend/src/metabase/lib/schema_metadata.js:364
+#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Entre"
 
-#: frontend/src/metabase/lib/schema_metadata.js:359
+#: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
 msgstr "Mayor o igual a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:360
+#: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
 msgstr "Menos o igual a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
 msgstr "Contiene"
 
-#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
 msgstr "No contiene"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
 msgstr "Empieza con"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
 msgstr "Termina en"
 
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:264
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Antes"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:271
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Después"
 
-#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
 msgstr "Dentro"
 
-#: frontend/src/metabase/lib/schema_metadata.js:453
+#: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Solo una tabla con las filas en la respuesta, sin operaciones adicionales."
 
-#: frontend/src/metabase/lib/schema_metadata.js:459
+#: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
 msgstr "Número de filas"
 
-#: frontend/src/metabase/lib/schema_metadata.js:461
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
 msgstr "Número total de filas en la respuesta."
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
 msgstr "Suma de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:469
+#: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
 msgstr "Suma de todos los valores de una columna."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
 msgstr "Media de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
 msgstr "Promedio de todos los valores de una columna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
 msgstr "Número de valores distintos de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Número de valores únicos de una columna entre todas las filas en la respuesta."
 
-#: frontend/src/metabase/lib/schema_metadata.js:491
+#: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
 msgstr "Suma acumulada de ..."
 
@@ -3862,7 +3867,7 @@ msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over t
 msgstr "Suma aditiva de todos los valores de una columna.\n"
 " e.g. los ingresos totales a lo largo del tiempo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:499
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
 msgstr "Recuento acumulado de filas"
 
@@ -3871,105 +3876,105 @@ msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over
 msgstr "Recuento aditiva del número de filas.\n"
 " e.g. número total de ventas en el tiempo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
 msgstr "Desviación estándar de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:509
+#: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Número que expresa cuánto varían los valores de una columna entre todas las filas en la respuesta."
 
-#: frontend/src/metabase/lib/schema_metadata.js:515
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
 msgstr "Mínimo de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:517
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
 msgstr "Valor mínimo de una columna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:523
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
 msgstr "Máximo de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:525
+#: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
 msgstr "Valor máximo de una columna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:533
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
 msgstr "Desglosar por dimensión"
 
-#: frontend/src/metabase/lib/settings.js:93
+#: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
 msgstr "letra en minúsculas"
 
-#: frontend/src/metabase/lib/settings.js:95
+#: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
 msgstr "letra en mayúsculas"
 
-#: frontend/src/metabase/lib/settings.js:97
+#: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "número"
 
-#: frontend/src/metabase/lib/settings.js:99
+#: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
 msgstr "carácter especial"
 
-#: frontend/src/metabase/lib/settings.js:105
+#: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
 msgstr "debe ser"
 
-#: frontend/src/metabase/lib/settings.js:105
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:120
+#: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
 msgstr "caracteres"
 
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
 msgstr "Debe ser"
 
-#: frontend/src/metabase/lib/settings.js:122
+#: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
 msgstr "e incluir"
 
-#: frontend/src/metabase/lib/utils.js:92
+#: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
 msgstr "cero"
 
-#: frontend/src/metabase/lib/utils.js:93
+#: frontend/src/metabase/lib/utils.js:86
 msgid "one"
 msgstr "uno"
 
-#: frontend/src/metabase/lib/utils.js:94
+#: frontend/src/metabase/lib/utils.js:87
 msgid "two"
 msgstr "dos"
 
-#: frontend/src/metabase/lib/utils.js:95
+#: frontend/src/metabase/lib/utils.js:88
 msgid "three"
 msgstr "tres"
 
-#: frontend/src/metabase/lib/utils.js:96
+#: frontend/src/metabase/lib/utils.js:89
 msgid "four"
 msgstr "cuatro"
 
-#: frontend/src/metabase/lib/utils.js:97
+#: frontend/src/metabase/lib/utils.js:90
 msgid "five"
 msgstr "cinco"
 
-#: frontend/src/metabase/lib/utils.js:98
+#: frontend/src/metabase/lib/utils.js:91
 msgid "six"
 msgstr "seis"
 
-#: frontend/src/metabase/lib/utils.js:99
+#: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
 msgstr "siete"
 
-#: frontend/src/metabase/lib/utils.js:100
+#: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
 msgstr "ocho"
 
-#: frontend/src/metabase/lib/utils.js:101
+#: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
 msgstr "nueve"
 
@@ -4043,6 +4048,7 @@ msgstr "Tiempo"
 msgid "Date range, relative date, time of day, etc."
 msgstr "Rango de fechas, fecha relativa, hora del día, etc."
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
@@ -4065,7 +4071,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Categoría, Tipo, Modelo, Clasificación, etc."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
-#: frontend/src/metabase/user/components/UserSettings.jsx:54
+#: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
 msgstr "Configuración de la cuenta"
 
@@ -4077,56 +4083,56 @@ msgstr "Salir de Configuración"
 msgid "Logs"
 msgstr "Logs"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:64
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
 msgstr "Ayuda"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:67
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
 msgstr "Sobre Metabase"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:73
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
 msgstr "Salir"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:98
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
 msgstr "Gracias por utilizar"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
 msgstr "Estás en la versión"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
 msgstr "Construida el"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:124
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
 msgstr "es una marca registrada de"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:126
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
 msgstr "y está construido con cariño en San Francisco, CA"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:194
+#: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
 msgstr "Configuración Metabase"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:300
+#: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
 msgstr "Haz una pregunta"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:309
+#: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
 msgstr "Añadir nuevo Cuadro de Mando"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:315
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/nav/containers/Navbar.jsx:361
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
 msgstr "Nuevo pulso"
 
@@ -4134,16 +4140,16 @@ msgstr "Nuevo pulso"
 msgid "Reference"
 msgstr "Referencia"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:83
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
 msgstr "¿Qué Métrica?"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:110
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "La definición de métricas comunes para tu equipo hace que sea aún más fácil hacer preguntas"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:113
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
 msgstr "Cómo crear métricas"
 
@@ -4155,8 +4161,8 @@ msgstr "Consulta los datos a lo largo del tiempo, como un mapa, o gírelos para 
 msgid "Custom"
 msgstr "Personalizado"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:150
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:517
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
 msgstr "Nueva pregunta"
 
@@ -4164,22 +4170,22 @@ msgstr "Nueva pregunta"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Utiliza el generador de preguntas para ver tendencias, listas de cosas o para crear tus propias métricas."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:161
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Consulta nativa"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:162
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Para preguntas más complicadas, puedes escribir tu propia consulta SQL o nativa."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:240
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
 msgstr "Selecciona un valor por defecto…"
 
-#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:149
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
 msgstr "Actualizar filtro"
 
@@ -4187,14 +4193,14 @@ msgstr "Actualizar filtro"
 #: frontend/src/metabase/lib/query_time.js:123
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:9
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Today"
 msgstr "Hoy"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
 msgstr "Ayer"
 
@@ -4206,7 +4212,7 @@ msgstr "Ultimos 7 días"
 msgid "Past 30 days"
 msgstr "Ultimos 30 días"
 
-#: frontend/src/metabase/lib/query_time.js:195
+#: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:29
 #: src/metabase/api/table.clj
@@ -4215,7 +4221,7 @@ msgid_plural "Weeks"
 msgstr[0] "Semana"
 msgstr[1] "Semanas"
 
-#: frontend/src/metabase/lib/query_time.js:197
+#: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:30
 #: src/metabase/api/table.clj
@@ -4224,7 +4230,7 @@ msgid_plural "Months"
 msgstr[0] "Mes"
 msgstr[1] "Meses"
 
-#: frontend/src/metabase/lib/query_time.js:201
+#: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:31
 #: src/metabase/api/table.clj
@@ -4274,6 +4280,7 @@ msgstr "Introduce un valor..."
 msgid "Enter a default value..."
 msgstr "Introduce un valor predeterminado..."
 
+#: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Ha ocurrido un error"
@@ -4314,24 +4321,24 @@ msgstr "Publicar"
 msgid "Code"
 msgstr "Código"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:70
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
 msgstr "Estilo"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
 msgstr "¿Qué parámetros pueden usar los usuarios de este embebido?"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:83
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
 msgstr "Este {0} aún no tiene parámetros para configurar."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
 msgstr "Editable"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
 msgstr "Bloqueado"
 
@@ -4339,19 +4346,19 @@ msgstr "Bloqueado"
 msgid "Preview Locked Parameters"
 msgstr "Vista previa de los parámetros bloqueados"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:115
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
 msgstr "Intenta pasar algunos valores a tus parámetros bloqueados aquí. Tu servidor tendrá que proporcionar los valores reales en el token firmado al usar esto de manera real."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
 msgstr "Zona peligrosa"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
 msgstr "Esto deshabilitará la incrustación para este {0}."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:128
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
 msgstr "No publicar"
 
@@ -4391,64 +4398,64 @@ msgstr "Más {0}"
 msgid "examples on GitHub"
 msgstr "ejemplos en GitHub"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:72
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
 msgstr "Habilitar compartir"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
 msgstr "¿Deshabilitar este enlace público?"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:77
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
 msgstr "Esto hará que el enlace existente deje de funcionar. Puedes volver a habilitarlo, pero cuando lo hagas será un enlace diferente."
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
 msgstr "Enlace público"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:118
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
 msgstr "Comparte este {0} con personas que no tienen una cuenta de Metabase usando la siguiente URL:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:158
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
 msgstr "Incrustación pública"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:159
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
 msgstr "Incrusta este {0} en publicaciones de blogs o páginas web al copiar y pegar este fragmento:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:176
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
 msgstr "Incrustar este {0} en una aplicación"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:177
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
 msgstr "Al integrar con tu servidor de aplicaciones, puedes proporcionar un/a {0} segura limitada a un usuario específico, cliente, organización, etc."
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
 msgstr "Eliminar adjunto"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:95
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
 msgstr "Adjuntar archivo con resultados"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
 msgstr "Esta pregunta se añadirá como un archivo adjunto"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:128
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
 msgstr "Esta pregunta no estará incluida en tu Pulso"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:92
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
 msgstr "Este pulso ya no se enviará por correo electrónico a la dirección {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:94
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:376
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
 msgstr[0] "{0} dirección"
@@ -4458,39 +4465,39 @@ msgstr[1] "{0} direcciones"
 msgid "Slack channel {0} will no longer get this pulse {1}"
 msgstr "El canal Slack {0} ya no recibirá este pulso {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:110
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
 msgstr "El canal {0} ya no recibirá este pulso {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
 msgstr "Edita un pulso"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:131
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
 msgstr "¿Qué es un Pulso?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:141
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
 msgstr "Lo tengo"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
 msgstr "¿A dónde deberían ir estos datos?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:173
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
 msgstr "Desarchivando…"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
 msgstr "Ha fallado la recuperación"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
 msgstr "Desarchivado"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
 msgstr "Crea un pulso"
 
@@ -4500,7 +4507,7 @@ msgstr "Adjunto"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:673
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
 msgstr "Aviso"
 
@@ -4521,6 +4528,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Recomendamos mantener los pulsos pequeños y enfocados para ayudar a mantenerlos digeribles y útiles para todo el equipo."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
+#: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
 msgstr "Elige tus datos"
 
@@ -4536,47 +4544,47 @@ msgstr "Emails"
 msgid "Slack messages"
 msgstr "Mensajes Slack"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Enviado"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:222
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} se enviará a las"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:224
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Mensajes"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Enviar email ahora"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:241
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Enviar a {0} ahora"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Enviando…"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:244
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Ha fallado el envío"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "No se envió porque el pulso no tiene resultados."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:248
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Pulso enviado"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:287
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} debe ser configurado por un administrador."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:302
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
 msgstr "Slack"
 
@@ -4625,21 +4633,21 @@ msgid "Before {0}"
 msgstr "Antes de {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:295
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Vacío"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:301
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "No Vacío"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:213
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Todo el Tiempo"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:154
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
 msgstr "Aplicar"
 
@@ -4705,7 +4713,7 @@ msgstr "Distribución"
 msgid "View details"
 msgstr "Ver detalles"
 
-#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:54
+#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
 msgstr "Ver los {1} de {0}"
 
@@ -4729,22 +4737,22 @@ msgstr "Media"
 msgid "Distincts"
 msgstr "Distintos"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:32
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Ver el {0}"
 msgstr[1] "Ver estos {0}"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:225
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
 msgstr "Ampliar"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:19
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
 msgstr "Expresión Personalizada"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
 msgstr "Métricas Comunes"
 
@@ -4752,7 +4760,7 @@ msgstr "Métricas Comunes"
 msgid "Metabasics"
 msgstr "Metabasics"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
 msgstr "Nombre (opcional)"
 
@@ -4764,31 +4772,31 @@ msgstr "Elige una agregación"
 msgid "Set up your own alert"
 msgstr "Configura tu propia alerta"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:140
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
 msgstr "Dando de baja..."
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:145
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
 msgstr "Error al darse de baja"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:204
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
 msgstr "Darse de baja"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:235
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
 msgstr "Sin canal"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:263
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
 msgstr "De acuerdo, has sido dado de baja"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:335
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
 msgstr "Estás recibiendo las alertas de {0}"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
 msgstr "{0} has configurado una alerta"
 
@@ -4844,147 +4852,147 @@ msgstr "Edita tu alerta"
 msgid "Edit alert"
 msgstr "Editar alerta"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:374
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
 msgstr "Esta alerta ya no se enviará por correo electrónico a {0}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:382
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
 msgstr "El canal Slack {0} ya no recibirá esta alerta."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:386
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
 msgstr "El canal {0} ya no recibirá esta alerta."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:403
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
 msgstr "Elimina esta alerta"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:405
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
 msgstr "Detener el envío y elimina esta alerta. No se puede deshacer, así que ten cuidado."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:413
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
 msgstr "¿Eliminar esta alerta?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:497
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
 msgstr "Avísame cuando la línea…"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:498
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
 msgstr "Avísame cuando la barra de progreso…"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
 msgstr "Va por encima de la línea de objetivo"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
 msgstr "Llega al objetivo"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
 msgstr "Va por debajo de la línea de objetivo"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
 msgstr "Va por debajo del objetivo"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:512
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
 msgstr "¿La primera vez que cruza, o cada vez?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:513
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
 msgstr "¿La primera vez que alcanza el objetivo, o cada vez?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
 msgstr "La primera vez"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:516
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
 msgstr "Cada vez"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:619
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
 msgstr "¿A dónde quieres enviar estas alertas?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:630
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
 msgstr "Envía emails de alerta a:"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:672
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
 msgstr "{0} Las alertas basadas en objetivos aún no son compatibles para gráficos con más de una línea, por lo que esta alerta se enviará siempre que el gráfico tenga {1}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
 msgstr "resultados"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:679
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
 msgstr "{0} Este tipo de alerta es más útil cuando tu pregunta {1} no arroja ningún resultado, pero quieres saber cuándo lo hace."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:680
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
 msgstr "Consejo:"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
 msgstr "generalmente"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:57
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
 msgstr "Elige un segmento o tabla"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
 msgstr "Selecciona una base de datos"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:88
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
 msgstr "Seleccionar..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:128
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
 msgstr "Selecciona una tabla"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:793
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
 msgstr "No se encontraron tablas en esta base de datos."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:830
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
 msgstr "¿Falta una pregunta?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:834
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
 msgstr "Obtén más información sobre consultas anidadas"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:868
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
 msgstr "Campos"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:946
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
 msgstr "No se encontraron segmentos"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:969
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
 msgstr "Encuentra un segmento"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:46
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
 msgstr "Ver menos"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:56
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
 msgstr "Ver más"
 
@@ -4993,60 +5001,65 @@ msgid "Pick a field to sort by"
 msgstr "Elige un campo para ordenar por"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
 msgstr "Ordenar"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
 msgstr "Límite de filas"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:69
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
 msgstr "Campo Desconocido"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
 msgstr "campo"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:114
+#: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
 msgstr "Conincidencias"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
+#: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Añade filtros para limitar tu respuesta"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:284
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
 msgstr "Añadir una agrupación"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:322
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:102
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:113
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:152
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:194
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:59
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:68
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:75
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:225
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:231
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:237
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:70
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:75
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:64
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:89
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:131
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:176
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:302
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:308
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:314
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Datos"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:352
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
 msgstr "Filtrado por"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:369
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
 msgstr "Ver"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:386
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
 msgstr "Agrupado por"
 
@@ -5054,23 +5067,23 @@ msgstr "Agrupado por"
 msgid "None"
 msgstr "Ninguno"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:345
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
 msgstr "Esta pregunta está escrita en {0}"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:353
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
 msgstr "Esconder Editor"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:354
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
 msgstr "Esconder Consulta"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
 msgstr "Abrir Editor"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:360
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
 msgstr "Mostrar Consulta"
 
@@ -5091,15 +5104,15 @@ msgstr "Descargar esta información"
 msgid "Warning"
 msgstr "Aviso"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:52
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
 msgstr "Tu respuesta tiene una gran cantidad de filas, por lo que podría tardar un tiempo en descargarse."
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:53
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
 msgstr "El tamaño máximo de descarga es de 1 millón de filas."
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:232
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
 msgstr "Editar pregunta"
 
@@ -5115,17 +5128,17 @@ msgstr "CANCELAR"
 msgid "Move question"
 msgstr "Mover pregunta"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:283
+#: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
 msgstr "¿En qué colección debería estar esto?"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:313
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:110
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
+#: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
 msgstr "Variables"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:432
+#: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
 msgstr "Conoce tus datos"
 
@@ -5169,11 +5182,11 @@ msgstr "{0} de esta pregunta"
 msgid "Convert this question to {0}"
 msgstr "Convertir esta pregunta en {0}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:122
+#: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
 msgstr "Esta pregunta se actualizará en aproximadamente {0}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:131
+#: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
 msgstr "Actualizado hace {0}"
 
@@ -5191,11 +5204,11 @@ msgstr "Mostrando primeras {0} {1}"
 msgid "Showing {0} {1}"
 msgstr "Mostrando {0} {1}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:281
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
 msgstr "Haciendo ciencia"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:294
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
 msgstr "Si me das algunos datos, puedo mostrarte algo genial. ¡Ejecuta una consulta!"
 
@@ -5203,7 +5216,7 @@ msgstr "Si me das algunos datos, puedo mostrarte algo genial. ¡Ejecuta una cons
 msgid "How do I use this thing?"
 msgstr "¿Cómo uso esta cosa?"
 
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:28
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
 msgstr "Obtener Respuesta"
 
@@ -5231,39 +5244,39 @@ msgstr "Lo siento. Algo salió mal."
 msgid "Group time by"
 msgstr "Agrupar tiempo por"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:46
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
 msgstr "Tu pregunta tardó demasiado tiempo"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:47
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
 msgstr "No obtuvimos una respuesta de tu base de datos a tiempo, así que tuvimos que parar.Puedes volver a intentarlo en un minuto, o si el problema persiste, puedes enviar un correo electrónico a un administrador para avisarle."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:55
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
 msgstr "Estamos experimentando problemas con el servidor"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:56
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
 msgstr "Intenta actualizar la página después de esperar uno o dos minutos. Si el problema persiste, te recomendamos que te pongas en contacto con un administrador."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:88
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
 msgstr "Hubo un problema con tu pregunta"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:89
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
 msgstr "La mayoría de las veces esto es causado por una selección no válida o un valor de entrada incorrecto.Revisa tus entradas y vuelva a intentar la consulta."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:60
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
 msgstr "Esta puede ser la respuesta que estás buscando. De lo contrario, intenta eliminar o cambiar tus filtros para que sean menos específicos."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
 msgstr "También puedes {0} cuando hay algunos resultados."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:68
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
 msgstr "recibir una alerta"
 
@@ -5271,11 +5284,11 @@ msgstr "recibir una alerta"
 msgid "Back to last run"
 msgstr "Volver a la última ejecución"
 
-#: frontend/src/metabase/query_builder/components/VisualizationSettings.jsx:100
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
 msgstr "Visualización"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:96
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
 msgstr "Sin descripción"
 
@@ -5287,7 +5300,7 @@ msgstr "Usar para la pregunta actual"
 msgid "Potentially useful questions"
 msgstr "Preguntas potencialmente útiles"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:166
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
 msgstr "Agrupar por {0}"
 
@@ -5300,14 +5313,14 @@ msgstr "Suma de todos los valores de {0}"
 msgid "All distinct values of {0}"
 msgstr "Todos los valores distintos de {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:187
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
 msgstr "Número de {0} agrupadas por {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5323,34 +5336,34 @@ msgstr "Referencia de Datos"
 msgid "Learn more about your data structure to ask more useful questions"
 msgstr "Aprende más sobre tu estructura de datos para hacer preguntas más útiles"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:58
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:84
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
 msgstr "No se pudieron encontrar los metadatos de la tabla antes de crear una nueva pregunta"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:80
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
 msgstr "Ver {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:94
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
 msgstr "Definición de Métrica"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:118
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
 msgstr "Filtrar por {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:127
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
 msgstr "Número de {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
 msgstr "Ver todos los {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:148
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
 msgstr "Definición de Segmento"
 
@@ -5362,7 +5375,7 @@ msgstr "Se produjo un error al cargar la tabla"
 msgid "See the raw data for {0}"
 msgstr "Ver los datos de {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:180
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
 msgstr "Más"
 
@@ -5374,24 +5387,24 @@ msgstr "Expresión inválida"
 msgid "unknown error"
 msgstr "error no controlado"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:46
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
 msgstr "Fórmula de campo"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:57
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Piensa en esto como algo parecido a escribir una fórmula en un programa de hoja de cálculo: puedes usar números, campos de esta tabla, símbolos matemáticos como + y algunas funciones. Así puedes escribir algo como Subtotal - Cost."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
 msgstr "Aprende más"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:66
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
 msgstr "Dale un nombre"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:72
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
 msgstr "Algo agradable y descriptivo"
 
@@ -5443,7 +5456,8 @@ msgstr "verdadero"
 msgid "false"
 msgstr "falso"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
 msgstr "Añadir filtro"
 
@@ -5451,15 +5465,15 @@ msgstr "Añadir filtro"
 msgid "Item"
 msgstr "Elemento"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:221
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
 msgstr "Anterior"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:252
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
 msgstr "Actual"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:278
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
@@ -5470,7 +5484,7 @@ msgid "Enter desired number"
 msgstr "Introduce el número deseado"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:100
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
 msgstr "Vacío"
 
@@ -5494,35 +5508,35 @@ msgstr "Puedes introducir varios valores separados por comas"
 msgid "Enter desired text"
 msgstr "Introduce el texto deseado"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
 msgstr "Pruébalo"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
 msgstr "¿Para qué sirve esto?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
 msgstr "Las variables en las consultas nativas te permiten reemplazar dinámicamente los valores en tus consultas utilizando elementos de filtro o a través de la URL."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
 msgstr "{0} crea una variable en esta plantilla SQL llamada \"nombre_variable\". Puedes asignar tipos a las variables en el panel lateral, lo que cambia su comportamiento. Todos los tipos de variables que no sean \"Filtro de Campo\" provocarán automáticamente que se coloque un elemento de filtro en esta pregunta; con Filtros de Campo, esto es opcional. Cuando se rellena este elemento de filtro, ese valor reemplaza a la variable en la plantilla SQL."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:121
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
 msgstr "Filtros de Campo"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:123
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Darle a una variable el tipo \"Filtro de campo\" te permite vincular las tarjetas SQL con los elementos de filtro en los cuadros de mando o usar más tipos de elementos de filtro en tu pregunta de SQL. Una variable de filtro de campo inserta SQL similar a la generada por el generador de consultas GUI cuando se añaden filtros en columnas existentes."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:126
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
 msgstr "Al añadir una variable de Filtro de campo, deberás asignarla a un campo específico. A continuación, puedes optar por mostrar un elemento de filtro en tu pregunta, pero incluso si no lo haces, ahora puedes asignar tu variable de Filtro de campo a un filtro de cuadro de mando al agregar esta pregunta al mismo. Los filtros de campo deben usarse dentro de una cláusula \"WHERE\"."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:130
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
 msgstr "Cláusulas opcionales"
 
@@ -5530,59 +5544,61 @@ msgstr "Cláusulas opcionales"
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
 msgstr "los corchetes alrededor de un {0} crean una cláusula opcional en la plantilla. Si se establece la \"variable\", entonces la cláusula completa se coloca en la plantilla. Si no, entonces se ignora toda la cláusula."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:142
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
 msgstr "Para utilizar varias cláusulas opcionales, puedes incluir al menos una cláusula WHERE no opcional seguida de cláusulas opcionales que comiencen con \"AND\"."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
 msgstr "Lee la documentación completa"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:127
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
 msgstr "Filtro de Etiqueta"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:139
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
 msgstr "Tipo de Variable"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:143
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
 msgstr "Texto"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:150
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:119
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
 msgstr "Fecha"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
 msgstr "Filtro de Campo"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:157
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
 msgstr "Campo para mapear a"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
 msgstr "Tipo de filtro"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:201
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
 msgstr "¿Obligatorio?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:211
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
 msgstr "Valor por defecto del filtro"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:46
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
 msgstr "¿Archivar esta pregunta?"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:57
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Esta pregunta se eliminará de cualquier cuadro de mando o pulso que lo usen."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:136
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
 msgstr "Pregunta"
 
@@ -5599,21 +5615,21 @@ msgstr "Estás editando esta página"
 msgid "See this {0}"
 msgstr "Ver este {0}"
 
-#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:120
+#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
 msgstr "Un subconjunto de"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:68
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
 msgstr "Selecciona un tipo de campo"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:57
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
 msgstr "Sin tipo de campo"
 
@@ -5622,16 +5638,16 @@ msgid "by"
 msgstr "por"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
-#: frontend/src/metabase/reference/databases/FieldList.jsx:152
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
+#: frontend/src/metabase/reference/databases/FieldList.jsx:155
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
 msgstr "Tipo campo"
 
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:72
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
 msgstr "Selecciona una Clabe foránea"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:53
+#: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
 msgstr "Ver la fórmula de {0}"
 
@@ -5648,12 +5664,12 @@ msgid "Nothing important yet"
 msgstr "Nada importante todavía"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:168
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:233
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:211
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:215
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:219
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:229
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:236
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:214
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
 msgstr "Nada interesante todavía"
 
@@ -5662,12 +5678,12 @@ msgid "Things to be aware of about this {0}"
 msgstr "Cosas a tener en cuenta acerca de este {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:178
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:243
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:221
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:225
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:229
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:239
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:246
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:224
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
 msgstr "Nada de lo que estar enterado todavía"
 
@@ -5729,15 +5745,15 @@ msgstr "Motivo del cambio"
 msgid "Leave a note to explain what changes you made and why they were required"
 msgstr "Deja una nota para explicar qué cambios ha realizado y por qué fueron necesarios"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:166
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
 msgstr "Por qué esta base de datos es interesante"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:176
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
 msgstr "Cosas a tener en cuenta acerca de esta base de datos"
 
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:46
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
 msgstr "Bases de datos y tablas"
@@ -5745,42 +5761,42 @@ msgstr "Bases de datos y tablas"
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:41
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:170
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:173
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:34
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:184
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:187
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:30
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:188
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:187
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:191
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:190
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
 msgstr "Detalles"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
-#: frontend/src/metabase/reference/databases/TableList.jsx:111
+#: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
 msgstr "Tablas en {0}"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:222
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:200
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:218
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:203
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
 msgstr "Nombre real en la base de datos"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:231
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:227
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
 msgstr "Por qué este campo es interesante"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:241
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:237
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
 msgstr "Cosas a tener en cuenta sobre este campo"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:253
-#: frontend/src/metabase/reference/databases/FieldList.jsx:155
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:249
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
+#: frontend/src/metabase/reference/databases/FieldList.jsx:158
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
 msgstr "Tipo de dato"
 
@@ -5789,13 +5805,13 @@ msgstr "Tipo de dato"
 msgid "Fields in this table will appear here as they're added"
 msgstr "Los campos en esta tabla aparecerán aquí a medida que se añadan"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:134
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:135
+#: frontend/src/metabase/reference/databases/FieldList.jsx:137
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
 msgstr "Campos en {0}"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:149
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:150
+#: frontend/src/metabase/reference/databases/FieldList.jsx:152
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
 msgstr "Nombre de campo"
 
@@ -5819,7 +5835,10 @@ msgstr "Las bases de datos aparecerán aquí una vez que los administradores hay
 msgid "Connect a database"
 msgstr "Conecta una base de datos"
 
+#. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
+#. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
+#: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
 msgstr "Número de {0}"
 
@@ -5827,11 +5846,11 @@ msgstr "Número de {0}"
 msgid "See raw data for {0}"
 msgstr "Ver datos de {0}"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:209
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
 msgstr "Por qué esta tabla es interesante"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:219
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
 msgstr "Cosas a tener en cuenta sobre esta tabla"
 
@@ -5843,16 +5862,16 @@ msgstr "Las tablas en esta base de datos aparecerán aquí cuando se añadan"
 msgid "Questions about this table will appear here as they're added"
 msgstr "Las preguntas sobre esta tabla aparecerán aquí cuando se añadan"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:71
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:75
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:74
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
 msgstr "Preguntas sobre {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
 msgstr "Creado hace {0} por {1}"
 
@@ -5864,151 +5883,152 @@ msgstr "Campos en esta tabla"
 msgid "Questions about this table"
 msgstr "Preguntas sobre esta tabla"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:157
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
 msgstr "Ayuda a tu equipo a empezar con tus datos."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:159
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
 msgstr "Muestra a tu equipo lo que es más importante al elegir tu cuadro de mando, tus métricas y tus segmentos principales."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:165
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
 msgstr "Empieza"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:173
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
 msgstr "Nuestro cuadro de mando más importante"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:188
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
 msgstr "Números a los que prestamos atención"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:213
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
 msgstr "Las métricas son números destacados que le importan a tu empresa. A menudo representan un indicador central de cómo está funcionando el negocio."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:221
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
 msgstr "Ver todas las métricas"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:235
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
 msgstr "Segmentos y tablas"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
+#: frontend/src/metabase/home/containers/SearchApp.jsx:83
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
 msgstr "Tablas"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:262
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
 msgstr "Los segmentos y tablas son los componentes básicos de los datos de tu empresa. Las tablas son colecciones de información sin formato mientras que los segmentos son trozos acotados con significados específico, como {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:267
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
 msgstr "Las tablas son los componentes básicos de los datos de tu empresa."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:277
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
 msgstr "Ver todos los segmentos"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:293
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
 msgstr "Ver todas las tablas"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:301
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
 msgstr "Otras cosas que debes saber sobre nuestros datos"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
 msgstr "Descubre más"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:307
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
 msgstr "Una buena manera de conocer tus datos es dedicarle un poco de tiempo a explorar las diferentes tablas y otra información disponible. Puedes tardar un poco, pero comenzarás a reconocer nombres y significados con el tiempo."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:313
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
 msgstr "Explora nuestros datos"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:321
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
 msgstr "¿Tienes una pregunta?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:326
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
 msgstr "Habla con {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:248
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
 msgstr "Ayuda a los nuevos usuarios de Metabase a encontrar su camino."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:251
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
 msgstr "La guía de introducción destaca el cuadro de mando, las métricas, los segmentos y las tablas que más importan, e informa a los usuarios sobre cosas importantes que deberían saber antes de profundizar en los datos."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:258
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
 msgstr "¿Hay un cuadro de mando importante para tu equipo?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:260
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
 msgstr "Crea un cuadro de mando ahora"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:266
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
 msgstr "¿Cuál es tu cuadro de mando más importante?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:285
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
 msgstr "¿Tienes alguna métrica comúnmente referenciada?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:287
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
 msgstr "Aprende a definir una métrica"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:300
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
 msgstr "¿Cuáles son las 3-5 métricas más comúnmente referenciadas?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:344
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
 msgstr "Añade otra métrica"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:357
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
 msgstr "¿Tienes algún segmento o tabla comúnmente referenciado?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:359
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
 msgstr "Aprenda a crear un segmento"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:372
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
 msgstr "¿Cuáles son los 3-5 segmentos o tablas comúnmente referenciados que serían útiles paraesta audiencia?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:418
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
 msgstr "Añade otro segmento o tabla"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:427
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
 msgstr "¿Hay algo que tus usuarios deberían entender o saber antes de que comiencen a acceder a los datos?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:433
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
 msgstr "¿Qué debe saber un usuario de estos datos antes de que comiencen a acceder a ellos?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:437
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
 msgstr "Por ejemplo, las expectativas sobre la privacidad y el uso de datos, peligros comunes o malentendidos, información sobre el rendimiento del almacén de datos, avisos legales, etc."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
 msgstr "¿Hay alguien con quien tus usuarios puedan contactar si necesitan ayuda si están confundidos acerca de esta guía?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:457
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
 msgstr "¿A quién deben contactar los usuarios para obtener ayuda si están confundidos acerca de esta información?"
 
@@ -6017,39 +6037,39 @@ msgstr "¿A quién deben contactar los usuarios para obtener ayuda si están con
 msgid "Please enter a revision message"
 msgstr "Por favor añade un mensaje de revisión"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:213
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
 msgstr "Por qué esta métrica es interesante"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:223
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
 msgstr "Cosas a tener en cuenta acerca de esta métrica"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:233
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
 msgstr "Cómo se calcula esta métrica"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:235
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
 msgstr "Nada sobre cómo se calculó aún"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:293
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
 msgstr "Otros campos por los que puedes agrupar esta métrica"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:294
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
 msgstr "Campos por los que puedes agrupar esta métrica"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:23
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Las métricas son los números oficiales de los que tu equipo se preocupa"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Las métricas aparecerán aquí una vez que tus administradores hayan creado algunas"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
 msgstr "Aprende cómo crear métricas"
 
@@ -6061,9 +6081,9 @@ msgstr "Las preguntas sobre esta métrica aparecerán aquí cuando se añadan"
 msgid "There are no revisions for this metric"
 msgstr "No hay revisiones para esta métrica"
 
-#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:88
-#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
-#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:88
+#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
+#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
+#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
 msgstr "Historial de revisiones de {0}"
 
@@ -6071,27 +6091,27 @@ msgstr "Historial de revisiones de {0}"
 msgid "X-ray this metric"
 msgstr "Aplica rayos-X a esta métrica"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:217
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
 msgstr "Por qué este segmento es interesante"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:227
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
 msgstr "Cosas a tener en cuenta sobre este segmento"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
 msgstr "Los segmentos son subconjuntos interesantes de tablas"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "La definición de segmentos comunes para tu equipo hace que sea aún más fácil hacer preguntas"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
 msgstr "Los segmentos aparecerán aquí una vez que los administradores hayan creado algunos"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
 msgstr "Aprende a crear segmentos"
 
@@ -6119,7 +6139,7 @@ msgstr "Aplica rayos-X a este segmento"
 msgid "Login"
 msgstr "Iniciar sesión"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:130
+#: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
 msgstr "Buscar"
@@ -6136,99 +6156,99 @@ msgstr "Nueva Pregunta"
 msgid "Select the type of Database you use"
 msgstr "Selecciona el tipo de base de datos que utilizas"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:141
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
 msgstr "Añade tus datos"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:145
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
 msgstr "Añadiré mis propios datos más tarde"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
 msgstr "Conectando con {0}"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:165
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
 msgstr "Necesitarás información sobre tu base de datos, como el nombre de usuario y la contraseña. Si no tienes eso ahora mismo, Metabase también viene con un conjunto de datos de muestra con los que puedes empezar."
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:196
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
 msgstr "Añadiré mis datos más tarde"
 
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:41
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
 msgstr "Control de escaneos automáticos"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:53
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
 msgstr "Preferencias de uso de datos"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
 msgstr "Gracias por ayudarnos a mejorar"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:57
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
 msgstr "No recopilaremos ningún evento de uso"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:76
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Para ayudarnos a mejorar Metabase, nos gustaría recopilar cierta información sobre el uso a través de Google Analytics."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
 msgstr "Aquí hay una lista completa de todo lo que rastreamos y por qué."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:98
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Permitir que Metabase recopile eventos de uso de forma anónima"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} recopila información sobre tus datos o resultados de preguntas."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:106
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
 msgstr "nunca"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
 msgstr "Toda la información obtenida es completamente anónima."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "La recopilación puede desactivarse en cualquier momento en la sección de configuración."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:45
+#: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
 msgstr "Si te sientes abrumado"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:52
+#: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
 msgstr "nuestra guía de inicio"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:53
+#: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
 msgstr "esta a un solo click."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:95
+#: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
 msgstr "Bienvenid@ a Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:96
+#: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Parece que todo está funcionando. ¡Ahora vamos a conocerte, conectarte con tus datos y comenzar a encontrarte algunas respuestas!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:100
+#: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
 msgstr "Empecemos"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:145
+#: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
 msgstr "¡Estás listo!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:156
+#: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
 msgstr "Llévame a Metabase"
 
@@ -6245,7 +6265,7 @@ msgid "Create a password"
 msgstr "Crea una contraseña"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:116
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
 msgstr "Shhh..."
 
@@ -6439,11 +6459,11 @@ msgstr "Inicia sesión con la dirección de correo electrónico de Google"
 msgid "User Details"
 msgstr "Detalles Usuario"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:275
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
 msgstr "Restablecer los valores predeterminados"
 
-#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:133
+#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
 msgstr "mapa desconocido"
 
@@ -6455,24 +6475,24 @@ msgstr "El mapa de cuadrícula requiere longitud/latitud agrupada."
 msgid "more"
 msgstr "más"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:101
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
 msgstr "¿Qué campos quieres usar para los ejes X e Y?"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:103
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:60
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
 msgstr "Elige campos"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:204
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
 msgstr "Guardar como vista predeterminada"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
 msgstr "Dibujar cuadro para filtrar"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
 msgstr "Cancelar Filtro"
 
@@ -6480,7 +6500,7 @@ msgstr "Cancelar Filtro"
 msgid "Pin Map"
 msgstr "Mapa de Pin"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:303
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
 msgstr "Desmarcar"
 
@@ -6488,31 +6508,31 @@ msgstr "Desmarcar"
 msgid "Rows {0}-{1} of {2}"
 msgstr "Filas {0}-{1} de {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:189
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
 msgstr "Datos truncados a {0} filas."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:364
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
 msgstr "No se pudo encontrar la visualización"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:371
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
 msgstr "No se pudo mostrar este gráfico con esta información."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:469
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
 msgstr "Sin resultados!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:490
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
 msgstr "Esperando..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:493
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
 msgstr "Esto suele tardar unos {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:499
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Es un poco largo para un cuadro de mando)"
 
@@ -6528,11 +6548,11 @@ msgstr "Selecciona un campo"
 msgid "error"
 msgstr "error"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:126
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
 msgstr "Pulsa y arrastra para cambiar el orden"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:139
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
 msgstr "Añade campos de la lista inferior"
 
@@ -6623,7 +6643,7 @@ msgid "Highlight the whole row"
 msgstr "Resalta la fila entera"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:98
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Colores"
 
@@ -6688,20 +6708,20 @@ msgstr "La visualización con ese identificador ya está registrada:"
 msgid "No visualization for {0}"
 msgstr "No hay visualización para {0}"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:75
+#: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
 msgstr "\"{0}\" es un campo no agregado: si tienes más de un valor en un punto en el eje X, los valores se sumarán."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:91
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
 msgstr "Este tipo de gráfico requiere al menos 2 columnas."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:96
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
 msgstr "Este tipo de gráfico no admite más de {0} series de datos."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:51
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:297
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
 msgstr "Objetivo"
 
@@ -6741,25 +6761,25 @@ msgstr "Editar Configuración"
 msgid "xValues missing!"
 msgstr "Faltan valores x!"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:114
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "Eje-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:140
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
 msgstr "Añade un desglose de series..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:153
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Eje-Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:178
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
 msgstr "Añade otra serie..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:195
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
 msgstr "Tamaño de burbuja"
 
@@ -6773,7 +6793,7 @@ msgid "Curve"
 msgstr "Curva"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:69
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
 msgstr "Paso"
 
@@ -6781,27 +6801,27 @@ msgstr "Paso"
 msgid "Show point markers on lines"
 msgstr "Mostrar marcadores de puntos en líneas"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:235
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
 msgstr "Apilado"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:239
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
 msgstr "No Apilado"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:240
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
 msgstr "Apilar"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:241
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
 msgstr "Apilado - 100%"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:300
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
 msgstr "Mostrar objetivo"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:306
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
 msgstr "Valor del Objetivo"
 
@@ -6821,126 +6841,126 @@ msgstr "Nada"
 msgid "Linear Interpolated"
 msgstr "Lineal Interpolado"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:371
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
 msgstr "Escala Eje-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
 msgstr "Series de tiempo"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:391
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:409
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:381
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
 msgstr "Lineal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:410
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:383
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
 msgstr "Exponente"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:384
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
 msgstr "Logarítmico"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:396
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
 msgstr "Histograma"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:398
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
 msgstr "Ordinal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:404
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
 msgstr "Escala Eje-Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:417
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
 msgstr "Mostrar línea y marcas del Eje-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:423
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
 msgstr "Compacto"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:424
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
 msgstr "Rotar 45°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
 msgstr "Rotar 90°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
 msgstr "Mostrar línea y marcas del Eje-Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
 msgstr "Rango del Eje-Y automático"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
 msgstr "Utiliza un Eje-Y dividido cuando sea necesario"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
 msgstr "Mostrar etiqueta en el Eje-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:501
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
 msgstr "Etiqueta Eje-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:510
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
 msgstr "Mostrar etiqueta en el Eje-Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:516
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
 msgstr "Etiqueta Eje-Y"
 
-#: frontend/src/metabase/visualizations/lib/utils.js:129
+#: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
 msgstr "Desviación Estándar"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:275
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:17
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:256
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
 msgstr "Area"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
 msgstr "Gráfico de área"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:276
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:16
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:257
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
 msgstr "Barra"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
 msgstr "Gráfico de barras"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
 msgstr "¿Qué campos quieres usar?"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
 msgstr "Embudo"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:76
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:76
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Medida"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
 msgstr "Tipo Embudo"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:88
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
 msgstr "Gráfico de barras"
 
@@ -6948,141 +6968,141 @@ msgstr "Gráfico de barras"
 msgid "line chart"
 msgstr "Gráfico de líneas"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:224
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Selecciona las columnas de longitud y latitud en la configuración del gráfico."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
 msgstr "Por favor, selecciona un mapa de la región."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Selecciona las columnas de región y métricas en la configuración del gráfico."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:38
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:53
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
 msgstr "Tipo mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:57
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:149
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
 msgstr "Mapa de la región"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
 msgstr "Mapa de pin"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
 msgstr "Tipo Pin"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
 msgstr "Baldosas"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
 msgstr "Marcadores"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
 msgstr "Campo Latitud"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
 msgstr "Campo Longitud"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:142
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:168
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
 msgstr "Campo Métrica"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
 msgstr "Campo Región"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
 msgstr "Radio"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:198
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
 msgstr "Difuminar"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
 msgstr "Opacidad Mínima"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
 msgstr "Acercamiento Máximo"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:175
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
 msgstr "No se encontraron relaciones."
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:213
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:290
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
 msgstr "Esta {0} está conectada a:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:47
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
 msgstr "Detalle del Objeto"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
 msgstr "objeto"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
 msgstr "Total"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "¿Qué columnas quieres usar?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:44
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Pastel"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Dimensión"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:81
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Mostrar Leyenda"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:86
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Mostrar porcentajes en la leyenda"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:92
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Porcentaje mínimo de porción"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:146
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
 msgstr "Objetivo conseguido"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:148
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
 msgstr "Objetivo superado"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
 msgstr "Objetivo {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
 msgstr "La visualización del progreso requiere un número."
 
@@ -7090,9 +7110,9 @@ msgstr "La visualización del progreso requiere un número."
 msgid "Progress"
 msgstr "Progreso"
 
-#: frontend/src/metabase/entities/collections.js:108
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:176
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:57
+#: frontend/src/metabase/entities/collections.js:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Color"
 
@@ -7104,7 +7124,7 @@ msgstr "Gráfico de Filas"
 msgid "row chart"
 msgstr "gráfico de filas"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:357
+#: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
 msgstr "Estilo separador"
 
@@ -7112,15 +7132,15 @@ msgstr "Estilo separador"
 msgid "Number of decimal places"
 msgstr "Número de decimales"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:381
+#: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
 msgstr "Añade un prefijo"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:385
+#: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
 msgstr "Añade un sufijo"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:374
+#: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
 msgstr "Multiplicar por un número"
 
@@ -7132,7 +7152,7 @@ msgstr "Dispersión"
 msgid "scatter plot"
 msgstr "gráfico de dispersión"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:78
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
 msgstr "Pivote la tabla"
 
@@ -7141,7 +7161,7 @@ msgid "Visible fields"
 msgstr "Campos visibles"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-msgid "Write here, and use Markdown if you''d like"
+msgid "Write here, and use Markdown if you'd like"
 msgstr "Escribe aquí. Puedes utilizar Markdown"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
@@ -7182,13 +7202,13 @@ msgstr "Derecho"
 msgid "Show background"
 msgstr "Mostrar fondo"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:553
+#: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} agrupación"
 msgstr[1] "{0} agrupaciones"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:559
+#: frontend/src/metabase-lib/lib/Dimension.js:731
 msgid "Auto binned"
 msgstr "Agrupación Auto"
 
@@ -7456,26 +7476,26 @@ msgstr "Agrupación Auto"
 msgid "Don''t bin"
 msgstr "Sin Agrupación"
 
-#: frontend/src/metabase/lib/query_time.js:193 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Día"
 msgstr[1] "Días"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
-#: frontend/src/metabase/lib/query_time.js:189 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minuto"
 msgstr[1] "Minutos"
 
-#: frontend/src/metabase/lib/query_time.js:191 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Hora"
 msgstr[1] "Horas"
 
-#: frontend/src/metabase/lib/query_time.js:199 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
 msgstr[0] "Trimestre"
@@ -7542,7 +7562,7 @@ msgid "Bin every 20 degrees"
 msgstr "Agrupa cada 20 grados"
 
 #. returns `true` if successful -- see JavaDoc
-#: src/metabase/api/tiles.clj src/metabase/pulse/render.clj
+#: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
 msgstr "¡No se encontró un escritor de imágenes apropiado!"
 
@@ -7614,10 +7634,12 @@ msgstr "suma acumulativa"
 msgid "{0} and {1}"
 msgstr "{0} y {1}"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} de {1}"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
 msgstr "{0} por {1}"
@@ -7630,9 +7652,12 @@ msgstr "{0} en el segmento {1}"
 msgid "{0} segment"
 msgstr "{0} segmento"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
-msgstr "{0} métrica"
+msgid_plural "{0} metrics"
+msgstr[0] "{0} métrica"
+msgstr[1] "{0} métricas"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
@@ -8213,6 +8238,7 @@ msgid "Cannot save Question: source query has circular references."
 msgstr "No se puede guardar la pregunta debido a referencias circulares."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
+#: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
 msgstr "No existe la tarjeta {0}"
@@ -8615,7 +8641,7 @@ msgstr "El tipo de canal {0} es desconocido"
 msgid "Error sending notification!"
 msgstr "Error enviando norificación!"
 
-#: src/metabase/pulse/color.clj
+#: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
 msgstr "No se ha podido encontrar selector JS en ''{0}''"
 
@@ -8923,43 +8949,43 @@ msgstr "Permisos de acceso de datos"
 msgid "Collection permissions"
 msgstr "Permisos de acceso de colecciones"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:56
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
 msgstr "Ver todos los permisos de colecciones"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:25
+#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
 msgstr "También cambiar sub-colecciones"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:282
+#: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
 msgstr "Puede editar esta colección y sus contenidos"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:289
+#: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
 msgstr "Puede ver artículos en esta colección"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:749
+#: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
 msgstr "Acceso a Colección"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:825
+#: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Este grupo tiene permiso para ver al menos una subcolección de esta colección."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:830
+#: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Este grupo tiene permiso para editar al menos una subcolección de esta colección."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
 msgstr "Ver subcolección"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:211
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
 msgstr "Recuerdame"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:95
+#: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
 msgstr "Aplica rayos-X a este esquema"
 
@@ -8991,31 +9017,32 @@ msgstr "Guardar cuadros de mando, preguntas, y colecciones en \"{0}\""
 msgid "Access dashboards, questions, and collections in \"{0}\""
 msgstr "Acceder cuadros de mando, preguntas, y colecciones en \"{0}\""
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:221
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
 msgstr "Compara"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:229
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
 msgstr "Alejarse"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:233
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
 msgstr "Relacionado"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:293
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
 msgstr "Más Rayos-X"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:46
+#: frontend/src/metabase/home/containers/SearchApp.jsx:40
+#: src/metabase/pulse/render/body.clj
 msgid "No results"
 msgstr "No hay resultados"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:47
+#: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
 msgstr "Metabase no pudo encontrar ningún resultado para su busqueda."
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:111
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
 msgstr "Métricas no encontradas"
 
@@ -9057,7 +9084,7 @@ msgstr "Error al conceder permisos: {0}"
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
 msgstr "No se ha podido desencriptar la cadena. ¿Has configurado correctamenteMB_ENCRYPTION_SECRET_KEY?"
 
-#: frontend/src/metabase/entities/collections.js:164
+#: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
 msgstr "Todas las colecciones personales"
 
@@ -9221,18 +9248,18 @@ msgstr "No aplica"
 msgid "Windows domain"
 msgstr "Dominio de Windows"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:509
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:515
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:490
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:499
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
 msgstr "Etiquetas"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:329
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
 msgstr "Añadir miembros"
 
-#: frontend/src/metabase/entities/collections.js:115
+#: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
 msgstr "Colección que se guarda en"
 
@@ -9253,39 +9280,39 @@ msgid "Sharing"
 msgstr "Compartir"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:234
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:270
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:299
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:305
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:313
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:321
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:218
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:251
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:280
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:286
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:294
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:302
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:80
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:85
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:91
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:97
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:50
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:56
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
 msgstr "Visualización"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:370
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:416
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:431
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:487
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:358
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:406
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:447
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
 msgstr "Ejes"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:222
-#: frontend/src/metabase/admin/settings/selectors.js:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
+#: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
@@ -9319,21 +9346,21 @@ msgstr "Aplica rayos-X"
 msgid "Compare to the rest"
 msgstr "Compara con el resto"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:244
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Utiliza la zona horaria de la máquina virtual Java"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
 msgstr "Te sugerimos que desactives esto a menos que estés forzando manualmente la zona horaria en\n"
 "muchas o la mayoría de tus consultas con estos datos."
 
-#: frontend/src/metabase/containers/Overworld.jsx:310
+#: frontend/src/metabase/containers/Overworld.jsx:312
 msgid "Your team's most important dashboards go here"
 msgstr "Los cuadros de mando más importantes van aquí"
 
-#: frontend/src/metabase/containers/Overworld.jsx:311
+#: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
 msgstr "Fija los cuadros de mando en {0} para que aparezcan en este espacio para todos"
 
@@ -9349,32 +9376,32 @@ msgstr "Utiliza la zona horaria del JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Estamos analizando las tablas y los campos para ayudarte a explorar tus datos."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
 msgstr "Consejo: "
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:258
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
 msgstr "Selecciona un tipo de moneda"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:318
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
 msgstr "Tipo Campo"
 
 #: frontend/src/metabase/admin/routes.jsx:109
-#: frontend/src/metabase/nav/containers/Navbar.jsx:224
+#: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
 msgstr "Solución de problemas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:96
+#: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
 msgstr "Habilitar características de Rayos-X"
 
-#: frontend/src/metabase/admin/settings/selectors.js:323
+#: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
 msgstr "Opciones de Formato"
 
-#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:19
+#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
 msgstr "Detalles de la tarea"
 
@@ -9414,7 +9441,7 @@ msgstr "Moneda"
 msgid "Pick a user or channel..."
 msgstr "Elige un usuario o canal..."
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
+#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
 msgstr "Sin ajustes de formato"
 
@@ -9522,31 +9549,31 @@ msgstr "HH:MM:SS.MS"
 msgid "Time style"
 msgstr "Formato de hora"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:299
+#: frontend/src/metabase/visualizations/lib/settings/column.js:300
 msgid "Unit of currency"
 msgstr "Unidad de moneda"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:319
+#: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
 msgstr "Formato etiqueta de moneda"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:337
+#: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
 msgstr "Donde mostrar la unidad de moneda"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:370
+#: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
 msgstr "Número mínimo de decimales"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:271
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
 msgstr "Tipo de gráfico apilado"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:314
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
 msgstr "Etiqueta de Objetivo"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:322
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
 msgstr "Mostrar línea de tendencia"
 
@@ -9575,7 +9602,7 @@ msgstr "Línea + Barra"
 msgid "line and bar chart"
 msgstr "gráfico de línea y barra"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:72
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
 msgstr "La visualización del contador requiere un número."
 
@@ -9583,75 +9610,75 @@ msgstr "La visualización del contador requiere un número."
 msgid "Gauge"
 msgstr "Contador"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
 msgstr "Rangos del contador"
 
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
 msgstr "Campo a mostrar"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
 msgstr "último {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:185
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
 msgstr "{0} era {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:52
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Agrupa por un campo temporal para ver como ha cambiado a lo largo del tiempo"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
 msgstr "¿Mostrar colores positivos/negativos?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
 msgstr "Columna pivote"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:107
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
 msgstr "Columna celda"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:123
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
 msgstr "Columnas visibles"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:143
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
 msgstr "Formato condicional"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
 msgstr "Título columna"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
 msgstr "Mostrar una gráfica de barras en miniatura"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:183
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
 msgstr "Enlace"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:187
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
 msgstr "Enlace Email"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
 msgstr "Imagen"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:195
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
 msgstr "Automático"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:200
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
 msgstr "Ver como enlace o imagen"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
 msgstr "Texto del enlace"
 
@@ -9915,7 +9942,7 @@ msgstr "Error procesando la consulta"
 msgid "No native form returned."
 msgstr "No se ha obtenido un formulario nativo."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
 msgstr "Respuesta no válida del controlador de base de datos. No se ha definido el estado."
 
@@ -11281,7 +11308,7 @@ msgstr "No se ha podido establecer `query-caching-max-kb` a {0}"
 msgid "Values greater than {1} are not allowed."
 msgstr "No se permiten valores superiores a {1}"
 
-#: src/metabase/query_processor/middleware/resolve_database.clj
+#: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
 msgstr "La base de datos {0} no existe."
 
@@ -11330,7 +11357,7 @@ msgstr "Disparadores"
 msgid "View triggers"
 msgstr "Ver disparadores"
 
-#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:82
+#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
 msgstr "Información del Programador"
 
@@ -11362,7 +11389,7 @@ msgstr "Ultima Ejecución"
 msgid "May Fire Again?"
 msgstr "¿Puede ejecutarse de nuevo?"
 
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:75
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
 msgstr "Disparadores para {0}"
 
@@ -11374,19 +11401,19 @@ msgstr "Tareas"
 msgid "Jobs"
 msgstr "Trabajos"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
 msgstr "Duplicado {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:55
+#: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
 msgstr "Duplica este ítem"
 
-#: frontend/src/metabase/components/EntityItem.jsx:61
+#: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
 msgstr "Archiva este ítem"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:330
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
 msgstr "Duplicar Cuadro de Mando"
 
@@ -11436,63 +11463,64 @@ msgstr "hace {0} {1}"
 msgid "{0} {1} from now"
 msgstr "{0} {1} desde ahora"
 
-#: frontend/src/metabase/lib/query_time.js:187
+#: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
 msgstr[0] "Periodo por defecto"
 msgstr[1] "Periodos por defecto"
 
-#: frontend/src/metabase/lib/query_time.js:203
+#: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
 msgstr[0] "Minuto de la hora"
 msgstr[1] "Minutos de la hora"
 
-#: frontend/src/metabase/lib/query_time.js:205
+#: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
 msgstr[0] "Hora del día"
 msgstr[1] "Horas del día"
 
-#: frontend/src/metabase/lib/query_time.js:207
+#: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
 msgstr[0] "Día de la semana"
 msgstr[1] "Días de la semana"
 
-#: frontend/src/metabase/lib/query_time.js:209
+#: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
 msgstr[0] "Día del mes"
 msgstr[1] "Días del mes"
 
-#: frontend/src/metabase/lib/query_time.js:211
+#: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
 msgstr[0] "Día del año"
 msgstr[1] "Días del año"
 
-#: frontend/src/metabase/lib/query_time.js:213
+#: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
 msgstr[0] "Semana del año"
 msgstr[1] "Semanas del año"
 
-#: frontend/src/metabase/lib/query_time.js:215
+#: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
 msgstr[0] "Mes del año"
 msgstr[1] "Meses del año"
 
-#: frontend/src/metabase/lib/query_time.js:217
+#: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "Trimestre del año"
 msgstr[1] "Trimestres del año"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:79
+#: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} seleccionado"
@@ -11506,20 +11534,20 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "Este"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:64
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
 msgstr "Inválido"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:147
+#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
 msgstr "Añade una hora"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:170
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
 msgstr "Nada que comparar en el {0} anterior."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:517
+#: frontend/src/metabase-lib/lib/Dimension.js:678
 msgid "by {0}"
 msgstr "por {0}."
 
@@ -11813,35 +11841,35 @@ msgstr "Registrando el controlador de carga oportunista {0} ..."
 msgid "Error running query for Card {0}"
 msgstr "Error al ejecutar la consulta para la tarjeta {0}"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
 msgstr "La semana pasada"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This week"
 msgstr "Esta semana"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
 msgstr "El mes pasado"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This month"
 msgstr "Este mes"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
 msgstr "El trimestre pasado"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
 msgstr "Este trimestre"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
 msgstr "El año pasado"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This year"
 msgstr "Este año"
 
@@ -12088,7 +12116,7 @@ msgid "[[CreateDate]] by quarter of the year"
 msgstr "[[CreateDate]] por trimestre del año"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:200
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
 msgstr "Editar usuario"
 
@@ -12096,12 +12124,12 @@ msgstr "Editar usuario"
 msgid "New user"
 msgstr "Nuevo usuario"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
 msgstr "Restablecer contraseña"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:209
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
 msgstr "Desactivar usuario"
 
@@ -12113,40 +12141,40 @@ msgstr "¿Reactivar {0}?"
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
 msgstr "No se ha podido enviar la invitación por correo electrónico, así que asegúrate de decirles que inicien sesión utilizando {0} y esta contraseña que hemos generado para ellos:"
 
-#: frontend/src/metabase/entities/collections.js:21
+#: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
 msgstr "colección"
 
-#: frontend/src/metabase/entities/collections.js:22
+#: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
 msgstr "colecciones"
 
-#: frontend/src/metabase/entities/dashboards.js:29
+#: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
 msgstr "cuadro de mando"
 
-#: frontend/src/metabase/entities/dashboards.js:30
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
 msgstr "cuadros de mando"
 
-#: frontend/src/metabase/entities/users.js:125
+#: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
 msgstr "El nombre es obligatorio"
 
-#: frontend/src/metabase/entities/users.js:126
-#: frontend/src/metabase/entities/users.js:133
+#: frontend/src/metabase/entities/users.js:38
+#: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
 msgstr "Debe ser 100 caracteres o menos"
 
-#: frontend/src/metabase/entities/users.js:132
+#: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
 msgstr "El apellido es obligatorio"
 
-#: frontend/src/metabase/entities/users.js:138
+#: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
 msgstr "El email es obligatorio"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:90
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
 msgstr "Los artículos que archives aparecerán aquí."
 
@@ -12154,11 +12182,11 @@ msgstr "Los artículos que archives aparecerán aquí."
 msgid "No description"
 msgstr "Sin descripción"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:175
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
 msgstr "Suma de todos los valores"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:183
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
 msgstr "Ver todos los valores distintos"
 
@@ -12358,15 +12386,778 @@ msgstr "Agregando el usuario {0} al grupo de todos los usuarios..."
 msgid "Adding User {0} to Admin permissions group..."
 msgstr "Agregando el usuario {0} al grupo de permisos de administrador..."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
 msgstr "Fallo en la consulta"
 
-#: src/metabase/query_processor/async.clj
+#: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
 msgstr "Número máximo de consultas simultáneas permitidas por base de datos conectada."
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
 msgstr "Tiempo agotado después de {0} milisegundos."
+
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
+msgid "Misfire Instruction"
+msgstr "Instrucciones de fallo"
+
+#: frontend/src/metabase/components/ArchiveModal.jsx:31
+msgid "Archive this?"
+msgstr "¿Archivar esto?"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:244
+msgid "Learn about our data"
+msgstr "Aprende cosas de nuestros datos"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
+msgid "Use DNS SRV when connecting"
+msgstr "Utiliza DNS SRV al conectar"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
+msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
+"an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
+"leave this disabled."
+msgstr "Esta opción requiere que el host sea FQDN. Si se conecta a un clúster Atlas, es posible que deba habilitar esta opción. Si no sabe lo que esto significa, deje esto deshabilitado."
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
+msgid "Automatically run queries when doing simple filtering and summarizing"
+msgstr "Ejecutar consultas automáticamente al realizar un filtrado/resumen simple"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr "Cuando esto está activo en Metabase, se ejecutarán consultas automáticamente cuando los usuarios realicen exploraciones simples con los botones Resumir y Filtrar al ver una tabla o gráfico. Puedes desactivar esto si las consultas de esta base de datos son lentas. Esta configuración no afecta la obtención de detalles ni a las consultas SQL."
+
+#: frontend/src/metabase/containers/Overworld.jsx:247
+msgid "Learn about this database"
+msgstr "Aprende cosas sobre esta base de datos"
+
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+msgid "Archive this dashboard?"
+msgstr "¿Archivar este cuadro de mando?"
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:113
+msgid "All results"
+msgstr "Todos los resultados"
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:180
+msgid "Our Analytics"
+msgstr "Nuestras Analíticas"
+
+#: frontend/src/metabase/lib/schema_metadata.js:500
+msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
+msgstr "Suma aditiva de todos los valores de una columna.\\ne.g. ingresos totales a lo largo del tiempo."
+
+#: frontend/src/metabase/lib/schema_metadata.js:508
+msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
+msgstr "Conteo aditivo del número de filas.\\ne.g. Número total de ventas en el tiempo."
+
+#: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
+msgid "Filter"
+msgstr "Filtro"
+
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+msgid "record"
+msgid_plural "records"
+msgstr[0] "registro"
+msgstr[1] "registros"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:346
+msgid "Browse Data"
+msgstr "Navegar "
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:376
+msgid "Write SQL"
+msgstr "Escribir SQL"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
+msgid "Simple question"
+msgstr "Pregunta Simple"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
+msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
+msgstr "Elige algunos datos, visualízalos y fíltralos, resúmelos y analízalos fácilmente."
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
+msgid "Custom question"
+msgstr "Pregunta personalizada"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
+msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
+msgstr "Utiliza el editor avanzado para unir datos, crear columnas personalizadas, hacer cálculos matemáticos y más."
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+msgid "Basic Metrics"
+msgstr "Indicadores básicos"
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+msgid "Custom…"
+msgstr "Personalizado..."
+
+#: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
+msgid "Add grouping"
+msgstr "Añadir agrupación"
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
+msgid "Pick a limit"
+msgstr "Seleccione un límite"
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
+msgid "Show maximum"
+msgstr "Mostrar máximo"
+
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
+msgid "Get Preview"
+msgstr "Vista previa"
+
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
+msgid "Back to previous results"
+msgstr "Volver a los resultados anteriores"
+
+#: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
+msgid "Sample values"
+msgstr "Valores de ejemplo"
+
+#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
+msgstr "Explora el contenido de tus bases de datos, tablas y columnas. Elige una base de datos para empezar."
+
+#: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
+msgid "Visualize"
+msgstr "Visualizar"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
+msgid "Join data"
+msgstr "Unir datos"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
+msgid "Custom column"
+msgstr "Columna personalizada"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
+msgid "Summarize"
+msgstr "Resumir"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
+msgid "Aggregate"
+msgstr "Agregar"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
+msgid "Breakout"
+msgstr "Desglosar"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
+msgid "Pick the metric you want to see"
+msgstr "Elige la métrica que quieres ver"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
+#: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
+msgid "Pick a column to group by"
+msgstr "Elige una columna para agrupar"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
+msgid "Pick your starting data"
+msgstr "Elige tus datos iniciales"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select None"
+msgstr "Selecciona Ninguno"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select All"
+msgstr "Selecciona Todos"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
+msgid "Pick a table..."
+msgstr "Elige una tabla..."
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
+msgid "Enter a limit"
+msgstr "Introduce un límite"
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
+msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
+msgstr "Los corchetes alrededor de un {0} crean una cláusula opcional en la plantilla. Si se establece \"variable\", la cláusula completa se coloca en la plantilla. Si no, se ignora toda la cláusula."
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
+msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
+msgstr "Cuando se usa un Filtro de Campo, el nombre de la columna no debe incluirse en la SQL. En su lugar, la variable debe asignarse a un campo en el panel lateral."
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
+msgid "View the native query"
+msgstr "Ver la consulta nativa"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
+msgid "Native query for this question"
+msgstr "Consulta nativa de esta pregunta"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
+msgid "Convert this question to a native query"
+msgstr "Convertir esta pregunta en una consulta nativa"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
+msgid "SQL for this question"
+msgstr "SQL de esta pregunta"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
+msgid "Convert this question to SQL"
+msgstr "Convertir esta pregunta a SQL"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
+msgid "Get alerts"
+msgstr "Recibir alertas"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
+msgid "{0} breakout"
+msgid_plural "{0} breakouts"
+msgstr[0] "desglose de {0}"
+msgstr[1] "desgloses de {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
+msgid "Hide filters"
+msgstr "Esconder filtros"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
+msgid "Show filters"
+msgstr "Mostrar filtros"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
+msgid "Started from"
+msgstr "Iniciado desde"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
+msgid "{0} row"
+msgid_plural "{0} rows"
+msgstr[0] "{0} fila"
+msgstr[1] "{0} filas"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
+msgid "Show all rows"
+msgstr "Mostrar todas las filas"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
+msgid "Show {0}"
+msgstr "Mostrar {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
+msgid "Showing first {0}"
+msgstr "Mostrando los primeros {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
+msgid "Showing {0}"
+msgstr "Mostrando {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
+msgid "Summarized"
+msgstr "Resumido"
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Hide editor"
+msgstr "Esconder editor"
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Show editor"
+msgstr "Mostrar editor"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
+msgid "Pick the metric you'd like to see"
+msgstr "Elige la métrica que quieres ver"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
+msgid "{0} options"
+msgstr "{0} opciones"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
+msgid "Choose a visualization"
+msgstr "Elige una visualización"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
+msgid "Filter by"
+msgstr "Filtrar por"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+msgid "Summarize by"
+msgstr "Resumir por"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+msgid "Group by"
+msgstr "Agrupar por"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+msgid "Add a metric"
+msgstr "Añadir una métrica"
+
+#: frontend/src/metabase/user/components/UserSettings.jsx:57
+msgid "Profile"
+msgstr "Perfil"
+
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:548
+msgid "This is usually pretty fast but seems to be taking a while right now."
+msgstr "Esto suele ser bastante rápido, pero parece estar tardando un poco en este momento."
+
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
+msgid "Combo"
+msgstr "Combo"
+
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
+msgid "Row"
+msgstr "Fila"
+
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
+msgid "Trend"
+msgstr "Tendencia"
+
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:129
+msgid "Boolean"
+msgstr "Booleano"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+msgid "Unknown Segment"
+msgstr "Segmento Desconocido"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+msgid "Unknown Filter"
+msgstr "Filtro Desconocido"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
+msgid "Left outer join"
+msgstr "Unión izquierda externa"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
+msgid "Right outer join"
+msgstr "Unión derecha externa"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
+msgid "Inner join"
+msgstr "Unión interna"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
+msgid "Full outer join"
+msgstr "Unión externa completa"
+
+#: src/metabase/api/card.clj
+msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
+msgstr "FALTAN los metadatos de resultados de la tarjeta en el API. Ejecutando la consulta para obtener los metadatos correctos."
+
+#: src/metabase/api/session.clj
+msgid "Problem connecting to LDAP server, will fall back to local authentication"
+msgstr "Problema al conectarse al servidor LDAP, utilizaré la autentificación local"
+
+#: src/metabase/api/setup.clj
+msgid "Cannot create Database: cannot find driver {0}."
+msgstr "No se puede crear la base de datos: no se puede encontrar el controlador {0}."
+
+#: src/metabase/api/tiles.clj
+msgid "Query failed"
+msgstr "Falló la consulta"
+
+#: src/metabase/async/util.clj
+msgid "Warning: {0} returned `nil`"
+msgstr "Aviso: {0} devolvió `nulo`"
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing result to output channel: already closed"
+msgstr "Error inesperado al escribir el resultado en el canal de salida: ya cerrado"
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing exception to output channel: already closed"
+msgstr "Error inesperado al escribir la excepción en el canal de salida: ya cerrado"
+
+#: src/metabase/async/util.clj
+msgid "Request canceled, canceling future."
+msgstr "Solicitud cancelada, cancelando futuro."
+
+#: src/metabase/cmd/load_from_h2.clj
+msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
+msgstr "Metabase solo puede transferir datos de H2 a Postgres o MySQL/MariaDB."
+
+#: src/metabase/db.clj
+msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
+msgstr "ADVERTENCIA: No se recomienda usar Metabase con una base de datos de aplicaciones H2 para implementaciones de producción."
+
+#: src/metabase/db.clj
+msgid "Application database setup"
+msgstr "Configuración de la base de datos de la aplicación"
+
+#: src/metabase/driver.clj
+msgid "Could not find {0} driver."
+msgstr "No se pudo encontrar el controlador {0}."
+
+#: src/metabase/driver.clj
+msgid "Abstract drivers cannot derive from concrete parent drivers."
+msgstr "Los controladores abstractos no pueden derivar de controladores padres concretos."
+
+#: src/metabase/driver/mysql.clj
+msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
+msgstr "Es posible que tengas que añadir 'trustServerCertificate=true' a las opciones de conexión adicionales para conectarte con SSL."
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifer."
+msgstr "No sé cómo hacer un alias de {0}, esperaba un identificador."
+
+#: src/metabase/driver/sql_jdbc/execute.clj
+msgid "Client closed connection, canceling query"
+msgstr "Conexión cerrada por el cliente, cancelando la consulta"
+
+#: src/metabase/integrations/ldap.clj
+msgid "{0} is not a valid DN."
+msgstr "{0} no es un DN válido."
+
+#: src/metabase/middleware/log.clj
+msgid "Error logging API request"
+msgstr "Error al registrar la solicitud de la API"
+
+#: src/metabase/middleware/misc.clj
+msgid "Failed to set site-url"
+msgstr "No he podido guardar la URL del sitio"
+
+#: src/metabase/models/database.clj
+msgid "Error destroying thread pool for DB."
+msgstr "Error al destruir el grupo de subprocesos para la BBDD."
+
+#: src/metabase/models/humanization.clj
+msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
+msgstr "Actualizando el nombre a mostrar de {0} \"{1}\": \"{2}\" -> \"{3}\""
+
+#. "humanización" no tengo claro que sea la palabra correcta
+#: src/metabase/models/humanization.clj
+msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
+msgstr "Estrategia de humanización no válida \"{0}\". Las estrategias válidas son: {1}"
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr "Cambiando la estrategia de humanización de nombres de tablas y campos de \"{0}\" a \"{1}\""
+
+#: src/metabase/models/task_history.clj src/metabase/sync/util.clj
+msgid "Error saving task history"
+msgstr "Error guardando el historial de tarea."
+
+#: src/metabase/plugins.clj
+msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
+msgstr "spark-deps.jar ya no es necesario para Metabase 0.32.0+. Puede eliminarlo del directorio de plugins."
+
+#: src/metabase/plugins/classloader.clj
+msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
+msgstr "Utilizando la clase NEWLY CREATED como cargador de clases de contexto compartido: {0}"
+
+#: src/metabase/plugins/files.clj
+msgid "Failed to copy file"
+msgstr "No se ha podido copiar el fichero"
+
+#: src/metabase/public_settings.clj
+msgid "Invalid site URL: {0}"
+msgstr "URL inválida: {0}"
+
+#: src/metabase/public_settings.clj
+msgid "site-url is invalid; returning nil for now. Will be reset on next request."
+msgstr "la URL del sitio no es válida; devolviendo nulo por ahora. Se restablecerá en la próxima solicitud."
+
+#: src/metabase/pulse/render/body.clj
+msgid "More results have been included as a file attachment"
+msgstr "Se han incluido más resultados como un archivo adjunto"
+
+#: src/metabase/pulse/render/body.clj
+msgid "This question has been included as a file attachment"
+msgstr "Esta pregunta se ha incluido como un archivo adjunto"
+
+#: src/metabase/pulse/render/body.clj
+msgid "We were unable to display this Pulse."
+msgstr "No he podido mostrar este Pulso."
+
+#: src/metabase/pulse/render/body.clj
+msgid "Please view this card in Metabase."
+msgstr "Por favor mostrar esta tarjeta en Metabase."
+
+#: src/metabase/pulse/render/body.clj
+msgid "An error occurred while displaying this card."
+msgstr "Se ha producido un error al mostrar esta tarjeta."
+
+#: src/metabase/query_processor.clj
+msgid "Can only determine expected columns for MBQL queries."
+msgstr "Solo puedo determinar las columnas esperadas para las consultas MBQL."
+
+#: src/metabase/query_processor.clj
+msgid "No columns returned."
+msgstr "No se han obtenido columnas."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr "Advertencia: no se pueden determinar los campos para una `consulta-fuente` explícita a menos que también incluya` metadatos-fuente`."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
+msgstr "No se puede resolver {0}: el campo no existe o su tabla pertenece a una base de datos diferente."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
+msgstr "No se puede resolver :field-literal inside :fk-> a menos que se una por dentro con un alias explícito."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot find Table ID for {0}"
+msgstr "No he podido encontrar el ID de tabla {0}"
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "No matching info found."
+msgstr "No se encontró información coincidente."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Could not resolve {0}"
+msgstr "No se pudo resolver {0}"
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Invalid fk-> clause: nowhere to add corresponding join."
+msgstr "fk-> no válida: no se puede agregar el join correspondiente."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "{0} driver does not support foreign keys."
+msgstr "El controlador {0} no soporta claves foráneas"
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
+msgstr "No se puede inferir `:source-metadata` para la consulta de origen con consulta de origen nativa sin metadatos de origen."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Query processor error: number of columns returned by driver does not match results."
+msgstr "Error del procesador de consultas: número de columnas devueltas por el controlador no coincide con los resultados."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Expected {0} columns, but first row of resuls has {1} columns."
+msgstr "Se esperaban {0} columnas, pero la primera fila de resultados tiene {1} columnas."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "No expression named {0} found. Found: {1}"
+msgstr "No he encontrado una expresión de nombre {0}. He encontrado {1}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Distinct values of {0}"
+msgstr "Valores únicos de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Average of {0}"
+msgstr "Media de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0}"
+msgstr "Suma de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "SD of {0}"
+msgstr "DS de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Min of {0}"
+msgstr "Mínimo de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Max of {0}"
+msgstr "Máximo de {0}"
+
+#. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0} matching condition"
+msgstr "Suma de {0} con condición"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Share of rows matching condition"
+msgstr "Cuota de filas con condición"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Count of rows matching condition"
+msgstr "Número de filas coincidentes con la condición"
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Request already canceled, will not run synchronous QP code."
+msgstr "Solicitud ya cancelada, no se ejecutará el código QP síncrono."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unexpectedly got `nil` Query Processor response."
+msgstr "Inesperadamente recibí la respuesta del procesador de consultas `nil`."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Got InterruptedException. Canceling query."
+msgstr "Se interrumpió la excepción. Cancelando consulta."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
+msgstr "Excepción no controlada, se espera que el middleware `catch-exceptions` lo maneje."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Query timed out after %s"
+msgstr "Se agotó el tiempo de espera de la consulta después de %s"
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Creating new query thread pool for Database {0}"
+msgstr "Creando un nuevo grupo de subprocesos de consulta para la base de datos {0}"
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Destroying query thread pool for Database {0}"
+msgstr "Destrucción del grupo de subprocesos de consulta para la base de datos {0}"
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Request canceled, canceling pending query"
+msgstr "Solicitud cancelada, cancelando consulta pendiente"
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: query is missing source-metadata"
+msgstr "No se puede actualizar el campo agrupado: faltan los metadatos en la consulta"
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
+msgstr "No se puede actualizar el campo agrupado: no se encontraron metadatos coincidentes para el campo \"{0}\""
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Using query processor cache backend: {0}"
+msgstr "Uso el caché del procesador de consultas: {0}"
+
+#: src/metabase/query_processor/middleware/expand_macros.clj
+msgid "Invalid metric: {0} reason: {1}"
+msgstr "Métrica inválida: {0} razón: {1}"
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unknown error"
+msgstr "Error desconocido"
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unexpected nil response from query processor."
+msgstr "Respuesta nula inesperada del procesador de consultas."
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Query canceled"
+msgstr "Consulta cancelada"
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
+msgstr "No es posible resolver la consulta: falta o no es válida `:database` ID."
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: Database {0} does not exist."
+msgstr "No es posible resolver la consulta: base de datos {0} no existe."
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr "No se puede usar :fields :all in join contra la consulta de origen a menos que tenga :source-metadata."
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
+msgstr "Problema: join entre campos: el join con alias \"{0}\" no existe. Encontrado: {1}"
+
+#: src/metabase/query_processor/middleware/resolve_source_table.clj
+msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
+msgstr "tabla \"{0}\" inválida: ya debería haberse convertido en un ID de tabla."
+
+#: src/metabase/query_processor/store.clj
+msgid "Cannot store Tables or Fields before Database is stored."
+msgstr "No se pueden guardar tablas o campos antes de guardar la base de datos."
+
+#: src/metabase/query_processor/store.clj
+msgid "Attempting to fetch second Database. Queries can only reference one Database."
+msgstr "Intentando recuperar la segunda base de datos. Las consultas sólo pueden referenciar a una base de datos."
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
+msgstr "Error al recuperar la Tabla {0}: no existe dicha tabla o pertenece a otra base de datos."
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
+msgstr "Error al recuperar el Campo {0}: no existe dicho campo o pertenece a otra base de datos."
+
+#: src/metabase/routes/index.clj
+msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
+msgstr "Error al cargar la plantilla \"{0}\". ¿Te acordaste de construir la interfaz de Metabase?"
+
+#: src/metabase/sample_data.clj
+msgid "Sample dataset DB file ''{0}'' cannot be found."
+msgstr "No se puede encontrar el archivo de base de datos de muestra ''{0}''."
+
+#: src/metabase/sample_data.clj
+msgid "Loading sample dataset..."
+msgstr "Cargando datos de muestra..."
+
+#: src/metabase/sample_data.clj
+msgid "Failed to load sample dataset"
+msgstr "No se ha podido cargar los datos de muestra"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Found new tables:"
+msgstr "Encontrado tablas nuevas:"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Marking tables as inactive:"
+msgstr "Marcando tablas como inactivas:"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Updating description for tables:"
+msgstr "Actualizando la descripción de las tablas:"
+
+#: src/metabase/task.clj
+msgid "Rescheduling job {0}"
+msgstr "Reprogramando el trabajo {0}"
+
+#: src/metabase/task.clj
+msgid "Error rescheduling job"
+msgstr "Error al reprogramar trabajo"
+
+#: src/metabase/task/send_pulses.clj
+msgid "Starting Pulse Execution: {0}"
+msgstr "Iniciando la ejecución del Pulso: {0}"
+
+#: src/metabase/task/send_pulses.clj
+msgid "Finished Pulse Execution: {0}"
+msgstr "Finalizado la ejecución del Pulso: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Failed to schedule tasks for Database {0}"
+msgstr "Error al programar tareas para la base de datos {0}"
+
+#: src/metabase/util/schema.clj
+msgid "All elements must be distinct."
+msgstr "Todos los elementos deben ser distintos."
+
+#: 
+msgctxt "Modal for selecting columns in source data or when doing a join."
+msgid "Pick the columns you want to include"
+msgstr "Elige las columnas que quieres incluir"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr "Al activar esto, Metabase ejecutará consultas automáticamente cuando los usuarios realicen exploraciones simples con los botones Resumir y Filtrar ea tablas o gráficos. Puedes desactivar esto si las consultas de esta base de datos son lentas. Esta configuración no afecta a los detalles ni a las consultas SQL."
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
+msgid "Change join type"
+msgstr "Cambia el tipo de unión"
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifier."
+msgstr "No sé cómo obtener un alias de {0}, esperaba un identificador."
+
+#: src/metabase/integrations/common.clj
+msgid "Error adding User {0} to Group {1}"
+msgstr "Error añadiendo el Usuario {0} al Grupo {1}"
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr "Cambiando la estrategia de humanización de nombres de tablas y campos de \"{0}\" a \"{1}\""
+
+#: src/metabase/query_processor.clj
+msgid "Infinite loop detected: recursively preprocessed query {0} times."
+msgstr "Bucle infinito detectado: consulta preprocesada recursivamente {0} veces."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr "Advertencia: no se pueden determinar los campos de una `consulta-fuente` explícita a menos que también incluya `metadatos`."
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Error determining expected columns for query"
+msgstr "Error al determinar las columnas esperadas de la consulta"
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
+msgstr "Excepción no controlada, se espera que el proceso `catch-exceptions` lo manejara."
 

--- a/locales/fa.po
+++ b/locales/fa.po
@@ -32,18 +32,19 @@ msgstr "این داده ها را کاوش کن"
 msgid "Select a database type"
 msgstr "یک نوع پایگاه داده را انتخاب کن"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:75
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:401
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:71
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:182
+#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:410
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:74
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:203
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:180
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:197
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:193
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:171
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:180
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:164
 #, fuzzy
 msgid "Save"
@@ -66,7 +67,7 @@ msgid "This is a lightweight process that checks for\n"
 msgstr "این یک فرایند سبک برای برسی بروز بودن شمای پایگاه داده هست. در بیشتر موارد، بهتر است برای همگام سازی ساعتی صبر نمایید."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:184
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
 #, fuzzy
 msgid "Scan"
 msgstr "بررسی"
@@ -83,132 +84,134 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "متابیس می‌تواند تمامی مقادیر حاضر در هر فید این دیتابیس را اسکن کند تا فیلترهای جعبه چک را در داشبوردها و سؤالات فعّال کند. این می‌تواند تاحدّی یک پردازش با مصرف زیاد از منابع باشد، به‌خصوص اگر شما یک دیتابیس خیلی بزرگ دارید."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:159
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 #, fuzzy
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "چه زمانی باید متابیس به صورت اتوماتیک مقادیر فیلدها را برسی و در حافظه نگه دارد؟"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:164
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
 msgstr "به طور معمول، روی یک زمانبندی"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:195
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
 msgstr "تنها وقتی که یک ویجت فیلتر افزوده شود"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:199
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
 msgstr "هنگامی که یک کاربر یک فیلتر جدید را به یک داشبورد یا سوال SQL اضافه می کند، Metabase خواهد شد\n"
 "اسکن فیلد (ها) به آن فیلتر برای نمایش لیستی از مقادیر انتخاب شده."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:210
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
 #, fuzzy
 msgid "Never, I'll do this manually if I need to"
 msgstr "هرگز، اگر لازم داشته باشم به صورت دستی انجام خواهم داد"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:222
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:222
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:426
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
 #, fuzzy
 msgid "Saving..."
 msgstr "درحال ذخیره‌سازی..."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:39
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
 #, fuzzy
 msgid "Server error encountered"
 msgstr "با مشکلی در سمت سرور مواجه شدیم"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:58
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 #, fuzzy
 msgid "Delete this database?"
 msgstr "آیا این پایگاه داده حذف شود؟"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
 msgstr "تمام سوالات ذخیره شده، معیارها و بخش هایی که بر اساس این پایگاه داده تکیه می کنند، از بین می روند."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:67
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
 msgstr "این قابل بازگشت نیست."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
 msgstr "اگر اطمینان دارید، لطفا بنویسید"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:53
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
 msgstr "حذف کردن"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:71
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
 msgstr "داخل این کادر:"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:82
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:50
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:93
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:58
-#: frontend/src/metabase/admin/permissions/selectors.js:160
-#: frontend/src/metabase/admin/permissions/selectors.js:170
-#: frontend/src/metabase/admin/permissions/selectors.js:185
-#: frontend/src/metabase/admin/permissions/selectors.js:224
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:355
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:181
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:247
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:61
+#: frontend/src/metabase/admin/permissions/selectors.js:163
+#: frontend/src/metabase/admin/permissions/selectors.js:173
+#: frontend/src/metabase/admin/permissions/selectors.js:188
+#: frontend/src/metabase/admin/permissions/selectors.js:227
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:202
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:268
+#: frontend/src/metabase/components/ArchiveModal.jsx:35
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
-#: frontend/src/metabase/components/form/StandardForm.jsx:61
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:196
+#: frontend/src/metabase/components/form/StandardForm.jsx:62
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:198
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:289
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:162
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:153
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:38
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:189
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:24
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:48
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:41
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:92
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:259
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "لغو"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:88
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:121
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:132
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
 msgstr "حذف"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:128
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:74
-#: frontend/src/metabase/admin/permissions/selectors.js:320
-#: frontend/src/metabase/admin/permissions/selectors.js:327
-#: frontend/src/metabase/admin/permissions/selectors.js:423
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
+#: frontend/src/metabase/admin/permissions/selectors.js:323
+#: frontend/src/metabase/admin/permissions/selectors.js:330
+#: frontend/src/metabase/admin/permissions/selectors.js:426
 #: frontend/src/metabase/admin/routes.jsx:53
-#: frontend/src/metabase/nav/containers/Navbar.jsx:214
+#: frontend/src/metabase/nav/containers/Navbar.jsx:243
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
 msgstr "پایگاه داده"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:129
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
 msgstr "اضافه کردن پایگاه داده"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
 msgstr "ارتباط"
@@ -217,107 +220,107 @@ msgstr "ارتباط"
 msgid "Scheduling"
 msgstr "برنامه ریزی کردن"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:78
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:84
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:26
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:221
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
 msgstr "ذخیره کردن تغییرات"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:185
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:38
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:38
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
 msgstr "اقدام"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:193
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
 msgstr "در حال همگام سازی شمای دیتابیس"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:194
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:206
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:109
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
 msgstr "در حال شروع..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:195
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
 msgstr "موفق به همگام سازی نشد"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
 msgstr "همگام سازی شروع شد!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:205
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
 msgstr "در حال بررسی مجدد مقادیر فیلد"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:207
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
 msgstr "بررسی انجام نگرفت"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
 msgstr "اسکن باعث شده است!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:215
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:401
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
 msgstr "منطقه خطر"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:221
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
 msgstr "نادیده گرفتن مقادیر فیلد ذخیره شده"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
 msgstr "این پایگاه داده را حذف کنید"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:73
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
 msgstr "اضافه کردن پایگاه داده"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:85
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:36
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:36
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:122
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:32
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:399
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:446
 #: frontend/src/metabase/containers/EntitySearch.jsx:26
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:218
-#: frontend/src/metabase/entities/collections.js:93
-#: frontend/src/metabase/entities/dashboards.js:145
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:461
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:81
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:220
+#: frontend/src/metabase/entities/collections.js:94
+#: frontend/src/metabase/entities/dashboards.js:142
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
 msgstr "نام"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:86
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
 msgstr "موتور"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:115
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
 msgstr "درحال حذف کردن"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:145
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
 msgstr "در حال بارگذاری"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:161
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
 msgstr "مجموعه داده نمونه را بازگردانید"
 
@@ -334,9 +337,9 @@ msgid "Successfully saved!"
 msgstr "با موفقیت ذخیره شد!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:177
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:197
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
 msgstr "ویرایش"
@@ -345,87 +348,91 @@ msgstr "ویرایش"
 msgid "Revision History"
 msgstr "تاریخچه نسخه گذاری"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
 msgstr "بازنشستگی این {0}؟"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
 msgstr "سوالات ذخیره شده و موارد دیگر که به این {0} بستگی دارد، به کار ادامه خواهد داد، اما این {1} دیگر از سازنده پرس و جو انتخاب نخواهد شد."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
 msgstr "اگر مطمئن هستید که می خواهید این {0} بازنشسته شود، لطفا یک توضیح سریع از اینکه چرا بازنشسته می شوید، بنویسید:"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
 msgstr "این در خوراک فعالیت و در یک ایمیل نشان داده خواهد شد که به هر کسی که در تیم شما ارسال می شود، چیزی را که از این {0} استفاده می کند، ارسال می کند."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
 msgstr "بازنشستگی"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
 msgstr "بازنشستگی ..."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
 msgstr "ناموفق"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
 msgstr "موفقیت"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:91
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
+#: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 #, fuzzy
 msgid "Preview"
 msgstr "پیش نمایش"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
 msgstr "هیچ توصیف ستونی هنوز وجود ندارد"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:135
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
 msgstr "انتخاب قابلیت مشاهده یک فیلد"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:210
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
 msgstr "نوع خاصی یافت نشد"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:211
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:148
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
 msgstr "سایر"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:231
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "یک نوع خاص را انتخاب کنید"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:277
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
 msgstr "یک هدف را انتخاب کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:77
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:89
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:106
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:122
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
 msgstr "ستون‌ها"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "ستون"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:121
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:306
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
 msgstr "رؤیت"
 
@@ -433,52 +440,52 @@ msgstr "رؤیت"
 msgid "Type"
 msgstr "نوع"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
 msgstr "پایگاه داده فعلی:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
 msgstr "نمایش طرح اولیه"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:45
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
 msgstr "نوع داده"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
 msgstr "اطلاعات اضافی"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
 msgstr "یک طرح را پیدا کنید"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:51
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "{0} طرح"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
 msgstr "چرا پنهان شدی؟"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
 msgstr "داده های فنی"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
 msgstr "بی ربط / Cruft"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
 msgid "Queryable"
 msgstr "قابل پرس و جو"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:91
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
 msgstr "پنهان"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
 msgstr "هیچ توضیحی در جدول وجود ندارد"
 
@@ -486,63 +493,65 @@ msgstr "هیچ توضیحی در جدول وجود ندارد"
 msgid "Metadata Strength"
 msgstr "قدرت متادیتا"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} جدول پرس و جو"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:96
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} جدول پنهان"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
 msgstr "یک جدول را پیدا کنید"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
 msgstr "طرح ها"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:24
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:137
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:68
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:56
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:190
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
 msgstr "متریک‌ها"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
 msgstr "یک سنجش اضافه کن"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:37
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "تعریف"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "ایجاد متریک برای اضافه کردن آنها به نمایش کشویی در سازنده پرس و جو"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:24
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:930
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:952
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:56
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "بخش ها"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
 msgstr "یک بخش اضافه کن"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "ایجاد بخش ها برای افزودن آنها به فیلتر کشویی در کوری ساز"
 
@@ -570,53 +579,53 @@ msgstr "ویرایش ␣"
 msgid "made some changes"
 msgstr "ایجاد بعضی تغییرات"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
-#: frontend/src/metabase/home/components/Activity.jsx:80
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:332
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/home/components/Activity.jsx:82
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
 msgstr "شما"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
 msgstr "مدل داده"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
 msgstr "تاریخچه␣"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:48
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
 msgstr "تاریخچه نسخه گذاری برای"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:239
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
 msgstr "{0} - تنظیمات فیلد"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
 msgstr "کجا این فیلد در سراسر Metabase ظاهر می شود"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:329
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "فیلتر کردن این فیلد"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "هنگامی که این فیلد در یک فیلتر استفاده می شود، چه افرادی باید برای وارد کردن مقدار مورد نظر برای فیلتر کردن، چه استفاده کنند؟"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:453
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "هنوز برای این قیلد توضیحی نوشته نشده است"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:379
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
 msgstr "مقدار اصلی"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:380
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
 msgid "Mapped value"
 msgstr "مقدار Map شده"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:423
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
 msgstr "مقدار را وارد کنید"
 
@@ -633,7 +642,7 @@ msgid "Custom mapping"
 msgstr "Map سفارشی"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:155
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
 msgid "Unrecognized mapping type"
 msgstr "نوع Map غیر قابل تشخیص"
 
@@ -641,23 +650,23 @@ msgstr "نوع Map غیر قابل تشخیص"
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "فیلد جاری دارای کلید خارجی نیست یا متا دیتای جدولی که هدف کلید خارجی است وجود ندارد"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:187
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
 msgstr "فیلد انتخابی کلید خارجی نیست"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:347
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
 msgstr "نمایش مقادیر"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:348
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "انتخاب کنید که ارزش اصلی را از پایگاه داده نشان می دهد یا این اطلاعات را نمایش داده یا مرتبط کنید."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:268
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
 msgstr "یک فیلد را انخاب کنید"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:289
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
 msgstr "لطفا یک ستون را برای نمایش انتخاب کنید."
 
@@ -665,16 +674,16 @@ msgstr "لطفا یک ستون را برای نمایش انتخاب کنید."
 msgid "Tip:"
 msgstr "نکته:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "شما ممکن است بخواهید نام فیلد را به روز کنید تا مطمئن شوید که هنوز بر اساس گزینه های بازخوانی شما منطقی است."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:364
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:102
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
 msgstr "مقادیر فیلد ذخیره شده"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:365
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase می تواند مقادیر این فیلد را فعال کند تا فیلترهای جعبه چک را در داشبورد و سوالات فعال کند."
 
@@ -683,168 +692,169 @@ msgid "Re-scan this field"
 msgstr "دوباره این زمینه را اسکن کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
 msgstr "نادیده گرفتن مقادیر فیلد ذخیره شده"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:118
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
 msgstr "نادیده گرفتن مقادیر ناموفق بود"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard triggered!"
 msgstr "تغییرات را نادیده بگیر!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:105
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "جدولی را برای مشاهد شما و یا ویرایش متادیتا انتخاب نمایید."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:37
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:34
-#: frontend/src/metabase/entities/collections.js:96
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/entities/collections.js:97
 #, fuzzy
 msgid "Name is required"
 msgstr "نام مورد نیاز است"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:40
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
 msgstr "توضیح مورد نیاز است"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:44
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:41
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
 msgstr "پیام بازبینی مورد نیاز است"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:50
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
 msgstr "یکپارچه‌سازی لازم است"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
 msgstr "متریک خود را ویرایش کنید"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
 msgstr "متریک خود را ایجاد کنید"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:115
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "تغییر در متریک خود را انجام دهید و یک یادداشت توضیحی را ترک کنید."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "شما می توانید معیارهای ذخیره شده را برای افزودن یک گزینه متریک نام به این جدول ایجاد کنید. معیارهای ذخیره شده شامل نوع تجمع، فیلد جمع شده و به صورت اختیاری هر فیلتر اضافه می شود. به عنوان مثال، شما ممکن است از این برای ایجاد چیزی شبیه روش رسمی محاسبه \"میانگین قیمت\" برای جدول سفارشات استفاده کنید."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
 msgstr "نتیجه:"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
 msgstr "نام متریک خود را"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
 msgstr "نام متریک خود را برای کمک به دیگران پیدا کنید."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:162
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
 msgstr "چیزی توصیفی اما نه خیلی طولانی"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
 msgstr "متریک خود را شرح دهید"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "توضیحات متریک خود را برای کمک به دیگران درک کنید."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "این مکان بسیار خوبی است که درمورد قوانین متریک کمتر آشکارتر باشد"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:179
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
 msgstr "دلیل تغییرات"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:177
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "یک یادداشت را برای توضیح آنچه که تغییراتی ایجاد کرده اید و چرا آنها مورد نیاز بود را ترک کنید."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "این در تاریخ تجدید نظر برای این متریک نشان داده خواهد شد تا به همه کمک کند که به یاد داشته باشید که چرا همه چیز تغییر کرده است"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
 msgstr "حداقل یک فیلتر مورد نیاز است"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
 msgstr "بخش شما را ویرایش کنید"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
 msgstr "ایجاد بخش شما"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:121
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "تغییرات را در بخش خود انجام دهید و یک یادداشت توضیحی را ترک کنید."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "برای ایجاد بخش جدید خود برای جدول {0} را انتخاب کنید و فیلترها را اضافه کنید"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
 msgstr "بخش خود را بنویسید"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:162
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
 msgstr "بخش خود را به نام برای کمک به دیگران پیدا کنید."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:170
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
 msgstr "بخش خود را توصیف کنید"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "شرح خود را به بخش خود بدهید تا دیگران را در درک آنچه در مورد آن هستید کمک کنید."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:175
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "این مکان خوبی است که در مورد قوانین جزئی کمتر آشکار باشد"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:185
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "این در تاریخ تجدید نظر برای این بخش نشان داده خواهد شد تا به همه کمک کند که به یاد داشته باشید که چرا همه چیز تغییر کرده است"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:266
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:87
-#: frontend/src/metabase/nav/containers/Navbar.jsx:199
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:269
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:91
+#: frontend/src/metabase/nav/containers/Navbar.jsx:228
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
 msgstr "تنضیمات"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:103
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase می تواند مقادیر در این جدول را اسکن کند تا فیلترهای جعبه چک را در داشبورد و سوالات فعال کند."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:108
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
 msgstr "دوباره این جدول را اسکن کنید"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:253
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
 msgstr "اضافه کردن"
 
@@ -853,20 +863,22 @@ msgstr "اضافه کردن"
 msgid "Not a valid formatted email address"
 msgstr "یک آدرس ایمیل فرمت معتبر نیست"
 
+#: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:100
 msgid "First name"
 msgstr "نام"
 
+#: frontend/src/metabase/entities/users.js:42
 #: frontend/src/metabase/setup/components/UserStep.jsx:203
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:117
 msgid "Last name"
 msgstr "نام خانوادگی"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:77
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:158
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:161
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:470
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:481
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
@@ -880,36 +892,37 @@ msgstr "گروه های مجوز"
 msgid "Make this user an admin"
 msgstr "این کاربر را admin کنید"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:32
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
 msgstr "تمام کاربران متعلق به گروه {0} هستند و نمی توانند از آن حذف شوند. تنظیم مجوز برای این گروه راهی عالی برای\n"
 "مطمئن شوید که می دانید چه کاربران جدید Metabase قادر خواهند بود ببینند."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:41
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
 msgstr "این یک گروه خاص است که اعضا میتوانند همه چیز را در نمونه متاباز ببینند و چه کسی میتواند به آن دسترسی پیدا کند و تغییر دهد\n"
 "تنظیمات در پنل مدیریت، از جمله تغییر مجوز! بنابراین، افراد را به این گروه اضافه کنید."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:45
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
 msgstr "برای اینکه اطمینان حاصل کنید که از Metabase قفل نشده اید، همیشه باید حداقل یک کاربر در این گروه باشد."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
 msgstr "اعضا"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:124
-#: frontend/src/metabase/admin/settings/selectors.js:113
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
+#: frontend/src/metabase/admin/settings/selectors.js:110
+#: frontend/src/metabase/entities/users.js:50
 #: frontend/src/metabase/lib/core.js:55
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
 msgstr "ایمیل"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:203
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
 msgstr "گروه فقط به عنوان اعضای آن است."
 
@@ -920,8 +933,8 @@ msgid "Admin"
 msgstr "مدیر/ مدیر سیستم"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:237
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:290
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
 msgstr "و"
 
@@ -950,13 +963,13 @@ msgstr "شما مطمئن هستید؟ همه اعضای این گروه هر ت
 "این نمیتواند لغو شود"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
 msgstr "بله"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
 msgstr "خیر"
 
@@ -975,10 +988,11 @@ msgstr "حذف گروه"
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:107
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:327
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:395
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:265
+#: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
 msgstr "انجام شد"
 
@@ -988,9 +1002,9 @@ msgstr "نام گروه"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:131
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:88
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
 msgstr "گروه‌ها"
 
@@ -1019,9 +1033,9 @@ msgid "Deactivate"
 msgstr "غیرفعال"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:93
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
-#: frontend/src/metabase/nav/containers/Navbar.jsx:204
+#: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
 msgstr "مردم"
 
@@ -1063,7 +1077,6 @@ msgid "We've re-sent {0}'s invite"
 msgstr "دعوت {0} را دوباره فرستادیم"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
-#: frontend/src/metabase/tutorial/Tutorial.jsx:253
 msgid "Okay"
 msgstr "باشه"
 
@@ -1095,13 +1108,13 @@ msgstr "آنها دوباره قادر به ورود به سیستم خواهن�
 msgid "Reset {0}'s password?"
 msgstr "رمز عبور {0} را دوباره تنظیم کنید؟"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:77
+#: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
 msgstr "بارگذازی مجدد"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:44
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
 msgstr "آیا مطمئنید که می خواهید این کار را انجام دهید؟"
 
@@ -1117,75 +1130,77 @@ msgstr "در اینجا یک گذرواژه موقت است که می تواند
 msgid "We've sent them an email with instructions for creating a new password."
 msgstr "ما آنها را یک ایمیل با دستورالعمل برای ایجاد یک رمز عبور جدید فرستاده ایم."
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:101
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
 msgstr "فعال"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:127
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
 msgstr "غیرفعالسازی"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:115
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
 msgstr "کسی را اضافه کنید"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
 msgstr "آخرین ورود"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:153
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
 msgstr "ثبت نام شده به وسیله گوگل"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:158
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
 msgstr "ثبت نام شده به وسیله LDAP"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:170
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
 msgstr "این اکانت را مجددا فعال کنید"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:193
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
 msgstr "هرگز"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:27
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
 msgstr[0] "{0} جدول"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:45
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
 msgstr " خواهد بود"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:48
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
 msgstr "دسترسی داده به"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:53
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
 msgstr "-و-"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:56
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
 msgstr "عدم دسترسی به / امکان سترسی به .... وجود ندارد"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:70
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
 msgstr " دیگر قادر نخواهد بود"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:71
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
 msgstr " حالا قادر خواهد بود"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:79
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
 msgstr " نمایش داده بومی برای"
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
-#: frontend/src/metabase/nav/containers/Navbar.jsx:219
+#: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
 msgstr "دسترسی ها"
 
@@ -1210,15 +1225,15 @@ msgstr "هیچ تغییری در مجوز انجام نخواهد شد."
 msgid "You've made changes to permissions."
 msgstr "شما مجوزها را تغییر داده اید."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:52
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
 msgstr "مجوزهای این مجموعه"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
 msgstr "شما تغییرات ذخیره نشده دارید"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:54
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
 msgstr "آیا می خواهید این صفحه را ترک کنید و تغییرات خود را رد کنید؟"
 
@@ -1238,119 +1253,119 @@ msgstr "هر کاربر Metabase متعلق به گروه همه کاربران 
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
 msgstr "MetaBot ربات Slack Metabase است. شما می توانید آنچه را که به آن دسترسی داشته اید را انتخاب کنید."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:119
+#: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
 msgstr "گروه \"{0}\" ممکن است به یک مجموعه متفاوت از {1} از این گروه دسترسی داشته باشد، که ممکن است این گروه دسترسی اضافی به برخی {2} را داشته باشد."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:124
+#: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
 msgstr "گروه \"{0}\" سطح دسترسی بیشتری نسبت به این دارد که این تنظیم را برطرف می کند. شما باید \"{1}\" دسترسی گروه به این مورد را محدود یا لغو کنید."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
 msgstr "محدودیت"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
 msgstr "لغو"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:156
+#: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
 msgstr "حتی اگر {0} دسترسی بیشتری داشته باشد"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:258
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
 msgstr "محدودیت دسترسی"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:223
-#: frontend/src/metabase/admin/permissions/selectors.js:266
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:226
+#: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
 msgstr "لغو دسترسی"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:168
+#: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
 msgstr "تغییر دسترسی به این پایگاه داده به محدود؟"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:169
+#: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
 msgstr "تغییر"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:182
+#: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
 msgstr "اجازه نوشتن پرس و جو خام را بدهید؟"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:183
+#: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
 msgstr "این امر همچنین دسترسی داده های این گروه را به Unrestricted برای این پایگاه داده تغییر خواهد داد."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:184
+#: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
 msgstr "مجاز"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:221
+#: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
 msgstr "دسترسی به تمام جداول را لغو کنید؟"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:222
+#: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
 msgstr "این همچنین دسترسی این گروه به درخواستهای خام برای این پایگاه داده را لغو خواهد کرد."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:251
+#: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
 msgstr "دسترسی غیر محدود"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:252
+#: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
 msgstr "دسترسی نامحدود"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:259
+#: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
 msgstr "دسترسی محدود"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:267
+#: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
 msgstr "دسترسی ندارید"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:273
+#: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
 msgstr "نامه های خام را بنویسید"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:274
+#: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
 msgstr "می توانید پرس و جوهای خام را بنویسید"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:281
+#: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
 msgstr "مجموعه گردنبند"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:288
+#: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
 msgstr "مشاهده مجموعه"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:331
-#: frontend/src/metabase/admin/permissions/selectors.js:427
-#: frontend/src/metabase/admin/permissions/selectors.js:524
+#: frontend/src/metabase/admin/permissions/selectors.js:334
+#: frontend/src/metabase/admin/permissions/selectors.js:430
+#: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
 msgstr "دسترسی به داده ها"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:492
-#: frontend/src/metabase/admin/permissions/selectors.js:649
-#: frontend/src/metabase/admin/permissions/selectors.js:654
+#: frontend/src/metabase/admin/permissions/selectors.js:495
+#: frontend/src/metabase/admin/permissions/selectors.js:652
+#: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
 msgstr "مشاهده جداول"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:590
+#: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
 msgstr "SQL Queries"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:660
+#: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
 msgstr "نمایش طرح ها"
 
 #: frontend/src/metabase/admin/routes.jsx:59
-#: frontend/src/metabase/nav/containers/Navbar.jsx:209
+#: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
 msgstr "مدل داده"
 
@@ -1359,30 +1374,30 @@ msgstr "مدل داده"
 msgid "Sign in with Google"
 msgstr "با Google وارد شوید"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:13
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
 msgstr "به کاربران امکان می دهد با حساب های Metabase موجود برای ورود به حساب Google که با آدرس ایمیل خود علاوه بر نام کاربری و رمز عبور متاباز خود نیز منطبق باشد."
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:17
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
 msgstr "پیکربندی"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
-#: frontend/src/metabase/admin/settings/selectors.js:207
+#: frontend/src/metabase/admin/settings/selectors.js:204
 msgid "LDAP"
 msgstr "LDAP"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:25
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
 msgstr "اجازه می دهد تا کاربران در دایرکتوری LDAP خود را به Metabase با اعتبار LDAP خود وارد شوند، و اجازه می دهد تا نقشه های خودکار LDAP را به گروه های Metabase بطور خودکار."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
-#: frontend/src/metabase/admin/settings/selectors.js:160
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
 msgstr "این یک آدرس ایمیل معتبر نیست"
 
@@ -1420,7 +1435,7 @@ msgstr "پاک کردن"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:202
+#: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
 msgstr "احراز هویت"
 
@@ -1484,21 +1499,21 @@ msgstr "برای استفاده از MetaBot یک کاربر Slack Bot ایجا�
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "هنگامی که شما آنجا هستید، نام آن را بنویسید و {0} را کلیک کنید. سپس Token Bot API را به فیلد زیر کپی و جایگذاری کنید. پس از اتمام کار، کانال \"metabase_files\" را در Slack ایجاد کنید. Metabase برای بارگذاری نمودارها نیاز دارد."
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:90
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
 msgstr "شما Metabase {0} را اجرا می کنید که آخرین و بزرگترین است!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:99
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0} در دسترس است شما در حال اجرا {1}"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:112
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
 msgstr "به روز رسانی"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:116
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
 msgstr "تغییر چه چیزی است:"
 
@@ -1511,80 +1526,80 @@ msgstr "یک نقشه اضافه کنید"
 msgid "URL"
 msgstr "نشانی اینترنتی"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:199
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
 msgstr "حذف نقشه سفارشی"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:327
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:40
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:181
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
 msgstr "پاک کردن"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:226
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:187
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:241
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:246
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
 msgstr "اتخاب..."
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:241
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
 msgstr "متغیر نمونه"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
 msgstr "یک نقشه‌ی جدید وارد کنید"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
 msgstr "ویرایش نقشه"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:280
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
 msgstr "چه چیزی می خواهید این نقشه را فرا بگیرید؟"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
 msgstr "به عنوان مثال، بریتانیا، برزیل، مریخ"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:292
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
 msgstr "URL برای فایل GeoJSON که می خواهید استفاده کنید"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:298
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
 msgstr "مانند https://my-mb-server.com/maps/my-map.json"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:33
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
 msgstr "تازه کردن"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
 msgstr "بارگذاری"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:315
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
 msgstr "کدام ویژگی شناسه منطقه را مشخص می کند؟"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:324
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
 msgstr "کدام ویژگی نام نمایشی منطقه را مشخص می کند؟"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:345
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
 msgstr "بارگذاری یک فایل GeoJSON برای دیدن یک پیش نمایش"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
 msgstr "ذخیره نقشه"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
 msgstr "اضافه کردن نقشه"
 
@@ -1596,11 +1611,11 @@ msgstr "با استفاده از تعبیه"
 msgid "By enabling embedding you're agreeing to the embedding license located at"
 msgstr "با فعال کردن تعبیه، شما موافقت میکنید که مجوز تعبیه در آن قرار دارد"
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:19
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
 msgstr "در زبان انگليسي ساده، هنگامي كه نمودارها يا داشبوردهاي خود را از Metabase در برنامه خود قرار ميدهيد، اين نرم افزار تحت مجوز Public Affero General كه بقيه متاباز را پوشش ميدهد، در صورتي كه آرم Metabase را حفظ كرده و «Powered by Metabase» را مشاهده كنيد در آن جاسازی ها. با این حال، باید متن مجوزی که در بالا به آن اشاره شد را بخوانید زیرا این مجوز واقعی است که با فعال کردن این ویژگی موافقت می کنید."
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:32
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
 msgstr "فعال کردن"
 
@@ -1624,19 +1639,19 @@ msgstr "خرید یک علامت"
 msgid "Enter a token"
 msgstr "یک نشانه وارد کنید"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:134
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
 msgstr "ویرایش نقشه ها"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:140
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
 msgstr "نقشه های گروه"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:147
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
 msgstr "ایجاد یک نقشه برداری"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1644,7 +1659,7 @@ msgstr "نقشه ها اجازه می دهد Metabase به طور خودکار �
 "سرور دایرکتوری عضویت در گروه مدیریت می تواند از طریق نمایش داده شود، اما به صورت خودکار به عنوان یک حذف نمی شود\n"
 "اندازه گیری بی وقفه"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
 msgstr "نام متمایز"
 
@@ -1656,43 +1671,43 @@ msgstr "لینک عمومی"
 msgid "Revoke Link"
 msgstr "لینک لغو"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:121
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
 msgstr "این لینک را غیرفعال کنید؟"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:122
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
 msgstr "آنها دیگر کار نخواهند کرد و نمی توانند بازسازی شوند، اما شما می توانید لینک های جدید ایجاد کنید."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
 msgstr "فهرست داشبورد عمومی"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:152
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
 msgstr "هیچ داشبورد به صورت عمومی به اشتراک گذاشته نشده است."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:160
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
 msgstr "لیست کارت های عمومی"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:163
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
 msgstr "هنوز هیچ سؤالی به صورت عمومی منتشر نشده است."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:172
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
 msgstr "فهرست داشبورد جاسازی شده"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
 msgstr "هیچ داشبورد هنوز تعبیه نشده است."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:183
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
 msgstr "فهرست کارت های جاسازی شده"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:184
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
 msgstr "هیچ سؤالی هنوز تعبیه نشده است."
 
@@ -1713,18 +1728,17 @@ msgid "Generate Key"
 msgstr "تولید کلید"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:78
-#: frontend/src/metabase/admin/settings/selectors.js:87
+#: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
 msgstr "فعالسازی"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:83
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:103
+#: frontend/src/metabase/admin/settings/selectors.js:82
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "غیرفعال سازی"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:116
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
 msgstr "تنظیم ناشناخته {0}"
 
@@ -1732,7 +1746,7 @@ msgstr "تنظیم ناشناخته {0}"
 msgid "Setup"
 msgstr "برپایی"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
 msgstr "عمومی"
@@ -1761,11 +1775,11 @@ msgstr "پایگاه داده پیش فرض"
 msgid "Select a timezone"
 msgstr "یک منطقه زمانی انتخاب کنید"
 
-#: frontend/src/metabase/admin/settings/selectors.js:55
+#: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "همه پایگاه های داده از زمان زنجیره پشتیبانی نمی کنند، و در این صورت این تنظیم تاثیری نخواهد داشت."
 
-#: frontend/src/metabase/admin/settings/selectors.js:60
+#: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
 msgstr "زبان"
 
@@ -1773,202 +1787,202 @@ msgstr "زبان"
 msgid "Select a language"
 msgstr "یک زبان انتخاب کنید"
 
-#: frontend/src/metabase/admin/settings/selectors.js:70
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
 msgstr "پیگیری ناشناس"
 
-#: frontend/src/metabase/admin/settings/selectors.js:75
+#: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
 msgstr "جدول دوستانه و نام های میدان"
 
-#: frontend/src/metabase/admin/settings/selectors.js:81
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
 msgstr "فقط با استفاده از فضاهای زیر حروف و خطوط را جایگزین کنید"
 
-#: frontend/src/metabase/admin/settings/selectors.js:91
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
 msgstr "مسدود سازی پرس و جوها را فعال کنید"
 
-#: frontend/src/metabase/admin/settings/selectors.js:102
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
 msgstr "به روز رسانی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:107
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
 msgstr "بررسی برای به روز رسانی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:118
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
 msgstr "میزبان SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:126
+#: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
 msgstr "پورت SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:130
-#: frontend/src/metabase/admin/settings/selectors.js:230
+#: frontend/src/metabase/admin/settings/selectors.js:127
+#: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
 msgstr "این یک شماره پورت معتبر نیست"
 
-#: frontend/src/metabase/admin/settings/selectors.js:134
+#: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
 msgstr "SMTP امنیت"
 
-#: frontend/src/metabase/admin/settings/selectors.js:142
+#: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
 msgstr "نام کاربری SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
 msgstr "رمز عبور SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
 msgstr "از آدرس"
 
-#: frontend/src/metabase/admin/settings/selectors.js:170
+#: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
 msgstr "Slack API Token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:172
+#: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
 msgstr "رمزتان را که از Slack دریافت کرده اید وارد کنید"
 
-#: frontend/src/metabase/admin/settings/selectors.js:189
+#: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
 msgstr "تنها ورودی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:213
+#: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
 msgstr "تأیید هویت LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:219
+#: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
 msgstr "میزبان LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:227
+#: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
 msgstr "پورت LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:234
+#: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
 msgstr "امنیت LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
 msgstr "نام کاربری یا DN"
 
-#: frontend/src/metabase/admin/settings/selectors.js:247
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:188
-#: frontend/src/metabase/user/components/UserSettings.jsx:72
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:191
+#: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
 msgstr "کلمه عبور"
 
-#: frontend/src/metabase/admin/settings/selectors.js:252
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "User search base"
 msgstr "پایگاه جستجوی کاربر"
 
-#: frontend/src/metabase/admin/settings/selectors.js:258
+#: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
 msgstr "فیلتر کاربر"
 
-#: frontend/src/metabase/admin/settings/selectors.js:264
+#: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
 msgstr "پرانتزهای خود را بررسی کنید"
 
-#: frontend/src/metabase/admin/settings/selectors.js:270
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
 msgstr "ویژگی ایمیل"
 
-#: frontend/src/metabase/admin/settings/selectors.js:275
+#: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
 msgstr "نام شناسه اول"
 
-#: frontend/src/metabase/admin/settings/selectors.js:280
+#: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
 msgstr "مولفه‌ی نام خانوادگی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:285
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
 msgstr "همگام سازی اعضای گروه"
 
-#: frontend/src/metabase/admin/settings/selectors.js:291
+#: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
 msgstr "پایگاه جستجوی گروهی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:300
+#: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
 msgstr "نقشه"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
 msgstr "URL کاشی نقشه کاشی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:306
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase از طریق OpenStreetMaps به طور پیش فرض استفاده می کند."
 
-#: frontend/src/metabase/admin/settings/selectors.js:311
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
 msgstr "نقشه های سفارشی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:312
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "فایل های GeoJSON خودتان را برای افزودن تصویر های مختلف نقشه های منطقه اضافه کنید"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
 msgstr "اشتراک عمومی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:336
+#: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
 msgstr "اشتراکگذاری عمومی را فعال کنید"
 
-#: frontend/src/metabase/admin/settings/selectors.js:341
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
 msgstr "داشبورد به اشتراک گذاشته شده"
 
-#: frontend/src/metabase/admin/settings/selectors.js:347
+#: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
 msgstr "سوالات مشترک"
 
-#: frontend/src/metabase/admin/settings/selectors.js:354
+#: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
 msgstr "تعبیه در برنامه های دیگر"
 
-#: frontend/src/metabase/admin/settings/selectors.js:381
+#: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Enable Embedage Metabase در برنامه های دیگر"
 
-#: frontend/src/metabase/admin/settings/selectors.js:391
+#: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
 msgstr "بستن کلید مخفی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:397
+#: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
 msgstr "داشبورد جاسازی شده"
 
-#: frontend/src/metabase/admin/settings/selectors.js:403
+#: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
 msgstr "سوالات جاسازی شده"
 
-#: frontend/src/metabase/admin/settings/selectors.js:410
+#: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
 msgstr "ذخیره سازی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:415
+#: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
 msgstr "فعال کردن ذخیره سازی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:420
+#: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
 msgstr "حداقل مدت زمان پرس و جو"
 
-#: frontend/src/metabase/admin/settings/selectors.js:427
+#: frontend/src/metabase/admin/settings/selectors.js:424
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "زمان کشیدن به زمان (TTL) ضرب"
 
-#: frontend/src/metabase/admin/settings/selectors.js:434
+#: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
 msgstr "حداکثر اندازه ورودی کش"
 
@@ -1984,11 +1998,11 @@ msgstr "هشدار شما به روز شد"
 msgid "The alert was successfully deleted."
 msgstr "هشدار با موفقیت حذف شد"
 
-#: frontend/src/metabase/auth/auth.js:33
+#: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
 msgstr "لطفا یک آدرس ایمیل فرمت شده معتبر وارد کنید"
 
-#: frontend/src/metabase/auth/auth.js:116
+#: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
@@ -2030,91 +2044,88 @@ msgstr "ارسال ایمیل بازیابی پسورد"
 msgid "Check your email for instructions on how to reset your password."
 msgstr "برای دریافت دستورالعمل در مورد چگونگی بازنشانی گذرواژه خود، ایمیل خود را بررسی کنید."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:128
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
 msgstr "به Metabase وارد شوید"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:138
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
 msgstr "یا"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:157
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
 msgstr "نام کاربری یا آدرس ایمیل"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:217
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
 msgstr "ورود"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:230
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
 msgstr "به نظر می رسد رمز عبور من را فراموش کرده ام"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
 msgstr "درخواست یک ایمیل"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:120
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
 msgstr "اوه، این یک لینک منقضی شده است"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:122
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
 msgstr "به دلایل امنیتی، لینک های بازنشانی رمز عبور بعد از چند لحظه منقضی می شوند. اگر هنوز هم نیاز دارید\n"
 "برای بازنشانی گذرواژه خود، میتوانید {0} را انتخاب کنید."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:147
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
 msgstr "رمز عبور جدید"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:149
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
 msgstr "برای حفظ اطلاعات خود، گذرواژه {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:163
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
 msgstr "پسورد جدید بسازید"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:170
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:141
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
 msgstr "مطمئن شوید که ایمن مانند دستورالعمل بالا است"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:184
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:150
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
 msgstr "تایید پسورد جدید"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:191
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:159
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
 msgstr "اطمینان حاصل کنید که آن را با آنکه وارد کردید مطابقت دهید"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:216
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
 msgstr "گذرواژه شما تنظیم مجدد شده است"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:222
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:227
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
 msgstr "با گذرواژه جدید خود وارد شوید"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:182
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:251
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "ذخیره سازی ناموفق"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:183
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:129
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:225
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:252
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
 msgstr "ذخیره شد"
 
@@ -2122,24 +2133,22 @@ msgstr "ذخیره شد"
 msgid "Ok"
 msgstr "خوب"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:38
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
 msgstr "این مجموعه را بایگانی کنید؟"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:43
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "داشبورد، مجموعه ها و پالس ها در این مجموعه نیز بایگانی خواهند شد."
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
-#: frontend/src/metabase/components/CollectionLanding.jsx:624
+#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: frontend/src/metabase/components/CollectionLanding.jsx:620
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:47
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:195
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:200
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:40
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:53
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
 msgstr "آرشیو"
@@ -2148,28 +2157,27 @@ msgstr "آرشیو"
 msgid "This {0} has been archived"
 msgstr "این {0} بایگانی شده است"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:715
+#: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
 msgstr "آرشیو را ببینید"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:43
+#: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
 msgstr "این را {0} بایگانی کنید"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:70
-#: frontend/src/metabase/components/BrowseApp.jsx:132
-#: frontend/src/metabase/components/BrowseApp.jsx:225
+#: frontend/src/metabase/components/BrowseApp.jsx:39
+#: frontend/src/metabase/components/BrowseApp.jsx:102
+#: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
 msgstr "اطلاعات ما"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:169
+#: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
 msgstr "اشعه ایکس این جدول"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:183
-#: frontend/src/metabase/containers/Overworld.jsx:246
+#: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
 msgstr "درباره این جدول اطلاعاتی کسب کنید"
 
@@ -2187,31 +2195,31 @@ msgstr "ذخیره شد!"
 msgid "Saving failed."
 msgstr "ذخیره سازی ناموفق بود."
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
 msgstr "ی‌ش"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
 msgstr "دش"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
 msgstr "س‌ش"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
 msgstr "چ‌ش"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
 msgstr "پ‌ش"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
 msgstr "جم"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
 msgstr "شن"
 
@@ -2256,60 +2264,60 @@ msgstr "پالس ها به شما اجازه می دهد تا آخرین اطل�
 msgid "Questions are a saved look at your data."
 msgstr "سوالات نگاه ذخیره شده به اطلاعات شما هستند."
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:287
+#: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
 msgstr "پین"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:341
+#: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
 msgstr "چیزی را در اینجا بکشید تا آن را به بالا ببرید"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:737
-#: frontend/src/metabase/components/CollectionLanding.jsx:353
-#: frontend/src/metabase/home/containers/SearchApp.jsx:35
-#: frontend/src/metabase/home/containers/SearchApp.jsx:92
+#: frontend/src/metabase/admin/permissions/selectors.js:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:352
+#: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
 msgstr "مجموعه‌ها"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:432
-#: frontend/src/metabase/components/CollectionLanding.jsx:455
+#: frontend/src/metabase/components/CollectionLanding.jsx:431
+#: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
 msgstr "برای un-pin به اینجا بکشید"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:490
+#: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
 msgstr[0] "{0} مورد انتخاب شده است"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:522
+#: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
 msgstr "{0} موارد را انتقال دهید؟"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:523
+#: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
 msgstr "حرکت \"{0}\"؟"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:631
+#: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
 msgstr "انتقال"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:692
+#: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
 msgstr "این مجموعه را ویرایش کنید"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:700
+#: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
 msgstr "بایگانی این مجموعه"
 
-#: frontend/src/metabase/components/CollectionList.jsx:64
-#: frontend/src/metabase/entities/collections.js:155
+#: frontend/src/metabase/components/CollectionList.jsx:67
+#: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
 msgstr "مجموعه شخصی من"
 
-#: frontend/src/metabase/components/CollectionList.jsx:106
+#: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
 msgstr "مجموعه جدید"
 
@@ -2317,11 +2325,11 @@ msgstr "مجموعه جدید"
 msgid "Copied!"
 msgstr "کپی شده!"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:216
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
 msgstr "برای اتصال به پایگاه داده از یک تونل SSH استفاده کنید"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
@@ -2329,75 +2337,76 @@ msgstr "برخی از تاسیسات پایگاه داده تنها با اتص�
 "این گزینه همچنین یک لایه اضافی امنیتی را هنگامی که یک VPN در دسترس نیست فراهم می کند.\n"
 "فعال کردن این معمولا کمتر از یک اتصال مستقیم است."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:271
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "این یک پایگاه داده بزرگ است، بنابراین اجازه دهید زمانی که Metabase همگام سازی و اسکن کند، انتخاب کنم"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:273
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "به طور پیش فرض، Metabase یک همگام سازی ساعته سبک و یک روزه اسکن شدید از مقادیر فیلد را می دهد.\n"
 "اگر شما یک پایگاه داده بزرگ دارید، توصیه می کنیم این را به کار ببندید و بررسی کنید که چه زمانی و چه مقدار ارزش فیلد اتفاق می افتد."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:289
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} برای ایجاد شناسه مشتری و مشتری راز برای پروژه شما."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:291
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:353
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
 msgstr "اینجا کلیک کنید"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "به عنوان نوع برنامه، \"دیگر\" را انتخاب کنید. نام هر آنچه را که دوست دارید."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:316
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
 msgstr "{0} برای دریافت کد Auth"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:328
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
 msgstr "با مجوزهای Google Drive"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:348
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "برای استفاده از Metabase با این داده ها باید دسترسی API را در کنسول Google Developers ها فعال کنید."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:351
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} برای رفتن به کنسول اگر قبلا چنین کاری نکرده اید."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
 msgstr "چگونه می خواهید به این پایگاه داده مراجعه کنید؟"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:427
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:237
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:188
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:74
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:194
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:79
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
 msgstr "بعدی"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:52
+#: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
 msgstr "حذف این {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:43
+#: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
 msgstr "این مورد را پین کنید"
 
-#: frontend/src/metabase/components/EntityItem.jsx:49
+#: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
 msgstr "این گزینه را انتقال بدین"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
 msgstr "این سوال را ویرایش کنید"
 
@@ -2410,6 +2419,7 @@ msgstr "نوع اقدام"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
 msgstr "مشاهده تاریخچه ویرایش"
 
@@ -2425,8 +2435,7 @@ msgstr "اقدام بایگانی"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:329
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:342
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
 msgstr "اضافه کردن به داشبورد"
 
@@ -2450,13 +2459,12 @@ msgstr "نوع دیگری از عمل"
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:449
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:454
 msgid "Get alerts about this"
 msgstr "دریافت هشدار در مورد این"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
 msgstr "مشاهده SQL"
 
@@ -2476,43 +2484,43 @@ msgstr "اینجا پیام خطای کامل است"
 msgid "Hi, Metabot here."
 msgstr "سلام متابوت اینجاست"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:95
+#: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
 msgstr "بر اساس طرح"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:174
+#: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
 msgstr "یک نگاه به تو"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:234
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
 msgstr "جستجو در لیست"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:238
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
 msgstr "جستجو توسط {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
 msgstr " یا یک شناسه وارد کنید"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
 msgstr "یک شناسه وارد کنید"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
 msgstr "شماره را وارد کنید"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:248
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
 msgstr "بعضی از متن ها را وارد کنید"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:355
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
 msgstr "هیچ تطابق {0} یافت نشد"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:363
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "از جمله هر گزینه ای در فیلتر شما احتمالا زیاد کار نمی کند ..."
 
@@ -2528,17 +2536,17 @@ msgstr "ما به خطا رسیده ایم شما می توانید صفحه ر�
 #: frontend/src/metabase/components/HeaderBar.jsx:45
 #: frontend/src/metabase/components/ListItem.jsx:37
 #: frontend/src/metabase/reference/components/Detail.jsx:47
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:158
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:213
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:191
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:205
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:209
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:209
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:161
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:216
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:194
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:208
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
 msgstr "هنوز توضیحی ندارید"
 
 #: frontend/src/metabase/components/Header.jsx:112
-#: frontend/src/metabase/entities/containers/EntityForm.jsx:43
+#: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
 msgstr "جدید {0}"
 
@@ -2546,54 +2554,53 @@ msgstr "جدید {0}"
 msgid "Asked by {0}"
 msgstr "درخواست شده توسط {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:13
+#: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
 msgstr "امروز"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:15
+#: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
 msgstr "دیروز"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:68
+#: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
 msgstr "تجدید نظر اول"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:70
+#: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
 msgstr "بازگشت به یک نسخه پیشین و {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:82
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:289
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:379
-#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
+#: frontend/src/metabase/components/HistoryModal.jsx:42
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
+#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
 msgstr "تاریخچه ویرایشهای"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:90
+#: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
 msgstr "چه زمیانی"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:91
+#: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
 msgstr "چه کسی"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:92
+#: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
 msgstr "چه چیز"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:113
+#: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
 msgstr "بازگرداندن"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:114
+#: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
 msgstr "بازگرداندن ..."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:115
+#: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
 msgstr "بازگرداندن ناموفق بود"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:116
+#: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
 msgstr "بازگشت"
 
@@ -2602,26 +2609,24 @@ msgid "Everything"
 msgstr "هر چیز"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
-#: frontend/src/metabase/home/containers/SearchApp.jsx:69
 msgid "Dashboards"
 msgstr "داشبورد"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
-#: frontend/src/metabase/home/containers/SearchApp.jsx:115
 msgid "Questions"
 msgstr "سوال"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:321
+#: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
 msgstr "پالس ها"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:103
+#: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
 msgstr "بازگشت"
 
-#: frontend/src/metabase/components/ListSearchField.jsx:18
+#: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
 msgstr "یافتن..."
 
@@ -2658,14 +2663,14 @@ msgid "Temporary Password"
 msgstr "گذرواژه موقت"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
 msgstr "پنهان"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:412
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
 msgstr "نمایش دادن"
 
@@ -2730,7 +2735,7 @@ msgstr "15th (Midpoint)"
 msgid "Calendar Day"
 msgstr "روز تقویم"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:210
+#: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
 msgstr "منطقه زمانی Metabase شما"
 
@@ -2759,11 +2764,11 @@ msgid "A component used to make a selection"
 msgstr "جزء مورد استفاده برای انتخاب"
 
 #: frontend/src/metabase/components/Select.info.js:20
-#: frontend/src/metabase/components/Select.info.js:28
+#: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
 msgstr "انتخاب کنید"
 
-#: frontend/src/metabase/components/Select.jsx:297
+#: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
 msgstr "هیچ چیز برای انتخاب"
 
@@ -2776,7 +2781,7 @@ msgid "Unknown error encountered"
 msgstr "خطای ناشناخته رخ داده است"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/nav/containers/Navbar.jsx:304
+#: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
 msgstr "بسازید"
 
@@ -2785,13 +2790,11 @@ msgid "Create dashboard"
 msgstr "ایجاد داشبورد"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:331
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:60
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
 msgstr "جدول"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:306
 msgid "Database"
 msgstr "پایگاه داده"
 
@@ -2799,22 +2802,20 @@ msgstr "پایگاه داده"
 msgid "Creator"
 msgstr "ایجاد کننده"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:238
+#: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
 msgstr "نتیجه ای پیدا نشد"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:239
+#: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
 msgstr "سعی کنید فیلتر خود را برای پیدا کردن آنچه که دنبال می کنید، تنظیم کنید."
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:258
+#: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
 msgstr "مشاهده توسط"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:494
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:84
-#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:69
-#: frontend/src/metabase/tutorial/TutorialModal.jsx:34
+#: frontend/src/metabase/containers/EntitySearch.jsx:495
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
 msgstr "از"
 
@@ -2827,13 +2828,13 @@ msgid "Once you connect your own data, I can show you some automatic exploration
 msgstr "هنگامی که دادههای خود را به هم وصل میکنید، میتوانم به شما برخی از کاوشهای خودکار را به نام اشعه ایکس نشان دهم. در اینجا چند نمونه با داده های نمونه است."
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
-#: frontend/src/metabase/containers/Overworld.jsx:299
+#: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
 msgstr "از اینجا شروع کنید"
 
-#: frontend/src/metabase/containers/Overworld.jsx:294
-#: frontend/src/metabase/entities/collections.js:147
+#: frontend/src/metabase/containers/Overworld.jsx:296
+#: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
 msgstr "تجزیه و تحلیل ما"
@@ -2842,53 +2843,53 @@ msgstr "تجزیه و تحلیل ما"
 msgid "Browse all items"
 msgstr "همه موارد را مرور کنید"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:165
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
 msgstr "جایگزین یا ذخیره شده به عنوان جدید؟"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:173
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
 msgstr "سوال اصلی را تغییر دهید، \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:178
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
 msgstr "به عنوان سوال جدید ذخیره کنید"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:187
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
 msgstr "اول، سوال خود را ذخیره کنید"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:188
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
 msgstr "صرفه جویی در سوال"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:224
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
 msgstr "نام کارت شما چیست؟"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:232
-#: frontend/src/metabase/entities/collections.js:101
-#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:234
+#: frontend/src/metabase/entities/collections.js:102
+#: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/lib/core.js:50 frontend/src/metabase/lib/core.js:205
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:156
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:211
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:203
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:207
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:207
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:24
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:159
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:214
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:192
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:206
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:210
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
 msgstr "توضیحات"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:238
-#: frontend/src/metabase/entities/dashboards.js:153
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
+#: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
 msgstr "این اختیاری است اما اوه، خیلی مفید است"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:245
-#: frontend/src/metabase/entities/dashboards.js:157
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
+#: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "کدام مجموعه باید این باشد؟"
 
@@ -2900,7 +2901,7 @@ msgstr "اصلاح شده"
 msgid "item"
 msgstr "آیتم"
 
-#: frontend/src/metabase/containers/UndoListing.jsx:81
+#: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
 msgstr "لغو"
 
@@ -2924,15 +2925,15 @@ msgstr "ما مطمئن نیستیم که آیا این سوال سازگار ا
 msgid "Archive Dashboard"
 msgstr "داشبورد بایگانی"
 
-#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:20
+#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "اطمینان حاصل کنید که انتخاب برای هر سری، یا فیلتر بر روی این کارت کار نخواهد کرد."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:300
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
 msgstr "این داشبورد خالی است."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:301
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
 msgstr "یک سوال برای شروع مفید بودن اضافه کنید"
 
@@ -2952,59 +2953,58 @@ msgstr "خروج از تمام صفحه"
 msgid "Enter fullscreen"
 msgstr "ورود به حالت تمام صفحه"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:181
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:183
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "درحال ذخیره‌ سازی"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:216
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
 msgstr "سوالی اضافه کنید"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:219
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
 msgstr "یک سوال به این داشبورد اضافه کنید"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:248
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
 msgstr "یک فیلتر اضافه کنید"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:254
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:78
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "مولفه های"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:275
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
 msgstr "یک جعبه متن را اضافه کنید"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
 msgstr "حرکت داشبورد"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:302
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
 msgstr "ویرایش داشبورد"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:306
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
 msgstr "ویرایش طرح بندی داشبورد"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:369
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
 msgstr "شما در حال ویرایش داشبورد هستید"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:374
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
 msgstr "فیلد را انتخاب کنید که باید برای هر کارت فیلتر شود"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:28
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
 msgstr "حرکت داشبورد به ..."
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:52
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
 msgstr "داشبورد به {0} منتقل شد"
 
@@ -3019,7 +3019,7 @@ msgstr "چه نوع فیلتر؟"
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:179
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
 msgstr "خاموش"
 
@@ -3059,174 +3059,174 @@ msgstr "بازخوانی در"
 msgid "Remove this question?"
 msgstr "این سوال پاک شود؟"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:71
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
 msgstr "پایگاه داده شما ذخیره شده است"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:745
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:76
+#: frontend/src/metabase/components/CollectionLanding.jsx:744
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
 msgstr "آن را ببینید"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:137
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
 msgstr "ذخیرش کن"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:170
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
 msgstr "نمایش بیشتر در مورد این"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:140
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
 msgstr "این کارت هیچ فیلدی یا پارامتری ندارد که بتواند به این نوع پارامتر نقشه بگذارد."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:142
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "مقادیر این فیلد با مقادیر هر فیلد دیگری که انتخاب کرده اید همپوشانی ندارد."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:186
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
 msgstr "هیچ فیلد معتبر وجود ندارد"
 
-#: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
 msgstr "نام باید 100 عدد یا کمتر باشد"
 
-#: frontend/src/metabase/entities/collections.js:111
+#: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
 msgstr "رنگ مورد نیاز است"
 
-#: frontend/src/metabase/entities/dashboards.js:146
+#: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
 msgstr "نام داشبورد شما چیست؟"
 
-#: frontend/src/metabase/home/components/Activity.jsx:92
+#: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
 msgstr "برخی چیزهای فوق العاده بسیار عالی که برای توصیف سخت است انجام داد"
 
-#: frontend/src/metabase/home/components/Activity.jsx:101
-#: frontend/src/metabase/home/components/Activity.jsx:116
+#: frontend/src/metabase/home/components/Activity.jsx:103
+#: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
 msgstr "هشدار در مورد ایجاد کرد"
 
-#: frontend/src/metabase/home/components/Activity.jsx:126
-#: frontend/src/metabase/home/components/Activity.jsx:141
+#: frontend/src/metabase/home/components/Activity.jsx:128
+#: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
 msgstr "هشدار در مورد حذف شد"
 
-#: frontend/src/metabase/home/components/Activity.jsx:152
+#: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
 msgstr "یک سوال در مورد ذخیره کرد"
 
-#: frontend/src/metabase/home/components/Activity.jsx:165
+#: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
 msgstr "یک سوال را ذخیره کردید"
 
-#: frontend/src/metabase/home/components/Activity.jsx:169
+#: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
 msgstr "یک سوال را حذف کرد"
 
-#: frontend/src/metabase/home/components/Activity.jsx:172
+#: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
 msgstr "یک داشبورد ایجاد کرد"
 
-#: frontend/src/metabase/home/components/Activity.jsx:175
+#: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
 msgstr "داشبورد حذف شد"
 
-#: frontend/src/metabase/home/components/Activity.jsx:181
-#: frontend/src/metabase/home/components/Activity.jsx:196
+#: frontend/src/metabase/home/components/Activity.jsx:183
+#: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
 msgstr "یک سوال به داشبورد اضافه کرد -"
 
-#: frontend/src/metabase/home/components/Activity.jsx:206
-#: frontend/src/metabase/home/components/Activity.jsx:221
+#: frontend/src/metabase/home/components/Activity.jsx:208
+#: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
 msgstr "یک سوال از داشبورد حذف شد -"
 
-#: frontend/src/metabase/home/components/Activity.jsx:231
-#: frontend/src/metabase/home/components/Activity.jsx:238
+#: frontend/src/metabase/home/components/Activity.jsx:233
+#: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
 msgstr "آخرین اطلاعات دریافت شده از"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:621
-#: frontend/src/metabase/home/components/Activity.jsx:244
+#: frontend/src/metabase-lib/lib/Dimension.js:814
+#: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
 msgstr "ناشناخته"
 
-#: frontend/src/metabase/home/components/Activity.jsx:251
+#: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
 msgstr "سلام دنیا!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:252
+#: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
 msgstr "Metabase در حال اجرا است."
 
-#: frontend/src/metabase/home/components/Activity.jsx:258
-#: frontend/src/metabase/home/components/Activity.jsx:288
+#: frontend/src/metabase/home/components/Activity.jsx:260
+#: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
 msgstr "متریک اضافه شده است"
 
-#: frontend/src/metabase/home/components/Activity.jsx:272
-#: frontend/src/metabase/home/components/Activity.jsx:362
+#: frontend/src/metabase/home/components/Activity.jsx:274
+#: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
 msgstr " به"
 
-#: frontend/src/metabase/home/components/Activity.jsx:282
-#: frontend/src/metabase/home/components/Activity.jsx:322
-#: frontend/src/metabase/home/components/Activity.jsx:372
-#: frontend/src/metabase/home/components/Activity.jsx:413
+#: frontend/src/metabase/home/components/Activity.jsx:284
+#: frontend/src/metabase/home/components/Activity.jsx:324
+#: frontend/src/metabase/home/components/Activity.jsx:374
+#: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
 msgstr " جدول"
 
-#: frontend/src/metabase/home/components/Activity.jsx:298
-#: frontend/src/metabase/home/components/Activity.jsx:328
+#: frontend/src/metabase/home/components/Activity.jsx:300
+#: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
 msgstr "تغییرات را به متریک انجام داد"
 
-#: frontend/src/metabase/home/components/Activity.jsx:312
-#: frontend/src/metabase/home/components/Activity.jsx:403
+#: frontend/src/metabase/home/components/Activity.jsx:314
+#: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
 msgstr " در"
 
-#: frontend/src/metabase/home/components/Activity.jsx:335
+#: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
 msgstr "متریک را حذف کرد"
 
-#: frontend/src/metabase/home/components/Activity.jsx:338
+#: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
 msgstr "پالس ایجاد کرد"
 
-#: frontend/src/metabase/home/components/Activity.jsx:341
+#: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
 msgstr "پالس را حذف کردید"
 
-#: frontend/src/metabase/home/components/Activity.jsx:347
-#: frontend/src/metabase/home/components/Activity.jsx:378
+#: frontend/src/metabase/home/components/Activity.jsx:349
+#: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
 msgstr "فیلتر اضافه شد"
 
-#: frontend/src/metabase/home/components/Activity.jsx:388
-#: frontend/src/metabase/home/components/Activity.jsx:419
+#: frontend/src/metabase/home/components/Activity.jsx:390
+#: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
 msgstr "ساخته شده تغییرات در فیلتر"
 
-#: frontend/src/metabase/home/components/Activity.jsx:426
+#: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
 msgstr "فیلتر {0} را حذف کرد"
 
-#: frontend/src/metabase/home/components/Activity.jsx:429
+#: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
 msgstr "پیوست"
 
-#: frontend/src/metabase/home/components/Activity.jsx:529
+#: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
 msgstr "هوم، به نظر می رسد هیچ چیز هنوز اتفاق افتاده است."
 
-#: frontend/src/metabase/home/components/Activity.jsx:532
+#: frontend/src/metabase/home/components/Activity.jsx:534
 msgid "Save a question and get this baby going!"
 msgstr "یک سوال را ذخیره کنید و این نوزاد را در حال رفتن!"
 
@@ -3274,21 +3274,21 @@ msgstr "به تازگی بازدید شده"
 msgid "You haven't looked at any dashboards or questions recently"
 msgstr "شما اخیرا به هیچ داشبورد یا سوالی نگاه نکردید"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:99
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
 msgstr "{0} مورد انتخاب شده است"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:121
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:172
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
 msgstr "بازخوانی"
 
-#: frontend/src/metabase/home/containers/HomepageApp.jsx:74
-#: frontend/src/metabase/nav/containers/Navbar.jsx:331
+#: frontend/src/metabase/home/containers/HomepageApp.jsx:77
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
 msgstr "فعالیت"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:28
+#: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
 msgstr "نتایج برای \"{0}\""
 
@@ -3353,6 +3353,7 @@ msgstr "URL تصویر آواتار"
 msgid "Common"
 msgstr "مشترک"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
@@ -3389,8 +3390,9 @@ msgstr "عرض جغرافیایی"
 msgid "Longitude"
 msgstr "عرض جغرافیایی"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:149
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
 msgstr "شماره"
@@ -3487,7 +3489,7 @@ msgstr "امتیاز"
 
 #: frontend/src/metabase/lib/core.js:210
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:17
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
 msgstr "عنوان"
 
@@ -3544,8 +3546,9 @@ msgid "Metabase will never retrieve this field. Use this for sensitive or irrele
 msgstr "Metabase هرگز این فیلد را بازیابی نخواهد کرد. از این اطلاعات برای اطلاعات حساس یا بی اهمیت استفاده کنید."
 
 #: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:614
-#: frontend/src/metabase/visualizations/lib/utils.js:126
+#: frontend/src/metabase/lib/query.js:300
+#: frontend/src/metabase/visualizations/lib/utils.js:130
+#: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -3560,7 +3563,7 @@ msgstr "جمع انباشته"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
-#: frontend/src/metabase/visualizations/lib/utils.js:127
+#: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
 msgstr "جمع"
 
@@ -3569,7 +3572,7 @@ msgid "CumulativeSum"
 msgstr "مجموع جمله"
 
 #: frontend/src/metabase/lib/expressions/config.js:11
-#: frontend/src/metabase/visualizations/lib/utils.js:128
+#: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
 msgstr "متمایز"
 
@@ -3578,34 +3581,34 @@ msgid "StandardDeviation"
 msgstr "انحراف معیار"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/visualizations/lib/utils.js:125
+#: frontend/src/metabase/visualizations/lib/utils.js:129
 msgid "Average"
 msgstr "میانگین"
 
 #: frontend/src/metabase/lib/expressions/config.js:14
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:25
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
 msgstr "کمترین"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
 msgstr "بیشترین"
 
-#: frontend/src/metabase/lib/expressions/parser.js:384
+#: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
 msgstr "غم انگیز غم انگیز پاندا، اشتباهات لایسنس شناسایی شده است"
 
-#: frontend/src/metabase/lib/formatting.js:707
+#: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} ثانیه"
 
-#: frontend/src/metabase/lib/formatting.js:710
+#: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} دقیقه"
@@ -3643,222 +3646,224 @@ msgstr "در ذهن شما چیست؟"
 msgid "What do you want to find out?"
 msgstr "چه می خواهید بیرون بیایید؟"
 
-#: frontend/src/metabase/lib/query.js:612
-#: frontend/src/metabase/lib/schema_metadata.js:451
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:246
+#: frontend/src/metabase/lib/query.js:298
+#: frontend/src/metabase/lib/schema_metadata.js:458
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
 msgstr "داده های خام"
 
-#: frontend/src/metabase/lib/query.js:616
+#: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
 msgstr "شمارش تجمعی"
 
-#: frontend/src/metabase/lib/query.js:619
+#: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
 msgstr "میانگین از"
 
-#: frontend/src/metabase/lib/query.js:624
+#: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
 msgstr "مقادیر مشخصی از"
 
-#: frontend/src/metabase/lib/query.js:629
+#: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
 msgstr "انحراف استاندارد از"
 
-#: frontend/src/metabase/lib/query.js:634
+#: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
 msgstr "مجموع از"
 
-#: frontend/src/metabase/lib/query.js:639
+#: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
 msgstr "جمع تجمعی"
 
-#: frontend/src/metabase/lib/query.js:644
+#: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
 msgstr "حداکثر"
 
-#: frontend/src/metabase/lib/query.js:649
+#: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
 msgstr "حداقل از"
 
-#: frontend/src/metabase/lib/query.js:663
+#: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
 msgstr "گروه بندی شده توسط"
 
-#: frontend/src/metabase/lib/query.js:677
+#: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
 msgstr "فیلتر شده توسط"
 
-#: frontend/src/metabase/lib/query.js:706
+#: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
 msgstr "مرتب شده بر اساس"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
 msgstr "درست است"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
 msgstr "نادرست"
 
-#: frontend/src/metabase/lib/schema_metadata.js:305
+#: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
 msgstr "فیلد طول جغرافیایی را انتخاب کنید"
 
-#: frontend/src/metabase/lib/schema_metadata.js:306
+#: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
 msgstr "طول عرضی بالا را وارد کنید"
 
-#: frontend/src/metabase/lib/schema_metadata.js:307
+#: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
 msgstr "طول جغرافیایی را وارد کنید"
 
-#: frontend/src/metabase/lib/schema_metadata.js:308
+#: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
 msgstr "عرض پایین را وارد کنید"
 
-#: frontend/src/metabase/lib/schema_metadata.js:309
+#: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
 msgstr "طول جغرافیایی را وارد کنید"
 
-#: frontend/src/metabase/lib/schema_metadata.js:345
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase-lib/lib/Dimension.js:505
+#: frontend/src/metabase-lib/lib/Dimension.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:351
+#: frontend/src/metabase/lib/schema_metadata.js:371
 #: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:387
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
 msgstr "است"
 
-#: frontend/src/metabase/lib/schema_metadata.js:346
-#: frontend/src/metabase/lib/schema_metadata.js:366
-#: frontend/src/metabase/lib/schema_metadata.js:376
-#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/lib/schema_metadata.js:352
+#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:396
+#: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
 msgstr "نیست"
 
-#: frontend/src/metabase/lib/schema_metadata.js:347
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:369
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:353
+#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
 msgstr "خالی است"
 
-#: frontend/src/metabase/lib/schema_metadata.js:348
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:370
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:402
+#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
 msgstr "خالی نیست"
 
-#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
 msgstr "مساوی با"
 
-#: frontend/src/metabase/lib/schema_metadata.js:355
+#: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
 msgstr "برابر نیست با"
 
-#: frontend/src/metabase/lib/schema_metadata.js:356
+#: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
 msgstr "بزرگتر از"
 
-#: frontend/src/metabase/lib/schema_metadata.js:357
+#: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
 msgstr "کمتر از"
 
-#: frontend/src/metabase/lib/schema_metadata.js:358
-#: frontend/src/metabase/lib/schema_metadata.js:384
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:285
+#: frontend/src/metabase/lib/schema_metadata.js:364
+#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "بین"
 
-#: frontend/src/metabase/lib/schema_metadata.js:359
+#: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
 msgstr "بزرگتر یا مساوی با"
 
-#: frontend/src/metabase/lib/schema_metadata.js:360
+#: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
 msgstr "کمتر یا برابر است"
 
-#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
 msgstr "شامل"
 
-#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
 msgstr "شامل نمی شود"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
 msgstr "شروع می شود با"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
 msgstr "به پایان می رسد با"
 
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:264
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "قبل از"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:271
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "بعد از"
 
-#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
 msgstr "داخل"
 
-#: frontend/src/metabase/lib/schema_metadata.js:453
+#: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "فقط یک جدول با ردیف در پاسخ، هیچ عملیات اضافی."
 
-#: frontend/src/metabase/lib/schema_metadata.js:459
+#: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
 msgstr "تعداد ردیف ها"
 
-#: frontend/src/metabase/lib/schema_metadata.js:461
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
 msgstr "تعداد ردیف ها در پاسخ."
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
 msgstr "مجموع ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:469
+#: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
 msgstr "مجموع تمام مقادیر یک ستون."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
 msgstr "میانگین ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
 msgstr "میانگین تمام مقادیر یک ستون"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
 msgstr "تعداد مقادیر متمایز ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "تعداد مقادیر منحصر به فرد یک ستون در میان تمام ردیف در پاسخ."
 
-#: frontend/src/metabase/lib/schema_metadata.js:491
+#: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
 msgstr "جمع تجمعی ..."
 
@@ -3866,7 +3871,7 @@ msgstr "جمع تجمعی ..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "مجموع افزودنی تمام مقادیر یک ستون. \\\\ ne.x. درآمد کل در طول زمان."
 
-#: frontend/src/metabase/lib/schema_metadata.js:499
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
 msgstr "تعداد تجمعی ردیف"
 
@@ -3874,105 +3879,105 @@ msgstr "تعداد تجمعی ردیف"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "تعداد افزودنی تعداد ردیفها. \\\\ ne.x. تعداد کل فروش در طول زمان."
 
-#: frontend/src/metabase/lib/schema_metadata.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
 msgstr "انحراف استاندارد ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:509
+#: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "شماره ای که بیان می کند مقدار مقادیر یک ستون در میان تمام ردیف ها در جواب متفاوت است."
 
-#: frontend/src/metabase/lib/schema_metadata.js:515
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
 msgstr "حداقل از ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:517
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
 msgstr "حداقل مقدار یک ستون"
 
-#: frontend/src/metabase/lib/schema_metadata.js:523
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
 msgstr "حداکثر ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:525
+#: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
 msgstr "حداکثر مقدار یک ستون"
 
-#: frontend/src/metabase/lib/schema_metadata.js:533
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
 msgstr "شکستن بعد"
 
-#: frontend/src/metabase/lib/settings.js:93
+#: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
 msgstr "حروف کوچک"
 
-#: frontend/src/metabase/lib/settings.js:95
+#: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
 msgstr "نامه بزرگ"
 
-#: frontend/src/metabase/lib/settings.js:97
+#: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "عدد"
 
-#: frontend/src/metabase/lib/settings.js:99
+#: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
 msgstr "شخصیت خاص"
 
-#: frontend/src/metabase/lib/settings.js:105
+#: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
 msgstr "باید باشد"
 
-#: frontend/src/metabase/lib/settings.js:105
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:120
+#: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
 msgstr "شخصیت های طولانی"
 
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
 msgstr "باید باشد"
 
-#: frontend/src/metabase/lib/settings.js:122
+#: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
 msgstr "و شامل"
 
-#: frontend/src/metabase/lib/utils.js:92
+#: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
 msgstr "صفر"
 
-#: frontend/src/metabase/lib/utils.js:93
+#: frontend/src/metabase/lib/utils.js:86
 msgid "one"
 msgstr "یکی"
 
-#: frontend/src/metabase/lib/utils.js:94
+#: frontend/src/metabase/lib/utils.js:87
 msgid "two"
 msgstr "دو"
 
-#: frontend/src/metabase/lib/utils.js:95
+#: frontend/src/metabase/lib/utils.js:88
 msgid "three"
 msgstr "سه"
 
-#: frontend/src/metabase/lib/utils.js:96
+#: frontend/src/metabase/lib/utils.js:89
 msgid "four"
 msgstr "چهار"
 
-#: frontend/src/metabase/lib/utils.js:97
+#: frontend/src/metabase/lib/utils.js:90
 msgid "five"
 msgstr "پنج"
 
-#: frontend/src/metabase/lib/utils.js:98
+#: frontend/src/metabase/lib/utils.js:91
 msgid "six"
 msgstr "شش"
 
-#: frontend/src/metabase/lib/utils.js:99
+#: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
 msgstr "هفت"
 
-#: frontend/src/metabase/lib/utils.js:100
+#: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
 msgstr "هشت"
 
-#: frontend/src/metabase/lib/utils.js:101
+#: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
 msgstr "نه"
 
@@ -4046,6 +4051,7 @@ msgstr "زمان"
 msgid "Date range, relative date, time of day, etc."
 msgstr "دامنه تاریخ، تاریخ نسبی، زمان روز و غیره"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
@@ -4068,7 +4074,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "رده، نوع، مدل، رتبه و غیره"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
-#: frontend/src/metabase/user/components/UserSettings.jsx:54
+#: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
 msgstr "تنظیمات حساب"
 
@@ -4080,56 +4086,56 @@ msgstr "خروج از مدیر"
 msgid "Logs"
 msgstr "سیاههها"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:64
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
 msgstr "کمک"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:67
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
 msgstr "درباره Metabase"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:73
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
 msgstr "خروج"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:98
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
 msgstr "با تشکر برای استفاده"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
 msgstr "شما در نسخه هستید"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
 msgstr "ساخته شده بر پایه ی"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:124
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
 msgstr "علامت تجاری است"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:126
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
 msgstr "و با مراقبت در سان فرانسیسکو، کالیفرنیا ساخته شده است"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:194
+#: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
 msgstr "مدیر متاباکس"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:300
+#: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
 msgstr "یک سوال بپرس"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:309
+#: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
 msgstr "داشبورد جدید"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:315
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/nav/containers/Navbar.jsx:361
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
 msgstr "پالس جدید"
 
@@ -4137,16 +4143,16 @@ msgstr "پالس جدید"
 msgid "Reference"
 msgstr "ارجاع"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:83
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
 msgstr "کدام متریک؟"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:110
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "تعریف معیارهای رایج برای تیم شما باعث می شود که سؤالاتتان را حتی ساده تر کنید"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:113
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
 msgstr "چگونه برای ایجاد معیارهای"
 
@@ -4158,8 +4164,8 @@ msgstr "اطلاعات را در طول زمان مشاهده کنید، به ع
 msgid "Custom"
 msgstr "سفارشی"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:150
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:517
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
 msgstr "سوال جدید"
 
@@ -4167,22 +4173,22 @@ msgstr "سوال جدید"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "از سازنده سؤال ساده برای دیدن روند، فهرستی از چیزها یا برای ایجاد معیارهای خود استفاده کنید."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:161
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "پرس و جو بومی"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:162
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "برای سوالات پیچیده تر، شما می توانید پرس و جو SQL خود و یا بومی خود را بنویسید."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:240
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
 msgstr "یک مقدار پیش فرض را انتخاب کنید ..."
 
-#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:149
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
 msgstr "به روز رسانی فیلتر"
 
@@ -4190,14 +4196,14 @@ msgstr "به روز رسانی فیلتر"
 #: frontend/src/metabase/lib/query_time.js:123
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:9
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Today"
 msgstr "امروز"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
 msgstr "دیروز"
 
@@ -4209,7 +4215,7 @@ msgstr "7 روز گذشته"
 msgid "Past 30 days"
 msgstr "30 روز گذشته"
 
-#: frontend/src/metabase/lib/query_time.js:195
+#: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:29
 #: src/metabase/api/table.clj
@@ -4217,7 +4223,7 @@ msgid "Week"
 msgid_plural "Weeks"
 msgstr[0] "هفته"
 
-#: frontend/src/metabase/lib/query_time.js:197
+#: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:30
 #: src/metabase/api/table.clj
@@ -4225,7 +4231,7 @@ msgid "Month"
 msgid_plural "Months"
 msgstr[0] "ماه"
 
-#: frontend/src/metabase/lib/query_time.js:201
+#: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:31
 #: src/metabase/api/table.clj
@@ -4274,6 +4280,7 @@ msgstr "یک مقدار را وارد کنید"
 msgid "Enter a default value..."
 msgstr "مقدار پیش فرض را وارد کنید ..."
 
+#: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "یک خطا رخ داده است"
@@ -4314,24 +4321,24 @@ msgstr "انتشار"
 msgid "Code"
 msgstr "کد"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:70
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
 msgstr "سبک"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
 msgstr "کدام پارامترها می توانند از کاربران این جاسازی استفاده کنند؟"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:83
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
 msgstr "این {0} هیچ پارامتری برای پیکربندی هنوز وجود ندارد."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
 msgstr "قابل ویرایش"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
 msgstr "قفل شده"
 
@@ -4339,19 +4346,19 @@ msgstr "قفل شده"
 msgid "Preview Locked Parameters"
 msgstr "پیش نمایش پارامترهای قفل شده"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:115
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
 msgstr "سعی کنید برخی از مقادیر را به پارامترهای قفل شده خود منتقل کنید. هنگام استفاده از این برای واقعی، سرور شما باید مقادیر واقعی را در امضای امضا ارائه دهد."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
 msgstr "منطقه خطر"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
 msgstr "این تعبیه را برای این {0} غیرفعال می کند."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:128
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
 msgstr "لغو انتشار"
 
@@ -4391,64 +4398,64 @@ msgstr "بیشتر {0}"
 msgid "examples on GitHub"
 msgstr "نمونه در GitHub"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:72
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
 msgstr "اشتراکگذاری را فعال کنید"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
 msgstr "این پیوند عمومی را غیرفعال کنید؟"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:77
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
 msgstr "این باعث می شود که لینک فعلی کار را متوقف کند. شما می توانید آن را مجددا فعال کنید، اما زمانی که شما آن را انجام خواهد شد یک لینک متفاوت است."
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
 msgstr "لینک عمومی"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:118
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
 msgstr "به اشتراک گذاشتن این {0} با افرادی که حساب متاباید با استفاده از URL زیر ندارند:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:158
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
 msgstr "جاسازی عمومی"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:159
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
 msgstr "قراردادن این {0} در پستهای وبلاگ یا صفحات وب با کپی کردن و چسباندن این قطعه:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:176
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
 msgstr "قراردادن این {0} در یک برنامه"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:177
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
 msgstr "با ادغام با کد سرور برنامه شما می توانید آمار امن {0} را به یک کاربر خاص، مشتری، سازمان و غیره ارائه دهید."
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
 msgstr "پیوست را حذف کنید"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:95
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
 msgstr "ضمیمه فایل با نتایج"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
 msgstr "این سوال به عنوان پیوست فایل اضافه می شود"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:128
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
 msgstr "این سوال در Pulse شما موجود نیست"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:92
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
 msgstr "این پالس دیگر به {0} {1} ایمیل نخواهد شد"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:94
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:376
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
 msgstr[0] "{0} آدرس"
@@ -4457,39 +4464,39 @@ msgstr[0] "{0} آدرس"
 msgid "Slack channel {0} will no longer get this pulse {1}"
 msgstr "کانال Slack {0} دیگر این پالس را دریافت نخواهد کرد {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:110
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
 msgstr "کانال {0} دیگر این پالس را دریافت نخواهد کرد {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
 msgstr "ویرایش پالس"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:131
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
 msgstr "پالس چیست؟"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:141
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
 msgstr "فهمیدم"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
 msgstr "این داده ها کجا باید برود؟"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:173
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
 msgstr "نوشتن ..."
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
 msgstr "بازخوانی نشد"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
 msgstr "بازاریابی نشده"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
 msgstr "ایجاد پالس"
 
@@ -4499,7 +4506,7 @@ msgstr "ضمیمه"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:673
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
 msgstr "سر به بالا"
 
@@ -4520,6 +4527,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "ما توصیه می کنیم پالس ها را کوچک نگه داریم و متمرکز شویم تا بتوانیم آنها را هضم کنیم و برای کل تیم مفید باشیم."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
+#: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
 msgstr "اطلاعات خود را انتخاب کنید"
 
@@ -4535,47 +4543,47 @@ msgstr "ایمیل ها"
 msgid "Slack messages"
 msgstr "پیام های خالی"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "ارسال شد"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:222
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} فرستاده خواهد شد"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:224
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "پیام ها"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "اکنون ایمیل بفرست"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:241
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "ارسال به {0} در حال حاضر"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "در حال ارسال…"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:244
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "ارسال نشد"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "فرستاده نشد زیرا پالس هیچ نتیجه ای ندارد"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:248
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "پالس ارسال شد"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:287
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} باید توسط یک مدیر تنظیم شود."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:302
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
 msgstr "لاغر"
 
@@ -4624,21 +4632,21 @@ msgid "Before {0}"
 msgstr "قبل از {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:295
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "خالی است"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:301
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "خالی نیست"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:213
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "همیشه"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:154
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
 msgstr "درخواست دادن"
 
@@ -4704,7 +4712,7 @@ msgstr "توزیع"
 msgid "View details"
 msgstr "دیدن جزئیات"
 
-#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:54
+#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
 msgstr "مشاهده این {0} {1}"
 
@@ -4728,21 +4736,21 @@ msgstr "میانگین"
 msgid "Distincts"
 msgstr "تمایز"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:32
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "مشاهده این {0}"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:225
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
 msgstr "بزرگنمایی"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:19
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
 msgstr "عبارتی سفارشی"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
 msgstr "معیارهای معمول"
 
@@ -4750,7 +4758,7 @@ msgstr "معیارهای معمول"
 msgid "Metabasics"
 msgstr "متابازیک"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
 msgstr "نام (اختیاری)"
 
@@ -4762,31 +4770,31 @@ msgstr "یک تجمع را انتخاب کنید"
 msgid "Set up your own alert"
 msgstr "هشدار خود را تنظیم کنید"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:140
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
 msgstr "لغو اشتراک ..."
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:145
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
 msgstr "لغو عضویت لغو نشد"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:204
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
 msgstr "لغو اشتراک"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:235
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
 msgstr "هیچ کانال"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:263
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
 msgstr "خوب، شما لغو اشتراک هستید"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:335
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
 msgstr "شما هشدار {0} دریافت می کنید"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
 msgstr "{0} هشدار را تنظیم کنید"
 
@@ -4842,147 +4850,147 @@ msgstr "هشدار خود را ویرایش کنید"
 msgid "Edit alert"
 msgstr "هشدار را ویرایش کنید"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:374
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
 msgstr "این هشدار دیگر به {0} ایمیل نخواهد شد."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:382
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
 msgstr "کانال Slack {0} دیگر این هشدار را دریافت نخواهد کرد."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:386
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
 msgstr "کانال {0} دیگر این هشدار را دریافت نخواهد کرد."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:403
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
 msgstr "این هشدار را حذف کنید"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:405
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
 msgstr "تحویل را متوقف کنید و این هشدار را حذف کنید. هیچ واکنشی وجود ندارد، پس مراقب باشید."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:413
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
 msgstr "این هشدار را حذف کنید؟"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:497
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
 msgstr "خط خطی من ..."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:498
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
 msgstr "وقتی نوار پیشرفت من را آزار ..."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
 msgstr "می رود بالاتر از خط دروازه"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
 msgstr "رسیدن به هدف"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
 msgstr "می رود زیر خط دروازه"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
 msgstr "می رود زیر هدف"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:512
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
 msgstr "اولین بار از آن عبور می کند یا هر بار؟"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:513
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
 msgstr "اولین بار به هدف یا هر زمان برمیگردد؟"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
 msgstr "اولین بار"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:516
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
 msgstr "هر زمان"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:619
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
 msgstr "کجا می خواهید این هشدارها را ارسال کنید؟"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:630
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
 msgstr "هشدار ایمیل به:"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:672
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
 msgstr "{0} هشدارهای مبتنی بر هدف برای نمودارها با بیش از یک خط هنوز پشتیبانی نمی شوند بنابراین این هشدار هر بار که {1} نمودار ارسال می شود ارسال می شود."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
 msgstr "نتایج"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:679
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
 msgstr "{0} این نوع هشدار بیشتر مفید است وقتی که پرسش ذخیره شده شما {1} هر نتیجه را بر نمی گرداند، اما شما می خواهید بدانید که چه زمانی انجام می شود."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:680
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
 msgstr "نکته"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
 msgstr "معمولا"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:57
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
 msgstr "یک بخش یا جدول را انتخاب کنید"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
 msgstr "یک پایگاه داده را انتخاب کنید"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:88
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
 msgstr "انتخاب کنید..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:128
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
 msgstr "یک جدول را انتخاب کنید"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:793
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
 msgstr "هیچ جداول موجود در این پایگاه داده یافت نشد."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:830
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
 msgstr "یک سوال گم شده است؟"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:834
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
 msgstr "درباره پرس و جوهای توزیع شده بیشتر بدانید"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:868
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
 msgstr "زمینه های"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:946
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
 msgstr "هیچ بخش یافت نشد"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:969
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
 msgstr "یک قطعه را پیدا کنید"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:46
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
 msgstr "نمایش کمتر"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:56
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
 msgstr "بیشتر ببینید"
 
@@ -4991,60 +4999,65 @@ msgid "Pick a field to sort by"
 msgstr "فیلد مرتب سازی را انتخاب کنید"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
 msgstr "مرتب سازی"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
 msgstr "محدودیت ردیف"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:69
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
 msgstr "میدان ناشناخته"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
 msgstr "رشته"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:114
+#: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
 msgstr "مسابقات"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
+#: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "فیلتر را اضافه کنید تا پاسخ شما محدود شود"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:284
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
 msgstr "یک گروه را اضافه کنید"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:322
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:102
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:113
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:152
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:194
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:59
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:68
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:75
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:225
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:231
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:237
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:70
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:75
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:64
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:89
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:131
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:176
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:302
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:308
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:314
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "داده ها"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:352
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
 msgstr "فیلتر شده توسط"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:369
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
 msgstr "چشم انداز"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:386
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
 msgstr "گروه بندی شده توسط"
 
@@ -5052,23 +5065,23 @@ msgstr "گروه بندی شده توسط"
 msgid "None"
 msgstr "هیچ یک"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:345
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
 msgstr "این سوال در {0} نوشته شده است."
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:353
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
 msgstr "مخفی کردن ویرایشگر"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:354
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
 msgstr "پنهان کردن پرس و جو"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
 msgstr "بازکردن ویرایشگر"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:360
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
 msgstr "نمایش پرس و جو"
 
@@ -5089,15 +5102,15 @@ msgstr "این داده ها را دانلود کنید"
 msgid "Warning"
 msgstr "هشدار"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:52
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
 msgstr "پاسخ شما دارای تعداد زیادی ردیف است، بنابراین ممکن است چندین بار برای بارگیری استفاده شود."
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:53
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
 msgstr "حداکثر اندازه دانلود 1 میلیون ردیف است."
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:232
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
 msgstr "ویرایش سوال"
 
@@ -5113,17 +5126,17 @@ msgstr "لغو"
 msgid "Move question"
 msgstr "انتقال سوال"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:283
+#: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
 msgstr "کدام مجموعه باید این باشد؟"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:313
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:110
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
+#: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
 msgstr "متغیرها"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:432
+#: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
 msgstr "درباره دادههای خود اطلاعاتی کسب کنید"
 
@@ -5167,11 +5180,11 @@ msgstr "{0} برای این سوال"
 msgid "Convert this question to {0}"
 msgstr "این سوال را به {0} تبدیل کنید"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:122
+#: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
 msgstr "این سوال تقریبا {0} را برای تازه کردن انجام خواهد داد"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:131
+#: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
 msgstr "به روز شده {0}"
 
@@ -5188,11 +5201,11 @@ msgstr "نمایش {0} {1} اول"
 msgid "Showing {0} {1}"
 msgstr "نمایش {0} {1}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:281
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
 msgstr "انجام علم"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:294
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
 msgstr "اگر شما برخی از داده ها را به من بدهید، می توانم چیزی را باهم نشان دهم. یک پرس و جو را اجرا کنید"
 
@@ -5200,7 +5213,7 @@ msgstr "اگر شما برخی از داده ها را به من بدهید، م
 msgid "How do I use this thing?"
 msgstr "چطور از این چیزی استفاده کنم؟"
 
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:28
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
 msgstr "دریافت پاسخ"
 
@@ -5228,39 +5241,39 @@ msgstr "متاسف. چیزی اشتباه رفت"
 msgid "Group time by"
 msgstr "زمان گروهی توسط"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:46
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
 msgstr "سوال شما خیلی طول کشید"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:47
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
 msgstr "ما در زمان پاسخی از پایگاه داده خود دریافت نکردیم، بنابراین مجبور شدیم متوقف شویم. میتوانید بعد از یک دقیقه دوباره تلاش کنید یا اگر مشکل باقی بماند، میتوانید یک مدیر را برای اطلاع از آنها ایمیل کنید."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:55
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
 msgstr "ما مشکالت سرور را تجربه می کنیم"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:56
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
 msgstr "پس از یک دقیقه یا دو دقیقه یک صفحه را تمیز کنید. اگر مشکل باقی می ماند، توصیه می کنیم با یک مدیر تماس بگیرید."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:88
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
 msgstr "مشکلی با سوال شما وجود داشت"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:89
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
 msgstr "اغلب اوقات این مسئله ناشی از انتخاب نامعتبر یا ارزش ورودی بد است. دو ورودی خود را بررسی کنید و درخواست خود را دوباره امتحان کنید."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:60
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
 msgstr "این ممکن است پاسخ شما به دنبال آن هستید. اگر نه، سعی کنید فیلتر ها را از بین ببرید یا تغییر دهید تا آنها را کمتر مشخص کنید."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
 msgstr "شما همچنین می توانید {0} زمانی که برخی نتایج وجود دارد."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:68
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
 msgstr "هشدار بده"
 
@@ -5268,11 +5281,11 @@ msgstr "هشدار بده"
 msgid "Back to last run"
 msgstr "بازگشت به آخرین اجرا"
 
-#: frontend/src/metabase/query_builder/components/VisualizationSettings.jsx:100
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
 msgstr "تجسم"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:96
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
 msgstr "بدون شرح"
 
@@ -5284,7 +5297,7 @@ msgstr "برای سوال فعلی استفاده کنید"
 msgid "Potentially useful questions"
 msgstr "سوالات بالقوه مفید"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:166
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
 msgstr "گروه توسط {0}"
 
@@ -5297,14 +5310,14 @@ msgstr "مجموع تمام مقادیر {0}"
 msgid "All distinct values of {0}"
 msgstr "تمام مقادیر متمایز {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:187
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
 msgstr "تعداد {0} گروه بندی شده توسط {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5320,34 +5333,34 @@ msgstr "مرجع داده"
 msgid "Learn more about your data structure to ask more useful questions"
 msgstr "درباره ساختار داده های خود بیشتر بدانید تا سؤالات مفیدتری را بیاموزید"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:58
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:84
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
 msgstr "قبل از ایجاد یک سوال جدید، ابرداده جدول یافت نشد"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:80
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
 msgstr "{0} را ببینید"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:94
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
 msgstr "تعریف متریک"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:118
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
 msgstr "فیلتر توسط {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:127
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
 msgstr "تعداد {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
 msgstr "مشاهده تمام {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:148
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
 msgstr "تعریف بخش"
 
@@ -5359,7 +5372,7 @@ msgstr "هنگام بارگیری جدول خطایی روی داد"
 msgid "See the raw data for {0}"
 msgstr "داده های خام برای {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:180
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
 msgstr "بیشتر"
 
@@ -5371,24 +5384,24 @@ msgstr "عبارت نادرست"
 msgid "unknown error"
 msgstr "خطای ناشناخته"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:46
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
 msgstr "فرمول فیلد"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:57
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "از این به عنوان نوعی از نوشتن یک فرمول در یک برنامه صفحه گسترده استفاده کنید. میتوانید از اعداد، فیلدها در این جدول، نمادهای ریاضی مانند + و برخی از توابع استفاده کنید. بنابراین شما می توانید چیزی مانند Subtotal - Cost را تایپ کنید."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
 msgstr "بیشتر بدانید"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:66
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
 msgstr "نام آن را بدهید"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:72
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
 msgstr "چیزی خوب و توصیفی"
 
@@ -5440,7 +5453,8 @@ msgstr "درست است"
 msgid "false"
 msgstr "نادرست"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
 msgstr "اضافه کردن فیلتر"
 
@@ -5448,15 +5462,15 @@ msgstr "اضافه کردن فیلتر"
 msgid "Item"
 msgstr "مورد"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:221
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
 msgstr "قبلی"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:252
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
 msgstr "جاری"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:278
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
@@ -5467,7 +5481,7 @@ msgid "Enter desired number"
 msgstr "شماره مورد نظر را وارد کنید"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:100
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
 msgstr "خالی"
 
@@ -5491,35 +5505,35 @@ msgstr "شما می توانید چندین عدد را با کاما وارد �
 msgid "Enter desired text"
 msgstr "متن دلخواه را وارد کنید"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
 msgstr "آن را امتحان کنید"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
 msgstr "این چیست؟"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
 msgstr "متغیرها در نمایشهای بومی شما به صورت پویا ارزشها را در نمایشهای خود با استفاده از ویدجت فیلتر یا از طریق URL جایگزین می کنند."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
 msgstr "{0} یک متغیر در این قالب SQL ایجاد می کند که نام \"متغیر_ نام\" است. متغیرها می توانند در پانل سمت چپ انواع داده شوند که رفتار آنها را تغییر می دهد. همه انواع متغیر غیر از فیلد فیلد به صورت خودکار باعث می شود ویجت فیلتر بر روی این سوال قرار گیرد. با فیلتر فیلدها، این اختیاری است. وقتی این ویجت فیلتر پر شده است، آن مقدار متغیری را در قالب SQL جایگزین می کند."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:121
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
 msgstr "فیلترهای فیلد"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:123
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "دادن یک متغیر نوع فیلد فیلد اجازه می دهد تا کارت های SQL را به ویدجت های فیلتر دسکتاپ پیوند دهید یا از انواع بیشتر ویدجت های فیلتر در سوال SQL خود استفاده کنید. یک فیلد فیلد فیلد SQL را همانند آنچه که توسط سازنده پرس و جو GUI ایجاد شده است در هنگام اضافه کردن فیلتر در ستون های موجود اضافه می کند."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:126
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
 msgstr "هنگام اضافه کردن متغیر فیلد فیلد، باید آن را به یک فیلد مشخص کنید. سپس می توانید یک ویجت فیلتر را روی سوال خود انتخاب کنید، اما حتی اگر این کار را نکنید، می توانید در هنگام اضافه کردن این سوال به داشبورد، فیلد فیلد فیلد خود را به فیلد داشبورد نشان دهید. فیلدهای فیلد باید در داخل یک «WHERE» قرار گیرد."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:130
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
 msgstr "مقررات اختیاری"
 
@@ -5527,59 +5541,61 @@ msgstr "مقررات اختیاری"
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
 msgstr "براکت در اطراف یک {0} یک بند اختیاری در قالب ایجاد کنید. اگر \"متغیر\" تنظیم شده باشد، کل عبارت در قالب قرار می گیرد. اگر نه، پس کل عبارت نادیده گرفته می شود."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:142
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
 msgstr "برای استفاده از چندین پارامتر اختیاری می توانید حداقل یک عبارت WHERE غیر اختیاری همراه با پاراگراف های اختیاری را با «AND» وارد کنید."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
 msgstr "مستندات کامل را بخوانید"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:127
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
 msgstr "برچسب فیلتر"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:139
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
 msgstr "نوع متغیر"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:143
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
 msgstr "متن"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:150
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:119
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
 msgstr "تاریخ"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
 msgstr "فیلتر فیلد"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:157
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
 msgstr "فیلد برای نقشه"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
 msgstr "نوع ویجت فیلتر"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:201
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
 msgstr "ضروری؟"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:211
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
 msgstr "مقدار ویجت فیلتر پیش فرض"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:46
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
 msgstr "بایگانی این سوال؟"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:57
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "این سوال از هر داشبورد یا پالس از آن حذف خواهد شد."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:136
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
 msgstr "سوال"
 
@@ -5596,21 +5612,21 @@ msgstr "شما در حال ویرایش این صفحه هستید"
 msgid "See this {0}"
 msgstr "این را ببینید {0}"
 
-#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:120
+#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
 msgstr "زیر مجموعه ای از"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:68
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
 msgstr "یک نوع فیلد را انتخاب کنید"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:57
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
 msgstr "نوع فیلد نیست"
 
@@ -5619,16 +5635,16 @@ msgid "by"
 msgstr "توسط"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
-#: frontend/src/metabase/reference/databases/FieldList.jsx:152
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
+#: frontend/src/metabase/reference/databases/FieldList.jsx:155
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
 msgstr "نوع فیلد"
 
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:72
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
 msgstr "یک کلید خارجی را انتخاب کنید"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:53
+#: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
 msgstr "فرمول {0} را ببینید"
 
@@ -5645,12 +5661,12 @@ msgid "Nothing important yet"
 msgstr "هیچ چیز مهم نیست"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:168
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:233
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:211
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:215
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:219
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:229
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:236
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:214
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
 msgstr "هیچ چیز جالب نیست"
 
@@ -5659,12 +5675,12 @@ msgid "Things to be aware of about this {0}"
 msgstr "چیزهایی که در مورد این آگاه هستند {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:178
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:243
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:221
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:225
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:229
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:239
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:246
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:224
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
 msgstr "هیچ چیز از قبل هنوز آگاه نیست"
 
@@ -5726,15 +5742,15 @@ msgstr "دلیل تغییرات"
 msgid "Leave a note to explain what changes you made and why they were required"
 msgstr "یک یادداشت را برای توضیح آنچه که تغییراتی ایجاد کرده اید و چرا آنها مورد نیاز بود را ترک کنید"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:166
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
 msgstr "چرا این پایگاه جالب است؟"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:176
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
 msgstr "چیزهایی که باید درباره این پایگاه اطلاعات بدانند"
 
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:46
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
 msgstr "پایگاه های داده و جداول"
@@ -5742,42 +5758,42 @@ msgstr "پایگاه های داده و جداول"
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:41
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:170
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:173
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:34
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:184
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:187
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:30
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:188
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:187
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:191
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:190
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
 msgstr "جزئیات"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
-#: frontend/src/metabase/reference/databases/TableList.jsx:111
+#: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
 msgstr "جداول در {0}"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:222
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:200
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:218
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:203
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
 msgstr "نام واقعی در پایگاه داده"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:231
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:227
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
 msgstr "چرا این زمینه جالب است"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:241
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:237
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
 msgstr "چیزهایی که در مورد این زمینه آگاهی دارند"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:253
-#: frontend/src/metabase/reference/databases/FieldList.jsx:155
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:249
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
+#: frontend/src/metabase/reference/databases/FieldList.jsx:158
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
 msgstr "نوع داده"
 
@@ -5786,13 +5802,13 @@ msgstr "نوع داده"
 msgid "Fields in this table will appear here as they're added"
 msgstr "فیلدها در این جدول در اینجا به نظر میرسند زیرا آنها اضافه شدهاند"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:134
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:135
+#: frontend/src/metabase/reference/databases/FieldList.jsx:137
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
 msgstr "فیلدها در {0}"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:149
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:150
+#: frontend/src/metabase/reference/databases/FieldList.jsx:152
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
 msgstr "نام زمینه"
 
@@ -5816,7 +5832,10 @@ msgstr "پایگاه های داده در اینجا ظاهر خواهد شد، 
 msgid "Connect a database"
 msgstr "یک پایگاه داده را وصل کنید"
 
+#. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
+#. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
+#: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
 msgstr "تعداد {0}"
 
@@ -5824,11 +5843,11 @@ msgstr "تعداد {0}"
 msgid "See raw data for {0}"
 msgstr "اطلاعات خام را برای {0} مشاهده کنید"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:209
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
 msgstr "چرا این جدول جالب است"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:219
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
 msgstr "چیزهایی که باید در مورد این جدول آگاه باشند"
 
@@ -5840,16 +5859,16 @@ msgstr "جداول در این پایگاه داده در اینجا به هما
 msgid "Questions about this table will appear here as they're added"
 msgstr "سوالات در مورد این جدول در اینجا به عنوان آنها اضافه شده است"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:71
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:75
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:74
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
 msgstr "سوالات در مورد {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
 msgstr "{0} توسط {1} ایجاد شد"
 
@@ -5861,151 +5880,152 @@ msgstr "زمینه های این جدول"
 msgid "Questions about this table"
 msgstr "سوالات در مورد این جدول"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:157
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
 msgstr "کمک به تیم خود را با داده های خود را آغاز کنید."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:159
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
 msgstr "تیم خود را با انتخاب مهمترین داشبورد، معیارها و بخشهای خود مهم تر کنید."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:165
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
 msgstr "شروع کنید"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:173
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
 msgstr "مهم ترین داشبورد ما"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:188
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
 msgstr "اعدادی که به آن توجه می کنیم"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:213
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
 msgstr "معیارهای مهم هستند که شرکت شما در مورد آن اهمیت دارد. آنها اغلب نشان دهنده شاخص اصلی عملکرد کسب و کار هستند."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:221
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
 msgstr "تمام معیارها را ببینید"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:235
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
 msgstr "بخش ها و جداول"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
+#: frontend/src/metabase/home/containers/SearchApp.jsx:83
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
 msgstr "جداول"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:262
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
 msgstr "بخش ها و جداول بلوک های داده های شرکت شما هستند. جداول مجموعه ای از اطلاعات خام است در حالی که بخش ها برش های خاصی با معانی خاصی مانند {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:267
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
 msgstr "جداول بلوک های داده های شرکت شما هستند."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:277
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
 msgstr "تمام بخشها را ببینید"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:293
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
 msgstr "تمام جداول را ببینید"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:301
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
 msgstr "چیزهای دیگر در مورد اطلاعات ما می دانیم"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
 msgstr "اطلاعات بیشتر"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:307
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
 msgstr "یک راه خوب برای شناختن اطلاعات شما با صرف کمی وقت است که از جداول مختلف و سایر اطلاعات موجود برای شما استفاده کنید. ممکن است کمی طول بکشد، اما در طول زمان، اسامی و معانی را خواهید فهمید."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:313
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
 msgstr "کاوش داده های ما"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:321
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
 msgstr "سوالی دارید؟"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:326
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
 msgstr "تماس بگیرید {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:248
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
 msgstr "کمک به کاربران جدید Metabase راه خود را پیدا می کنند."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:251
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
 msgstr "راهنمای شروع به کار، داشبورد، متریک ها، بخش ها و جداول را مهم تر می کند و کاربران را از موارد مهم که باید قبل از حفر نمودن آنها به داده ها اطلاع دهند، اطلاع می دهد."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:258
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
 msgstr "آیا داشبورد مهم برای تیم شما وجود دارد؟"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:260
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
 msgstr "اکنون داشبورد را ایجاد کنید"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:266
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
 msgstr "مهمترین داشبورد مهم شما چیست؟"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:285
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
 msgstr "آیا شما معیارهای رایج را دارید؟"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:287
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
 msgstr "یاد بگیرید که چگونه یک متریک را تعریف کنید"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:300
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
 msgstr "3-5 معیارهای رایج ترین معیار شما چیست؟"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:344
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
 msgstr "یک متریک دیگر اضافه کنید"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:357
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
 msgstr "آیا شما هر بخش یا جداول رایج را دارید؟"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:359
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
 msgstr "یاد بگیرید چگونه یک بخش ایجاد کنید"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:372
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
 msgstr "3-6 بخش یا جدول جداگانه که معمولا برای این مخاطب مفید است، 3-5 هستند."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:418
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
 msgstr "یک بخش یا جدول دیگر اضافه کنید"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:427
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
 msgstr "آیا قبل از شروع به دسترسی به داده ها، کاربران باید قبل از شروع دسترسی به آنها، باید بدانند یا بدانند؟"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:433
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
 msgstr "قبل از شروع دسترسی به این اطلاعات باید یک کاربر از این اطلاعات بداند؟"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:437
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
 msgstr "به عنوان مثال، انتظارات در مورد حریم خصوصی و استفاده از داده ها، مشکلات رایج یا سوء تفاهم ها، اطلاعات مربوط به عملکرد انبار داده، اعلامیه های قانونی و غیره"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
 msgstr "آیا کسی وجود دارد که کاربران شما می توانند برای کمک در صورت بروز این اشتباه در مورد این راهنما چاره کنند؟"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:457
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
 msgstr "اگر در مورد این اطلاعات اشتباه گرفته شود، کاربران باید برای کمک تماس بگیرند؟"
 
@@ -6014,39 +6034,39 @@ msgstr "اگر در مورد این اطلاعات اشتباه گرفته شو�
 msgid "Please enter a revision message"
 msgstr "لطفا یک پیام تجدید نظر را وارد کنید"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:213
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
 msgstr "چرا این متریک جالب است"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:223
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
 msgstr "چیزهایی که در مورد این متریال آگاه هستند"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:233
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
 msgstr "چگونه این متریک محاسبه شده است"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:235
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
 msgstr "هیچ چیز در مورد چگونگی محاسبه هنوز"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:293
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
 msgstr "دیگر زمینه های شما می توانید این متریک با گروه"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:294
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
 msgstr "زمینه های شما می توانید این متریک با گروه"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:23
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "معیارهای رسمی اعداد رسمی است که تیم شما در مورد آن مورد توجه قرار گرفته است"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
 msgstr "پس از اینکه مدیران شما برخی از آنها ایجاد کرد، معیارها در اینجا ظاهر می شوند"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
 msgstr "یاد بگیرید چگونه برای ایجاد معیارها"
 
@@ -6058,9 +6078,9 @@ msgstr "سوالاتی درباره این معیار در اینجا به عن�
 msgid "There are no revisions for this metric"
 msgstr "برای این متریک تجدیدنظر وجود ندارد"
 
-#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:88
-#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
-#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:88
+#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
+#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
+#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
 msgstr "تاریخچه ویرایش برای {0}"
 
@@ -6068,27 +6088,27 @@ msgstr "تاریخچه ویرایش برای {0}"
 msgid "X-ray this metric"
 msgstr "اشعه ایکس این متریک"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:217
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
 msgstr "چرا این بخش جالب است"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:227
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
 msgstr "چیزهایی که در مورد این بخش آگاهی دارند"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
 msgstr "بخش ها بخش های جالب از جداول هستند"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "تعریف بخش های عادی برای تیم شما، باعث می شود که سؤالات بیشتری از شما بپرسید"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
 msgstr "Segments در اینجا ظاهر خواهد شد، هنگامی که مدیران شما برخی را ایجاد کرده اند"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
 msgstr "یاد بگیرید چگونه برای ایجاد بخش"
 
@@ -6116,7 +6136,7 @@ msgstr "اشعه ایکس این بخش"
 msgid "Login"
 msgstr "ورود"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:130
+#: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
 msgstr "جستجو کردن"
@@ -6133,99 +6153,99 @@ msgstr "سوال جدید"
 msgid "Select the type of Database you use"
 msgstr "نوع پایگاه داده ای که استفاده می کنید را انتخاب کنید"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:141
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
 msgstr "اطلاعات خود را اضافه کنید"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:145
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
 msgstr "بعدا داده های خودم را اضافه خواهم کرد"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
 msgstr "اتصال به {0}"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:165
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
 msgstr "شما به اطلاعاتی درباره پایگاه داده خود نیاز دارید، مانند نام کاربری و رمز عبور. اگر شما آن را در حال حاضر ندارید، Metabase همچنین با مجموعه داده های نمونه ای که می توانید از آن استفاده کنید."
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:196
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
 msgstr "بعدا داده هایم را اضافه خواهم کرد"
 
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:41
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
 msgstr "کنترل اسکن خودکار"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:53
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
 msgstr "تنظیمات داده استفاده"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
 msgstr "با تشکر برای کمک به بهبود ما"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:57
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
 msgstr "ما هر گونه رویداد استفاده را جمع آوری نخواهیم کرد"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:76
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "به منظور کمک به بهبود Metabase، ما می خواهیم اطلاعات خاصی در مورد استفاده از طریق Google Analytics جمع آوری کنیم."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
 msgstr "در اینجا یک لیست کامل از همه چیز ما پیگیری و به همین دلیل است."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:98
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "اجازه دهید Metabase به صورت ناشناس رویدادهای استفاده را جمع آوری کند"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} اطلاعاتی درباره نتایج یا نتایج شما را جمع آوری می کند."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:106
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
 msgstr "هرگز"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
 msgstr "تمام مجموعه کاملا ناشناس است."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "مجموعه را می توانید در هر نقطه از تنظیمات مدیریت خود خاموش کنید."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:45
+#: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
 msgstr "اگر احساس می کنید گیر کرده اید"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:52
+#: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
 msgstr "راهنمای شروع به کار ما"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:53
+#: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
 msgstr "فقط یک کلیک دور است"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:95
+#: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
 msgstr "به Metabase خوش آمدید"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:96
+#: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "به نظر می رسد همه چیز در حال کار است اکنون اجازه دهید شما را بشناسیم، با داده هایتان ارتباط برقرار کنید و برخی از پاسخ ها را پیدا کنید!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:100
+#: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
 msgstr "بیا شروع کنیم"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:145
+#: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
 msgstr "همه شما تنظیم شده اند!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:156
+#: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
 msgstr "من را به Metabase ببر"
 
@@ -6242,7 +6262,7 @@ msgid "Create a password"
 msgstr "یک رمز عبور ایجاد کنید"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:116
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
 msgstr "شیخ ..."
 
@@ -6436,11 +6456,11 @@ msgstr "با آدرس ایمیل Google وارد شوید"
 msgid "User Details"
 msgstr "اطلاعات کاربر"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:275
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
 msgstr "بازنشانی به پیش فرضها"
 
-#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:133
+#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
 msgstr "نقشه ناشناخته"
 
@@ -6452,24 +6472,24 @@ msgstr "نقشه شبکه نیازمند طول جغرافیایی / عرض جغ
 msgid "more"
 msgstr "بیشتر"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:101
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
 msgstr "کدام زمینه ها برای محورهای X و Y مورد استفاده قرار می گیرد؟"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:103
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:60
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
 msgstr "زمینه ها را انتخاب کنید"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:204
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
 msgstr "نمایش به صورت پیش فرض ذخیره شود"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
 msgstr "جعبه قرعه کشی برای فیلتر کردن"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
 msgstr "لغو فیلتر"
 
@@ -6477,7 +6497,7 @@ msgstr "لغو فیلتر"
 msgid "Pin Map"
 msgstr "نقشه پین"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:303
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
 msgstr "گمشده"
 
@@ -6485,31 +6505,31 @@ msgstr "گمشده"
 msgid "Rows {0}-{1} of {2}"
 msgstr "ردیف {0} - {1} از {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:189
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
 msgstr "داده های کوتاه شده به {0} ردیف."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:364
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
 msgstr "تجسم یافت نشد"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:371
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
 msgstr "این نمودار را نمیتوان با این اطلاعات نمایش داد."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:469
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
 msgstr "هیچ نتیجه ای!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:490
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
 msgstr "هنوز منتظرم..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:493
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
 msgstr "این معمولا طول می کشد به طور متوسط ​​{0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:499
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
 msgstr "(این کمی طولانی برای داشبورد است)"
 
@@ -6525,11 +6545,11 @@ msgstr "یک فیلد را انتخاب کنید"
 msgid "error"
 msgstr "خطا"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:126
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
 msgstr "برای تغییر سفارش خود روی بکشید و بکشید"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:139
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
 msgstr "فیلدهای را از لیست زیر اضافه کنید"
 
@@ -6620,7 +6640,7 @@ msgid "Highlight the whole row"
 msgstr "تمام سطر را برجسته کنید"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:98
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "رنگ ها"
 
@@ -6685,20 +6705,20 @@ msgstr "تجسم با آن شناسه قبلا ثبت شده است:"
 msgid "No visualization for {0}"
 msgstr "هیچ تصویری برای {0}"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:75
+#: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
 msgstr "\"{0}\" یک فیلد جمع نشده است: در صورتی که دارای مقدار بیش از یک مقدار در یک محور x باشد، مقادیر جمع می شوند."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:91
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
 msgstr "این نوع نمودار نیاز به حداقل 2 ستون دارد."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:96
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
 msgstr "این نوع نمودار بیش از {0} سری داده ها را پشتیبانی نمی کند."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:51
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:297
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
 msgstr "هدف"
 
@@ -6736,25 +6756,25 @@ msgstr "ویرایش تنظیمات"
 msgid "xValues missing!"
 msgstr "xValues ​​گم شده!"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:114
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "محور X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:140
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
 msgstr "شکستن سریال اضافه کنید ..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:153
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "محور Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:178
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
 msgstr "یک سری دیگر اضافه کنید ..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:195
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
 msgstr "اندازه حباب"
 
@@ -6768,7 +6788,7 @@ msgid "Curve"
 msgstr "منحنی"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:69
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
 msgstr "گام"
 
@@ -6776,27 +6796,27 @@ msgstr "گام"
 msgid "Show point markers on lines"
 msgstr "نشانگرهای نقطه در خطوط"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:235
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
 msgstr "پشتهسازی"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:239
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
 msgstr "پشته نکن"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:240
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
 msgstr "پشته"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:241
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
 msgstr "پشته - 100٪"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:300
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
 msgstr "نمایش هدف"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:306
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
 msgstr "ارزش هدف"
 
@@ -6816,126 +6836,126 @@ msgstr "هیچ چی"
 msgid "Linear Interpolated"
 msgstr "خطی Interpolated"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:371
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
 msgstr "مقیاس محور X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
 msgstr "سری زمانی"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:391
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:409
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:381
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
 msgstr "خطی"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:410
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:383
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
 msgstr "قدرت"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:384
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
 msgstr "ورود"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:396
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
 msgstr "هیستوگرام"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:398
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
 msgstr "Ordinal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:404
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
 msgstr "مقیاس محور Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:417
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
 msgstr "نمایش خط x محور و علائم"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:423
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
 msgstr "فشرده"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:424
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
 msgstr "چرخش 45 درجه"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
 msgstr "چرخش 90 درجه"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
 msgstr "نمایش خط محور y و علائم"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
 msgstr "محدوده ی محدوده ی خودکار"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
 msgstr "در صورت لزوم از محور y تقسیم استفاده کنید"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
 msgstr "برچسب را روی محور x نشان دهید"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:501
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
 msgstr "برچسب محور X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:510
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
 msgstr "نمایش برچسب در محور y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:516
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
 msgstr "برچسب محور Y"
 
-#: frontend/src/metabase/visualizations/lib/utils.js:129
+#: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
 msgstr "انحراف معیار"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:275
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:17
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:256
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
 msgstr "حوزه"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
 msgstr "نمودار منطقه"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:276
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:16
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:257
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
 msgstr "بار"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
 msgstr "نمودار میله ای"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
 msgstr "کدام فیلدها را می خواهید استفاده کنید؟"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
 msgstr "کانال"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:76
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:76
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "اندازه گرفتن"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
 msgstr "نوع قیف"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:88
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
 msgstr "نمودار میله ای"
 
@@ -6943,141 +6963,141 @@ msgstr "نمودار میله ای"
 msgid "line chart"
 msgstr "نمودار خط"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:224
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "لطفا ستون طول و عرض جغرافیایی را در تنظیمات نمودار انتخاب کنید."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
 msgstr "لطفا یک نقشه منطقه را انتخاب کنید"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 msgid "Please select region and metric columns in the chart settings."
 msgstr "لطفا ستون های منطقه و متریک را در تنظیمات نمودار انتخاب کنید."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:38
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "نقشه"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:53
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
 msgstr "نوع نقشه"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:57
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:149
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
 msgstr "نقشه منطقه"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
 msgstr "نقشه پین"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
 msgstr "نوع پین"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
 msgstr "کاشی"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
 msgstr "نشانگرها"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
 msgstr "زمینه عرض"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
 msgstr "میدان طول جغرافیایی"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:142
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:168
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
 msgstr "زمینه متریک"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
 msgstr "زمینه منطقه"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
 msgstr "شعاع"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:198
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
 msgstr "تاری"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
 msgstr "حداقل ابعاد"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
 msgstr "حداکثر زوم"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:175
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
 msgstr "هیچ روابطی پیدا نشد"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:213
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
 msgstr "از طریق {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:290
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
 msgstr "این {0} به متصل است:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:47
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
 msgstr "جزئیات شیء"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
 msgstr "هدف - شی"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
 msgstr "جمع"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "کدام ستون ها می خواهید استفاده کنید؟"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:44
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "پای"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "بعد، ابعاد، اندازه"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:81
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "نمایش افسانه"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:86
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "نمایش درصد در افسانه"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:92
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "حداقل قطعه قطعه"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:146
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
 msgstr "هدف ملاقات کرد"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:148
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
 msgstr "هدف بیش از حد است"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
 msgstr "هدف {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
 msgstr "تجسم پیشرفت نیاز به یک عدد دارد"
 
@@ -7085,9 +7105,9 @@ msgstr "تجسم پیشرفت نیاز به یک عدد دارد"
 msgid "Progress"
 msgstr "پیش رفتن"
 
-#: frontend/src/metabase/entities/collections.js:108
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:176
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:57
+#: frontend/src/metabase/entities/collections.js:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "رنگ"
 
@@ -7099,7 +7119,7 @@ msgstr "نمودار ردیف"
 msgid "row chart"
 msgstr "نمودار ردیف"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:357
+#: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
 msgstr "سبک جداساز"
 
@@ -7107,15 +7127,15 @@ msgstr "سبک جداساز"
 msgid "Number of decimal places"
 msgstr "تعداد اعشاری"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:381
+#: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
 msgstr "افزودن یک پیشوند"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:385
+#: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
 msgstr "یک پسوند را اضافه کنید"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:374
+#: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
 msgstr "ضرب به یک عدد"
 
@@ -7127,7 +7147,7 @@ msgstr "پراکنده"
 msgid "scatter plot"
 msgstr "طرح پراکنده"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:78
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
 msgstr "جدول را محکم بگیرید"
 
@@ -7136,7 +7156,8 @@ msgid "Visible fields"
 msgstr "زمینه های قابل مشاهده"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-msgid "Write here, and use Markdown if you''d like"
+#, fuzzy
+msgid "Write here, and use Markdown if you'd like"
 msgstr "اینجا بنویسید و از Markdown استفاده کنید اگر دوست دارید"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
@@ -7177,12 +7198,12 @@ msgstr "درست"
 msgid "Show background"
 msgstr "نمایش پس زمینه"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:553
+#: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} بن"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:559
+#: frontend/src/metabase-lib/lib/Dimension.js:731
 msgid "Auto binned"
 msgstr "خودکار متصل"
 
@@ -7450,23 +7471,23 @@ msgstr "بنز اتوماتیک"
 msgid "Don''t bin"
 msgstr "نه بیرون"
 
-#: frontend/src/metabase/lib/query_time.js:193 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "روز"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
-#: frontend/src/metabase/lib/query_time.js:189 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "دقیقه"
 
-#: frontend/src/metabase/lib/query_time.js:191 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "ساعت"
 
-#: frontend/src/metabase/lib/query_time.js:199 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
 msgstr[0] "ربع"
@@ -7532,7 +7553,7 @@ msgid "Bin every 20 degrees"
 msgstr "بن هر 20 درجه"
 
 #. returns `true` if successful -- see JavaDoc
-#: src/metabase/api/tiles.clj src/metabase/pulse/render.clj
+#: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
 msgstr "هیچ نویسنده تصویر مناسب پیدا نشد!"
 
@@ -7604,10 +7625,12 @@ msgstr "جمع تجمعی"
 msgid "{0} and {1}"
 msgstr "{0} و {1}"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} از {1}"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
 msgstr "{0} توسط {1}"
@@ -7620,9 +7643,11 @@ msgstr "{0} در بخش {1}"
 msgid "{0} segment"
 msgstr "{0} بخش"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
-msgstr "{0} متریک"
+msgid_plural "{0} metrics"
+msgstr[0] "{0} متریک"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
@@ -8203,6 +8228,7 @@ msgid "Cannot save Question: source query has circular references."
 msgstr "نتوانست سوال را نجات دهد: پرس و جو منبع دارای مراجع دایره ای است."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
+#: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
 msgstr "کارت {0} وجود ندارد."
@@ -8604,7 +8630,7 @@ msgstr "نوع کانال نامشخص {0}"
 msgid "Error sending notification!"
 msgstr "خطا در ارسال اعلان!"
 
-#: src/metabase/pulse/color.clj
+#: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
 msgstr "می توانید انتخاب رنگ JS را در '' {0} '' پیدا کنید"
 
@@ -8911,43 +8937,43 @@ msgstr "دسترسی‌های داده"
 msgid "Collection permissions"
 msgstr "مجوزهای مجموعه"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:56
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
 msgstr "تمام مجوزهای مجموعه را مشاهده کنید"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:25
+#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
 msgstr "همچنین زیر مجموعه ها را تغییر دهید"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:282
+#: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
 msgstr "می توانید این مجموعه و محتویات آن را ویرایش کنید"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:289
+#: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
 msgstr "می توانید آیتم های موجود در این مجموعه را مشاهده کنید"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:749
+#: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
 msgstr "دسترسی به مجموعه"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:825
+#: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "این گروه اجازه می دهد حداقل یک زیر مجموعه از این مجموعه را مشاهده کنید."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:830
+#: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "این گروه اجازه ویرایش حداقل یک زیر مجموعه از این مجموعه را دارد."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
 msgstr "مشاهده زیر مجموعه ها"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:211
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
 msgstr "مرا به خاطر بسپار"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:95
+#: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
 msgstr "اشعه ایکس این طرح"
 
@@ -8979,31 +9005,32 @@ msgstr "ذخیره داشبورد ها، سوالات و مجموعه ها در 
 msgid "Access dashboards, questions, and collections in \"{0}\""
 msgstr "دسترسی به داشبورد ها، سوالات و مجموعه ها در \"{0}\""
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:221
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
 msgstr "مقایسه"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:229
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
 msgstr "کوچک‌نمایی"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:233
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
 msgstr "مربوط"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:293
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
 msgstr "اشعه X بیشتر"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:46
+#: frontend/src/metabase/home/containers/SearchApp.jsx:40
+#: src/metabase/pulse/render/body.clj
 msgid "No results"
 msgstr "بدون نتیجه"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:47
+#: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
 msgstr "Metabase نمی تواند برای جستجوی شما هیچ نتیجه ای پیدا کند."
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:111
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
 msgstr "بدون معیارهای"
 
@@ -9045,7 +9072,7 @@ msgstr "مجوزها مجاز نبود: {0}"
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
 msgstr "رشته رمزنگاری را نمی توان رمزگشایی کرد. آیا تغییر کرده اید یا فراموش کرده اید MB_ENCRYPTION_SECRET_KEY را تنظیم کنید؟"
 
-#: frontend/src/metabase/entities/collections.js:164
+#: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
 msgstr "همه مجموعه های شخصی"
 
@@ -9209,19 +9236,19 @@ msgstr "ناموجود"
 msgid "Windows domain"
 msgstr "دامین ویندوز"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:509
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:515
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:490
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:499
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
 msgstr "برچسب ها"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:329
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 #, fuzzy
 msgid "Add members"
 msgstr "افزودن عضو"
 
-#: frontend/src/metabase/entities/collections.js:115
+#: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
 msgstr "مجموعه آن ذخیره شده است"
 
@@ -9242,39 +9269,39 @@ msgid "Sharing"
 msgstr "اشتراک گذاری"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:234
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:270
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:299
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:305
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:313
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:321
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:218
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:251
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:280
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:286
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:294
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:302
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:80
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:85
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:91
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:97
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:50
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:56
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
 msgstr "نمایش دادن"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:370
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:416
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:431
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:487
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:358
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:406
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:447
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
 msgstr "محورها"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:222
-#: frontend/src/metabase/admin/settings/selectors.js:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
+#: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
@@ -9308,21 +9335,21 @@ msgstr "اشعه X"
 msgid "Compare to the rest"
 msgstr "با بقیه مقایسه کن."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:244
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "از منطقه زمانی ماشین مجازی جاوا استفاده کن."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
 msgstr "ما پیشنهاد می کنیم که این کار را ترک کنید مگر اینکه در حال انجام مراحل مربوط به زمان بندی کاربر هستید\n"
 "بسیاری از یا بیشتر از پرس و جو خود را با این داده ها."
 
-#: frontend/src/metabase/containers/Overworld.jsx:310
+#: frontend/src/metabase/containers/Overworld.jsx:312
 msgid "Your team's most important dashboards go here"
 msgstr "مهمترین داشبورد تیم شما در اینجا قرار دارد"
 
-#: frontend/src/metabase/containers/Overworld.jsx:311
+#: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
 msgstr "پانل داشبورد در {0} برای اینکه آنها در این فضا برای همه ظاهر شوند"
 
@@ -9338,32 +9365,32 @@ msgstr "استفاده از منطقه زمانی JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "برای کمک به  در حال تحلیل جداول و "
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
 msgstr ""
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:258
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
 msgstr "یک واحد پول انتخاب کنید"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:318
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
 msgstr "نوع فیلد"
 
 #: frontend/src/metabase/admin/routes.jsx:109
-#: frontend/src/metabase/nav/containers/Navbar.jsx:224
+#: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
 msgstr "عیب‌یابی"
 
-#: frontend/src/metabase/admin/settings/selectors.js:96
+#: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
 msgstr "فعال‌کردن ویژگی X-ray"
 
-#: frontend/src/metabase/admin/settings/selectors.js:323
+#: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
 msgstr "گزینه های قالب بندی"
 
-#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:19
+#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
 msgstr "جزییات کار"
 
@@ -9403,7 +9430,7 @@ msgstr "واحد پول"
 msgid "Pick a user or channel..."
 msgstr "یک کاربر یا کانال را انتخاب کنید..."
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
+#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
 msgstr "بدون تنظیمات قالب بندی"
 
@@ -9439,33 +9466,33 @@ msgstr "برابر با"
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:31
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:38
 msgid "is not equal to"
-msgstr ""
+msgstr "مساوی نیست با"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:32
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:39
 msgid "is null"
-msgstr ""
+msgstr "تهی هست"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:33
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:40
 msgid "is not null"
-msgstr ""
+msgstr "تهی نیست"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:41
 msgid "contains"
-msgstr ""
+msgstr "شامل می شود"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:42
 msgid "does not contain"
-msgstr ""
+msgstr "شامل نمی شود"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:43
 msgid "starts with"
-msgstr ""
+msgstr "شروع با"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:44
 msgid "ends with"
-msgstr ""
+msgstr "پایان با"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:292
 msgid "When a cell in these columns {0} it will be tinted this color."
@@ -9477,23 +9504,23 @@ msgstr ""
 
 #: frontend/src/metabase/visualizations/lib/errors.js:42
 msgid "This visualization requires you to group by a field."
-msgstr ""
+msgstr "برای نمایش باید داده های خود را بر اساس یک فیلد گروه کنید. "
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:178
 msgid "Date style"
-msgstr ""
+msgstr "استایل تاریخ"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:196
 msgid "Date separators"
-msgstr ""
+msgstr "جداکننده تاریخ"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:215
 msgid "Abbreviate names of days and months"
-msgstr ""
+msgstr "نام اختصاری روزها و ماه‌ها"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:225
 msgid "Show the time"
-msgstr ""
+msgstr "زمان را نشان بده"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:232
 msgid "HH:MM"
@@ -9511,31 +9538,31 @@ msgstr ""
 msgid "Time style"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:299
+#: frontend/src/metabase/visualizations/lib/settings/column.js:300
 msgid "Unit of currency"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:319
+#: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:337
+#: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:370
+#: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:271
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:314
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:322
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
 msgstr ""
 
@@ -9564,7 +9591,7 @@ msgstr ""
 msgid "line and bar chart"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:72
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
 msgstr ""
 
@@ -9572,75 +9599,75 @@ msgstr ""
 msgid "Gauge"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:185
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:52
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:107
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:123
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:143
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:183
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:187
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:195
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:200
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
 msgstr ""
 
@@ -9904,7 +9931,7 @@ msgstr ""
 msgid "No native form returned."
 msgstr ""
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
 msgstr ""
 
@@ -11270,7 +11297,7 @@ msgstr ""
 msgid "Values greater than {1} are not allowed."
 msgstr ""
 
-#: src/metabase/query_processor/middleware/resolve_database.clj
+#: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
 msgstr ""
 
@@ -11319,7 +11346,7 @@ msgstr ""
 msgid "View triggers"
 msgstr ""
 
-#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:82
+#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
 msgstr ""
 
@@ -11351,7 +11378,7 @@ msgstr ""
 msgid "May Fire Again?"
 msgstr ""
 
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:75
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
 msgstr ""
 
@@ -11363,19 +11390,19 @@ msgstr ""
 msgid "Jobs"
 msgstr ""
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
 msgstr ""
 
-#: frontend/src/metabase/components/EntityItem.jsx:55
+#: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
 msgstr ""
 
-#: frontend/src/metabase/components/EntityItem.jsx:61
+#: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
 msgstr ""
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:330
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
 msgstr ""
 
@@ -11425,54 +11452,55 @@ msgstr ""
 msgid "{0} {1} from now"
 msgstr ""
 
-#: frontend/src/metabase/lib/query_time.js:187
+#: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:203
+#: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:205
+#: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:207
+#: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:209
+#: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:211
+#: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:213
+#: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:215
+#: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:217
+#: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] ""
 
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:79
+#: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] ""
@@ -11485,20 +11513,20 @@ msgstr ""
 msgid "This"
 msgstr ""
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:64
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
 msgstr ""
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:147
+#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:170
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
 msgstr ""
 
-#: frontend/src/metabase-lib/lib/Dimension.js:517
+#: frontend/src/metabase-lib/lib/Dimension.js:678
 msgid "by {0}"
 msgstr ""
 
@@ -11792,35 +11820,35 @@ msgstr ""
 msgid "Error running query for Card {0}"
 msgstr ""
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
 msgstr ""
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This week"
 msgstr ""
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
 msgstr ""
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This month"
 msgstr ""
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
 msgstr ""
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
 msgstr ""
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
 msgstr ""
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This year"
 msgstr ""
 
@@ -11838,7 +11866,7 @@ msgstr ""
 
 #: src/metabase/sync/sync_metadata/fields/common.clj
 msgid "Field"
-msgstr ""
+msgstr "فیلد"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error checking if Fields {0} need to be created or reactivated"
@@ -12067,7 +12095,7 @@ msgid "[[CreateDate]] by quarter of the year"
 msgstr ""
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:200
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
 msgstr ""
 
@@ -12075,12 +12103,12 @@ msgstr ""
 msgid "New user"
 msgstr ""
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
 msgstr ""
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:209
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
 msgstr ""
 
@@ -12092,40 +12120,40 @@ msgstr ""
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
 msgstr ""
 
-#: frontend/src/metabase/entities/collections.js:21
+#: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
 msgstr ""
 
-#: frontend/src/metabase/entities/collections.js:22
+#: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
 msgstr ""
 
-#: frontend/src/metabase/entities/dashboards.js:29
+#: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
 msgstr ""
 
-#: frontend/src/metabase/entities/dashboards.js:30
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
 msgstr ""
 
-#: frontend/src/metabase/entities/users.js:125
+#: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
 msgstr ""
 
-#: frontend/src/metabase/entities/users.js:126
-#: frontend/src/metabase/entities/users.js:133
+#: frontend/src/metabase/entities/users.js:38
+#: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
 msgstr ""
 
-#: frontend/src/metabase/entities/users.js:132
+#: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
 msgstr ""
 
-#: frontend/src/metabase/entities/users.js:138
+#: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
 msgstr ""
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:90
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
 msgstr ""
 
@@ -12133,11 +12161,11 @@ msgstr ""
 msgid "No description"
 msgstr ""
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:175
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
 msgstr ""
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:183
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
 msgstr ""
 
@@ -12337,15 +12365,774 @@ msgstr ""
 msgid "Adding User {0} to Admin permissions group..."
 msgstr ""
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
 msgstr ""
 
-#: src/metabase/query_processor/async.clj
+#: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
 msgstr ""
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
+msgstr ""
+
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
+msgid "Misfire Instruction"
+msgstr ""
+
+#: frontend/src/metabase/components/ArchiveModal.jsx:31
+msgid "Archive this?"
+msgstr ""
+
+#: frontend/src/metabase/components/BrowseApp.jsx:244
+msgid "Learn about our data"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
+msgid "Use DNS SRV when connecting"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
+msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
+"an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
+"leave this disabled."
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
+msgid "Automatically run queries when doing simple filtering and summarizing"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr ""
+
+#: frontend/src/metabase/containers/Overworld.jsx:247
+msgid "Learn about this database"
+msgstr ""
+
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+msgid "Archive this dashboard?"
+msgstr ""
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:113
+msgid "All results"
+msgstr ""
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:180
+msgid "Our Analytics"
+msgstr ""
+
+#: frontend/src/metabase/lib/schema_metadata.js:500
+msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
+msgstr ""
+
+#: frontend/src/metabase/lib/schema_metadata.js:508
+msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
+msgstr ""
+
+#: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
+msgid "Filter"
+msgstr ""
+
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+msgid "record"
+msgid_plural "records"
+msgstr[0] ""
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:346
+msgid "Browse Data"
+msgstr ""
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:376
+msgid "Write SQL"
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
+msgid "Simple question"
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
+msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
+msgid "Custom question"
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
+msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+msgid "Basic Metrics"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+msgid "Custom…"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
+msgid "Add grouping"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
+msgid "Pick a limit"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
+msgid "Show maximum"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
+msgid "Get Preview"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
+msgid "Back to previous results"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
+msgid "Sample values"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
+msgid "Visualize"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
+msgid "Join data"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
+msgid "Custom column"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
+msgid "Summarize"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
+msgid "Aggregate"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
+msgid "Breakout"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
+msgid "Pick the metric you want to see"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
+#: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
+msgid "Pick a column to group by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
+msgid "Pick your starting data"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select None"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select All"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
+msgid "Pick a table..."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
+msgid "Enter a limit"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
+msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
+msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
+msgid "View the native query"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
+msgid "Native query for this question"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
+msgid "Convert this question to a native query"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
+msgid "SQL for this question"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
+msgid "Convert this question to SQL"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
+msgid "Get alerts"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
+msgid "{0} breakout"
+msgid_plural "{0} breakouts"
+msgstr[0] ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
+msgid "Hide filters"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
+msgid "Show filters"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
+msgid "Started from"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
+msgid "{0} row"
+msgid_plural "{0} rows"
+msgstr[0] ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
+msgid "Show all rows"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
+msgid "Show {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
+msgid "Showing first {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
+msgid "Showing {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
+msgid "Summarized"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Hide editor"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Show editor"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
+msgid "Pick the metric you'd like to see"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
+msgid "{0} options"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
+msgid "Choose a visualization"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
+msgid "Filter by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+msgid "Summarize by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+msgid "Group by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+msgid "Add a metric"
+msgstr ""
+
+#: frontend/src/metabase/user/components/UserSettings.jsx:57
+msgid "Profile"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:548
+msgid "This is usually pretty fast but seems to be taking a while right now."
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
+msgid "Combo"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
+msgid "Row"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
+msgid "Trend"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:129
+msgid "Boolean"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+msgid "Unknown Segment"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+msgid "Unknown Filter"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
+msgid "Left outer join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
+msgid "Right outer join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
+msgid "Inner join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
+msgid "Full outer join"
+msgstr ""
+
+#: src/metabase/api/card.clj
+msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
+msgstr ""
+
+#: src/metabase/api/session.clj
+msgid "Problem connecting to LDAP server, will fall back to local authentication"
+msgstr ""
+
+#: src/metabase/api/setup.clj
+msgid "Cannot create Database: cannot find driver {0}."
+msgstr ""
+
+#: src/metabase/api/tiles.clj
+msgid "Query failed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Warning: {0} returned `nil`"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing result to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing exception to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Request canceled, canceling future."
+msgstr ""
+
+#: src/metabase/cmd/load_from_h2.clj
+msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "Application database setup"
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Could not find {0} driver."
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Abstract drivers cannot derive from concrete parent drivers."
+msgstr ""
+
+#: src/metabase/driver/mysql.clj
+msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifer."
+msgstr ""
+
+#: src/metabase/driver/sql_jdbc/execute.clj
+msgid "Client closed connection, canceling query"
+msgstr ""
+
+#: src/metabase/integrations/ldap.clj
+msgid "{0} is not a valid DN."
+msgstr ""
+
+#: src/metabase/middleware/log.clj
+msgid "Error logging API request"
+msgstr ""
+
+#: src/metabase/middleware/misc.clj
+msgid "Failed to set site-url"
+msgstr ""
+
+#: src/metabase/models/database.clj
+msgid "Error destroying thread pool for DB."
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/models/task_history.clj src/metabase/sync/util.clj
+msgid "Error saving task history"
+msgstr ""
+
+#: src/metabase/plugins.clj
+msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
+msgstr ""
+
+#: src/metabase/plugins/classloader.clj
+msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
+msgstr ""
+
+#: src/metabase/plugins/files.clj
+msgid "Failed to copy file"
+msgstr ""
+
+#: src/metabase/public_settings.clj
+msgid "Invalid site URL: {0}"
+msgstr ""
+
+#: src/metabase/public_settings.clj
+msgid "site-url is invalid; returning nil for now. Will be reset on next request."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "More results have been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "This question has been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "We were unable to display this Pulse."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "Please view this card in Metabase."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "An error occurred while displaying this card."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Can only determine expected columns for MBQL queries."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "No columns returned."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot find Table ID for {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "No matching info found."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Could not resolve {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Invalid fk-> clause: nowhere to add corresponding join."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "{0} driver does not support foreign keys."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Query processor error: number of columns returned by driver does not match results."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Expected {0} columns, but first row of resuls has {1} columns."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "No expression named {0} found. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Distinct values of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Average of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "SD of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Min of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Max of {0}"
+msgstr ""
+
+#. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0} matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Share of rows matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Count of rows matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Request already canceled, will not run synchronous QP code."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unexpectedly got `nil` Query Processor response."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Got InterruptedException. Canceling query."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Query timed out after %s"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Creating new query thread pool for Database {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Destroying query thread pool for Database {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Request canceled, canceling pending query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: query is missing source-metadata"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Using query processor cache backend: {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/expand_macros.clj
+msgid "Invalid metric: {0} reason: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unknown error"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unexpected nil response from query processor."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Query canceled"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: Database {0} does not exist."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_source_table.clj
+msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Cannot store Tables or Fields before Database is stored."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Attempting to fetch second Database. Queries can only reference one Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
+msgstr ""
+
+#: src/metabase/routes/index.clj
+msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Sample dataset DB file ''{0}'' cannot be found."
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Loading sample dataset..."
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Failed to load sample dataset"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Found new tables:"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Marking tables as inactive:"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Updating description for tables:"
+msgstr ""
+
+#: src/metabase/task.clj
+msgid "Rescheduling job {0}"
+msgstr ""
+
+#: src/metabase/task.clj
+msgid "Error rescheduling job"
+msgstr ""
+
+#: src/metabase/task/send_pulses.clj
+msgid "Starting Pulse Execution: {0}"
+msgstr ""
+
+#: src/metabase/task/send_pulses.clj
+msgid "Finished Pulse Execution: {0}"
+msgstr ""
+
+#: src/metabase/task/sync_databases.clj
+msgid "Failed to schedule tasks for Database {0}"
+msgstr ""
+
+#: src/metabase/util/schema.clj
+msgid "All elements must be distinct."
+msgstr ""
+
+#: 
+msgctxt "Modal for selecting columns in source data or when doing a join."
+msgid "Pick the columns you want to include"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
+msgid "Change join type"
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifier."
+msgstr ""
+
+#: src/metabase/integrations/common.clj
+msgid "Error adding User {0} to Group {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Infinite loop detected: recursively preprocessed query {0} times."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Error determining expected columns for query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr ""
 

--- a/locales/it.po
+++ b/locales/it.po
@@ -28,18 +28,19 @@ msgstr "Analizza questi dati"
 msgid "Select a database type"
 msgstr "Selezionare il tipo di database"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:75
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:401
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:71
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:182
+#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:410
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:74
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:203
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:180
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:197
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:193
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:171
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:180
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:164
 msgid "Save"
 msgstr "Salva"
@@ -59,7 +60,7 @@ msgid "This is a lightweight process that checks for\n"
 msgstr "Questo é un processo leggero che controlla aggiornamenti allo schema del database. Nella maggior parte dei casi, andrá bene impostarlo ad ogni ora"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:184
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
 msgid "Scan"
 msgstr "Scansione"
 
@@ -74,126 +75,128 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase puó cercare i valori presenti in ogni campo di questo database per abilitare i checkbox dei filtri nelle dashboard e questions. Questo processo puó essere intensivo, in particolare se hai un database molto grande."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:159
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Quando Metabase dovrebbe automaticamente scansionare e fare cache dei valori?"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:164
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
 msgstr "Regolarmente secondo schedulazione"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:195
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
 msgstr "Solo quando si aggiunge un nuovo filtro nel widget"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:199
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
 msgstr "Quando un utente aggiunge un nuovo filtro a una Dashboard o Question, Metabase cercherá nei campi mappati dal filtro per mostrare la lista dei valori selezionabili."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:210
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
 msgid "Never, I'll do this manually if I need to"
 msgstr "Mai, lo farò manualmente se necessario"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:222
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:222
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:426
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
 msgid "Saving..."
 msgstr "Salvataggio..."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:39
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
 msgid "Server error encountered"
 msgstr "Errore nel server"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:58
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
 msgstr "Cancellare il database?"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
 msgstr "Tutte le Questions, Metriche e segmenti salvati per questo database andranno persi."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:67
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
 msgstr "Questo non può essere ripristinato"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
 msgstr "Se sei sicuro digita"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:53
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
 msgstr "CANCELLA"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:71
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
 msgstr "in questa casella:"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:82
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:50
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:93
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:58
-#: frontend/src/metabase/admin/permissions/selectors.js:160
-#: frontend/src/metabase/admin/permissions/selectors.js:170
-#: frontend/src/metabase/admin/permissions/selectors.js:185
-#: frontend/src/metabase/admin/permissions/selectors.js:224
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:355
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:181
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:247
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:61
+#: frontend/src/metabase/admin/permissions/selectors.js:163
+#: frontend/src/metabase/admin/permissions/selectors.js:173
+#: frontend/src/metabase/admin/permissions/selectors.js:188
+#: frontend/src/metabase/admin/permissions/selectors.js:227
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:202
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:268
+#: frontend/src/metabase/components/ArchiveModal.jsx:35
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
-#: frontend/src/metabase/components/form/StandardForm.jsx:61
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:196
+#: frontend/src/metabase/components/form/StandardForm.jsx:62
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:198
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:289
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:162
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:153
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:38
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:189
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:24
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:48
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:41
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:92
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:259
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Annulla"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:88
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:121
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:132
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
 msgstr "Elimina"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:128
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:74
-#: frontend/src/metabase/admin/permissions/selectors.js:320
-#: frontend/src/metabase/admin/permissions/selectors.js:327
-#: frontend/src/metabase/admin/permissions/selectors.js:423
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
+#: frontend/src/metabase/admin/permissions/selectors.js:323
+#: frontend/src/metabase/admin/permissions/selectors.js:330
+#: frontend/src/metabase/admin/permissions/selectors.js:426
 #: frontend/src/metabase/admin/routes.jsx:53
-#: frontend/src/metabase/nav/containers/Navbar.jsx:214
+#: frontend/src/metabase/nav/containers/Navbar.jsx:243
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
 msgstr "Basi di Dati"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:129
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
 msgstr "Aggiungi un Database"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
 msgstr "Connessione"
@@ -202,107 +205,107 @@ msgstr "Connessione"
 msgid "Scheduling"
 msgstr "Schedulazione"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:78
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:84
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:26
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:221
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
 msgstr "Salva i cambiamenti"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:185
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:38
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:38
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
 msgstr "Azioni"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:193
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
 msgstr "Sincronizza lo schema database ora"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:194
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:206
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:109
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
 msgstr "Avvio..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:195
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
 msgstr "Sync fallito"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
 msgstr "Sync azionato!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:205
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
 msgstr "Ri-scansiona i valori dei campi adesso"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:207
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
 msgstr "Inizio della scansione fallito"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
 msgstr "Scan azionato!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:215
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:401
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
 msgstr "Zona Pericolosa"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:221
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
 msgstr "Scarta valori campo salvati"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
 msgstr "Rimuovere questo database"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:73
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
 msgstr "Aggiungi un database"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:85
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:36
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:36
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:122
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:32
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:399
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:446
 #: frontend/src/metabase/containers/EntitySearch.jsx:26
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:218
-#: frontend/src/metabase/entities/collections.js:93
-#: frontend/src/metabase/entities/dashboards.js:145
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:461
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:81
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:220
+#: frontend/src/metabase/entities/collections.js:94
+#: frontend/src/metabase/entities/dashboards.js:142
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
 msgstr "Nome"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:86
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
 msgstr "Motore"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:115
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
 msgstr "In cancellazione..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:145
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
 msgstr "Caricamento..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:161
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
 msgstr "Ripristinare i dati d'esempio"
 
@@ -319,9 +322,9 @@ msgid "Successfully saved!"
 msgstr "Salvataggio riuscito!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:177
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:197
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
 msgstr "Edita"
@@ -330,86 +333,90 @@ msgstr "Edita"
 msgid "Revision History"
 msgstr "Storico Revisioni"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
 msgstr "Rimuoverlo {0}?"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
 msgstr "Le domande salvate e altre cose che dipendono da questo {0} continueranno a funzionare, ma questo {1} non sarà più selezionabile dal generatore di query."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
 msgstr "Se sei sicuro di voler rimuovere questo {0}, ti preghiamo di scrivere una rapida spiegazione del motivo per cui è stato rimosso:"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
 msgstr "Questo verrà visualizzato nel feed di attività e in un'email che verrà inviata a chiunque nel tuo team che ha creato qualcosa che utilizza questo {0}."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
 msgstr "Rimuovi"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
 msgstr "Rimozione..."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
 msgstr "Fallito"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
 msgstr "Riuscito"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:91
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
+#: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Anteprima"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
 msgstr "Ancora nessuna descrizione della colonna"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:135
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
 msgstr "Selezionare la visibilità del campo"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:210
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
 msgstr "Nessun tipo speciale"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:211
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:148
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
 msgstr "Altri"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:231
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Seleziona uno speciale tipo"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:277
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
 msgstr "Seleziona una destinazione"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:77
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:89
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:106
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:122
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
 msgstr "Colonne"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Colonna"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:121
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:306
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
 msgstr "Visibilità"
 
@@ -417,53 +424,53 @@ msgstr "Visibilità"
 msgid "Type"
 msgstr "Tipo"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
 msgstr "Database corrente:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
 msgstr "Mostra lo schema originale"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:45
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
 msgstr "Tipo dei dati"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
 msgstr "Informazioni addizionali"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
 msgstr "Trova uno schema"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:51
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "schema"
 msgstr[1] "schemi"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
 msgstr "Perché nasconderlo?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
 msgstr "Dati Tecnici"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
 msgstr "Irrilevante/Mal progettato"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
 msgid "Queryable"
 msgstr "Interrogabile"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:91
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
 msgstr "Nascosto"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
 msgstr "Nessuna descrizione della tabella ancora"
 
@@ -471,65 +478,67 @@ msgstr "Nessuna descrizione della tabella ancora"
 msgid "Metadata Strength"
 msgstr "Forza del metadata"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "Tabella interrogabile"
 msgstr[1] "Tabelle interrogabili"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:96
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "Tabella nascosta"
 msgstr[1] "Tabelle nascoste"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
 msgstr "Trova una tabella"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
 msgstr "Schemi"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:24
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:137
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:68
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:56
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:190
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
 msgstr "Metriche"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
 msgstr "Aggiungi una metrica"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:37
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Definizione"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Crea metriche per aggiungerle al menu a discesa dela Vista nel generatore di query"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:24
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:930
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:952
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:56
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segmenti"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
 msgstr "Aggiungi un segmento"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Crea segmenti per aggiungerle nel menu a discesa dei Filtri nel generatore di query"
 
@@ -557,53 +566,53 @@ msgstr "Modificato il␣"
 msgid "made some changes"
 msgstr "fatte alcune modifiche"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
-#: frontend/src/metabase/home/components/Activity.jsx:80
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:332
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/home/components/Activity.jsx:82
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
 msgstr "Tu"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
 msgstr "Modello dei dati"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
 msgstr "Storico"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:48
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
 msgstr "Cronologia delle revisioni per"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:239
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
 msgstr "{0} – Impostazioni dei campi"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
 msgstr "Dove questo campo apparirà in tutto Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:329
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filtra per questo campo"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Quando questo campo é usato in un filtro, cosa dovrebbero usare le persone per inserire il valore per il quale vogliono filtrare?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:453
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Nessuna descrizione per questo campo fino ad ora"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:379
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
 msgstr "Valore originale"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:380
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
 msgid "Mapped value"
 msgstr "Valore mappato"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:423
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
 msgstr "Inserire valore"
 
@@ -620,7 +629,7 @@ msgid "Custom mapping"
 msgstr "Mapping personalizzato"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:155
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
 msgid "Unrecognized mapping type"
 msgstr "Tipo mapping non riconosciuto"
 
@@ -628,23 +637,23 @@ msgstr "Tipo mapping non riconosciuto"
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Il campo corrente non é una Foreign Key o il metadata della tabella target della FK é mancante"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:187
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
 msgstr "Il campo selezionato non é una foreign key"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:347
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
 msgstr "Visualizza valori"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:348
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Scegli se mostrare il valore originale dal database o se visualizzare questo campo associato o informazioni personalizzate."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:268
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
 msgstr "Scegli un campo"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:289
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
 msgstr "Prego selezionare una colonna da usare per visualizzazione"
 
@@ -652,16 +661,16 @@ msgstr "Prego selezionare una colonna da usare per visualizzazione"
 msgid "Tip:"
 msgstr "Suggerimento:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Potresti voler aggiornare il nome del campo per assicurarti che abbia ancora senso in base alle tue scelte di rimappatura."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:364
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:102
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
 msgstr "Valori del campo memorizzato nella cache"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:365
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase può analizzare i valori per questo campo in modo da abilitare i filtri delle caselle di controllo nelle 'dashboard' e nelle 'question'."
 
@@ -670,167 +679,168 @@ msgid "Re-scan this field"
 msgstr "Ri-scansiona questo campo"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
 msgstr "Scarta la cache dei valori"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:118
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
 msgstr "Errore durante la cancellazione del valore"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard triggered!"
 msgstr "Cancellazione avviata"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:105
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Seleziona una qualsiasi tabella per vederne lo schema o cambiarne i metadati"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:37
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:34
-#: frontend/src/metabase/entities/collections.js:96
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "Nome è obbligatorio"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:40
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
 msgstr "Descrizione è obbligatorio"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:44
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:41
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
 msgstr "Sono richieste le informazioni di revisione"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:50
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
 msgstr "E' richiesta un' aggregazione"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
 msgstr "Modifica la tua Metrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
 msgstr "Crea la tua metrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:115
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Cambia le tue metriche e aggiungi una nota esplicativa"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "È possibile creare metriche salvate per aggiungere un'opzione metrica con nome a questa tabella. Le metriche salvate includono il tipo di aggregazione, il campo aggregato e, facoltativamente, qualsiasi filtro aggiunto. Ad esempio, è possibile utilizzarlo per creare qualcosa come il modo ufficiale di calcolare 'Prezzo medio' per una tabella Ordini."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
 msgstr "Risultato:"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
 msgstr "Dai un nome alla tua Metrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
 msgstr "Dai un nome alla tua Metrica per aiutare gli altri a trovarla."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:162
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
 msgstr "Qualcosa di descrittivo ma non troppo dettagliato"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
 msgstr "Descrivi la tua Metrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Dai alla tua Metrica una descrizione per aiutare gli altri a capire di cosa tratta"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Questo é un buon posto per essere piú specifici riguardo le metriche meno ovvie"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:179
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
 msgstr "Motivo per le modifiche"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:177
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Lascia un commento per spiegare quali cambiamenti hai fatto e perché li ritenevi necessari."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Questo verrá mostrato nello storico revisioni di questa metrica per aiutare tutti a ricordarsi perché le cose sono cambiate"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
 msgstr "Al meno uno filtro è obbligatorio"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
 msgstr "Modifica il tuo Segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
 msgstr "Crea il tuo Segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:121
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Cambia il tuo segmento e aggiungi una nota esplicativa"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Seleziona un filtro da aggiungere per creare un nuovo segmento sulla tabella {0}"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
 msgstr "Dai un nome al tuo Segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:162
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
 msgstr "Dai un nome al tuo segmento per aiutare gli altri a trovarlo"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:170
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
 msgstr "Discrivi il tuo segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Dai una descrizione al tuo segmento per aiutare gli altri a capire di cosa si tratta."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:175
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "questo e' un buon posto per essere precisi nel descrivere le regole di segmento meno ovvie"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:185
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Questo verrà visualizzato nella cronologia delle revisioni di questo segmento per aiutare tutti a ricordare perché le cose sono cambiate"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:266
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:87
-#: frontend/src/metabase/nav/containers/Navbar.jsx:199
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:269
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:91
+#: frontend/src/metabase/nav/containers/Navbar.jsx:228
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:103
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase può analizzare i valori per questa tabella in modo da abilitare i filtri delle caselle di controllo nelle 'dashboard' e nelle 'question'. "
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:108
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
 msgstr "Riscansiona questa tabella"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:253
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
 msgstr "Aggiungi"
 
@@ -839,20 +849,22 @@ msgstr "Aggiungi"
 msgid "Not a valid formatted email address"
 msgstr "Indirizzo email formattato non correttamente"
 
+#: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:100
 msgid "First name"
 msgstr "Primo nome"
 
+#: frontend/src/metabase/entities/users.js:42
 #: frontend/src/metabase/setup/components/UserStep.jsx:203
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:117
 msgid "Last name"
 msgstr "Cognome"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:77
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:158
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:161
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:470
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:481
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
@@ -866,36 +878,37 @@ msgstr "Gruppi di Sicurezza"
 msgid "Make this user an admin"
 msgstr "Rendi admin questo user"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:32
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
 msgstr "Tutti gli utenti appartengono al gruppo {0} e non possono essere rimossi da esso. L'impostazione dei permessi per questo gruppo è un ottimo modo per \n"
 "assicurarti di sapere quali nuovi utenti di Metabase saranno in grado di vedere."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:41
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
 msgstr "Questo è un gruppo speciale i cui membri possono vedere tutto dell'istanza di Metabase e chi vi accede può apportare modifiche alle\n"
 "impostazioni nel Pannello di amministrazione, compresi i permessi di modifica! Quindi, aggiungi le persone a questo gruppo con cura."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:45
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
 msgstr "Per essere sicuro di non restare bloccato da Metabase, deve sempre esserci almeno un utente in questo gruppo."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
 msgstr "Utenti"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:124
-#: frontend/src/metabase/admin/settings/selectors.js:113
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
+#: frontend/src/metabase/admin/settings/selectors.js:110
+#: frontend/src/metabase/entities/users.js:50
 #: frontend/src/metabase/lib/core.js:55
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
 msgstr "Email"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:203
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
 msgstr "Un gruppo é tanto buono quanto lo sono i suoi membri."
 
@@ -906,8 +919,8 @@ msgid "Admin"
 msgstr "Admin"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:237
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:290
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
 msgstr "e"
 
@@ -936,13 +949,13 @@ msgid "Are you sure? All members of this group will lose any permissions setting
 msgstr "Sei sicuro? Tutti i membri di questo gruppo perderanno tutti i permessi basati su di esso. Operazione irreversibile."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
 msgstr "Sì"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
 msgstr "No"
 
@@ -961,10 +974,11 @@ msgstr "Rimuovi gruppo"
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:107
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:327
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:395
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:265
+#: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
 msgstr "Fatto"
 
@@ -974,9 +988,9 @@ msgstr "Nome del gruppo"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:131
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:88
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
 msgstr "Gruppi"
 
@@ -1005,9 +1019,9 @@ msgid "Deactivate"
 msgstr "Disattiva"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:93
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
-#: frontend/src/metabase/nav/containers/Navbar.jsx:204
+#: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
 msgstr "Persone"
 
@@ -1049,7 +1063,6 @@ msgid "We've re-sent {0}'s invite"
 msgstr "Sono stati inviati gli inviti di {0}"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
-#: frontend/src/metabase/tutorial/Tutorial.jsx:253
 msgid "Okay"
 msgstr "Ok"
 
@@ -1081,13 +1094,13 @@ msgstr "Saranno in grado di accedere di nuovo e verranno reinseriti nei gruppi i
 msgid "Reset {0}'s password?"
 msgstr "Reimposta la password di {0}?"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:77
+#: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
 msgstr "Reset"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:44
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
 msgstr "Sei sicuro di volerlo fare?"
 
@@ -1103,76 +1116,78 @@ msgstr "Ecco una password temporanea si può utilizzare per accedere ,sucessivam
 msgid "We've sent them an email with instructions for creating a new password."
 msgstr "Abbiamo spedito una email con le istruzioni per creare una nuova password"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:101
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
 msgstr "Attivo"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:127
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
 msgstr "Deattivato"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:115
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
 msgstr "Aggiungi qualcuno"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
 msgstr "Ultimo Login"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:153
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
 msgstr "Iscritto  tramite  Google"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:158
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
 msgstr "Accesso con LDAP"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:170
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
 msgstr "Riattivare questo account"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:193
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
 msgstr "Mai"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:27
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
 msgstr[0] "{0} tabella"
 msgstr[1] "{0} tabelle"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:45
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
 msgstr " sarà "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:48
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
 msgstr "Accesso permesso a"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:53
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
 msgstr " e "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:56
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
 msgstr "Accesso proibito a"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:70
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
 msgstr " non sarà più in grado di "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:71
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
 msgstr " non sarà in grado di "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:79
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
 msgstr " query native per "
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
-#: frontend/src/metabase/nav/containers/Navbar.jsx:219
+#: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
 msgstr "Permessi"
 
@@ -1197,15 +1212,15 @@ msgstr "Nessun cambiamento ai permessi sará fatto"
 msgid "You've made changes to permissions."
 msgstr "Hai cambiato i permessi"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:52
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
 msgstr "Permessi per questa collection"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
 msgstr "Hai modifiche non salvate"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:54
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
 msgstr "Vuoi lasciare questa pagina e scartare le tue modifiche?"
 
@@ -1225,119 +1240,119 @@ msgstr "Ogni utente di Metabase appartiene al gruppo 'Tutti gli utenti' (All Use
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
 msgstr "MetaBot è il bot Slack di Metabase. Puoi scegliere a cosa può accedere qui."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:119
+#: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
 msgstr "Il \"{0}\" gruppo può avere accesso a un diverso insieme di {1} rispetto a questo gruppo, che può dare a questo gruppo ulteriore accesso ad alcune {2}."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:124
+#: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
 msgstr "Il gruppo \"{0}\" ha un livello di accesso superiore a questo, per cui sarà sostutuita questa impostazione. Devi limitare o revocare l'accesso del gruppo \"{1}\" a questo elemento."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
 msgstr "Limita"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
 msgstr "Revoca"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:156
+#: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
 msgstr "accesso anche se \"{0}\" ha un accesso maggiore?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:258
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
 msgstr "Limita l'accesso"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:223
-#: frontend/src/metabase/admin/permissions/selectors.js:266
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:226
+#: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
 msgstr "Revoca L'accesso"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:168
+#: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
 msgstr "Modificare l'accesso a questo database a limitato?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:169
+#: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
 msgstr "Cambia"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:182
+#: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
 msgstr "Consenti scrittura di query?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:183
+#: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
 msgstr "Questo cambierà anche l'accesso ai dati di questo gruppo a 'Non ristretto' (Unrestricted) per questo database."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:184
+#: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
 msgstr "Permetto"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:221
+#: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
 msgstr "Revocare l'accesso a tutte le tabelle?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:222
+#: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
 msgstr "Questo revocherà anche l'accesso di questo gruppo alle query per questo database."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:251
+#: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
 msgstr "Concedere l'accesso illimitato"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:252
+#: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
 msgstr "Accesso Illimitato"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:259
+#: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
 msgstr "Acceso limitato"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:267
+#: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
 msgstr "Accesso Negato"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:273
+#: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
 msgstr "Scrivi Query"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:274
+#: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
 msgstr "Puoi scrivere query brutali"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:281
+#: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
 msgstr "Cura la collezione"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:288
+#: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
 msgstr "Vedi collezione"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:331
-#: frontend/src/metabase/admin/permissions/selectors.js:427
-#: frontend/src/metabase/admin/permissions/selectors.js:524
+#: frontend/src/metabase/admin/permissions/selectors.js:334
+#: frontend/src/metabase/admin/permissions/selectors.js:430
+#: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
 msgstr "Accesso ai dati"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:492
-#: frontend/src/metabase/admin/permissions/selectors.js:649
-#: frontend/src/metabase/admin/permissions/selectors.js:654
+#: frontend/src/metabase/admin/permissions/selectors.js:495
+#: frontend/src/metabase/admin/permissions/selectors.js:652
+#: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
 msgstr "Vedi tabelle"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:590
+#: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
 msgstr "SQL query"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:660
+#: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
 msgstr "Vedi schemi"
 
 #: frontend/src/metabase/admin/routes.jsx:59
-#: frontend/src/metabase/nav/containers/Navbar.jsx:209
+#: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
 msgstr "Modello dei dati"
 
@@ -1346,30 +1361,30 @@ msgstr "Modello dei dati"
 msgid "Sign in with Google"
 msgstr "Accesso con Google"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:13
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
 msgstr "Consente agli utenti con account Metabase esistenti di accedere con un account Google che corrisponda al loro indirizzo email oltre al nome utente e alla password di Metabase."
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:17
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
 msgstr "Configurare"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
-#: frontend/src/metabase/admin/settings/selectors.js:207
+#: frontend/src/metabase/admin/settings/selectors.js:204
 msgid "LDAP"
 msgstr "LDAP"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:25
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
 msgstr "Consente agli utenti all'interno della directory LDAP di accedere a Metabase con le proprie credenziali LDAP e consente la mappatura automatica dei gruppi LDAP ai gruppi di metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
-#: frontend/src/metabase/admin/settings/selectors.js:160
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
 msgstr "Email non valida"
 
@@ -1407,7 +1422,7 @@ msgstr "Pulisci"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:202
+#: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
 msgstr "Autenticazione"
 
@@ -1471,21 +1486,21 @@ msgstr "Crea un Utente Bot Slack per MetaBot"
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Una volta che sei lì, dagli un nome e fai clicca {0}. Quindi copia e incolla il token API Bot nel campo sottostante. Una volta terminato, crea un canale \"metabase_files\" in Slack. Metabase ha bisogno di questo per caricare grafici."
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:90
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
 msgstr "Stai usando Metabase {0} che é l'ultimo e il migliore!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:99
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
 msgstr "É disponibile Metabase {0}. La versione in uso é la {1}."
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:112
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
 msgstr "Aggiornare"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:116
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
 msgstr "Cos'è cambiato:"
 
@@ -1498,80 +1513,80 @@ msgstr "Aggiungi una mappa"
 msgid "URL"
 msgstr "URL"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:199
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
 msgstr "Cancellare mappa personalizzata"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:327
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:40
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:181
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
 msgstr "Rimuovere"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:226
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:187
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:241
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:246
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
 msgstr "Seleziona..."
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:241
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
 msgstr "Valori di esempio:"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
 msgstr "Aggiungi una nuova mappa"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
 msgstr "Modifica mappa"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:280
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
 msgstr "Come vuoi chiamare questa mappa?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
 msgstr "p.es. United Kingdom, Brazil, Mars"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:292
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
 msgstr "URL per il file GeoJSON che vuoi usare"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:298
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
 msgstr "Come https://my-mb-server.com/maps/my-map.json"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:33
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
 msgstr "Aggiorna"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
 msgstr "Carica"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:315
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
 msgstr "Quale proprietà specifica l'identificativo della regione?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:324
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
 msgstr "Quale proprietà specifica il nome da mostrare della regione?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:345
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
 msgstr "Carica un file GeoJSON per vedere l'anteprima"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
 msgstr "Salva mappa"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
 msgstr "Aggiungi mappa"
 
@@ -1583,11 +1598,11 @@ msgstr "Usa la modalità \"embedded\""
 msgid "By enabling embedding you're agreeing to the embedding license located at"
 msgstr "Abilitando l'incorporamento accetti la licenza di incorporamento situata in"
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:19
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
 msgstr "In italiano semplice, quando si incorporano grafici o 'dashboard' da Metabase nella propria applicazione, tale applicazione non è soggetta alla 'Affero General Public License' che copre il resto di Metabase, purché si mantenga visibile il logo della metabase e il \"Powered by Metabase\" su quegli elementi inclusi. Tuttavia, dovresti leggere il testo della licenza linkato in alto, poiché questa è la licenza effettiva a cui dovrai accettare abilitando questa funzione."
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:32
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
 msgstr "Abilita"
 
@@ -1611,19 +1626,19 @@ msgstr "Acquista un token"
 msgid "Enter a token"
 msgstr "Inserisci un Token"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:134
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
 msgstr "Modifica Mapping"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:140
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
 msgstr "Raggruppa Mapping"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:147
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
 msgstr "Crea Mapping"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
@@ -1631,7 +1646,7 @@ msgstr "I mapping consentono a Metabase di aggiungere e rimuovere automaticament
 ". L'appartenenza al gruppo di amministrazione può essere concessa tramite associazioni, ma non verrà automaticamente rimossa come misura \n"
 "failsafe."
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
 msgstr "Nome distinto"
 
@@ -1643,43 +1658,43 @@ msgstr "Link Pubblico"
 msgid "Revoke Link"
 msgstr "Revoca Link"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:121
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
 msgstr "Vuoi disabilitare questo link"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:122
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
 msgstr "Non funzioneranno più e non possono essere ripristinati, ma puoi creare nuovi collegamenti."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
 msgstr "Lista delle 'dashboard' pubbliche"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:152
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
 msgstr "Nessuna dashboard è stato ancora pubblicamente condivisa."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:160
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
 msgstr "Lista delle card pubbliche"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:163
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
 msgstr "Nessuna domanda è stato ancora pubblicamente condivisa."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:172
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
 msgstr "Lista delle  'dashboard'  inserite"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
 msgstr "Nessuna 'dashboard' è stata ancora inserita"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:183
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
 msgstr "Lista delle card incorporate"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:184
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
 msgstr "Nessuna domanda è stata ancora incorporata."
 
@@ -1700,18 +1715,17 @@ msgid "Generate Key"
 msgstr "Chiave generata"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:78
-#: frontend/src/metabase/admin/settings/selectors.js:87
+#: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
 msgstr "Abilitata"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:83
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:103
+#: frontend/src/metabase/admin/settings/selectors.js:82
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Disabilitato"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:116
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
 msgstr "Impostazione sconosciuta {0}"
 
@@ -1719,7 +1733,7 @@ msgstr "Impostazione sconosciuta {0}"
 msgid "Setup"
 msgstr "Imposta"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
 msgstr "Generale"
@@ -1748,11 +1762,11 @@ msgstr "Database predefinito"
 msgid "Select a timezone"
 msgstr "Seleziona una timezone"
 
-#: frontend/src/metabase/admin/settings/selectors.js:55
+#: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Non tutti i database supportano i fusi orari, nel qual caso questa impostazione non avrà effetto."
 
-#: frontend/src/metabase/admin/settings/selectors.js:60
+#: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
 msgstr "Lingua"
 
@@ -1760,202 +1774,202 @@ msgstr "Lingua"
 msgid "Select a language"
 msgstr "Seleziona una lingua"
 
-#: frontend/src/metabase/admin/settings/selectors.js:70
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
 msgstr "Tracciamento Anonimo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:75
+#: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
 msgstr "Nomi tabelle e campi amichevoli"
 
-#: frontend/src/metabase/admin/settings/selectors.js:81
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Sostituisci solo caratteri di sottolineatura e trattini con spazi"
 
-#: frontend/src/metabase/admin/settings/selectors.js:91
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
 msgstr "Abilita le query annidate"
 
-#: frontend/src/metabase/admin/settings/selectors.js:102
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
 msgstr "Aggiornamenti"
 
-#: frontend/src/metabase/admin/settings/selectors.js:107
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
 msgstr "Controlla Aggiornamenti"
 
-#: frontend/src/metabase/admin/settings/selectors.js:118
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
 msgstr "Host SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:126
+#: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
 msgstr "Porta SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:130
-#: frontend/src/metabase/admin/settings/selectors.js:230
+#: frontend/src/metabase/admin/settings/selectors.js:127
+#: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
 msgstr "Questo non e' un numero diporta valido"
 
-#: frontend/src/metabase/admin/settings/selectors.js:134
+#: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
 msgstr "Tipo sicurezza SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:142
+#: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
 msgstr "SMTP Username"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
 msgstr "SMTP Password"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
 msgstr "\"Da\" Indirizzo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:170
+#: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
 msgstr "Slack API Token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:172
+#: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
 msgstr "Inserisci il token di slack"
 
-#: frontend/src/metabase/admin/settings/selectors.js:189
+#: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
 msgstr "Single Sign-On"
 
-#: frontend/src/metabase/admin/settings/selectors.js:213
+#: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
 msgstr "Autenticazione LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:219
+#: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
 msgstr "LDAP Host"
 
-#: frontend/src/metabase/admin/settings/selectors.js:227
+#: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
 msgstr "Porta LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:234
+#: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
 msgstr "Sicurezza LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
 msgstr "Username o DN"
 
-#: frontend/src/metabase/admin/settings/selectors.js:247
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:188
-#: frontend/src/metabase/user/components/UserSettings.jsx:72
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:191
+#: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
 msgstr "Password"
 
-#: frontend/src/metabase/admin/settings/selectors.js:252
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "User search base"
 msgstr "Base di ricerca degli utenti"
 
-#: frontend/src/metabase/admin/settings/selectors.js:258
+#: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
 msgstr "Filtro utente"
 
-#: frontend/src/metabase/admin/settings/selectors.js:264
+#: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
 msgstr "Controlla le tue parentesi"
 
-#: frontend/src/metabase/admin/settings/selectors.js:270
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
 msgstr "Attributo email"
 
-#: frontend/src/metabase/admin/settings/selectors.js:275
+#: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
 msgstr "Attributo nome"
 
-#: frontend/src/metabase/admin/settings/selectors.js:280
+#: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
 msgstr "Attributo cognome"
 
-#: frontend/src/metabase/admin/settings/selectors.js:285
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
 msgstr "Sincronizza le appartenenze ai gruppi"
 
-#: frontend/src/metabase/admin/settings/selectors.js:291
+#: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
 msgstr "Ricerca base gruppo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:300
+#: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
 msgstr "Mappe"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
 msgstr "URL del MAP TILE SERVER"
 
-#: frontend/src/metabase/admin/settings/selectors.js:306
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase utilizza OpenStreetMaps per impostazione predefinita."
 
-#: frontend/src/metabase/admin/settings/selectors.js:311
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
 msgstr "Mappe personalizzate"
 
-#: frontend/src/metabase/admin/settings/selectors.js:312
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Aggiungi i tuoi file GeoJSON per abilitare visualizzazioni di mappe di regioni diverse"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
 msgstr "Condivisione pubblica"
 
-#: frontend/src/metabase/admin/settings/selectors.js:336
+#: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
 msgstr "Abilita la condivisione pubblica"
 
-#: frontend/src/metabase/admin/settings/selectors.js:341
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
 msgstr "'Dashboard' condivise"
 
-#: frontend/src/metabase/admin/settings/selectors.js:347
+#: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
 msgstr "Question condivise"
 
-#: frontend/src/metabase/admin/settings/selectors.js:354
+#: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
 msgstr "Incorporamento in altre applicazioni"
 
-#: frontend/src/metabase/admin/settings/selectors.js:381
+#: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Abilita incorporamento di Metabase in altre applicazioni"
 
-#: frontend/src/metabase/admin/settings/selectors.js:391
+#: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
 msgstr "Chiave segreta incorporata"
 
-#: frontend/src/metabase/admin/settings/selectors.js:397
+#: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
 msgstr "'Dashboard' incorporate"
 
-#: frontend/src/metabase/admin/settings/selectors.js:403
+#: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
 msgstr "Question incorporate"
 
-#: frontend/src/metabase/admin/settings/selectors.js:410
+#: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
 msgstr "Caching"
 
-#: frontend/src/metabase/admin/settings/selectors.js:415
+#: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
 msgstr "Abilita caching"
 
-#: frontend/src/metabase/admin/settings/selectors.js:420
+#: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
 msgstr "Durata minima Query"
 
-#: frontend/src/metabase/admin/settings/selectors.js:427
+#: frontend/src/metabase/admin/settings/selectors.js:424
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Moltiplicatore Time-To-Live (TTL) della cache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:434
+#: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
 msgstr "Dimensione massima della cache"
 
@@ -1971,11 +1985,11 @@ msgstr "L'avviso è stato aggiornato."
 msgid "The alert was successfully deleted."
 msgstr "L'avviso è stato cancellato con successo."
 
-#: frontend/src/metabase/auth/auth.js:33
+#: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
 msgstr "Per piacere inserisci un indirizzo email valido"
 
-#: frontend/src/metabase/auth/auth.js:116
+#: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
@@ -2017,91 +2031,88 @@ msgstr "Invia email di reimpostazione della password"
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Controlla la tua e-mail per le istruzioni su come reimpostare la password."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:128
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
 msgstr "Accedi a Metabase"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:138
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
 msgstr "O"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:157
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
 msgstr "Username e indirizzo email"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:217
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
 msgstr "Accedi"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:230
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
 msgstr "Mi sembra di aver dimenticato la mia password"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
 msgstr "richiedi una nuova email di ripristino"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:120
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
 msgstr "Ops, questo è un link scaduto"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:122
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
 msgstr "Per motivi di sicurezza, i link di reimpostazione password scadono dopo un po 'di tempo. Se hai ancora bisogno\n"
 "per resettare la tua password, puoi {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:147
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
 msgstr "Nuova password"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:149
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
 msgstr "Per proteggere i dati, password {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:163
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
 msgstr "Crea una nuova password"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:170
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:141
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
 msgstr "Assicurati che sia sicuro come le istruzioni sopra"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:184
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:150
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
 msgstr "Conferma la nuova password"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:191
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:159
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
 msgstr "Assicurati che corrisponda a quello che hai appena inserito"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:216
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
 msgstr "La tua password è stata appena reimpostata"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:222
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:227
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
 msgstr "Accedi con la tua nuova password"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:182
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:251
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "salvataggio fallito"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:183
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:129
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:225
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:252
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
 msgstr "Salvato"
 
@@ -2109,24 +2120,22 @@ msgstr "Salvato"
 msgid "Ok"
 msgstr "Ok"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:38
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
 msgstr "Archiviare questa collezione"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:43
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Anche le 'dashboard', le collezioni, e i 'pulse' in questa collezione saranno archiviati"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
-#: frontend/src/metabase/components/CollectionLanding.jsx:624
+#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: frontend/src/metabase/components/CollectionLanding.jsx:620
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:47
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:195
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:200
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:40
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:53
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
 msgstr "Archivia"
@@ -2135,28 +2144,27 @@ msgstr "Archivia"
 msgid "This {0} has been archived"
 msgstr "Questo {0} è stato archiviato"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:715
+#: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
 msgstr "Vedi l'archivio"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:43
+#: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
 msgstr "Annulla questo {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:70
-#: frontend/src/metabase/components/BrowseApp.jsx:132
-#: frontend/src/metabase/components/BrowseApp.jsx:225
+#: frontend/src/metabase/components/BrowseApp.jsx:39
+#: frontend/src/metabase/components/BrowseApp.jsx:102
+#: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
 msgstr "I tuoi dati"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:169
+#: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
 msgstr "Verifica questa tabella"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:183
-#: frontend/src/metabase/containers/Overworld.jsx:246
+#: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
 msgstr "Ulteriori informazioni su questa tabella"
 
@@ -2174,31 +2182,31 @@ msgstr "salvato!"
 msgid "Saving failed."
 msgstr "Salvataggio fallito."
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
 msgstr "Do"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
 msgstr "Lu"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
 msgstr "Ma"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
 msgstr "Me"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
 msgstr "Gio"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
 msgstr "Ve"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
 msgstr "Sa"
 
@@ -2243,61 +2251,61 @@ msgstr "Le pulsazioni ti consentono di inviare gli ultimi dati al tuo team in ba
 msgid "Questions are a saved look at your data."
 msgstr "Le richieste (question) sono una vista salvata dei tuoi dati."
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:287
+#: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
 msgstr "Fissa"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:341
+#: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
 msgstr "Trascina qualcosa qui per fissarlo in cima"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:737
-#: frontend/src/metabase/components/CollectionLanding.jsx:353
-#: frontend/src/metabase/home/containers/SearchApp.jsx:35
-#: frontend/src/metabase/home/containers/SearchApp.jsx:92
+#: frontend/src/metabase/admin/permissions/selectors.js:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:352
+#: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
 msgstr "Collezioni"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:432
-#: frontend/src/metabase/components/CollectionLanding.jsx:455
+#: frontend/src/metabase/components/CollectionLanding.jsx:431
+#: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
 msgstr "Trascian qui per sbloccare"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:490
+#: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
 msgstr[0] "{0} elemento selezionato"
 msgstr[1] "{0} elementi selezionati"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:522
+#: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
 msgstr "Vuoi spostare {0} elementi"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:523
+#: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
 msgstr "Vuoi spostare \"{0}\"?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:631
+#: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
 msgstr "Sposta"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:692
+#: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
 msgstr "Modifica la collezione"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:700
+#: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
 msgstr "Archivia questa collezione"
 
-#: frontend/src/metabase/components/CollectionList.jsx:64
-#: frontend/src/metabase/entities/collections.js:155
+#: frontend/src/metabase/components/CollectionList.jsx:67
+#: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
 msgstr "La mia collezione personale"
 
-#: frontend/src/metabase/components/CollectionList.jsx:106
+#: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
 msgstr "Nuova collezione"
 
@@ -2305,11 +2313,11 @@ msgstr "Nuova collezione"
 msgid "Copied!"
 msgstr "Copiato!"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:216
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Usa un tunnel-SSH per le connessioni col database"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
@@ -2317,75 +2325,76 @@ msgstr "È possibile accedere ad alcune installazioni di database solo collegand
 "Questa opzione fornisce anche un ulteriore livello di sicurezza quando una VPN non è disponibile.\n"
 "Abilitare ciò è di solito più lento rispetto ad una connessione diretta."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:271
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Questo è un database grande, quindi lasciami scegliere quando Metabase deve sincronizzare e scansionare"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:273
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Come impostazione predefinita, Metabase esegue una sincronizzazione oraria leggera e un'analisi giornaliera intensiva dei valori dei campi.\n"
 "Se si dispone di un database di grandi dimensioni, si consiglia di attivarlo e rivedere quando e con quale frequenza si verificano le scansioni dei valori di campo."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:289
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} per generare un ID client e un client segreto per il progetto."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:291
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:353
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
 msgstr "Clicca qui"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Scegli \"Altro\" come tipo di applicazione. Chiamalo come preferisci."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:316
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
 msgstr "{0} per prendere un codice di autenticazione"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:328
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
 msgstr "con i permessi di Google Drive"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:348
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Per usare Metabase con questi dati, devi abilitare l'accesso API nella console degli sviluppatori Google (Google Developers Console)."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:351
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} per andare alla console se non lo hai già fatto"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
 msgstr "Come vorresti fare riferimento a questo database?"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:427
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:237
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:188
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:74
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:194
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:79
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
 msgstr "Successivo"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:52
+#: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
 msgstr "Cancella questo {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:43
+#: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
 msgstr "Blocca questo elemento"
 
-#: frontend/src/metabase/components/EntityItem.jsx:49
+#: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
 msgstr "Sposta questo elemento"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
 msgstr "Modifica questa domanda (question)"
 
@@ -2398,6 +2407,7 @@ msgstr "Tipo di azione"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
 msgstr "Vedi storia di revisione"
 
@@ -2413,8 +2423,7 @@ msgstr "Archivia azione"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:329
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:342
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
 msgstr "Aggiungi alla 'dashboard'"
 
@@ -2438,13 +2447,12 @@ msgstr "Un altro tipo di azione"
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:449
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:454
 msgid "Get alerts about this"
 msgstr "Ricevi avvisi su questo"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
 msgstr "Mostra SQL"
 
@@ -2464,43 +2472,43 @@ msgstr "Qui c'è un messaggio completo di errore"
 msgid "Hi, Metabot here."
 msgstr "Ciao, sono Metabot"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:95
+#: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
 msgstr "Basato sullo schema"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:174
+#: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
 msgstr "Uno sguardo alla tua"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:234
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
 msgstr "Cerca la lista"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:238
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
 msgstr "Cercato da {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
 msgstr " o inserisci un ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
 msgstr "Inserisci un ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
 msgstr "Inserisci un numero"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:248
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
 msgstr "Inserisci del testo"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:355
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
 msgstr "Nessun {0} corrispondente trovato"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:363
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Includendo tutte le opzioni nel tuo filtro probabilmente non farai molto..."
 
@@ -2516,17 +2524,17 @@ msgstr "Ci siamo imbattuti in un errore. Puoi provare ad aggiornare la pagina, o
 #: frontend/src/metabase/components/HeaderBar.jsx:45
 #: frontend/src/metabase/components/ListItem.jsx:37
 #: frontend/src/metabase/reference/components/Detail.jsx:47
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:158
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:213
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:191
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:205
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:209
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:209
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:161
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:216
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:194
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:208
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
 msgstr "Ancora nessuna descrizione"
 
 #: frontend/src/metabase/components/Header.jsx:112
-#: frontend/src/metabase/entities/containers/EntityForm.jsx:43
+#: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
 msgstr "Nuovo {0}"
 
@@ -2534,54 +2542,53 @@ msgstr "Nuovo {0}"
 msgid "Asked by {0}"
 msgstr "Chiesto da {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:13
+#: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
 msgstr "Oggi, "
 
-#: frontend/src/metabase/components/HistoryModal.jsx:15
+#: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
 msgstr "Ieri, "
 
-#: frontend/src/metabase/components/HistoryModal.jsx:68
+#: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
 msgstr "Prima revisione."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:70
+#: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
 msgstr "Ripristinato a una revisione precedente e {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:82
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:289
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:379
-#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
+#: frontend/src/metabase/components/HistoryModal.jsx:42
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
+#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
 msgstr "Storia di revisione"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:90
+#: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
 msgstr "Quando"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:91
+#: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
 msgstr "Chi"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:92
+#: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
 msgstr "Cosa"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:113
+#: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
 msgstr "Ripristina"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:114
+#: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
 msgstr "Ripristino..."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:115
+#: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
 msgstr "Ripristino fallito"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:116
+#: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
 msgstr "Ripristinato"
 
@@ -2590,26 +2597,24 @@ msgid "Everything"
 msgstr "Ogni cosa"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
-#: frontend/src/metabase/home/containers/SearchApp.jsx:69
 msgid "Dashboards"
 msgstr "Dashboard"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
-#: frontend/src/metabase/home/containers/SearchApp.jsx:115
 msgid "Questions"
 msgstr "Domande"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:321
+#: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
 msgstr "Pulse"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:103
+#: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
 msgstr "Indietro"
 
-#: frontend/src/metabase/components/ListSearchField.jsx:18
+#: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
 msgstr "Trova..."
 
@@ -2646,14 +2651,14 @@ msgid "Temporary Password"
 msgstr "Password temporanea"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
 msgstr "Nascondi"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:412
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
 msgstr "Mostra"
 
@@ -2718,7 +2723,7 @@ msgstr "15mo (Medio)"
 msgid "Calendar Day"
 msgstr "Giorno di calendario"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:210
+#: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
 msgstr "il tuo timezone di Metabase"
 
@@ -2747,11 +2752,11 @@ msgid "A component used to make a selection"
 msgstr "Un componente utilizzato per fare una selezione"
 
 #: frontend/src/metabase/components/Select.info.js:20
-#: frontend/src/metabase/components/Select.info.js:28
+#: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
 msgstr "Selezionato"
 
-#: frontend/src/metabase/components/Select.jsx:297
+#: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
 msgstr "Niente da selezionare"
 
@@ -2764,7 +2769,7 @@ msgid "Unknown error encountered"
 msgstr "C'è stato un errore sconosciuto"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/nav/containers/Navbar.jsx:304
+#: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
 msgstr "Crea"
 
@@ -2773,13 +2778,11 @@ msgid "Create dashboard"
 msgstr "Crea una 'dashboard'"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:331
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:60
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
 msgstr "Tabella"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:306
 msgid "Database"
 msgstr "Database"
 
@@ -2787,22 +2790,20 @@ msgstr "Database"
 msgid "Creator"
 msgstr "Creatore"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:238
+#: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
 msgstr "Nessun risultto trovato"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:239
+#: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
 msgstr "Prova ad aggiustare il tuo filtro per trovare ciò che stai cercando."
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:258
+#: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
 msgstr "Visto da"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:494
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:84
-#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:69
-#: frontend/src/metabase/tutorial/TutorialModal.jsx:34
+#: frontend/src/metabase/containers/EntitySearch.jsx:495
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
 msgstr "di"
 
@@ -2815,13 +2816,13 @@ msgid "Once you connect your own data, I can show you some automatic exploration
 msgstr "Una volta che hai collegato i tuoi dati, posso mostrarti alcune esplorazioni automatiche chiamate raggi X. Ecco alcuni esempi con dati di esempio."
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
-#: frontend/src/metabase/containers/Overworld.jsx:299
+#: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
 msgstr "Inizia qui"
 
-#: frontend/src/metabase/containers/Overworld.jsx:294
-#: frontend/src/metabase/entities/collections.js:147
+#: frontend/src/metabase/containers/Overworld.jsx:296
+#: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
 msgstr "La nostra analisi"
@@ -2830,53 +2831,53 @@ msgstr "La nostra analisi"
 msgid "Browse all items"
 msgstr "Sfoglia tutti gli elementi"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:165
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
 msgstr "Sostituisci o salva come nuovo?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:173
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
 msgstr "Sostituisci la richiesta (`question`) originaria, {0}"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:178
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
 msgstr "Salva come nuova richiesta (`question`)"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:187
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
 msgstr "Prima, salva la tua richiesta (`question`)"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:188
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
 msgstr "Salva la richiesta (`question`)"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:224
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
 msgstr "Quale è il nome della tua card?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:232
-#: frontend/src/metabase/entities/collections.js:101
-#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:234
+#: frontend/src/metabase/entities/collections.js:102
+#: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/lib/core.js:50 frontend/src/metabase/lib/core.js:205
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:156
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:211
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:203
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:207
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:207
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:24
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:159
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:214
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:192
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:206
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:210
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
 msgstr "Descrizione"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:238
-#: frontend/src/metabase/entities/dashboards.js:153
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
+#: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
 msgstr "E' opzionale ma oh, così utile"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:245
-#: frontend/src/metabase/entities/dashboards.js:157
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
+#: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "In quale raccolta dovrebbe andare?"
 
@@ -2888,7 +2889,7 @@ msgstr "modificato"
 msgid "item"
 msgstr "elemento"
 
-#: frontend/src/metabase/containers/UndoListing.jsx:81
+#: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
 msgstr "Annulla"
 
@@ -2912,15 +2913,15 @@ msgstr "Non siamo sicuri che questa richiesta sia compatibile"
 msgid "Archive Dashboard"
 msgstr "Archivia la 'dashboard'"
 
-#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:20
+#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Assicurati di fare una selezione per ogni serie, altrimenti il filtro non funzionerà su questa card."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:300
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
 msgstr "Questa dashboard sembra vuota"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:301
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
 msgstr "Aggiungi una richiesta(Question) per iniziare a renderla utile!"
 
@@ -2940,59 +2941,58 @@ msgstr "Esci dallo schermo intero"
 msgid "Enter fullscreen"
 msgstr "Porta a tutto schermo"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:181
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:183
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Salvataggio...."
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:216
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
 msgstr "Aggiungi una richiesta (question)"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:219
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
 msgstr "Aggiungi una richiesta (question) alla dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:248
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
 msgstr "Aggiungi un filtro"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:254
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:78
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Parametri"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:275
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
 msgstr "Aggiungi un campo di testo"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
 msgstr "Sposta la Dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:302
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
 msgstr "Modifica la dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:306
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
 msgstr "Modifica il layout della dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:369
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
 msgstr "Stai modificando una dashboard"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:374
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
 msgstr "Seleziona il campo che vorresti fosse filtrato per ogni card"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:28
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
 msgstr "Sposta la dasboard in..."
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:52
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
 msgstr "Dashboard spostata in {0}"
 
@@ -3007,7 +3007,7 @@ msgstr "Che tipo di filtro?"
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:179
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
 msgstr "Spegni"
 
@@ -3047,174 +3047,174 @@ msgstr "Aggiornando in"
 msgid "Remove this question?"
 msgstr "Eliminare la richiesta (Question)?"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:71
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
 msgstr "La tua dashboard è stata salvata"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:745
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:76
+#: frontend/src/metabase/components/CollectionLanding.jsx:744
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
 msgstr "Guardalo"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:137
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
 msgstr "Salvalo"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:170
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
 msgstr "Mostra di più su questo"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:140
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
 msgstr "Questa scheda non ha campi o parametri che possono essere associati a questo tipo di parametro."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:142
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "I valori in questo campo non si sovrappongono ai valori di altri campi che hai scelto."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:186
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
 msgstr "Nessun campo valido."
 
-#: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
 msgstr "Il nome deve avere 100 caratteri o meno"
 
-#: frontend/src/metabase/entities/collections.js:111
+#: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
 msgstr "Colore richiesto"
 
-#: frontend/src/metabase/entities/dashboards.js:146
+#: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
 msgstr "Quale è il nome della tua dashboard?"
 
-#: frontend/src/metabase/home/components/Activity.jsx:92
+#: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
 msgstr "ha fatto delle cose fantastiche che è difficile da descrivere"
 
-#: frontend/src/metabase/home/components/Activity.jsx:101
-#: frontend/src/metabase/home/components/Activity.jsx:116
+#: frontend/src/metabase/home/components/Activity.jsx:103
+#: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
 msgstr "creata una alert su - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:126
-#: frontend/src/metabase/home/components/Activity.jsx:141
+#: frontend/src/metabase/home/components/Activity.jsx:128
+#: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
 msgstr "cancellata una alert su - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:152
+#: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
 msgstr "salvata una richiesta (Question) su "
 
-#: frontend/src/metabase/home/components/Activity.jsx:165
+#: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
 msgstr "salvata una richiesta"
 
-#: frontend/src/metabase/home/components/Activity.jsx:169
+#: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
 msgstr "cancellata una richiesta"
 
-#: frontend/src/metabase/home/components/Activity.jsx:172
+#: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
 msgstr "creata una dashboard"
 
-#: frontend/src/metabase/home/components/Activity.jsx:175
+#: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
 msgstr "cancellata una dashboard"
 
-#: frontend/src/metabase/home/components/Activity.jsx:181
-#: frontend/src/metabase/home/components/Activity.jsx:196
+#: frontend/src/metabase/home/components/Activity.jsx:183
+#: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
 msgstr "aggiunta una richiesta (Question) alla dashboard"
 
-#: frontend/src/metabase/home/components/Activity.jsx:206
-#: frontend/src/metabase/home/components/Activity.jsx:221
+#: frontend/src/metabase/home/components/Activity.jsx:208
+#: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
 msgstr "eliminata una richiesta dalla dashboard - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:231
-#: frontend/src/metabase/home/components/Activity.jsx:238
+#: frontend/src/metabase/home/components/Activity.jsx:233
+#: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
 msgstr "ricevuti gli ultimi dati da"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:621
-#: frontend/src/metabase/home/components/Activity.jsx:244
+#: frontend/src/metabase-lib/lib/Dimension.js:814
+#: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#: frontend/src/metabase/home/components/Activity.jsx:251
+#: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
 msgstr "Ciao Mondo!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:252
+#: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
 msgstr "Metabase è su ed è in funzione"
 
-#: frontend/src/metabase/home/components/Activity.jsx:258
-#: frontend/src/metabase/home/components/Activity.jsx:288
+#: frontend/src/metabase/home/components/Activity.jsx:260
+#: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
 msgstr "aggiunta la metrica "
 
-#: frontend/src/metabase/home/components/Activity.jsx:272
-#: frontend/src/metabase/home/components/Activity.jsx:362
+#: frontend/src/metabase/home/components/Activity.jsx:274
+#: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
 msgstr " al "
 
-#: frontend/src/metabase/home/components/Activity.jsx:282
-#: frontend/src/metabase/home/components/Activity.jsx:322
-#: frontend/src/metabase/home/components/Activity.jsx:372
-#: frontend/src/metabase/home/components/Activity.jsx:413
+#: frontend/src/metabase/home/components/Activity.jsx:284
+#: frontend/src/metabase/home/components/Activity.jsx:324
+#: frontend/src/metabase/home/components/Activity.jsx:374
+#: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
 msgstr " tabella"
 
-#: frontend/src/metabase/home/components/Activity.jsx:298
-#: frontend/src/metabase/home/components/Activity.jsx:328
+#: frontend/src/metabase/home/components/Activity.jsx:300
+#: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
 msgstr "fatti cambiamenti alla metrica "
 
-#: frontend/src/metabase/home/components/Activity.jsx:312
-#: frontend/src/metabase/home/components/Activity.jsx:403
+#: frontend/src/metabase/home/components/Activity.jsx:314
+#: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
 msgstr " nel "
 
-#: frontend/src/metabase/home/components/Activity.jsx:335
+#: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
 msgstr "cancellata la metrica "
 
-#: frontend/src/metabase/home/components/Activity.jsx:338
+#: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
 msgstr "creato un pulse"
 
-#: frontend/src/metabase/home/components/Activity.jsx:341
+#: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
 msgstr "cancellato un pulse"
 
-#: frontend/src/metabase/home/components/Activity.jsx:347
-#: frontend/src/metabase/home/components/Activity.jsx:378
+#: frontend/src/metabase/home/components/Activity.jsx:349
+#: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
 msgstr "aggiunto un filtro"
 
-#: frontend/src/metabase/home/components/Activity.jsx:388
-#: frontend/src/metabase/home/components/Activity.jsx:419
+#: frontend/src/metabase/home/components/Activity.jsx:390
+#: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
 msgstr "fatti cambiamenti al filtro"
 
-#: frontend/src/metabase/home/components/Activity.jsx:426
+#: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
 msgstr "cancellato il filtro {0}"
 
-#: frontend/src/metabase/home/components/Activity.jsx:429
+#: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
 msgstr "iscritto!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:529
+#: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
 msgstr "mmm, sembra che non sia ancora successo nulla."
 
-#: frontend/src/metabase/home/components/Activity.jsx:532
+#: frontend/src/metabase/home/components/Activity.jsx:534
 msgid "Save a question and get this baby going!"
 msgstr "Salva una richiesta e fai andare questa bambina!"
 
@@ -3262,21 +3262,21 @@ msgstr "Recentemente visualizzato"
 msgid "You haven't looked at any dashboards or questions recently"
 msgstr "Di recente non hai guardato dashboard o domande"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:99
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
 msgstr "{0} elementi selezionati"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:121
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:172
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
 msgstr "Non archiviare"
 
-#: frontend/src/metabase/home/containers/HomepageApp.jsx:74
-#: frontend/src/metabase/nav/containers/Navbar.jsx:331
+#: frontend/src/metabase/home/containers/HomepageApp.jsx:77
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
 msgstr "Attività"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:28
+#: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
 msgstr "Risultati per \"{0}\""
 
@@ -3341,6 +3341,7 @@ msgstr "URL dell'immagine di avatar"
 msgid "Common"
 msgstr "Comune"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
@@ -3377,8 +3378,9 @@ msgstr "Latitudine"
 msgid "Longitude"
 msgstr "Longitudine"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:149
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
 msgstr "Numero"
@@ -3475,7 +3477,7 @@ msgstr "Punteggio"
 
 #: frontend/src/metabase/lib/core.js:210
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:17
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
 msgstr "Titolo"
 
@@ -3532,8 +3534,9 @@ msgid "Metabase will never retrieve this field. Use this for sensitive or irrele
 msgstr "Metabase non recupererà mai questo campo. Utilizzare questo per informazioni sensibili o irrilevanti."
 
 #: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:614
-#: frontend/src/metabase/visualizations/lib/utils.js:126
+#: frontend/src/metabase/lib/query.js:300
+#: frontend/src/metabase/visualizations/lib/utils.js:130
+#: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -3548,7 +3551,7 @@ msgstr "Conteggio cumulativo"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
-#: frontend/src/metabase/visualizations/lib/utils.js:127
+#: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
 msgstr "Somma"
 
@@ -3557,7 +3560,7 @@ msgid "CumulativeSum"
 msgstr "Somma cumulativa"
 
 #: frontend/src/metabase/lib/expressions/config.js:11
-#: frontend/src/metabase/visualizations/lib/utils.js:128
+#: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
 msgstr "Distinto"
 
@@ -3566,35 +3569,35 @@ msgid "StandardDeviation"
 msgstr "DeviazioneStandard"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/visualizations/lib/utils.js:125
+#: frontend/src/metabase/visualizations/lib/utils.js:129
 msgid "Average"
 msgstr "Media"
 
 #: frontend/src/metabase/lib/expressions/config.js:14
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:25
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
 msgstr "Min"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
 msgstr "Max"
 
-#: frontend/src/metabase/lib/expressions/parser.js:384
+#: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
 msgstr "rilevati errori di lessico"
 
-#: frontend/src/metabase/lib/formatting.js:707
+#: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} secondo"
 msgstr[1] "{0} secondi"
 
-#: frontend/src/metabase/lib/formatting.js:710
+#: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuto"
@@ -3633,222 +3636,224 @@ msgstr "Cosa hai in mente?"
 msgid "What do you want to find out?"
 msgstr "Cosa vuoi scoprire?"
 
-#: frontend/src/metabase/lib/query.js:612
-#: frontend/src/metabase/lib/schema_metadata.js:451
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:246
+#: frontend/src/metabase/lib/query.js:298
+#: frontend/src/metabase/lib/schema_metadata.js:458
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
 msgstr "Dati grezzi"
 
-#: frontend/src/metabase/lib/query.js:616
+#: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
 msgstr "Conto cumulativo"
 
-#: frontend/src/metabase/lib/query.js:619
+#: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
 msgstr "Media di "
 
-#: frontend/src/metabase/lib/query.js:624
+#: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
 msgstr "Valori distinti di "
 
-#: frontend/src/metabase/lib/query.js:629
+#: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
 msgstr "Deviazione standard di "
 
-#: frontend/src/metabase/lib/query.js:634
+#: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
 msgstr "Somma di "
 
-#: frontend/src/metabase/lib/query.js:639
+#: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
 msgstr "Somma cumulativa di "
 
-#: frontend/src/metabase/lib/query.js:644
+#: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
 msgstr "Massimo di "
 
-#: frontend/src/metabase/lib/query.js:649
+#: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
 msgstr "Minimo di "
 
-#: frontend/src/metabase/lib/query.js:663
+#: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
 msgstr "Raggruppato per "
 
-#: frontend/src/metabase/lib/query.js:677
+#: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
 msgstr "Filtrato per "
 
-#: frontend/src/metabase/lib/query.js:706
+#: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
 msgstr "Ordinato per "
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
 msgstr "Vero"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
 msgstr "Falso"
 
-#: frontend/src/metabase/lib/schema_metadata.js:305
+#: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
 msgstr "Seleziona il campo longitudine"
 
-#: frontend/src/metabase/lib/schema_metadata.js:306
+#: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
 msgstr "Inserisci la latituine superiore"
 
-#: frontend/src/metabase/lib/schema_metadata.js:307
+#: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
 msgstr "inserisci la longitudine a sinistra"
 
-#: frontend/src/metabase/lib/schema_metadata.js:308
+#: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
 msgstr "Inserisci la latitudine inferiore"
 
-#: frontend/src/metabase/lib/schema_metadata.js:309
+#: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
 msgstr "Inserisci la longitudine a destra"
 
-#: frontend/src/metabase/lib/schema_metadata.js:345
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase-lib/lib/Dimension.js:505
+#: frontend/src/metabase-lib/lib/Dimension.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:351
+#: frontend/src/metabase/lib/schema_metadata.js:371
 #: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:387
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
 msgstr "E'"
 
-#: frontend/src/metabase/lib/schema_metadata.js:346
-#: frontend/src/metabase/lib/schema_metadata.js:366
-#: frontend/src/metabase/lib/schema_metadata.js:376
-#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/lib/schema_metadata.js:352
+#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:396
+#: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
 msgstr "Non è"
 
-#: frontend/src/metabase/lib/schema_metadata.js:347
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:369
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:353
+#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
 msgstr "E' vuoto"
 
-#: frontend/src/metabase/lib/schema_metadata.js:348
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:370
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:402
+#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
 msgstr "Non vuoto"
 
-#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
 msgstr "Uguale a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:355
+#: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
 msgstr "Non uguale a "
 
-#: frontend/src/metabase/lib/schema_metadata.js:356
+#: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
 msgstr "Più grande di"
 
-#: frontend/src/metabase/lib/schema_metadata.js:357
+#: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
 msgstr "Meno di"
 
-#: frontend/src/metabase/lib/schema_metadata.js:358
-#: frontend/src/metabase/lib/schema_metadata.js:384
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:285
+#: frontend/src/metabase/lib/schema_metadata.js:364
+#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Tra"
 
-#: frontend/src/metabase/lib/schema_metadata.js:359
+#: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
 msgstr "Più grande o uguale a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:360
+#: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
 msgstr "Meno di o uguale a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
 msgstr "Contiene"
 
-#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
 msgstr "Non contiene"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
 msgstr "Inizia con"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
 msgstr "Finisce con"
 
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:264
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Prima"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:271
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Dopo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
 msgstr "Dentro"
 
-#: frontend/src/metabase/lib/schema_metadata.js:453
+#: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Solo una tabella con le righe nella risposta, nessuna operazione aggiuntiva."
 
-#: frontend/src/metabase/lib/schema_metadata.js:459
+#: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
 msgstr "Conteggio di righe"
 
-#: frontend/src/metabase/lib/schema_metadata.js:461
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
 msgstr "Numero totale di righe nella risposta"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
 msgstr "Somma di ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:469
+#: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
 msgstr "Somma di tutti i valori di una colonna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
 msgstr "Media di ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
 msgstr "Media di tutti i valori di una colonna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
 msgstr "Numeri di valori distinti di ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Numero di valori univoci di una colonna tra tutte le righe nella risposta."
 
-#: frontend/src/metabase/lib/schema_metadata.js:491
+#: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
 msgstr "Somma cumulativa di ..."
 
@@ -3856,7 +3861,7 @@ msgstr "Somma cumulativa di ..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Somma additiva di tutti i valori di una colonna. \\\\ ne.x. entrate totali nel tempo."
 
-#: frontend/src/metabase/lib/schema_metadata.js:499
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
 msgstr "Conteggio cumulativo di righe"
 
@@ -3864,105 +3869,105 @@ msgstr "Conteggio cumulativo di righe"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Conteggio additivo del numero di righe. \\\\ ne.x. numero totale di vendite nel tempo."
 
-#: frontend/src/metabase/lib/schema_metadata.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
 msgstr "Deviazione standard di ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:509
+#: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Numero che esprime quanto i valori di una colonna variano tra tutte le righe nella risposta."
 
-#: frontend/src/metabase/lib/schema_metadata.js:515
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
 msgstr "Minimo di ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:517
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
 msgstr "Minimo valore di una colonna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:523
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
 msgstr "Massimo di ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:525
+#: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
 msgstr "Massimo valore di una colonna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:533
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
 msgstr "Scoppia per dimensione"
 
-#: frontend/src/metabase/lib/settings.js:93
+#: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
 msgstr "lettera minuscola"
 
-#: frontend/src/metabase/lib/settings.js:95
+#: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
 msgstr "lettera maiuscola"
 
-#: frontend/src/metabase/lib/settings.js:97
+#: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "numero"
 
-#: frontend/src/metabase/lib/settings.js:99
+#: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
 msgstr "carattere speciale"
 
-#: frontend/src/metabase/lib/settings.js:105
+#: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
 msgstr "deve essere"
 
-#: frontend/src/metabase/lib/settings.js:105
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:120
+#: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
 msgstr "carattere lungo"
 
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
 msgstr "Deve essere"
 
-#: frontend/src/metabase/lib/settings.js:122
+#: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
 msgstr "e include"
 
-#: frontend/src/metabase/lib/utils.js:92
+#: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
 msgstr "zero"
 
-#: frontend/src/metabase/lib/utils.js:93
+#: frontend/src/metabase/lib/utils.js:86
 msgid "one"
 msgstr "uno"
 
-#: frontend/src/metabase/lib/utils.js:94
+#: frontend/src/metabase/lib/utils.js:87
 msgid "two"
 msgstr "due"
 
-#: frontend/src/metabase/lib/utils.js:95
+#: frontend/src/metabase/lib/utils.js:88
 msgid "three"
 msgstr "tre"
 
-#: frontend/src/metabase/lib/utils.js:96
+#: frontend/src/metabase/lib/utils.js:89
 msgid "four"
 msgstr "quattro"
 
-#: frontend/src/metabase/lib/utils.js:97
+#: frontend/src/metabase/lib/utils.js:90
 msgid "five"
 msgstr "cinque"
 
-#: frontend/src/metabase/lib/utils.js:98
+#: frontend/src/metabase/lib/utils.js:91
 msgid "six"
 msgstr "sei"
 
-#: frontend/src/metabase/lib/utils.js:99
+#: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
 msgstr "sette"
 
-#: frontend/src/metabase/lib/utils.js:100
+#: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
 msgstr "otto"
 
-#: frontend/src/metabase/lib/utils.js:101
+#: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
 msgstr "nove"
 
@@ -4036,6 +4041,7 @@ msgstr "Tempo"
 msgid "Date range, relative date, time of day, etc."
 msgstr "Intervallo di date, data relativa, Ora del giorno, ecc,"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
@@ -4058,7 +4064,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Categoria, Tipo, Valutazione, ecc."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
-#: frontend/src/metabase/user/components/UserSettings.jsx:54
+#: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
 msgstr "Impostazioni di account"
 
@@ -4070,56 +4076,56 @@ msgstr "Esci da amministratore"
 msgid "Logs"
 msgstr "I log"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:64
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
 msgstr "Aiuto"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:67
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
 msgstr "Su Metabase"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:73
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
 msgstr "Esci"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:98
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
 msgstr "Grazie per l'uso"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
 msgstr "Tu stai usando la versione"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
 msgstr "Costruita su"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:124
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
 msgstr "E un Marchio di"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:126
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
 msgstr "ed è costruito con cura a San Francisco, in California"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:194
+#: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
 msgstr "Amministratore Metabase"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:300
+#: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
 msgstr "Poni una domanda"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:309
+#: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
 msgstr "Nuova Dashboard"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:315
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/nav/containers/Navbar.jsx:361
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
 msgstr "Nuovo Pulse"
 
@@ -4127,16 +4133,16 @@ msgstr "Nuovo Pulse"
 msgid "Reference"
 msgstr "Referente"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:83
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
 msgstr "Quale metrica?"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:110
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Definire metriche comuni per il tuo team rende ancora più facile fare domande"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:113
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
 msgstr "Come creare metriche"
 
@@ -4148,8 +4154,8 @@ msgstr "Visualizza i dati nel tempo, come una mappa o ruotati per aiutarti a cap
 msgid "Custom"
 msgstr "Personalizzato"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:150
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:517
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
 msgstr "Nuove domande"
 
@@ -4157,22 +4163,22 @@ msgstr "Nuove domande"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Utilizza il semplice generatore di domande per visualizzare tendenze, elenchi di cose o per creare le tue metriche."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:161
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Query native"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:162
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Per domande più complicate, puoi scrivere la tua query SQL o nativa."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:240
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
 msgstr "Seleziona un valore predefinito ..."
 
-#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:149
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
 msgstr "Filtro di aggiornamento"
 
@@ -4180,14 +4186,14 @@ msgstr "Filtro di aggiornamento"
 #: frontend/src/metabase/lib/query_time.js:123
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:9
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Today"
 msgstr "Oggi"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
 msgstr "Ieri"
 
@@ -4199,7 +4205,7 @@ msgstr "Ultimi 7 giorni"
 msgid "Past 30 days"
 msgstr "Ultimi 30 giorni"
 
-#: frontend/src/metabase/lib/query_time.js:195
+#: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:29
 #: src/metabase/api/table.clj
@@ -4208,7 +4214,7 @@ msgid_plural "Weeks"
 msgstr[0] "Settimana"
 msgstr[1] "Settimane"
 
-#: frontend/src/metabase/lib/query_time.js:197
+#: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:30
 #: src/metabase/api/table.clj
@@ -4217,7 +4223,7 @@ msgid_plural "Months"
 msgstr[0] "Mese"
 msgstr[1] "Mesi"
 
-#: frontend/src/metabase/lib/query_time.js:201
+#: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:31
 #: src/metabase/api/table.clj
@@ -4267,6 +4273,7 @@ msgstr "Inserisci un valore"
 msgid "Enter a default value..."
 msgstr "Inserisci un valore predefinito..."
 
+#: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "C'è stato un errore"
@@ -4307,24 +4314,24 @@ msgstr "Pubblicato"
 msgid "Code"
 msgstr "Codice"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:70
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
 msgstr "Stile"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
 msgstr "Quali parametri possono utilizzare gli utenti di questo embed?"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:83
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
 msgstr "Questo {0} non ha ancora parametri da configurare."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
 msgstr "Modificabile"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
 msgstr "Bloccato"
 
@@ -4332,19 +4339,19 @@ msgstr "Bloccato"
 msgid "Preview Locked Parameters"
 msgstr "Anteprima dei parametri bloccati"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:115
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
 msgstr "Prova a passare alcuni valori ai tuoi parametri bloccati qui. Il tuo server dovrà fornire i valori reali nel token firmato quando lo utilizzi per davvero."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
 msgstr "Zona pericolosa"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
 msgstr "Questo disabiliterà l'incorporamento per questo {0}."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:128
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
 msgstr "Spubblicato"
 
@@ -4384,64 +4391,64 @@ msgstr "Più {0}"
 msgid "examples on GitHub"
 msgstr "esempi su GitHub"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:72
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
 msgstr "Abilita condivisione"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
 msgstr "Disabilitare link pubblico?"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:77
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
 msgstr "Ciò causerà l'interruzione del funzionamento del collegamento esistente. Puoi riattivarlo, ma quando lo fai sarà un link diverso."
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
 msgstr "Link pubblico"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:118
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
 msgstr "Condividi questo {0} con persone che non hanno un account Metabase utilizzando l'URL di seguito:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:158
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
 msgstr "Inserimento pubblico"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:159
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
 msgstr "Incorpora questo {0} nei post del blog o nelle pagine Web copiando e incollando questo snippet:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:176
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
 msgstr "Incorpora questo {0} in un'applicazione"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:177
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
 msgstr "Integrando con il codice del server delle applicazioni, è possibile fornire statistiche sicure {0} limitate a uno specifico utente, cliente, organizzazione, ecc."
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
 msgstr "Rimuovi allegato"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:95
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
 msgstr "Allega file con risultati"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
 msgstr "Questa domanda verrà aggiunta come allegato al file"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:128
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
 msgstr "Questa domanda non sarà inclusa nel tuo Pulse"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:92
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
 msgstr "Questo impulso non verrà più inviato via email a {0} {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:94
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:376
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
 msgstr[0] "{0} Indirizzo"
@@ -4451,39 +4458,39 @@ msgstr[1] "{0} indirizzi"
 msgid "Slack channel {0} will no longer get this pulse {1}"
 msgstr "Il canale Slack {0} non riceverà più questo impulso {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:110
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
 msgstr "Il canale {0} non riceverà più questo impulso {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
 msgstr "modifica pulse"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:131
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
 msgstr "Cosa è un Pulse?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:141
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
 msgstr "Fatto"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
 msgstr "Dove dovrebbero andare questi dati?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:173
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
 msgstr "Sto togliendo dall'archivio..."
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
 msgstr "Eliminazione dall'archivio fallita"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
 msgstr "Non archiviato"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
 msgstr "Cra un pulse"
 
@@ -4493,7 +4500,7 @@ msgstr "Allegato"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:673
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
 msgstr "Dritta"
 
@@ -4514,6 +4521,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Raccomandiamo di mantenere gli impulsi piccoli e concentrati per mantenerli digeribili e utili a tutta la squadra."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
+#: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
 msgstr "Scegli i tuoi dati"
 
@@ -4529,47 +4537,47 @@ msgstr "Email"
 msgid "Slack messages"
 msgstr "Messaggi Slack"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Spedito"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:222
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} saranno spediti a"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:224
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Messaggi"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Spedisci email ora"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:241
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Spedisci {0} ora"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Invio..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:244
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Invio fallito"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Non spedire in quanto pulse non ha risultati"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:248
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Pulse ha inviato"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:287
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} deve essere impostato da un amministratore."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:302
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
 msgstr "Slack"
 
@@ -4618,21 +4626,21 @@ msgid "Before {0}"
 msgstr "Prima {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:295
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "è vuoto"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:301
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Non vuoto"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:213
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Sempre"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:154
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
 msgstr "Applica"
 
@@ -4698,7 +4706,7 @@ msgstr "Distribuzione"
 msgid "View details"
 msgstr "Vedi dettagli"
 
-#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:54
+#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
 msgstr "Mostra {1} di questo {0}"
 
@@ -4722,22 +4730,22 @@ msgstr "Media"
 msgid "Distincts"
 msgstr "Distinti"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:32
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Mostra questo {0}"
 msgstr[1] "Mostra questi {0}"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:225
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
 msgstr "Avvicina"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:19
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
 msgstr "Espressione custom"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
 msgstr "Metriche standard"
 
@@ -4745,7 +4753,7 @@ msgstr "Metriche standard"
 msgid "Metabasics"
 msgstr "Metabasi"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
 msgstr "Nome (opzionale)"
 
@@ -4757,31 +4765,31 @@ msgstr "Scegli una aggregazione"
 msgid "Set up your own alert"
 msgstr "Imposta il tuo alert"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:140
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
 msgstr "Disiscrivendo..."
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:145
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
 msgstr "Errore nel cancellarsi"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:204
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
 msgstr "Cancellati"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:235
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
 msgstr "Nessun canale"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:263
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
 msgstr "Ok, sei stato cancellato"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:335
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
 msgstr "Stai ricevendo {0} alert"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
 msgstr "{0} imposta un alert"
 
@@ -4837,147 +4845,147 @@ msgstr "Modifica il tuo alert"
 msgid "Edit alert"
 msgstr "Modifica alert"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:374
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
 msgstr "Questo alert non sarà più inviato a {0}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:382
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
 msgstr "Il canale Sllack {0} non riceverà più questo alert."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:386
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
 msgstr "Il canale {0} non riceverà più questo alert."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:403
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
 msgstr "Cancella questo alert"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:405
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
 msgstr "Ferma l'invio e cancella l'alert. Non si torna indietro, quindi sii attento."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:413
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
 msgstr "Eliminare l'alert?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:497
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
 msgstr "Avvisami quando la linea..."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:498
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
 msgstr "Avvisami quando la barra..."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
 msgstr "Supera la linea gol"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
 msgstr "Raggiunge il gol"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
 msgstr "Va sotto la linea gol"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
 msgstr "Va sotto il gol"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:512
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
 msgstr "La prima volta che lo supera, oppure ogni volta?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:513
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
 msgstr "La prima volta che raggiunge l'obiettivo, oppure sempre?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
 msgstr "La prima volta"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:516
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
 msgstr "Ogni volta"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:619
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
 msgstr "Dove vuoi inviare questi alert?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:630
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
 msgstr "Invia una email con gli alert a:"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:672
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
 msgstr "{0} Gli alert basati sugli obiettivi non sono al momento supportati per più di una linea, per cui questo alert sarà inviato ogni qualvolta il grafico abbia {1}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
 msgstr "risultati"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:679
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
 msgstr "{0} Questo tipo di alert è più utile quando la tua domanda salvata "
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:680
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
 msgstr "Consiglio"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
 msgstr "solitamente"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:57
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
 msgstr "Seleziona un segmento o una tabella"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
 msgstr "Seleziona un database"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:88
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
 msgstr "Seleziona..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:128
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
 msgstr "Seleziona una tabella"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:793
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
 msgstr "In questo database non è stata trovata nessuna tabella."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:830
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
 msgstr "Manca una domanda?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:834
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
 msgstr "Scopri di più sulle query annidate"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:868
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
 msgstr "Campi"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:946
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
 msgstr "Non è stato trovato alcun segmento"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:969
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
 msgstr "Trova un segmento"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:46
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
 msgstr "Mostra meno"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:56
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
 msgstr "Mostra di più"
 
@@ -4986,60 +4994,65 @@ msgid "Pick a field to sort by"
 msgstr "Seleziona il campo in base al quale ordinare"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
 msgstr "Ordina"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
 msgstr "Limite di righe"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:69
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
 msgstr "Campo sconosciuto"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
 msgstr "campo"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:114
+#: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
 msgstr "Combinazioni"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
+#: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Aggiungi filtri per restringere la tua risposta"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:284
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
 msgstr "Aggiungi un raggruppamento"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:322
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:102
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:113
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:152
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:194
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:59
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:68
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:75
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:225
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:231
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:237
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:70
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:75
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:64
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:89
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:131
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:176
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:302
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:308
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:314
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Dati"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:352
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
 msgstr "Filtrati per"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:369
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
 msgstr "Vista"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:386
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
 msgstr "Raggruppati per"
 
@@ -5047,23 +5060,23 @@ msgstr "Raggruppati per"
 msgid "None"
 msgstr "Nessuno"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:345
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
 msgstr "Questa domanda è scritta in {0}"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:353
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
 msgstr "Nascondi Editor"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:354
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
 msgstr "Nascondi Query"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
 msgstr "Apri Editor"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:360
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
 msgstr "Mostra Query"
 
@@ -5084,15 +5097,15 @@ msgstr "Scarica questi dati"
 msgid "Warning"
 msgstr "Attenzione"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:52
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
 msgstr "La tua risposta ha molte righe, per cui il download potrebbe metterci un po'."
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:53
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
 msgstr "La massima dimensione scaricabile è 1 milione di righe."
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:232
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
 msgstr "Modifica la domanda"
 
@@ -5108,17 +5121,17 @@ msgstr "ANNULLA"
 msgid "Move question"
 msgstr "Sposta la domanda"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:283
+#: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
 msgstr "In quale collezione va inserito?"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:313
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:110
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
+#: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
 msgstr "Variabili"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:432
+#: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
 msgstr "Scopri di più sui tuoi dati"
 
@@ -5162,11 +5175,11 @@ msgstr "{0} per questa domanda"
 msgid "Convert this question to {0}"
 msgstr "Trasforma questa domanda in {0}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:122
+#: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
 msgstr "Questa domanda impiegherà circa {0} per aggiornarsi"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:131
+#: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
 msgstr "Aggiornato {0}"
 
@@ -5184,11 +5197,11 @@ msgstr "Mostra i primi {0} {1}"
 msgid "Showing {0} {1}"
 msgstr "Mostra {0} {1}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:281
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
 msgstr "Calcolando"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:294
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
 msgstr "Se mi dai dei dati, posso mostrarti qualcosa di interessante. Lancia una Query!"
 
@@ -5196,7 +5209,7 @@ msgstr "Se mi dai dei dati, posso mostrarti qualcosa di interessante. Lancia una
 msgid "How do I use this thing?"
 msgstr "Come uso questa cosa?"
 
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:28
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
 msgstr "Ottieni la risposta"
 
@@ -5224,39 +5237,39 @@ msgstr "Mi dispiace. Qualcosa è andato storto."
 msgid "Group time by"
 msgstr "Aggrega il tempo per"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:46
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
 msgstr "La tua domanda ci ha messo troppo tempo"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:47
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
 msgstr "Non abbiamo ricevuto una risposta in tempo dal tuo database, per cui ci siamo fermati. Puoi riprovare tra un minuto e, se il problema rimane, inviare una mail a un amministratore per informarlo."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:55
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
 msgstr "Stiamo avendo problemi con il database"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:56
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
 msgstr "Prova a rinfrescare la pagina tra un paio di minuti. Se il problema rimane, ti consigliamo di contattare un amministratore."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:88
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
 msgstr "C'è stato un problema con la tua domanda"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:89
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
 msgstr "La maggior parte delle volte questo è causato da una selezione invalida o dall'inserimento di un valore anomalo. Ricontrolla l'inserimento e rilancia la query."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:60
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
 msgstr "Questa potrebbe essere la risposta che stai cercando. In caso contrario, prova a togliere o modificare i filtri in modo che siano meno specifici."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
 msgstr "Puoi anche {0} quando ci sono dei risultati"
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:68
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
 msgstr "ricevi un alert"
 
@@ -5264,11 +5277,11 @@ msgstr "ricevi un alert"
 msgid "Back to last run"
 msgstr "Torna all'ultima esecuzione"
 
-#: frontend/src/metabase/query_builder/components/VisualizationSettings.jsx:100
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
 msgstr "Visualizzazione"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:96
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
 msgstr "Nessuna descrizione impostata."
 
@@ -5280,7 +5293,7 @@ msgstr "Usa per la domanda corrente"
 msgid "Potentially useful questions"
 msgstr "Domande potenzialmente utili"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:166
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
 msgstr "Raggruppa per {0}"
 
@@ -5293,14 +5306,14 @@ msgstr "Somma di tutti i valori di {0}"
 msgid "All distinct values of {0}"
 msgstr "Tutti i valori che assume {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:187
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
 msgstr "Numero di {0} raggruppato per {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5316,34 +5329,34 @@ msgstr "Riferimento dati"
 msgid "Learn more about your data structure to ask more useful questions"
 msgstr "Scopri di più sulla struttura dei dati per fare domande più utili"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:58
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:84
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
 msgstr "Non posso trovare i metadati della tabella prima di creare una nuova domanda"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:80
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
 msgstr "Vedi {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:94
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
 msgstr "Definizione della metrica"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:118
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
 msgstr "Filtra per {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:127
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
 msgstr "Numero di {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
 msgstr "Mostra tutti {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:148
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
 msgstr "Definizione del segmento"
 
@@ -5355,7 +5368,7 @@ msgstr "Si è verificato un errore durante il caricamento della tabella"
 msgid "See the raw data for {0}"
 msgstr "Mostra i dati grezzi per {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:180
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
 msgstr "Altro"
 
@@ -5367,24 +5380,24 @@ msgstr "Espressione non valida"
 msgid "unknown error"
 msgstr "errore sconosciuto"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:46
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
 msgstr "Campo formula"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:57
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Pensa che è come scrivere una formula in un foglio di calcolo: puoi usare numeri, campi in questa tabella, simboli matematici come + e alcune funzioni. Quindi puoi digitare qualcosa come Subtotal - Cost."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
 msgstr "Scopri di più"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:66
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
 msgstr "Assegna un nome"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:72
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
 msgstr "Qualcosa di chiaro e descrittivo"
 
@@ -5436,7 +5449,8 @@ msgstr "vero"
 msgid "false"
 msgstr "falso"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
 msgstr "Aggiungi un filtro"
 
@@ -5444,15 +5458,15 @@ msgstr "Aggiungi un filtro"
 msgid "Item"
 msgstr "Elemento"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:221
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
 msgstr "Precedente"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:252
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
 msgstr "Corrente"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:278
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
@@ -5463,7 +5477,7 @@ msgid "Enter desired number"
 msgstr "Inserisci il numero desiderato"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:100
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
 msgstr "Vuoto"
 
@@ -5487,36 +5501,36 @@ msgstr "Puoi inserire più valori separati da virgola"
 msgid "Enter desired text"
 msgstr "Inserisci il testo desiderato"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
 msgstr "Prova"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
 msgstr "A cosa serve?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
 msgstr "Le variabili nelle query native ti permettono di sostituire dinamicamente i valori nelle tue query utilizzando i filtri widget o attraverso l'URL."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
 msgstr "{0} crea una variabile in questo modello SQL chiamato \"nome_variabile\". Le variabili possono essere tipi dati nel pannello laterale, che cambia il loro comportamento. Tutti i tipi di variabile diversi da \"Field Filter\" causeranno automaticamente il posizionamento di un filtro su questa domanda; con i filtri di campo, questo è opzionale. Quando questo widget di filtro viene utilizzato, tale valore sostituisce la variabile nel modello SQL."
 
 #. Per essere più intuitivi utilizzerei il termine colonna così che gli utenti sanno che questi sono i filtri che poi si basano sui dati presenti nella colonna che andranno a scegliere
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:121
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
 msgstr "Filtri per colonna"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:123
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Fornendo una variabile il tipo \"Campo Filtro\" consente di collegare le schede SQL ai widget filtro dashboard o utilizzare più tipi di widget filtro sulla richiesta SQL. Una variabile Field Filter inserisce SQL simile a quello generato dal generatore di query della GUI quando si aggiungono filtri su colonne esistenti."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:126
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
 msgstr "Quando aggiungi una variabile Field Filter, dovrai mapparla a un campo specifico. Puoi quindi scegliere di visualizzare un widget filtro nella tua domanda, ma anche se non lo fai, puoi ora mappare la variabile Filtro campo a un filtro dashboard quando aggiungi questa domanda a una dashboard. I filtri di campo dovrebbero essere utilizzati all'interno di una clausola \"WHERE\"."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:130
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
 msgstr "Clausole opzionali"
 
@@ -5524,59 +5538,61 @@ msgstr "Clausole opzionali"
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
 msgstr "parentesi attorno a {0} creano una clausola facoltativa nel modello. Se è impostata \"variabile\", l'intera clausola viene inserita nel modello. In caso contrario, l'intera clausola viene ignorata."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:142
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
 msgstr "Per utilizzare più clausole facoltative, è possibile includere almeno una clausola WHERE non facoltativa seguita da clausole facoltative che iniziano con \"AND\"."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
 msgstr "Leggi la documentazione completa"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:127
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
 msgstr "Etichetta di filtro"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:139
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
 msgstr "Tipo di variabile"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:143
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
 msgstr "Testo"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:150
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:119
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
 msgstr "Data"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
 msgstr "Filtro per colonna"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:157
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
 msgstr "Campo a cui mappare"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
 msgstr "Filtro tipo di widget"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:201
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
 msgstr "Richiesto?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:211
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
 msgstr "Valore di default del widget"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:46
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
 msgstr "Archivia questa domanda?"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:57
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Questa domanda sarà rimossa da ogni dashboard o pulse che la contiene"
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:136
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
 msgstr "Domanda"
 
@@ -5593,21 +5609,21 @@ msgstr "Stai modificando questa pagina"
 msgid "See this {0}"
 msgstr "Guarda questo {0}"
 
-#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:120
+#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
 msgstr "Un sottoinsieme di"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:68
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
 msgstr "Scegli un tipo di campo"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:57
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
 msgstr "Nessun tipo di campo"
 
@@ -5616,16 +5632,16 @@ msgid "by"
 msgstr "per"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
-#: frontend/src/metabase/reference/databases/FieldList.jsx:152
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
+#: frontend/src/metabase/reference/databases/FieldList.jsx:155
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
 msgstr "Tipo di campo"
 
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:72
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
 msgstr "Degli una chiave esterna"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:53
+#: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
 msgstr "Vedi la formula {0}"
 
@@ -5642,12 +5658,12 @@ msgid "Nothing important yet"
 msgstr "Nulla di importante per ora"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:168
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:233
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:211
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:215
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:219
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:229
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:236
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:214
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
 msgstr "Nulla di interessante per ora"
 
@@ -5656,12 +5672,12 @@ msgid "Things to be aware of about this {0}"
 msgstr "Cose da sapere su questo {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:178
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:243
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:221
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:225
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:229
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:239
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:246
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:224
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
 msgstr "Niente di cui essere ancora a conoscenza"
 
@@ -5723,15 +5739,15 @@ msgstr "Motivo delle modifiche"
 msgid "Leave a note to explain what changes you made and why they were required"
 msgstr "Lascia una nota per spiegare quali modifiche hai effettuato e perché erano necessarie"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:166
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
 msgstr "Perchè questo database è interessante"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:176
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
 msgstr "Punti di attenzione su questo database"
 
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:46
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
 msgstr "Database e tabelle"
@@ -5739,42 +5755,42 @@ msgstr "Database e tabelle"
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:41
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:170
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:173
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:34
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:184
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:187
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:30
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:188
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:187
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:191
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:190
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
 msgstr "Dettagli"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
-#: frontend/src/metabase/reference/databases/TableList.jsx:111
+#: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
 msgstr "Tabelle in {0}"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:222
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:200
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:218
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:203
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
 msgstr "Nome reale nel database"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:231
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:227
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
 msgstr "Perché questo campo è interessante"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:241
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:237
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
 msgstr "Punti di attenzione su questo campo"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:253
-#: frontend/src/metabase/reference/databases/FieldList.jsx:155
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:249
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
+#: frontend/src/metabase/reference/databases/FieldList.jsx:158
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
 msgstr "Tipo dati"
 
@@ -5783,13 +5799,13 @@ msgstr "Tipo dati"
 msgid "Fields in this table will appear here as they're added"
 msgstr "I campi in questa tabella appariranno qui man mano verranno aggiunti"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:134
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:135
+#: frontend/src/metabase/reference/databases/FieldList.jsx:137
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
 msgstr "Campi in {0}"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:149
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:150
+#: frontend/src/metabase/reference/databases/FieldList.jsx:152
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
 msgstr "Nome del campo"
 
@@ -5813,7 +5829,10 @@ msgstr "I database appariranno qui quando i tuoi amministratori li avranno aggiu
 msgid "Connect a database"
 msgstr "Connetti un database"
 
+#. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
+#. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
+#: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
 msgstr "Conteggio di {0}"
 
@@ -5821,11 +5840,11 @@ msgstr "Conteggio di {0}"
 msgid "See raw data for {0}"
 msgstr "Visualizza i dati piatti di {0}"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:209
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
 msgstr "Perchè questa tabella è interessante"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:219
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
 msgstr "Cose di cui essere a conoscenza riguardanti questa tabella"
 
@@ -5837,16 +5856,16 @@ msgstr "Le tabelle in questo database appariranno qui man mano verranno aggiunte
 msgid "Questions about this table will appear here as they're added"
 msgstr "Le domande su questa tabella appariranno qui man mano verranno aggiunte"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:71
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:75
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:74
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
 msgstr "Domande riguardanti {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
 msgstr "Creato {0} per {1}"
 
@@ -5858,151 +5877,152 @@ msgstr "Campi in questa tabella"
 msgid "Questions about this table"
 msgstr "Domande relative a questa tabella"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:157
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
 msgstr "Aiuta il tuo team ad iniziare a lavorare con i vostri dati."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:159
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
 msgstr "Mostra al tuo team la cosa più importante scegliendo la dashboard, le metriche e i segmenti più importanti."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:165
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
 msgstr "Inizia"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:173
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
 msgstr "La nostra dashboard più importante"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:188
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
 msgstr "Numeri importanti per noi"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:213
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
 msgstr "Le metriche sono numeri importanti che la tua azienda ritiene essenziali. Rappresentano spesso un indicatore chiave di come si sta svolgendo l'attività."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:221
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
 msgstr "Mostra tutte le metriche"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:235
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
 msgstr "Segmenti e tabelle"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
+#: frontend/src/metabase/home/containers/SearchApp.jsx:83
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
 msgstr "Tabelle"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:262
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
 msgstr "Segmenti e tabelle sono gli elementi costitutivi dei dati della tua azienda. Le tabelle sono raccolte delle informazioni non elaborate mentre i segmenti sono sezioni specifiche con significati specifici, come {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:267
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
 msgstr "Le tabelle sono i mattoncini che compongono l'insieme dei dati della vostra azienda."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:277
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
 msgstr "Mostra tutti i segmenti"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:293
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
 msgstr "Mostra tutte le tabelle"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:301
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
 msgstr "Altre cose da sapere sui nostri dati"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
 msgstr "Scopri di più"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:307
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
 msgstr "Un buon modo per conoscere i tuoi dati è trascorrere un po 'di tempo esplorando le diverse tabelle e altre informazioni disponibili. Potrebbe volerci un po ', ma inizierai a riconoscere nomi e significati nel tempo."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:313
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
 msgstr "Esplora i nostri dati"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:321
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
 msgstr "Ci sono domande?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:326
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
 msgstr "Contatta {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:248
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
 msgstr "Aiuta i nuovi utenti di Metabase a sentirsi a casa."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:251
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
 msgstr "La Guida introduttiva evidenzia la dashboard, le metriche, i segmenti e le tabelle che contano di più e informa gli utenti delle cose importanti che dovrebbero sapere prima di scavare nei dati."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:258
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
 msgstr "C'è una dashboard importante per il tuo team?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:260
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
 msgstr "Crea ora una dashboard"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:266
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
 msgstr "Qual è la tua dashboard più importante?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:285
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
 msgstr "Hai delle metriche a cui fai riferimento di frequente?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:287
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
 msgstr "Impara come definire una metrica"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:300
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
 msgstr "Quali solo le 3-5 metriche più richiamate?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:344
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
 msgstr "Aggiungi un'altra metrica"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:357
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
 msgstr "Hai dei segmenti o delle tabelle che sono richiamati frequentemente?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:359
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
 msgstr "Impara come creare un segmento"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:372
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
 msgstr "Quali sono 3-5 segmenti o tabelle comunemente citati che sarebbero utili per questo pubblico?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:418
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
 msgstr "Aggiungi un'altro segmento o tabella"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:427
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
 msgstr "C'è qualcosa che i tuoi utenti dovrebbero capire o sapere prima di iniziare ad accedere ai dati?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:433
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
 msgstr "Cosa deve sapere un utente di questi dati prima di iniziare ad accedervi?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:437
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
 msgstr "p.e., aspettative sulla privacy e sull'uso dei dati, insidie o incomprensioni comuni, informazioni sulle prestazioni del data warehouse, note legali, ecc."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
 msgstr "C'è qualcuno che i tuoi utenti potrebbero contattare per chiedere aiuto se sono confusi su questa guida?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:457
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
 msgstr "Chi dovrebbe contattare gli utenti per chiedere assistenza se sono confusi su questi dati?"
 
@@ -6011,39 +6031,39 @@ msgstr "Chi dovrebbe contattare gli utenti per chiedere assistenza se sono confu
 msgid "Please enter a revision message"
 msgstr "Per favore scrivi un messaggio per la revisione"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:213
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
 msgstr "Perché questa metrica è interessante"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:223
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
 msgstr "Cose di che dovresti sapere riguardo questa metrica"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:233
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
 msgstr "Come viene calcolata questa metrica"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:235
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
 msgstr "Per ora nulla rispetto a come è calcolato"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:293
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
 msgstr "Altri campi puoi raggruppare questa metrica per"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:294
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
 msgstr "Campi con cui puoi raggruppare questa metrica"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:23
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Le metriche sono i numeri ufficiali di cui il tuo team si prende cura"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Le metriche appariranno qui una volta che i tuoi amministratori ne avranno creati alcuni"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
 msgstr "Scopri come si creano metriche"
 
@@ -6055,9 +6075,9 @@ msgstr "Le 'question' su questa metrica verranno visualizzate qui man mano che v
 msgid "There are no revisions for this metric"
 msgstr "Non ci sono revisioni per questa metrica"
 
-#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:88
-#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
-#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:88
+#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
+#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
+#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
 msgstr "Storia delle revisioni per {0}"
 
@@ -6065,27 +6085,27 @@ msgstr "Storia delle revisioni per {0}"
 msgid "X-ray this metric"
 msgstr "Esegui raggi-X su questa metrica"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:217
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
 msgstr "Perché questo segmento è interessante"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:227
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
 msgstr "Cose da sapere su questo segmento"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
 msgstr "I segmenti sono sottoinsiemi interessanti di tabelle"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Definire segmenti comuni per il tuo team rende ancora più facile fare domande"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
 msgstr "I segmenti appariranno qui non appena i tuoi admin ne avranno creati"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
 msgstr "Impara come creare dei segmenti"
 
@@ -6114,7 +6134,7 @@ msgstr "Analizza il segmento ai Raggi-X"
 msgid "Login"
 msgstr "Accedi"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:130
+#: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
 msgstr "Cerca"
@@ -6132,99 +6152,99 @@ msgstr "Nuova domanda"
 msgid "Select the type of Database you use"
 msgstr "Seleziona il tipo di Database che utilizzi"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:141
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
 msgstr "Aggiungi i tuoi dati"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:145
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
 msgstr "Aggiungerò i miei dati più tardi"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
 msgstr "Mi sto connettendo a {0}"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:165
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
 msgstr "Avrai bisogno di alcune informazioni sul tuo database, come il nome utente e la password. Se non lo hai in questo momento, Metabase viene fornito con un set di dati di esempio con cui puoi iniziare."
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:196
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
 msgstr "Aggiungerò i miei dati più tardi"
 
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:41
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
 msgstr "Controlla le scansioni automatiche"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:53
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
 msgstr "Preferenze di utilizzo dei dati "
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
 msgstr "Grazie per averci aiutato a migliorare"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:57
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
 msgstr "Non raccoglieremo eventi di utilizzo"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:76
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Per aiutarci a migliorare Metabase, desideriamo raccogliere determinati dati sull'utilizzo tramite Google Analytics."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
 msgstr "Qui trovi la lista completa di cosa tracciamo e perché"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:98
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Consenti a Metabase di raccogliere dati anonimi sugli eventi"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} reccoglie nulla riguardo i tuoi dati e risultati."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:106
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
 msgstr "mai"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
 msgstr "Tutte le raccolte dati sono completamente anonime."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "La raccolta dati può essere disabilitata in qualsiasi momento dalle impostazioni di amministrazione."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:45
+#: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
 msgstr "Se ti senti bloccato"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:52
+#: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
 msgstr "la nostra guida rapida"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:53
+#: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
 msgstr "ti manca solo un click."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:95
+#: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
 msgstr "Benvenuto in Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:96
+#: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Sembra che tutto funzioni. Ora ti conosciamo, ti colleghiamo ai tuoi dati e inizi a trovarti delle risposte!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:100
+#: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
 msgstr "Iniziamo"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:145
+#: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
 msgstr "Abbiamo impostato tutto!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:156
+#: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
 msgstr "Portami su Metabase"
 
@@ -6241,7 +6261,7 @@ msgid "Create a password"
 msgstr "Crea una password"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:116
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
 msgstr "Shhh..."
 
@@ -6435,11 +6455,11 @@ msgstr "Accedi con Google"
 msgid "User Details"
 msgstr "Dettagli utente"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:275
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
 msgstr "Ripristina i valori di default"
 
-#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:133
+#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
 msgstr "mappa sconosciuta"
 
@@ -6451,24 +6471,24 @@ msgstr "La mappa a griglia richiede longitudine / latitudine separate."
 msgid "more"
 msgstr "di più"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:101
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
 msgstr "Quali campi vuoi usare per le coordinate X e Y?"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:103
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:60
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
 msgstr "Scegli i campi"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:204
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
 msgstr "Salva come vista di default"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
 msgstr "Disegna un box per filtrare"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
 msgstr "Annulla filtro"
 
@@ -6476,7 +6496,7 @@ msgstr "Annulla filtro"
 msgid "Pin Map"
 msgstr "Mappa a punti"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:303
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
 msgstr "Non impostato"
 
@@ -6484,31 +6504,31 @@ msgstr "Non impostato"
 msgid "Rows {0}-{1} of {2}"
 msgstr "Righe {0}-{1} di {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:189
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
 msgstr "Dati troncati a {0} righe"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:364
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
 msgstr "Impossibile trovare visualizzazione"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:371
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
 msgstr "Impossibile visualizzare questo grafico con questi dati"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:469
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
 msgstr "Nessun risultato!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:490
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
 msgstr "Sto ancora aspettando..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:493
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
 msgstr "Solitamente impiega una media di {0}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:499
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Questo è un po' lungo per una dashboard)"
 
@@ -6524,11 +6544,11 @@ msgstr "Seleziona un campo"
 msgid "error"
 msgstr "errore"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:126
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
 msgstr "Clicca e trascina per cambiarne l'ordine"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:139
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
 msgstr "Aggiungi i campi dalla lista sotto"
 
@@ -6618,7 +6638,7 @@ msgid "Highlight the whole row"
 msgstr "Evidenzia l'intera riga"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:98
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Colori"
 
@@ -6683,20 +6703,20 @@ msgstr "La visualizzazione con quell'identificatore è già registrata"
 msgid "No visualization for {0}"
 msgstr "Nessuna visualizzazione per {0}"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:75
+#: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
 msgstr "\"{0}\" è un campo non aggregato: se ha più di un valore nello stesso punto dell'asse X, i valori saranno sommati"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:91
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
 msgstr "Questo tipo di grafico richiede almeno 2 colonne"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:96
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
 msgstr "Questo tipo di grafico non supporta più di {0} serie di dati"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:51
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:297
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
 msgstr "Obbiettivo"
 
@@ -6736,25 +6756,25 @@ msgstr "Modifica Impostazioni"
 msgid "xValues missing!"
 msgstr "Manca il valore X!"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:114
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "Asse-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:140
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
 msgstr "Aggiungi una serie di interruzioni..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:153
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Asse-Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:178
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
 msgstr "Aggiungi un'altra serie..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:195
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
 msgstr "Dimensione del fumetto"
 
@@ -6768,7 +6788,7 @@ msgid "Curve"
 msgstr "Curva"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:69
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
 msgstr "Passaggio"
 
@@ -6776,27 +6796,27 @@ msgstr "Passaggio"
 msgid "Show point markers on lines"
 msgstr "Mostra marcatori di punti sulle linee"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:235
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
 msgstr "impilabile"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:239
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
 msgstr "Non impilare"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:240
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
 msgstr "Pila"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:241
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
 msgstr "Pila - 100%"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:300
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
 msgstr "Mostra obiettivo"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:306
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
 msgstr "Valore da raggiungere"
 
@@ -6816,126 +6836,126 @@ msgstr "Niente"
 msgid "Linear Interpolated"
 msgstr "Interpolato lineare"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:371
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
 msgstr "Scala dell'asse-X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
 msgstr "Serie temporali"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:391
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:409
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:381
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
 msgstr "Lineare"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:410
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:383
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
 msgstr "Esponente"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:384
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
 msgstr "Log"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:396
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
 msgstr "Istogramma"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:398
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
 msgstr "Ordinale"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:404
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
 msgstr "scala asse Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:417
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
 msgstr "Mostra linea e punti sull'asse X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:423
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
 msgstr "Compatta"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:424
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
 msgstr "Ruota di 45°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
 msgstr "Ruota di 90°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
 msgstr "Mostra linea e punti sull'asse X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
 msgstr "Auto range l'asse Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
 msgstr "Dividi l'asse Y quando necessario"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
 msgstr "Mostra etichetta sul asse X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:501
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
 msgstr "Etichetta asse X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:510
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
 msgstr "Mostra etichetta sul asse Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:516
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
 msgstr "Etichetta asse Y"
 
-#: frontend/src/metabase/visualizations/lib/utils.js:129
+#: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
 msgstr "Deviazione Standard"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:275
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:17
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:256
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
 msgstr "Area"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
 msgstr "grafico ad area"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:276
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:16
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:257
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
 msgstr "barre"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
 msgstr "grafico a barre"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
 msgstr "Quali campi vuoi usare?"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
 msgstr "Imbuto"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:76
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:76
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Misura"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
 msgstr "Tipo di imbuto"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:88
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
 msgstr "grafico a barre"
 
@@ -6943,141 +6963,141 @@ msgstr "grafico a barre"
 msgid "line chart"
 msgstr "grafico lineare"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:224
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Si prega di selezionare le colonne di longitudine e latitudine nelle impostazioni del grafico."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
 msgstr "Si prega di selezionare una mappa della regione."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Seleziona le colonne della regione e delle metriche nelle impostazioni del grafico."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:38
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Mappa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:53
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
 msgstr "Tipo di mappa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:57
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:149
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
 msgstr "Mappa della regione"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
 msgstr "Mappa puntine"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
 msgstr "Tipo di puntine"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
 msgstr "Riquadri"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
 msgstr "Marcatori"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
 msgstr "Campo latitudine"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
 msgstr "Campo longitudine"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:142
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:168
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
 msgstr "Campo per Metrica"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
 msgstr "Campo Regione"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
 msgstr "Raggio"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:198
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
 msgstr "Offusca"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
 msgstr "Opacità minima"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
 msgstr "Max Zoom"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:175
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
 msgstr "Nessuna relazione trovata"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:213
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:290
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
 msgstr "Questo {0} è connesso a:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:47
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
 msgstr "Dettagli oggetto"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
 msgstr "oggetto"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
 msgstr "Totale"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Quali colonne vuoi usare?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:44
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Torta"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Dimensione"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:81
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Mostra legenda"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:86
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Mostra percentuali nella legenda"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:92
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Percentuale della fetta minore"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:146
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
 msgstr "Obiettivo raggiunto"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:148
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
 msgstr "Obiettivo superato"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
 msgstr "Obiettivo {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
 msgstr "La visualizzazione del progresso richiede un numero."
 
@@ -7085,9 +7105,9 @@ msgstr "La visualizzazione del progresso richiede un numero."
 msgid "Progress"
 msgstr "Avanzamento"
 
-#: frontend/src/metabase/entities/collections.js:108
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:176
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:57
+#: frontend/src/metabase/entities/collections.js:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Colore"
 
@@ -7099,7 +7119,7 @@ msgstr "Grafico a righe"
 msgid "row chart"
 msgstr "grafico a righe"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:357
+#: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
 msgstr "stile del separatore"
 
@@ -7107,15 +7127,15 @@ msgstr "stile del separatore"
 msgid "Number of decimal places"
 msgstr "Numero di posizioni decimali"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:381
+#: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
 msgstr "Aggiungi un prefisso"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:385
+#: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
 msgstr "Aggiungi un suffisso"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:374
+#: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
 msgstr "Moltiplica per un numero"
 
@@ -7127,7 +7147,7 @@ msgstr "Dispersione"
 msgid "scatter plot"
 msgstr "Trama sparsa"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:78
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
 msgstr "Tabella Pivot"
 
@@ -7136,7 +7156,8 @@ msgid "Visible fields"
 msgstr "Campi visibili"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-msgid "Write here, and use Markdown if you''d like"
+#, fuzzy
+msgid "Write here, and use Markdown if you'd like"
 msgstr "Scrivi qui, e usa il `Markdown` se preferisci"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
@@ -7177,13 +7198,13 @@ msgstr "Destra"
 msgid "Show background"
 msgstr "Mostra sfondo"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:553
+#: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} bidone"
 msgstr[1] "{0} bidoni"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:559
+#: frontend/src/metabase-lib/lib/Dimension.js:731
 msgid "Auto binned"
 msgstr "intervallo automatico"
 
@@ -7451,26 +7472,26 @@ msgstr "intervallo automatico"
 msgid "Don''t bin"
 msgstr "nessun intervallo"
 
-#: frontend/src/metabase/lib/query_time.js:193 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Giorno"
 msgstr[1] "Giorni"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
-#: frontend/src/metabase/lib/query_time.js:189 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minuto"
 msgstr[1] "Minuti"
 
-#: frontend/src/metabase/lib/query_time.js:191 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Ora"
 msgstr[1] "Ore"
 
-#: frontend/src/metabase/lib/query_time.js:199 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
 msgstr[0] "Quadrimestre"
@@ -7537,7 +7558,7 @@ msgid "Bin every 20 degrees"
 msgstr "intervalla ogni 20 gradi"
 
 #. returns `true` if successful -- see JavaDoc
-#: src/metabase/api/tiles.clj src/metabase/pulse/render.clj
+#: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
 msgstr "Nessun Image Writer appropriato trovato!"
 
@@ -7609,10 +7630,12 @@ msgstr "somma cumulata"
 msgid "{0} and {1}"
 msgstr "{0} e {1}"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} di {1}"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
 msgstr "{0} per {1}"
@@ -7625,9 +7648,12 @@ msgstr "{0} nel segmento di {1}"
 msgid "{0} segment"
 msgstr "{0} segmento"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
-msgstr "{0} metrica"
+msgid_plural "{0} metrics"
+msgstr[0] "{0} metrica"
+msgstr[1] "{0} metriche"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
@@ -8208,6 +8234,7 @@ msgid "Cannot save Question: source query has circular references."
 msgstr "Non puoi salvare la Domanda: la query ha riferimenti circolari"
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
+#: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
 msgstr "La Carta {0} non esiste."
@@ -8609,7 +8636,7 @@ msgstr "Tipo di canale {0} non riconosciuto"
 msgid "Error sending notification!"
 msgstr "Errore nell'inviare la notifica!"
 
-#: src/metabase/pulse/color.clj
+#: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
 msgstr "Impossibile trovare il selettore di colori JS a ''{0}''"
 
@@ -8916,43 +8943,43 @@ msgstr "Permesso dati"
 msgid "Collection permissions"
 msgstr "Permessi della raccolta"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:56
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
 msgstr "Vedi tutti i permessi della raccolta"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:25
+#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
 msgstr "Cambia anche sotto-raccolte"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:282
+#: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
 msgstr "Puoi modificare questa raccolta e i suoi contenuti"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:289
+#: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
 msgstr "Può visualizzare gli elementi in questa raccolta"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:749
+#: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
 msgstr "Accesso alla raccolta"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:825
+#: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Questo gruppo ha il permesso di vedere almeno una sottoraccolta di questa raccolta."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:830
+#: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Questo gruppo ha il permesso di modificare almeno una sottoraccolta di questa raccolta."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
 msgstr "Visualizza sotto-raccolte"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:211
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
 msgstr "Ricordami"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:95
+#: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
 msgstr "Raggi X di questo schema"
 
@@ -8984,31 +9011,32 @@ msgstr "Salva dashboard, domande e collezioni in \"{0}\""
 msgid "Access dashboards, questions, and collections in \"{0}\""
 msgstr "Accedi a dashboard, domande e collezioni in \"{0}\" "
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:221
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
 msgstr "Confronto"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:229
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
 msgstr "Rimpicciolire"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:233
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
 msgstr "Relazionato"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:293
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
 msgstr "Altri raggi X"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:46
+#: frontend/src/metabase/home/containers/SearchApp.jsx:40
+#: src/metabase/pulse/render/body.clj
 msgid "No results"
 msgstr "Nessun risultato"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:47
+#: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
 msgstr "Metabase non può trovare nessun risultato per la tua ricerca."
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:111
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
 msgstr "Nessuna metrica presente"
 
@@ -9050,7 +9078,7 @@ msgstr "Impossibile concedere le autorizzazioni: {0}"
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
 msgstr "Impossibile decodificare la stringa crittografata. Hai cambiato o ti sei dimenticato di impostare MB_ENCRYPTION_SECRET_KEY?"
 
-#: frontend/src/metabase/entities/collections.js:164
+#: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
 msgstr "tutte le collezioni personali"
 
@@ -9215,18 +9243,18 @@ msgstr "N/A"
 msgid "Windows domain"
 msgstr "dominio Windows"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:509
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:515
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:490
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:499
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
 msgstr "Etichette"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:329
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
 msgstr "Aggiungi membri"
 
-#: frontend/src/metabase/entities/collections.js:115
+#: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
 msgstr "Collezione in cui è salvato"
 
@@ -9247,39 +9275,39 @@ msgid "Sharing"
 msgstr "Condividi"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:234
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:270
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:299
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:305
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:313
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:321
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:218
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:251
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:280
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:286
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:294
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:302
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:80
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:85
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:91
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:97
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:50
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:56
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
 msgstr "Display"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:370
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:416
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:431
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:487
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:358
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:406
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:447
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
 msgstr "Assi"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:222
-#: frontend/src/metabase/admin/settings/selectors.js:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
+#: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
@@ -9313,20 +9341,20 @@ msgstr "Raggi-X"
 msgid "Compare to the rest"
 msgstr "Confronta con il resto"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:244
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Usa la timezone di Java Virtual Machine (JVM)"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
 msgstr "Ti suggeriamo di lasciar perdere, a meno che tu non stia eseguendo manualmente il fuso orario in molte o la maggior parte delle tue query con questi dati."
 
-#: frontend/src/metabase/containers/Overworld.jsx:310
+#: frontend/src/metabase/containers/Overworld.jsx:312
 msgid "Your team's most important dashboards go here"
 msgstr "le dashboard più importanti del tuo team vanno qui"
 
-#: frontend/src/metabase/containers/Overworld.jsx:311
+#: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
 msgstr "Inserisci le dashboard in {0} per visualizzarli in questo spazio per tutti"
 
@@ -9342,32 +9370,32 @@ msgstr "Usa Il Time Zone di JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Stiamo analizzando le tabelle e i campi per aiutarti a esplorare i tuoi dati."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
 msgstr "Suggerimento: "
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:258
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
 msgstr "Seleziona un tipo di valuta"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:318
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
 msgstr "Tipo Campo"
 
 #: frontend/src/metabase/admin/routes.jsx:109
-#: frontend/src/metabase/nav/containers/Navbar.jsx:224
+#: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
 msgstr "Risoluzione Problemi"
 
-#: frontend/src/metabase/admin/settings/selectors.js:96
+#: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
 msgstr "Abilita funzioni raggi X"
 
-#: frontend/src/metabase/admin/settings/selectors.js:323
+#: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
 msgstr "Opzioni formattazione"
 
-#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:19
+#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
 msgstr "Dettagli processo"
 
@@ -9407,7 +9435,7 @@ msgstr "Valuta"
 msgid "Pick a user or channel..."
 msgstr "Scegli un utente o un canale..."
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
+#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
 msgstr "Nessuna impostazione di formattazione"
 
@@ -9515,31 +9543,31 @@ msgstr "HH:MM:SS.MS"
 msgid "Time style"
 msgstr "Stile ora"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:299
+#: frontend/src/metabase/visualizations/lib/settings/column.js:300
 msgid "Unit of currency"
 msgstr "Unità per valuta"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:319
+#: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
 msgstr "Stile etichetta valuta"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:337
+#: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
 msgstr "Dove mostrare l'unità della valuta"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:370
+#: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
 msgstr "Numero minimo di posizioni decimali"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:271
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
 msgstr "Tipo di grafico in pila"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:314
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
 msgstr "etichetta obbiettivo"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:322
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
 msgstr "Mostra la linea del trend"
 
@@ -9568,7 +9596,7 @@ msgstr "Linea + Barra"
 msgid "line and bar chart"
 msgstr "Grafico a barre e linea"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:72
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
 msgstr "La visualizzazione Gauge richiede un numero."
 
@@ -9576,75 +9604,75 @@ msgstr "La visualizzazione Gauge richiede un numero."
 msgid "Gauge"
 msgstr "Gauge"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
 msgstr "Intervallo Gauge"
 
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
 msgstr "Campo da mostrare"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
 msgstr "l'ultimo {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:185
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
 msgstr "{0} era {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:52
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Raggruppa per un campo \"time\" per vedere come è cambiato nel tempo"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
 msgstr "Cambia colori positivi / negativi"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
 msgstr "Colonna Pivot"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:107
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
 msgstr "Colonna della cella"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:123
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
 msgstr "Colonne visibili"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:143
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
 msgstr "Formattazione condizionale"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
 msgstr "Titolo della colonna"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
 msgstr "Mostra un grafico a barre mini"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:183
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
 msgstr "Link"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:187
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
 msgstr "Link dell'email"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
 msgstr "Immagine"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:195
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
 msgstr "Automatico"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:200
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
 msgstr "Visualizza come link o immagine"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
 msgstr "Testo del link"
 
@@ -9908,7 +9936,7 @@ msgstr "Errore durante la pre-elaborazione della query"
 msgid "No native form returned."
 msgstr "Nessun form nativo è stato restituito"
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
 msgstr "Risposta non valida dal driver del database. Nessuno stato fornito."
 
@@ -10623,7 +10651,7 @@ msgstr "Un'occhiata da vicino al tuo [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Heres a closer look at your [[this]] field"
-msgstr "Ecco uno sguardo più vicino al tuo [[this]] field"
+msgstr "Ecco uno sguardo più vicino al tuo [[this]] campo"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
@@ -11274,7 +11302,7 @@ msgstr "Impostazione di `query-caching-max-kb` a {0} fallita."
 msgid "Values greater than {1} are not allowed."
 msgstr "Valori maggiori a {1} non sono consentiti."
 
-#: src/metabase/query_processor/middleware/resolve_database.clj
+#: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
 msgstr "Il database {0} non esiste"
 
@@ -11323,7 +11351,7 @@ msgstr "Trigger"
 msgid "View triggers"
 msgstr "Vedi trigger"
 
-#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:82
+#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
 msgstr "Informazioni sullo scheduler"
 
@@ -11355,7 +11383,7 @@ msgstr "Tempo di innesco finale"
 msgid "May Fire Again?"
 msgstr "Può Lanciare ancora?"
 
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:75
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
 msgstr "Innesco per {0}"
 
@@ -11367,19 +11395,19 @@ msgstr "Tasks"
 msgid "Jobs"
 msgstr "Jobs"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
 msgstr "Duplicato {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:55
+#: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
 msgstr "Duplica questo elemento"
 
-#: frontend/src/metabase/components/EntityItem.jsx:61
+#: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
 msgstr "Archivia questo elemento"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:330
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
 msgstr "Duplica dashboard"
 
@@ -11429,63 +11457,64 @@ msgstr "{0} {1} fa"
 msgid "{0} {1} from now"
 msgstr "{0} {1} da ora"
 
-#: frontend/src/metabase/lib/query_time.js:187
+#: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
 msgstr[0] "Intervallo di default"
 msgstr[1] "Intervalli di default"
 
-#: frontend/src/metabase/lib/query_time.js:203
+#: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
 msgstr[0] "Minuto dell'ora"
 msgstr[1] "Minuti dell'ora"
 
-#: frontend/src/metabase/lib/query_time.js:205
+#: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
 msgstr[0] "Ora del giorno"
 msgstr[1] "Ore del giorno"
 
-#: frontend/src/metabase/lib/query_time.js:207
+#: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
 msgstr[0] "Giorno della settimana"
 msgstr[1] "Giorni della settimana"
 
-#: frontend/src/metabase/lib/query_time.js:209
+#: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
 msgstr[0] "Giorno del mese"
 msgstr[1] "Giorni del mese"
 
-#: frontend/src/metabase/lib/query_time.js:211
+#: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
 msgstr[0] "Giorno dell'anno"
 msgstr[1] "Giorni dell'anno"
 
-#: frontend/src/metabase/lib/query_time.js:213
+#: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
 msgstr[0] "Settimana dell'anno"
 msgstr[1] "Settimane dell'anno"
 
-#: frontend/src/metabase/lib/query_time.js:215
+#: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
 msgstr[0] "Mese dell'anno"
 msgstr[1] "Mesi dell'anno"
 
-#: frontend/src/metabase/lib/query_time.js:217
+#: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "Trimestre dell'anno"
 msgstr[1] "Trimestri dell'anno"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:79
+#: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} selezione"
@@ -11499,20 +11528,20 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "Questo"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:64
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
 msgstr "Invalido"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:147
+#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
 msgstr "Aggiungi tempo"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:170
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
 msgstr "Niente da confrontare con il precedente {0}"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:517
+#: frontend/src/metabase-lib/lib/Dimension.js:678
 msgid "by {0}"
 msgstr "di {0}"
 
@@ -11807,35 +11836,35 @@ msgstr "Registrazione del driver di caricamento in modo `lazy` {0}..."
 msgid "Error running query for Card {0}"
 msgstr "Errore nell'esecuzione della query per la Scheda {0}"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
 msgstr "Ultima settimana"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This week"
 msgstr "Questa settimana"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
 msgstr "Ultimo mese"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This month"
 msgstr "Questo mese"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
 msgstr "Ultimo trimestre"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
 msgstr "Questo trimestre"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
 msgstr "Ultimo anno"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This year"
 msgstr "Quest'anno"
 
@@ -12082,7 +12111,7 @@ msgid "[[CreateDate]] by quarter of the year"
 msgstr "[[CreateDate]] per trimestre dell'anno"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:200
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
 msgstr "Modifica utente"
 
@@ -12090,12 +12119,12 @@ msgstr "Modifica utente"
 msgid "New user"
 msgstr "Nuovo utente"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
 msgstr "Reset password"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:209
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
 msgstr "Disattiva utente"
 
@@ -12107,40 +12136,40 @@ msgstr "Riattivare {0}?"
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
 msgstr "Non è stato possibile inviare loro un invito via email, quindi assicurati di dire loro di accedere al log utilizzando {0} e questa password che abbiamo generato per loro:"
 
-#: frontend/src/metabase/entities/collections.js:21
+#: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
 msgstr "collezione"
 
-#: frontend/src/metabase/entities/collections.js:22
+#: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
 msgstr "collezioni"
 
-#: frontend/src/metabase/entities/dashboards.js:29
+#: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
 msgstr "dashboard"
 
-#: frontend/src/metabase/entities/dashboards.js:30
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
 msgstr "dashboards"
 
-#: frontend/src/metabase/entities/users.js:125
+#: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
 msgstr "Il nome è richiesto"
 
-#: frontend/src/metabase/entities/users.js:126
-#: frontend/src/metabase/entities/users.js:133
+#: frontend/src/metabase/entities/users.js:38
+#: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
 msgstr "Deve essere 100 caratteri o meno"
 
-#: frontend/src/metabase/entities/users.js:132
+#: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
 msgstr "Il cognome è richiesto"
 
-#: frontend/src/metabase/entities/users.js:138
+#: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
 msgstr "L'email è obbligatoria"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:90
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
 msgstr "Gli oggetti che archivierai appariranno qui."
 
@@ -12148,11 +12177,11 @@ msgstr "Gli oggetti che archivierai appariranno qui."
 msgid "No description"
 msgstr "Nessuna descrizione"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:175
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
 msgstr "Somma di tutti i valori"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:183
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
 msgstr "Vedi tutti i valori DISTINCT"
 
@@ -12352,15 +12381,778 @@ msgstr "Sto aggiungendo l'utente {0} al gruppo di Tutti gli Utenti"
 msgid "Adding User {0} to Admin permissions group..."
 msgstr "Sto aggiungendo l'utente {0} al gruppo dell'Amministratore"
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
 msgstr "Fallimento query"
 
-#: src/metabase/query_processor/async.clj
+#: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
 msgstr "Numero massimo di query contemporanee per il Database a cui si è connessi"
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
 msgstr "Si è verificato un Time out dopo {0} millisecondi."
+
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
+msgid "Misfire Instruction"
+msgstr "Istruzione per mancata accensione"
+
+#: frontend/src/metabase/components/ArchiveModal.jsx:31
+msgid "Archive this?"
+msgstr "Archiviare?"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:244
+msgid "Learn about our data"
+msgstr "Impara dai nostri dati"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
+msgid "Use DNS SRV when connecting"
+msgstr "usa DNS SRV quando ti connetti"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
+msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
+"an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
+"leave this disabled."
+msgstr "L'utilizzo di questa opzione richiede che l'host fornito sia un nome di dominio completo. Se ci si connette a un cluster Atlas, potrebbe essere necessario abilitare questa opzione. Se non sai cosa significa, lascialo disabilitato."
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
+msgid "Automatically run queries when doing simple filtering and summarizing"
+msgstr "Esegui automaticamente query quando esegui semplici filtri e riepiloghi"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr "Quando è attivo, Metabase eseguirà automaticamente le query quando gli utenti eseguono semplici esplorazioni con i pulsanti Riassumi e Filtro durante la visualizzazione di una tabella o di un grafico. È possibile disattivarlo se l'interrogazione di questo database è lenta. Questa impostazione non influisce sui drill-through o sulle query SQL."
+
+#: frontend/src/metabase/containers/Overworld.jsx:247
+msgid "Learn about this database"
+msgstr "Impara da questo database"
+
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+msgid "Archive this dashboard?"
+msgstr "Archiviare questa dashboard?"
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:113
+msgid "All results"
+msgstr "Tutti i risultati"
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:180
+msgid "Our Analytics"
+msgstr "La nostra analisi"
+
+#: frontend/src/metabase/lib/schema_metadata.js:500
+msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
+msgstr "Somma additiva di tutti i valori di una colonna. \\ne.x. entrate totali nel tempo."
+
+#: frontend/src/metabase/lib/schema_metadata.js:508
+msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
+msgstr "Conteggio additivo di tutti i valori di una riga. \\ne.x. numero totale di vendite nel tempo."
+
+#: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
+msgid "Filter"
+msgstr "Filtro"
+
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+msgid "record"
+msgid_plural "records"
+msgstr[0] "record"
+msgstr[1] "record"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:346
+msgid "Browse Data"
+msgstr "Sfoglia i dati"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:376
+msgid "Write SQL"
+msgstr "Scrivi SQL"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
+msgid "Simple question"
+msgstr "Domanda semplice"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
+msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
+msgstr "Raccogli qualche dato, guardalo, e filtra, riepilogalo e visualizzalo facilemnte"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
+msgid "Custom question"
+msgstr "`question` personalizzata"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
+msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+msgid "Basic Metrics"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+msgid "Custom…"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
+msgid "Add grouping"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
+msgid "Pick a limit"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
+msgid "Show maximum"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
+msgid "Get Preview"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
+msgid "Back to previous results"
+msgstr "Torna ai risultati precedenti"
+
+#: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
+msgid "Sample values"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
+msgid "Visualize"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
+msgid "Join data"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
+msgid "Custom column"
+msgstr "Colonna personalizzata"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
+msgid "Summarize"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
+msgid "Aggregate"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
+msgid "Breakout"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
+msgid "Pick the metric you want to see"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
+#: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
+msgid "Pick a column to group by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
+msgid "Pick your starting data"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select None"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select All"
+msgstr "Seleziona tutto"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
+msgid "Pick a table..."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
+msgid "Enter a limit"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
+msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
+msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
+msgid "View the native query"
+msgstr "Vedi la query originale"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
+msgid "Native query for this question"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
+msgid "Convert this question to a native query"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
+msgid "SQL for this question"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
+msgid "Convert this question to SQL"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
+msgid "Get alerts"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
+msgid "{0} breakout"
+msgid_plural "{0} breakouts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
+msgid "Hide filters"
+msgstr "Nascondi i filtri"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
+msgid "Show filters"
+msgstr "Mostra i filtri"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
+msgid "Started from"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
+msgid "{0} row"
+msgid_plural "{0} rows"
+msgstr[0] "{0} riga"
+msgstr[1] "{0} righe"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
+msgid "Show all rows"
+msgstr "Mostra tutte le righe"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
+msgid "Show {0}"
+msgstr "Mostra {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
+msgid "Showing first {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
+msgid "Showing {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
+msgid "Summarized"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Hide editor"
+msgstr "Nascondi l'editor"
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Show editor"
+msgstr "Mostra l'editor"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
+msgid "Pick the metric you'd like to see"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
+msgid "{0} options"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
+msgid "Choose a visualization"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
+msgid "Filter by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+msgid "Summarize by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+msgid "Group by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+msgid "Add a metric"
+msgstr ""
+
+#: frontend/src/metabase/user/components/UserSettings.jsx:57
+msgid "Profile"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:548
+msgid "This is usually pretty fast but seems to be taking a while right now."
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
+msgid "Combo"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
+msgid "Row"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
+msgid "Trend"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:129
+msgid "Boolean"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+msgid "Unknown Segment"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+msgid "Unknown Filter"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
+msgid "Left outer join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
+msgid "Right outer join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
+msgid "Inner join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
+msgid "Full outer join"
+msgstr ""
+
+#: src/metabase/api/card.clj
+msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
+msgstr ""
+
+#: src/metabase/api/session.clj
+msgid "Problem connecting to LDAP server, will fall back to local authentication"
+msgstr ""
+
+#: src/metabase/api/setup.clj
+msgid "Cannot create Database: cannot find driver {0}."
+msgstr ""
+
+#: src/metabase/api/tiles.clj
+msgid "Query failed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Warning: {0} returned `nil`"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing result to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing exception to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Request canceled, canceling future."
+msgstr ""
+
+#: src/metabase/cmd/load_from_h2.clj
+msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "Application database setup"
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Could not find {0} driver."
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Abstract drivers cannot derive from concrete parent drivers."
+msgstr ""
+
+#: src/metabase/driver/mysql.clj
+msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifer."
+msgstr ""
+
+#: src/metabase/driver/sql_jdbc/execute.clj
+msgid "Client closed connection, canceling query"
+msgstr ""
+
+#: src/metabase/integrations/ldap.clj
+msgid "{0} is not a valid DN."
+msgstr ""
+
+#: src/metabase/middleware/log.clj
+msgid "Error logging API request"
+msgstr ""
+
+#: src/metabase/middleware/misc.clj
+msgid "Failed to set site-url"
+msgstr ""
+
+#: src/metabase/models/database.clj
+msgid "Error destroying thread pool for DB."
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/models/task_history.clj src/metabase/sync/util.clj
+msgid "Error saving task history"
+msgstr ""
+
+#: src/metabase/plugins.clj
+msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
+msgstr ""
+
+#: src/metabase/plugins/classloader.clj
+msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
+msgstr ""
+
+#: src/metabase/plugins/files.clj
+msgid "Failed to copy file"
+msgstr ""
+
+#: src/metabase/public_settings.clj
+msgid "Invalid site URL: {0}"
+msgstr ""
+
+#: src/metabase/public_settings.clj
+msgid "site-url is invalid; returning nil for now. Will be reset on next request."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "More results have been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "This question has been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "We were unable to display this Pulse."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "Please view this card in Metabase."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "An error occurred while displaying this card."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Can only determine expected columns for MBQL queries."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "No columns returned."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot find Table ID for {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "No matching info found."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Could not resolve {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Invalid fk-> clause: nowhere to add corresponding join."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "{0} driver does not support foreign keys."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Query processor error: number of columns returned by driver does not match results."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Expected {0} columns, but first row of resuls has {1} columns."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "No expression named {0} found. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Distinct values of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Average of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "SD of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Min of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Max of {0}"
+msgstr ""
+
+#. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0} matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Share of rows matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Count of rows matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Request already canceled, will not run synchronous QP code."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unexpectedly got `nil` Query Processor response."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Got InterruptedException. Canceling query."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Query timed out after %s"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Creating new query thread pool for Database {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Destroying query thread pool for Database {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Request canceled, canceling pending query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: query is missing source-metadata"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Using query processor cache backend: {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/expand_macros.clj
+msgid "Invalid metric: {0} reason: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unknown error"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unexpected nil response from query processor."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Query canceled"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: Database {0} does not exist."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_source_table.clj
+msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Cannot store Tables or Fields before Database is stored."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Attempting to fetch second Database. Queries can only reference one Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
+msgstr ""
+
+#: src/metabase/routes/index.clj
+msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Sample dataset DB file ''{0}'' cannot be found."
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Loading sample dataset..."
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Failed to load sample dataset"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Found new tables:"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Marking tables as inactive:"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Updating description for tables:"
+msgstr ""
+
+#: src/metabase/task.clj
+msgid "Rescheduling job {0}"
+msgstr ""
+
+#: src/metabase/task.clj
+msgid "Error rescheduling job"
+msgstr ""
+
+#: src/metabase/task/send_pulses.clj
+msgid "Starting Pulse Execution: {0}"
+msgstr ""
+
+#: src/metabase/task/send_pulses.clj
+msgid "Finished Pulse Execution: {0}"
+msgstr ""
+
+#: src/metabase/task/sync_databases.clj
+msgid "Failed to schedule tasks for Database {0}"
+msgstr ""
+
+#: src/metabase/util/schema.clj
+msgid "All elements must be distinct."
+msgstr "All elements must be distinct.\n"
+""
+
+#: 
+msgctxt "Modal for selecting columns in source data or when doing a join."
+msgid "Pick the columns you want to include"
+msgstr "Scegli le colonne che desideri includere"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
+msgid "Change join type"
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifier."
+msgstr ""
+
+#: src/metabase/integrations/common.clj
+msgid "Error adding User {0} to Group {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Infinite loop detected: recursively preprocessed query {0} times."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Error determining expected columns for query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
+msgstr ""
 

--- a/locales/ja.po
+++ b/locales/ja.po
@@ -29,18 +29,19 @@ msgstr "このデータを詳しく見る"
 msgid "Select a database type"
 msgstr "データベースタイプを選択する"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:75
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:401
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:71
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:182
+#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:410
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:74
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:203
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:180
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:197
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:193
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:171
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:180
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:164
 msgid "Save"
 msgstr "保存"
@@ -60,7 +61,7 @@ msgid "This is a lightweight process that checks for\n"
 msgstr "データベーススキーマの更新チェックは軽量なプロセスです。ほとんどの場合、1時間ごとの同期で問題ありません。"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:184
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
 msgid "Scan"
 msgstr "スキャン"
 
@@ -76,126 +77,128 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabaseは、このデータベースの各フィールドの値をスキャンして、ダッシュボードや質問のチェックボックスフィルタを有効にすることができます。 データベースが非常に大きい場合は、ややリソースに負荷がかかる処理となります。"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:159
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "フィールド値のスキャンとキャッシュをいつ行いますか？"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:164
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
 msgstr "スケジュール通り定期的に行う"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:195
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
 msgstr "新しいフィルターウィジェットを追加したときのみ行う"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:199
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
-msgstr "ユーザーがダッシュボードまたはSQL質問に新しいフィルターを追加すると、Metabaseはそのフィルターにマップされたフィルターをスキャンし、選択可能な値一覧を表示します"
+msgstr "ユーザーがダッシュボードまたは質問に新しいフィルターを追加すると、Metabaseはそのフィルターにマップされたフィールドをスキャンし、選択可能な値一覧を表示します"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:210
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
 msgid "Never, I'll do this manually if I need to"
 msgstr "自動的に行わず、必要な時に手動設定する"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:222
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:222
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:426
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
 msgid "Saving..."
 msgstr "保存中..."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:39
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
 msgid "Server error encountered"
 msgstr "サーバエラーが発生しました"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:58
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
 msgstr "データベースを削除しますか？"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
 msgstr "保存された全ての質問、メトリクスおよびセグメントは、このデータベースが削除されると同時に削除されます。"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:67
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
 msgstr "この操作はやり直しできません。"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
 msgstr "間違いなければ入力してください。"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:53
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
 msgstr "削除"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:71
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
 msgstr "このテキストボックスに"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:82
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:50
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:93
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:58
-#: frontend/src/metabase/admin/permissions/selectors.js:160
-#: frontend/src/metabase/admin/permissions/selectors.js:170
-#: frontend/src/metabase/admin/permissions/selectors.js:185
-#: frontend/src/metabase/admin/permissions/selectors.js:224
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:355
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:181
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:247
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:61
+#: frontend/src/metabase/admin/permissions/selectors.js:163
+#: frontend/src/metabase/admin/permissions/selectors.js:173
+#: frontend/src/metabase/admin/permissions/selectors.js:188
+#: frontend/src/metabase/admin/permissions/selectors.js:227
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:202
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:268
+#: frontend/src/metabase/components/ArchiveModal.jsx:35
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
-#: frontend/src/metabase/components/form/StandardForm.jsx:61
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:196
+#: frontend/src/metabase/components/form/StandardForm.jsx:62
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:198
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:289
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:162
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:153
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:38
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:189
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:24
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:48
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:41
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:92
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:259
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:88
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:121
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:132
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
 msgstr "削除"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:128
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:74
-#: frontend/src/metabase/admin/permissions/selectors.js:320
-#: frontend/src/metabase/admin/permissions/selectors.js:327
-#: frontend/src/metabase/admin/permissions/selectors.js:423
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
+#: frontend/src/metabase/admin/permissions/selectors.js:323
+#: frontend/src/metabase/admin/permissions/selectors.js:330
+#: frontend/src/metabase/admin/permissions/selectors.js:426
 #: frontend/src/metabase/admin/routes.jsx:53
-#: frontend/src/metabase/nav/containers/Navbar.jsx:214
+#: frontend/src/metabase/nav/containers/Navbar.jsx:243
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
 msgstr "データベース"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:129
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
 msgstr "データベースを追加"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
 msgstr "接続"
@@ -204,107 +207,107 @@ msgstr "接続"
 msgid "Scheduling"
 msgstr "スケジューリング"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:78
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:84
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:26
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:221
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
 msgstr "変更を保存"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:185
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:38
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:38
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
 msgstr "アクション"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:193
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
 msgstr "今すぐデータベーススキーマと同期する"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:194
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:206
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:109
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
 msgstr "開始しています..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:195
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
 msgstr "同期に失敗しました"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
 msgstr "同期を開始しました！"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:205
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
 msgstr "フィールド値を再スキャンしています。"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:207
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
 msgstr "スキャンのスタートに失敗しました"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
 msgstr "スキャンを開始しました！"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:215
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:401
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
 msgstr "危険ゾーン"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:221
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
-msgstr "フィールド値を破棄する"
+msgstr "保存されたフィールド値を破棄する"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
 msgstr "このデータベースを削除する"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:73
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
 msgstr "データベースを追加"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:85
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:36
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:36
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:122
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:32
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:399
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:446
 #: frontend/src/metabase/containers/EntitySearch.jsx:26
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:218
-#: frontend/src/metabase/entities/collections.js:93
-#: frontend/src/metabase/entities/dashboards.js:145
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:461
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:81
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:220
+#: frontend/src/metabase/entities/collections.js:94
+#: frontend/src/metabase/entities/dashboards.js:142
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
 msgstr "名前"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:86
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
 msgstr "エンジン"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:115
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
 msgstr "削除中..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:145
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
 msgstr "読込中..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:161
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
 msgstr "サンプルデータセットを復元"
 
@@ -321,9 +324,9 @@ msgid "Successfully saved!"
 msgstr "保存されました！"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:177
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:197
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
 msgstr "編集"
@@ -332,86 +335,90 @@ msgstr "編集"
 msgid "Revision History"
 msgstr "履歴"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
 msgstr "{0}を放棄しますか？"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
-msgstr "保存した質問やその他情報は保持されますが、{1}はクエリビルダーから選択できなくなります。"
+msgstr "保存されている{0}に依存する質問やその他情報は保持されますが、{1}はクエリビルダーから選択できなくなります。"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
 msgstr "{0}を放棄して問題なければ、放棄する理由を簡単に説明してください。"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
 msgstr "{0}を使用して作成をした場合、アクティビティフィードと、あなたのチームに送信されるメールに表示されます。"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
 msgstr "放棄する"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
 msgstr "放棄中..."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
 msgstr "失敗"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
 msgstr "成功"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:91
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
+#: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "プレビュー"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
 msgstr "列説明はまだありません"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:135
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
 msgstr "フィールドの可視性を選択する"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:210
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
 msgstr "特別タイプなし"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:211
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:148
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
 msgstr "その他"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:231
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "特別タイプを選択する"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:277
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
 msgstr "ターゲットを選択する"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:77
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:89
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:106
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:122
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
 msgstr "列"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "列"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:121
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:306
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
 msgstr "可視性"
 
@@ -419,52 +426,52 @@ msgstr "可視性"
 msgid "Type"
 msgstr "タイプ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
 msgstr "現在のデータベース"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
 msgstr "元のスキーマを表示する"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:45
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
 msgstr "データタイプ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
 msgstr "付加情報"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
 msgstr "スキーマを見つける"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:51
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "{0} スキーマ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
 msgstr "なぜ非表示にしますか？"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
 msgstr "テクニカルデータ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
 msgstr "無関係/不正データ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
 msgid "Queryable"
 msgstr "利用可能"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:91
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
 msgstr "非表示"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
 msgstr "テーブルの説明はまだありません"
 
@@ -472,63 +479,65 @@ msgstr "テーブルの説明はまだありません"
 msgid "Metadata Strength"
 msgstr "メタデータ強度"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} 件の利用可能なテーブル"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:96
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} 非表示のテーブル"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
 msgstr "テーブルを探す"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
 msgstr "スキーマ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:24
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:137
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:68
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:56
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:190
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
 msgstr "メトリクス"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
 msgstr "メトリクスを追加する"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:37
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "定義"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "クエリビルダーの表示ドロップダウンにメトリクスを作成し追加する"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:24
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:930
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:952
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:56
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "セグメント"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
 msgstr "セグメントを追加する"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "クエリビルダーのフィルタードロップダウンにセグメントを作成し追加する"
 
@@ -556,53 +565,53 @@ msgstr "␣を編集する"
 msgid "made some changes"
 msgstr "変更されました"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
-#: frontend/src/metabase/home/components/Activity.jsx:80
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:332
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/home/components/Activity.jsx:82
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
 msgstr "あなた"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
 msgstr "データモデル"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
 msgstr "履歴"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:48
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
 msgstr "履歴"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:239
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
 msgstr "{0} - フィールド設定"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
 msgstr "Metabase上でフィールドが表示される箇所"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:329
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "このフィールドでフィルター設定しています"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "このフィールドでフィルター設定がされている場合、他ユーザーがフィルター設定したい値をどのように入力すればよいですか？"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:453
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "このフィールドには説明がまだありません"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:379
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
 msgstr "元の値"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:380
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
 msgid "Mapped value"
 msgstr "マップされた値"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:423
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
 msgstr "値を入力する"
 
@@ -619,7 +628,7 @@ msgid "Custom mapping"
 msgstr "カスタムマッピング"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:155
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
 msgid "Unrecognized mapping type"
 msgstr "マッピングタイプを識別できません"
 
@@ -627,23 +636,23 @@ msgstr "マッピングタイプを識別できません"
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "現在のフィールドは外部キーではないか、FKターゲットテーブルのメタデータがありません"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:187
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
 msgstr "選択されたフィールドは外部キーではありません"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:347
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
 msgstr "値を表示する"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:348
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "データベースから元の値を表示するか、このフィールドに関連する情報またはカスタム情報を表示するかを選択します。"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:268
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
 msgstr "フィールドを選択"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:289
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
 msgstr "表示に使用する列を選択してください。"
 
@@ -651,16 +660,16 @@ msgstr "表示に使用する列を選択してください。"
 msgid "Tip:"
 msgstr "ヒント:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
-msgstr "再マッピングの選択肢と内容が合うようにフィールド名を更新すると良いでしょう。"
+msgstr "再マッピングの選択と内容が合うようにフィールド名を更新すると良いでしょう。"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:364
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:102
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
 msgstr "フィールド値をキャッシュする"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:365
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabaseは、ダッシュボードまたは質問のチェックボックスを有効化するため、このフィールドの値をスキャンします"
 
@@ -669,167 +678,168 @@ msgid "Re-scan this field"
 msgstr "このフィールドを再スキャンする"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
 msgstr "キャッシュしたフィールド値を削除する"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:118
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
 msgstr "値の削除に失敗しました"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard triggered!"
 msgstr "削除されました！"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:105
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "テーブルを選択し、スキーマを見てメタデータを追加・編集する"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:37
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:34
-#: frontend/src/metabase/entities/collections.js:96
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "名前が必要です"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:40
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
 msgstr "説明が必要です"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:44
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:41
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
 msgstr "履歴メッセージが必要です"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:50
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
 msgstr "アグリゲーションが必要です"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
 msgstr "メトリクスを編集する"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
 msgstr "メトリクスを作成する"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:115
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "メトリクスを変更し注釈を加える"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "保存されたメトリクスを使用して、このテーブルに名前付きメトリクスオプションを追加することができます。 保存されたメトリクスには、集約タイプ、集約フィールド、およびオプションで追加するフィルタが含まれます。 たとえば、これを使用してOrdersテーブルの「平均価格」の公式な計算方法を作成することができます。"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
 msgstr "結果："
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
 msgstr "メトリクスに名前を付ける"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
 msgstr "他ユーザのためにメトリクスに名前を付ける"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:162
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
 msgstr "簡単な説明"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
 msgstr "メトリクスを説明する"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "他ユーザのためにメトリクスに説明を加える"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "メトリクスのルールについてより詳細な情報をこちらに記入してください"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:179
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
 msgstr "変更理由"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:177
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "変更箇所と変更理由を記入する"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "他ユーザーにも変更理由がわかるよう、このメトリクスの履歴に表示されます"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
 msgstr "最低1つのフィルターが必要です"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
 msgstr "セグメントを編集する"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
 msgstr "セグメントを作成する"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:121
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "セグメントを変更し注釈を加える"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "{0}テーブルの新しいセグメントを作成するためのフィルターを選択し追加する"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
 msgstr "セグメントに名前を付ける"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:162
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
 msgstr "他ユーザのためにセグメントを名前を付ける"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:170
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
 msgstr "セグメントを説明する"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "他ユーザーのためにセグメントに説明を加える"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:175
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "セグメントのルールについてより詳細な情報をこちらに記入してください"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:185
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "他ユーザーにも変更理由がわかるよう、このセグメントの履歴に表示されます"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:266
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:87
-#: frontend/src/metabase/nav/containers/Navbar.jsx:199
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:269
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:91
+#: frontend/src/metabase/nav/containers/Navbar.jsx:228
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
 msgstr "設定"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:103
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabaseは、ダッシュボードまたは質問のチェックボックスを有効化するため、このテーブルの値をスキャンします"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:108
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
 msgstr "このテーブルを再スキャンする"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:253
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
 msgstr "追加"
 
@@ -838,20 +848,22 @@ msgstr "追加"
 msgid "Not a valid formatted email address"
 msgstr "有効なメールアドレスではありません"
 
+#: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:100
 msgid "First name"
 msgstr "名"
 
+#: frontend/src/metabase/entities/users.js:42
 #: frontend/src/metabase/setup/components/UserStep.jsx:203
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:117
 msgid "Last name"
 msgstr "姓"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:77
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:158
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:161
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:470
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:481
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
@@ -865,34 +877,35 @@ msgstr "承認グループ"
 msgid "Make this user an admin"
 msgstr "このユーザを管理者にする"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:32
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
-msgstr "全てのユーザーは{0}グループに属しており、そのグループから削除することはできません。 このグループの権限を設定することで、新しいMetabseユーザーの閲覧可能範囲を確認することができます。"
+msgstr "全てのユーザーは{0}グループに属しており、そのグループから削除することはできません。 このグループの権限を設定することで、新しいMetabaseユーザーの閲覧可能範囲を確認することができます。"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:41
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
 msgstr "これは、メンバーがMetabaseインスタンス内の全データを参照できるだけでなく、権限の変更などを含む管理者パネルの設定ができる特別なグループです。このグループにメンバーを追加する場合は、十分にご注意ください。"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:45
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
 msgstr "Metabaseからロックアウトされないため、このグループには最低1ユーザーの登録が必要です"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
 msgstr "メンバー"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:124
-#: frontend/src/metabase/admin/settings/selectors.js:113
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
+#: frontend/src/metabase/admin/settings/selectors.js:110
+#: frontend/src/metabase/entities/users.js:50
 #: frontend/src/metabase/lib/core.js:55
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
 msgstr "メール"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:203
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
 msgstr "グループもそのメンバーもどちらも大事です。"
 
@@ -903,8 +916,8 @@ msgid "Admin"
 msgstr "管理者"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:237
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:290
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
 msgstr "そして"
 
@@ -932,13 +945,13 @@ msgid "Are you sure? All members of this group will lose any permissions setting
 msgstr "よろしいですか？このグループの全メンバーが。この操作はやり直すことができません。"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
 msgstr "はい"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
 msgstr "いいえ"
 
@@ -957,10 +970,11 @@ msgstr "グループを削除する"
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:107
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:327
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:395
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:265
+#: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
 msgstr "完了"
 
@@ -970,9 +984,9 @@ msgstr "グループ名"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:131
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:88
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
 msgstr "グループ"
 
@@ -982,7 +996,7 @@ msgstr "グループを作成する"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:370
 msgid "You can use groups to control your users' access to your data. Put users in groups and then go to the Permissions section to control each group's access. The Administrators and All Users groups are special default groups that can't be removed."
-msgstr "グループを使用して、ユーザーのデータへのアクセスを管理することができます。 ユーザーをグループに入れた後、権限のセクションに移動して各グループのアクセスを管理してください。 管理者グループと全ユーザーグループは、削除できない特殊なデフォルトグループです。"
+msgstr "グループを使用して、ユーザーのデータへのアクセスを管理することができます。 ユーザーをグループに入れた後、権限のセクションに移動して各グループのアクセスを管理してください。 管理者グループとAll Users グループは、削除できない特殊なデフォルトグループです。"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:79
 msgid "Edit Details"
@@ -1001,9 +1015,9 @@ msgid "Deactivate"
 msgstr "無効化"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:93
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
-#: frontend/src/metabase/nav/containers/Navbar.jsx:204
+#: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
 msgstr "ユーザー"
 
@@ -1043,7 +1057,6 @@ msgid "We've re-sent {0}'s invite"
 msgstr "招待メールを{0}に再送しました"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
-#: frontend/src/metabase/tutorial/Tutorial.jsx:253
 msgid "Okay"
 msgstr "確認しました"
 
@@ -1075,13 +1088,13 @@ msgstr "ログインが可能になり、無効化される前のグループに
 msgid "Reset {0}'s password?"
 msgstr "{0}のパスワードをリセットしますか？"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:77
+#: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
 msgstr "リセットする"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:44
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
 msgstr "よろしいですか？"
 
@@ -1097,75 +1110,77 @@ msgstr "この仮パスワードでログインし、パスワードを変更し
 msgid "We've sent them an email with instructions for creating a new password."
 msgstr "新しいパスワードの作成方法を記載したメールを送信しました"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:101
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
 msgstr "有効化する"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:127
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
 msgstr "無効化する"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:115
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
 msgstr "追加する"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
 msgstr "最終ログイン"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:153
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
 msgstr "Googleを利用して登録する"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:158
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
-msgstr "LDAPを利用して登録する"
+msgstr "LDAP経由で登録されました"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:170
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
 msgstr "このアカウントを再有効化する"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:193
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
 msgstr "しない"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:27
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
 msgstr[0] "{0}テーブル"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:45
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
 msgstr "␣は␣になります"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:48
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
 msgstr "にアクセスを付与する"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:53
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
 msgstr "␣と␣"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:56
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
 msgstr "拒否されたアクセス"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:70
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
 msgstr "␣はこれ以降␣できません"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:71
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
 msgstr "␣は␣できます"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:79
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
 msgstr "のネイティブクエリ"
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
-#: frontend/src/metabase/nav/containers/Navbar.jsx:219
+#: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
 msgstr "権限"
 
@@ -1190,15 +1205,15 @@ msgstr "権限は変更されません"
 msgid "You've made changes to permissions."
 msgstr "権限が変更されました"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:52
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
 msgstr "このコレクションの権限"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
 msgstr "保存されていない変更があります"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:54
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
 msgstr "変更を破棄してこのページから離れますか？"
 
@@ -1212,125 +1227,125 @@ msgstr "管理者にはMetabaseの全データへのアクセス権限があり�
 
 #: frontend/src/metabase/admin/permissions/selectors.js:67
 msgid "Every Metabase user belongs to the All Users group. If you want to limit or restrict a group's access to something, make sure the All Users group has an equal or lower level of access."
-msgstr "全てのMetabseユーザーは、全ユーザーグループに属します。 グループへのアクセスを制限またはブロックする場合は、全ユーザーグループのアクセスレベルが同等かそれ以下であることをご確認ください。"
+msgstr "全てのMetabaseユーザーは、All Users グループに属します。 グループへのアクセスを制限またはブロックする場合は、All Users グループのアクセスレベルが同等かそれ以下であることをご確認ください。"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:69
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
-msgstr "MetaBotはMetabseのSlackボットです。 ここにアクセスできるものを選択できます。"
+msgstr "MetaBotはMetabaseのSlackボットです。 ここにアクセスできるものを選択できます。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:119
+#: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
 msgstr "\"{0}\"グループは、このグループとは異なる{1}セットにアクセスする可能性があります。その場合、{0}グループには{2}への追加アクセス権が与えられます。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:124
+#: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
 msgstr "\"{0}\"グループのアクセスレベルはこれより高くなり、この設定が上書きされます。 \"{1}\"グループのこのアイテムへのアクセスをブロックまたは取り消す必要があります。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
 msgstr "制限する"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
 msgstr "無効にする"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:156
+#: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
 msgstr "{0}の方がより広いアクセス権限を持っていますが、アクセスを"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:258
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
 msgstr "アクセスを制限する"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:223
-#: frontend/src/metabase/admin/permissions/selectors.js:266
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:226
+#: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
 msgstr "アクセスを無効にする"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:168
+#: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
 msgstr "このデータベースへのアクセスを制限しますか？"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:169
+#: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
 msgstr "変更する"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:182
+#: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
 msgstr "ロークエリの作成を許可しますか？"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:183
+#: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
 msgstr "このグループのデータベースへのアクセス権が「無制限」に変更されます。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:184
+#: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
 msgstr "許可する"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:221
+#: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
 msgstr "すべてのテーブルへのアクセスを無効にしますか？"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:222
+#: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
 msgstr "このグループのデータベースのロークエリへのアクセスも取り消されます。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:251
+#: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
 msgstr "無制限のアクセスを許可する"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:252
+#: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
 msgstr "無制限のアクセス"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:259
+#: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
 msgstr "制限されたアクセス"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:267
+#: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
 msgstr "アクセスがありません"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:273
+#: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
 msgstr "ロークエリを書く"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:274
+#: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
 msgstr "ロークエリを書くことができる"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:281
+#: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
 msgstr "コレクションを公開する"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:288
+#: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
 msgstr "コレクションを見る"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:331
-#: frontend/src/metabase/admin/permissions/selectors.js:427
-#: frontend/src/metabase/admin/permissions/selectors.js:524
+#: frontend/src/metabase/admin/permissions/selectors.js:334
+#: frontend/src/metabase/admin/permissions/selectors.js:430
+#: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
 msgstr "データアクセス"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:492
-#: frontend/src/metabase/admin/permissions/selectors.js:649
-#: frontend/src/metabase/admin/permissions/selectors.js:654
+#: frontend/src/metabase/admin/permissions/selectors.js:495
+#: frontend/src/metabase/admin/permissions/selectors.js:652
+#: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
 msgstr "テーブルを見る"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:590
+#: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
 msgstr "SQLクエリ"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:660
+#: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
 msgstr "スキーマを見る"
 
 #: frontend/src/metabase/admin/routes.jsx:59
-#: frontend/src/metabase/nav/containers/Navbar.jsx:209
+#: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
 msgstr "データモデル"
 
@@ -1339,30 +1354,30 @@ msgstr "データモデル"
 msgid "Sign in with Google"
 msgstr "Googleを利用してサインインする"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:13
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
 msgstr "Metabaseアカウント保有者に、Metabaseユーザーネームとパスワード以外に、登録されたメールアドレスと一致するGoogleアカウントでログインすることを許可する"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:17
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
 msgstr "設定"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
-#: frontend/src/metabase/admin/settings/selectors.js:207
+#: frontend/src/metabase/admin/settings/selectors.js:204
 msgid "LDAP"
 msgstr "LDAP"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:25
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
 msgstr "LDAPディレクトリ内のユーザーに対し、LDAP資格情報によるMetabaseへのログインを許可し、LDAPグループをMetabaseグループに自動的にマッピングできるようにする。"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
-#: frontend/src/metabase/admin/settings/selectors.js:160
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
 msgstr "有効なメールアドレスではありません"
 
@@ -1400,7 +1415,7 @@ msgstr "クリア"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:202
+#: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
 msgstr "認証"
 
@@ -1462,23 +1477,23 @@ msgstr "MetaBotのSlack Botユーザーを作成する"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
-msgstr "名前を付けて{0}をクリックします。 ボットAPIトークンをコピーし、下のフィールドに貼り付けます。 完了したら、Slackで \"metabase_files\"チャンネルを作成します。 これはMetabseでグラフをアップロードするために必要な作業です。"
+msgstr "名前を付けて{0}をクリックします。 ボットAPIトークンをコピーし、下のフィールドに貼り付けます。 完了したら、Slackで \"metabase_files\"チャンネルを作成します。 これはMetabaseでグラフをアップロードするために必要な作業です。"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:90
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
 msgstr "お使いのMetabase {0}は最新です"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:99
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
-msgstr "Metabse {0}が利用可能です。現在{1}を利用中です。"
+msgstr "Metabase {0}が利用可能です。現在{1}を利用中です。"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:112
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
 msgstr "アップデートする"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:116
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
 msgstr "変更箇所："
 
@@ -1491,80 +1506,80 @@ msgstr "マップを追加する"
 msgid "URL"
 msgstr "URL"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:199
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
 msgstr "カスタムマップを削除する"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:327
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:40
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:181
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
 msgstr "削除する"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:226
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:187
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:241
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:246
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
 msgstr "選択..."
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:241
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
 msgstr "サンプル値："
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
 msgstr "新しいマップを追加する"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
 msgstr "マップを編集する"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:280
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
 msgstr "このマップを何と呼びますか？"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
 msgstr "例：イギリス、ブラジル、火星"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:292
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
 msgstr "使用したいGeoJSONファイルのURL"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:298
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
 msgstr "例：https://my-mb-server.com/maps/my-map.json"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:33
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
 msgstr "更新"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
 msgstr "読み込み"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:315
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
 msgstr "地域の識別子を指定するプロパティはどれですか？"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:324
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
 msgstr "地域の表示名を指定するプロパティはどれですか？"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:345
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
 msgstr "GeoJSONファイルを読み込み、プレビューを表示する"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
 msgstr "マップを保存する"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
 msgstr "マップを追加する"
 
@@ -1576,11 +1591,11 @@ msgstr "埋め込みを利用中"
 msgid "By enabling embedding you're agreeing to the embedding license located at"
 msgstr "埋め込みを有効にすると、␣にある埋め込みライセンスに同意します。"
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:19
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
 msgstr "Metabaseから独自のアプリケーションに図やダッシュボードを埋め込むと、Metabaseのロゴと「Powered by Metabase」が埋め込まれている場合には、そのアプリケーションはMetabaseの残りの部分をカバーするAffero General Public Licenseの対象になりません。ただし、上記リンク先のライセンステキストを必ずお読みください。このライセンステキストは、この機能を有効し同意する際と同じ内容になっています。"
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:32
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
 msgstr "有効化する"
 
@@ -1590,11 +1605,11 @@ msgstr "プレミアム埋め込みが有効化された"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:26
 msgid "Enter the token you bought from the Metabase Store"
-msgstr "Metabse Storeから購入したトークンを入力する"
+msgstr "Metabase Storeから購入したトークンを入力する"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:53
 msgid "Premium embedding lets you disable \"Powered by Metabase\" on your embedded dashboards and questions."
-msgstr "プレミアム埋め込みを利用すると、埋め込みされたダッシュボードや質問の「Powered by Metabse」という表示を無効化することができます"
+msgstr "プレミアム埋め込みを利用すると、埋め込みされたダッシュボードや質問の「Powered by Metabase」という表示を無効化することができます"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:60
 msgid "Buy a token"
@@ -1604,25 +1619,25 @@ msgstr "トークンを購入する"
 msgid "Enter a token"
 msgstr "トークンを入力する"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:134
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
 msgstr "マッピングを編集する"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:140
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
 msgstr "グループマッピング"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:147
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
 msgstr "マッピングを作成する"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
 msgstr "マッピングをすると、ディレクトリサーバーから提供される利用者情報に基づいて、グループからユーザーを自動的に追加または削除することができます。管理者グループへのメンバーシップはマッピングを介して付与できますが、フェイルセーフ対策として自動的に削除されることはありません。"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
 msgstr "識別名"
 
@@ -1634,43 +1649,43 @@ msgstr "公開リンク"
 msgid "Revoke Link"
 msgstr "リンクを無効にする"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:121
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
 msgstr "このリンクを無効化しますか？"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:122
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
 msgstr "作動ならびに復元はできません。ただし新しいリンクを作成することができます。"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
 msgstr "ダッシュボード一覧を公開する"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:152
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
 msgstr "公開されたダッシュボードがまだありません"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:160
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
 msgstr "カード一覧を公開する"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:163
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
 msgstr "公開された質問はまだありません。"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:172
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
 msgstr "埋め込みダッシュボード一覧"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
 msgstr "埋め込みされたダッシュボードはまだありません"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:183
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
 msgstr "埋め込みカード一覧"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:184
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
 msgstr "埋め込みされた質問はまだありません"
 
@@ -1691,18 +1706,17 @@ msgid "Generate Key"
 msgstr "キーを発行する"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:78
-#: frontend/src/metabase/admin/settings/selectors.js:87
+#: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
 msgstr "有効"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:83
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:103
+#: frontend/src/metabase/admin/settings/selectors.js:82
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "無効"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:116
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
 msgstr "不明な設定{0}"
 
@@ -1710,7 +1724,7 @@ msgstr "不明な設定{0}"
 msgid "Setup"
 msgstr "設定"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
 msgstr "一般"
@@ -1739,11 +1753,11 @@ msgstr "データベースのデフォルト"
 msgid "Select a timezone"
 msgstr "タイムゾーンを選択する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:55
+#: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "すべてのデータベースがタイムゾーンをサポートしているわけではありません。この場合、この設定は有効になりません。"
 
-#: frontend/src/metabase/admin/settings/selectors.js:60
+#: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
 msgstr "言語"
 
@@ -1751,202 +1765,202 @@ msgstr "言語"
 msgid "Select a language"
 msgstr "言語を選択する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:70
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
 msgstr "匿名のトラッキング"
 
-#: frontend/src/metabase/admin/settings/selectors.js:75
+#: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
 msgstr "わかりやすいテーブル名とフィールド名"
 
-#: frontend/src/metabase/admin/settings/selectors.js:81
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
 msgstr "アンダースコアとダッシュをスペースに置き換える"
 
-#: frontend/src/metabase/admin/settings/selectors.js:91
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
 msgstr "ネスト化したクエリを有効化する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:102
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
 msgstr "アップデート"
 
-#: frontend/src/metabase/admin/settings/selectors.js:107
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
 msgstr "アップデートを確認する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:118
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
 msgstr "SMTPホスト"
 
-#: frontend/src/metabase/admin/settings/selectors.js:126
+#: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
 msgstr "SMTPポート"
 
-#: frontend/src/metabase/admin/settings/selectors.js:130
-#: frontend/src/metabase/admin/settings/selectors.js:230
+#: frontend/src/metabase/admin/settings/selectors.js:127
+#: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
 msgstr "無効なポート番号です"
 
-#: frontend/src/metabase/admin/settings/selectors.js:134
+#: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
 msgstr "SMTPセキュリティ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:142
+#: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
 msgstr "SMTPユーザーネーム"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
 msgstr "SMTPパスワード"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
 msgstr "送信元アドレス"
 
-#: frontend/src/metabase/admin/settings/selectors.js:170
+#: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
 msgstr "Slack APIトークン"
 
-#: frontend/src/metabase/admin/settings/selectors.js:172
+#: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
 msgstr "Slackから受け取ったトークンを入力する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:189
+#: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
 msgstr "シングルサインオン(SSO)"
 
-#: frontend/src/metabase/admin/settings/selectors.js:213
+#: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
 msgstr "LDAP認証"
 
-#: frontend/src/metabase/admin/settings/selectors.js:219
+#: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
 msgstr "LDAPホスト"
 
-#: frontend/src/metabase/admin/settings/selectors.js:227
+#: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
 msgstr "LDAPポート"
 
-#: frontend/src/metabase/admin/settings/selectors.js:234
+#: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
 msgstr "LDAPセキュリティ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
 msgstr "ユーザーネームまたはDN"
 
-#: frontend/src/metabase/admin/settings/selectors.js:247
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:188
-#: frontend/src/metabase/user/components/UserSettings.jsx:72
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:191
+#: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
 msgstr "パスワード"
 
-#: frontend/src/metabase/admin/settings/selectors.js:252
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "User search base"
 msgstr "ユーザー検索ベース"
 
-#: frontend/src/metabase/admin/settings/selectors.js:258
+#: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
 msgstr "ユーザーフィルター"
 
-#: frontend/src/metabase/admin/settings/selectors.js:264
+#: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
 msgstr "かっこを確認する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:270
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
 msgstr "メール属性"
 
-#: frontend/src/metabase/admin/settings/selectors.js:275
+#: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
 msgstr "名の属性"
 
-#: frontend/src/metabase/admin/settings/selectors.js:280
+#: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
 msgstr "姓の属性"
 
-#: frontend/src/metabase/admin/settings/selectors.js:285
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
 msgstr "グループメンバーを同期する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:291
+#: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
 msgstr "グループ検索ベース"
 
-#: frontend/src/metabase/admin/settings/selectors.js:300
+#: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
 msgstr "マップ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
 msgstr "マップタイルサーバーのURL"
 
-#: frontend/src/metabase/admin/settings/selectors.js:306
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabaseはデフォルト設定でOpenStreetMapsを使用します"
 
-#: frontend/src/metabase/admin/settings/selectors.js:311
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
 msgstr "カスタムマップ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:312
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "独自のGeoJSONファイルを追加して、異なるリージョンマップのビジュアライゼーションを可能にする"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
 msgstr "公開"
 
-#: frontend/src/metabase/admin/settings/selectors.js:336
+#: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
 msgstr "公開を有効化する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:341
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
 msgstr "公開されたダッシュボード"
 
-#: frontend/src/metabase/admin/settings/selectors.js:347
+#: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
 msgstr "公開された質問"
 
-#: frontend/src/metabase/admin/settings/selectors.js:354
+#: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
 msgstr "他アプリケーションに埋め込む"
 
-#: frontend/src/metabase/admin/settings/selectors.js:381
+#: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "他アプリケーションへのMetabaseの埋め込みを有効化する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:391
+#: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
 msgstr "秘密キーを埋め込む"
 
-#: frontend/src/metabase/admin/settings/selectors.js:397
+#: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
 msgstr "埋め込みダッシュボード"
 
-#: frontend/src/metabase/admin/settings/selectors.js:403
+#: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
 msgstr "埋め込み質問"
 
-#: frontend/src/metabase/admin/settings/selectors.js:410
+#: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
 msgstr "キャッシュ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:415
+#: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
 msgstr "キャッシュを有効化する"
 
-#: frontend/src/metabase/admin/settings/selectors.js:420
+#: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
 msgstr "最低クエリ期間"
 
-#: frontend/src/metabase/admin/settings/selectors.js:427
+#: frontend/src/metabase/admin/settings/selectors.js:424
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "キャッシュTTL乗数"
 
-#: frontend/src/metabase/admin/settings/selectors.js:434
+#: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
 msgstr "最大キャッシュエントリーサイズ"
 
@@ -1962,11 +1976,11 @@ msgstr "アラートがアップデートされました"
 msgid "The alert was successfully deleted."
 msgstr "アラートが削除されました"
 
-#: frontend/src/metabase/auth/auth.js:33
+#: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
 msgstr "有効なメールアドレスを入力してください"
 
-#: frontend/src/metabase/auth/auth.js:116
+#: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
@@ -2008,90 +2022,87 @@ msgstr "パスワードリセットのメールを送信する"
 msgid "Check your email for instructions on how to reset your password."
 msgstr "パスワードのリセット方法についてはメールをご確認ください"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:128
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
 msgstr "Metabaseにサインインする"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:138
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
 msgstr "または"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:157
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
 msgstr "ユーザーネームまたはメールアドレス"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:217
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
 msgstr "サインイン"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:230
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
 msgstr "パスワードを忘れてしまいました"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
 msgstr "パスワードリセットのメールをリクエストする"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:120
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
 msgstr "このリンクは有効期限切れです"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:122
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
 msgstr "セキュリティの理由により、パスワードリセットのリンクは一定期間を過ぎると無効となります。パスワードリセットが必要な場合は、{0}ができます"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:147
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
 msgstr "新しいパスワード"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:149
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
 msgstr "データを安全に保つため、パスワードは{0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:163
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
 msgstr "新しいパスワードを作成する"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:170
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:141
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
 msgstr "設定方法に従いセキュリティ度の高いパスワードを設定してください"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:184
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:150
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
 msgstr "新しいパスワードの確認"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:191
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:159
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
 msgstr "上記で入力したパスワードと同じものを入力してください"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:216
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
 msgstr "パスワードがリセットされました"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:222
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:227
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
 msgstr "新しいパスワードでサインインする"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:182
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:251
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "保存が失敗しました"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:183
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:129
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:225
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:252
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
 msgstr "保存されました"
 
@@ -2099,24 +2110,22 @@ msgstr "保存されました"
 msgid "Ok"
 msgstr "確認しました"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:38
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
 msgstr "このコレクションをアーカイブしますか？"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:43
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "このコレクション内のダッシュボード、コレクション、パルスもアーカイブされます"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
-#: frontend/src/metabase/components/CollectionLanding.jsx:624
+#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: frontend/src/metabase/components/CollectionLanding.jsx:620
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:47
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:195
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:200
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:40
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:53
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
 msgstr "アーカイブ"
@@ -2125,28 +2134,27 @@ msgstr "アーカイブ"
 msgid "This {0} has been archived"
 msgstr "この{0}はアーカイブされました"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:715
+#: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
 msgstr "アーカイブを見る"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:43
+#: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
 msgstr "この[0}のアーカイブを取り消す"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:70
-#: frontend/src/metabase/components/BrowseApp.jsx:132
-#: frontend/src/metabase/components/BrowseApp.jsx:225
+#: frontend/src/metabase/components/BrowseApp.jsx:39
+#: frontend/src/metabase/components/BrowseApp.jsx:102
+#: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
 msgstr "データ"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:169
+#: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
 msgstr "このテーブルを自動探査(X-ray)する"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:183
-#: frontend/src/metabase/containers/Overworld.jsx:246
+#: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
 msgstr "このテーブルについて詳細を見る"
 
@@ -2164,31 +2172,31 @@ msgstr "保存されました！"
 msgid "Saving failed."
 msgstr "保存が失敗しました"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
 msgstr "日"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
 msgstr "月"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
 msgstr "火"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
 msgstr "水"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
 msgstr "木"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
 msgstr "金"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
 msgstr "土"
 
@@ -2233,60 +2241,60 @@ msgstr "パルスを利用することで、メールやスラックを通じて
 msgid "Questions are a saved look at your data."
 msgstr "データのクエリは質問として保存されました"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:287
+#: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
 msgstr "固定"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:341
+#: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
 msgstr "ドラッグしてトップに固定してください"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:737
-#: frontend/src/metabase/components/CollectionLanding.jsx:353
-#: frontend/src/metabase/home/containers/SearchApp.jsx:35
-#: frontend/src/metabase/home/containers/SearchApp.jsx:92
+#: frontend/src/metabase/admin/permissions/selectors.js:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:352
+#: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
 msgstr "コレクション"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:432
-#: frontend/src/metabase/components/CollectionLanding.jsx:455
+#: frontend/src/metabase/components/CollectionLanding.jsx:431
+#: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
 msgstr "固定を外すにはドラッグしてください"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:490
+#: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
 msgstr[0] "{0}アイテムが選択されました"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:522
+#: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
 msgstr "{0}アイテムを移動しますか？"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:523
+#: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
 msgstr "{0}を移動しますか？"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:631
+#: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
 msgstr "移動する"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:692
+#: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
 msgstr "このコレクションを編集する"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:700
+#: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
 msgstr "このコレクションをアーカイブする"
 
-#: frontend/src/metabase/components/CollectionList.jsx:64
-#: frontend/src/metabase/entities/collections.js:155
+#: frontend/src/metabase/components/CollectionList.jsx:67
+#: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
 msgstr "個人のコレクション"
 
-#: frontend/src/metabase/components/CollectionList.jsx:106
+#: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
 msgstr "新しいコレクション"
 
@@ -2294,84 +2302,85 @@ msgstr "新しいコレクション"
 msgid "Copied!"
 msgstr "コピーされました"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:216
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
 msgstr "データベース接続にSSHトンネルを利用する"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
 msgstr "一部のデータベースインストールは、SSHホストを介して接続することによってのみアクセスできます。VPNが利用できない場合、このオプションを使用することでセキュリティーレベルを高めることができます。この機能を有効にすると直接接続するよりも動作が遅くなりことがあります。"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:271
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "データベースが大きいため、Metabaseの同期とスキャンのタイミングを選択します"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:273
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Metabaseはフィールド値に対し1時間毎のクイックスキャンと毎日のフルスキャンを行うようデフォルトで設定されています。データーベースが大きい場合、この設定をオンにし、いつどのようにフィールド値のスキャンをするか確認することをお勧めします。"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:289
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "クライアントIDとクライアントシークレットを作成するには{0}してください"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:291
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:353
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
 msgstr "こちらをクリックしてください"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "アプリケーションタイプは「その他」を選択してください。名前は自由に付けられます。"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:316
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
 msgstr "認証コードを取得するため{0}"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:328
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
 msgstr "Googleドライブ権限で"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:348
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "このデータでMetabaseを利用するには、Google Developers ConsoleのAPIアクセスを有効化する必要があります"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:351
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "有効化していない場合は、Consoleで{0}してください"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
 msgstr "どのようにこのデータベースを参照しますか？"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:427
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:237
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:188
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:74
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:194
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:79
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
 msgstr "次へ"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:52
+#: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
 msgstr "この{0}を削除する"
 
-#: frontend/src/metabase/components/EntityItem.jsx:43
+#: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
 msgstr "このアイテムを固定する"
 
-#: frontend/src/metabase/components/EntityItem.jsx:49
+#: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
 msgstr "このアイテムを移動する"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
 msgstr "この質問を編集する"
 
@@ -2384,6 +2393,7 @@ msgstr "アクションタイプ"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
 msgstr "履歴を見る"
 
@@ -2399,8 +2409,7 @@ msgstr "アクションをアーカイブする"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:329
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:342
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
 msgstr "ダッシュボードに追加する"
 
@@ -2424,13 +2433,12 @@ msgstr "他のアクションタイプ"
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:449
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:454
 msgid "Get alerts about this"
 msgstr "これに関するアラートを受け取る"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
 msgstr "SQLを見る"
 
@@ -2450,43 +2458,43 @@ msgstr "エラーメッセージ全文です"
 msgid "Hi, Metabot here."
 msgstr "こんにちは、Metabotです"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:95
+#: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
 msgstr "スキーマに基づく"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:174
+#: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
 msgstr "見てみる"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:234
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
 msgstr "一覧を検索する"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:238
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
 msgstr "{0}で検索する"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
 msgstr "␣またはIDを入力する"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
 msgstr "IDを入力する"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
 msgstr "番号を入力する"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:248
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
 msgstr "テキストを入力する"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:355
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
 msgstr "一致する{0}が見つかりませんでした"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:363
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "フィルターに全てのオプションを含めてしまうと、効果的な結果が得られない場合があります"
 
@@ -2502,17 +2510,17 @@ msgstr "エラーが発生しました。このページを更新するか、前
 #: frontend/src/metabase/components/HeaderBar.jsx:45
 #: frontend/src/metabase/components/ListItem.jsx:37
 #: frontend/src/metabase/reference/components/Detail.jsx:47
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:158
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:213
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:191
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:205
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:209
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:209
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:161
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:216
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:194
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:208
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
 msgstr "まだ説明がありません"
 
 #: frontend/src/metabase/components/Header.jsx:112
-#: frontend/src/metabase/entities/containers/EntityForm.jsx:43
+#: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
 msgstr "新しい{0}"
 
@@ -2520,54 +2528,53 @@ msgstr "新しい{0}"
 msgid "Asked by {0}"
 msgstr "{0}により質問された"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:13
+#: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
 msgstr "本日は、"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:15
+#: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
 msgstr "昨日は、"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:68
+#: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
 msgstr "最初の履歴"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:70
+#: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
 msgstr "以前の履歴と{0}に戻しました"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:82
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:289
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:379
-#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
+#: frontend/src/metabase/components/HistoryModal.jsx:42
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
+#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
 msgstr "履歴"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:90
+#: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
 msgstr "いつ"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:91
+#: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
 msgstr "誰が"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:92
+#: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
 msgstr "何を"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:113
+#: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
 msgstr "元に戻す"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:114
+#: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
 msgstr "元に戻しています..."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:115
+#: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
 msgstr "元に戻すことができませんでした"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:116
+#: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
 msgstr "元に戻しました"
 
@@ -2576,26 +2583,24 @@ msgid "Everything"
 msgstr "全て"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
-#: frontend/src/metabase/home/containers/SearchApp.jsx:69
 msgid "Dashboards"
 msgstr "ダッシュボード"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
-#: frontend/src/metabase/home/containers/SearchApp.jsx:115
 msgid "Questions"
 msgstr "質問"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:321
+#: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
 msgstr "パルス"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:103
+#: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
 msgstr "戻る"
 
-#: frontend/src/metabase/components/ListSearchField.jsx:18
+#: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
 msgstr "探す..."
 
@@ -2632,14 +2637,14 @@ msgid "Temporary Password"
 msgstr "仮パスワード"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
 msgstr "非表示にする"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:412
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
 msgstr "表示する"
 
@@ -2657,7 +2662,7 @@ msgstr "今はしない"
 
 #: frontend/src/metabase/components/SaveStatus.jsx:53
 msgid "Error:"
-msgstr "エラー："
+msgstr "エラー:"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:23
 msgid "Sunday"
@@ -2704,7 +2709,7 @@ msgstr "15日（中日）"
 msgid "Calendar Day"
 msgstr "カレンダー日"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:210
+#: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
 msgstr "Metabaseのタイムゾーン"
 
@@ -2733,11 +2738,11 @@ msgid "A component used to make a selection"
 msgstr "選択に使用された要素"
 
 #: frontend/src/metabase/components/Select.info.js:20
-#: frontend/src/metabase/components/Select.info.js:28
+#: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
 msgstr "選択されました"
 
-#: frontend/src/metabase/components/Select.jsx:297
+#: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
 msgstr "選択するものがありません"
 
@@ -2750,7 +2755,7 @@ msgid "Unknown error encountered"
 msgstr "不明エラーが発生しました"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/nav/containers/Navbar.jsx:304
+#: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
 msgstr "作成する"
 
@@ -2759,13 +2764,11 @@ msgid "Create dashboard"
 msgstr "ダッシュボードを作成する"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:331
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:60
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
 msgstr "テーブル"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:306
 msgid "Database"
 msgstr "ダッシュボード"
 
@@ -2773,22 +2776,20 @@ msgstr "ダッシュボード"
 msgid "Creator"
 msgstr "作成者"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:238
+#: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
 msgstr "結果が見つかりませんでした"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:239
+#: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
 msgstr "お探しのデータを見つけるためフィルターの調整をお試しください"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:258
+#: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
 msgstr "で見る"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:494
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:84
-#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:69
-#: frontend/src/metabase/tutorial/TutorialModal.jsx:34
+#: frontend/src/metabase/containers/EntitySearch.jsx:495
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
 msgstr "の"
 
@@ -2801,13 +2802,13 @@ msgid "Once you connect your own data, I can show you some automatic exploration
 msgstr "データを接続すると、X線と呼ばれる自動探査を表示できます。サンプルデータの例をいくつか表示します。"
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
-#: frontend/src/metabase/containers/Overworld.jsx:299
+#: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
 msgstr "ここから開始する"
 
-#: frontend/src/metabase/containers/Overworld.jsx:294
-#: frontend/src/metabase/entities/collections.js:147
+#: frontend/src/metabase/containers/Overworld.jsx:296
+#: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
 msgstr "分析"
@@ -2816,53 +2817,53 @@ msgstr "分析"
 msgid "Browse all items"
 msgstr "全データをブラウズする"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:165
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
 msgstr "上書きしますか？新しいデータとして保存しますか？"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:173
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
 msgstr "元の質問に上書きし、{0}"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:178
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
 msgstr "新しい質問として保存する"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:187
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
 msgstr "まずは、質問を保存してください"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:188
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
 msgstr "質問を保存する"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:224
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
 msgstr "カードの名前は？"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:232
-#: frontend/src/metabase/entities/collections.js:101
-#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:234
+#: frontend/src/metabase/entities/collections.js:102
+#: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/lib/core.js:50 frontend/src/metabase/lib/core.js:205
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:156
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:211
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:203
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:207
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:207
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:24
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:159
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:214
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:192
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:206
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:210
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
 msgstr "説明"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:238
-#: frontend/src/metabase/entities/dashboards.js:153
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
+#: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
-msgstr "任意ですが、とても便利です"
+msgstr "任意ですが、入力しておくととても便利です"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:245
-#: frontend/src/metabase/entities/dashboards.js:157
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
+#: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "これはどのコレクションに保存しますか？"
 
@@ -2874,7 +2875,7 @@ msgstr "修正された"
 msgid "item"
 msgstr "アイテム"
 
-#: frontend/src/metabase/containers/UndoListing.jsx:81
+#: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
 msgstr "やり直す"
 
@@ -2898,15 +2899,15 @@ msgstr "この質問の互換性が不明です"
 msgid "Archive Dashboard"
 msgstr "ダッシュボードをアーカイブする"
 
-#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:20
+#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
-msgstr "各シリーズを必ず選択してください。選択しない場合、このカードでのフィルターが機能しません。"
+msgstr "各シリーズを必ず選択してください。選択しない場合、このカードでフィルターは機能しません。"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:300
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
 msgstr "このダッシュボードは空です"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:301
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
 msgstr "質問を追加して使い易くしましょう！"
 
@@ -2926,59 +2927,58 @@ msgstr "フルスクリーンを解除する"
 msgid "Enter fullscreen"
 msgstr "フルスクリーン"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:181
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:183
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "保存中..."
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:216
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
 msgstr "質問を追加する"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:219
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
 msgstr "このダッシュボードに質問を追加する"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:248
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
 msgstr "フィルターを追加する"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:254
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:78
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "パラメーター"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:275
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
 msgstr "テキストボックスを追加する"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
 msgstr "ダッシュボードを移動する"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:302
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
 msgstr "ダッシュボードを編集する"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:306
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
 msgstr "ダッシュボードのレイアウトを編集する"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:369
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
 msgstr "ダッシュボード編集中"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:374
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
 msgstr "各カードにフィルタリングするフィールドを選択する"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:28
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
 msgstr "にダッシュボードを移動する"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:52
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
 msgstr "{0}にダッシュボードを移動しました"
 
@@ -2993,7 +2993,7 @@ msgstr "どのようなフィルター？"
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:179
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
 msgstr "オフ"
 
@@ -3033,174 +3033,174 @@ msgstr "更新間隔"
 msgid "Remove this question?"
 msgstr "この質問を削除しますか？"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:71
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
 msgstr "ダッシュボードが保存されました"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:745
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:76
+#: frontend/src/metabase/components/CollectionLanding.jsx:744
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
 msgstr "見る"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:137
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
 msgstr "保存する"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:170
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
 msgstr "詳細を表示する"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:140
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
 msgstr "このパラメータタイプにマップできるフィールドやパラメータがこのカードにはありません。"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:142
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "このフィールドの値は、選択した他のフィールドの値と重複しません。"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:186
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
 msgstr "有効なフィールドがありません"
 
-#: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
 msgstr "名前は100文字以下で入力してください"
 
-#: frontend/src/metabase/entities/collections.js:111
+#: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
 msgstr "色が必要です"
 
-#: frontend/src/metabase/entities/dashboards.js:146
+#: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
 msgstr "このダッシュボードの名前は？"
 
-#: frontend/src/metabase/home/components/Activity.jsx:92
+#: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
 msgstr "表現できないぐらい最高なことをやろう"
 
-#: frontend/src/metabase/home/components/Activity.jsx:101
-#: frontend/src/metabase/home/components/Activity.jsx:116
+#: frontend/src/metabase/home/components/Activity.jsx:103
+#: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
 msgstr "␣に関するアラートを作成しました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:126
-#: frontend/src/metabase/home/components/Activity.jsx:141
+#: frontend/src/metabase/home/components/Activity.jsx:128
+#: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
 msgstr "␣に関するアラートを削除しました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:152
+#: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
 msgstr "␣に関する質問を保存しました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:165
+#: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
 msgstr "質問を保存しました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:169
+#: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
 msgstr "質問を削除しました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:172
+#: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
 msgstr "ダッシュボードを作成しました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:175
+#: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
 msgstr "ダッシュボードを削除しました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:181
-#: frontend/src/metabase/home/components/Activity.jsx:196
+#: frontend/src/metabase/home/components/Activity.jsx:183
+#: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
 msgstr "ダッシュボードに質問を追加しました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:206
-#: frontend/src/metabase/home/components/Activity.jsx:221
+#: frontend/src/metabase/home/components/Activity.jsx:208
+#: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
 msgstr "ダッシュボードから質問を削除しました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:231
-#: frontend/src/metabase/home/components/Activity.jsx:238
+#: frontend/src/metabase/home/components/Activity.jsx:233
+#: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
 msgstr "から最新のデータを受信しました"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:621
-#: frontend/src/metabase/home/components/Activity.jsx:244
+#: frontend/src/metabase-lib/lib/Dimension.js:814
+#: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
 msgstr "不明"
 
-#: frontend/src/metabase/home/components/Activity.jsx:251
+#: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
 msgstr "こんにちは、世界"
 
-#: frontend/src/metabase/home/components/Activity.jsx:252
+#: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
 msgstr "メタベースを起動しています..."
 
-#: frontend/src/metabase/home/components/Activity.jsx:258
-#: frontend/src/metabase/home/components/Activity.jsx:288
+#: frontend/src/metabase/home/components/Activity.jsx:260
+#: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
 msgstr "メトリクスを追加しました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:272
-#: frontend/src/metabase/home/components/Activity.jsx:362
+#: frontend/src/metabase/home/components/Activity.jsx:274
+#: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
 msgstr "に"
 
-#: frontend/src/metabase/home/components/Activity.jsx:282
-#: frontend/src/metabase/home/components/Activity.jsx:322
-#: frontend/src/metabase/home/components/Activity.jsx:372
-#: frontend/src/metabase/home/components/Activity.jsx:413
+#: frontend/src/metabase/home/components/Activity.jsx:284
+#: frontend/src/metabase/home/components/Activity.jsx:324
+#: frontend/src/metabase/home/components/Activity.jsx:374
+#: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
 msgstr "␣テーブル"
 
-#: frontend/src/metabase/home/components/Activity.jsx:298
-#: frontend/src/metabase/home/components/Activity.jsx:328
+#: frontend/src/metabase/home/components/Activity.jsx:300
+#: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
 msgstr "メトリクスが変更されました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:312
-#: frontend/src/metabase/home/components/Activity.jsx:403
+#: frontend/src/metabase/home/components/Activity.jsx:314
+#: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
 msgstr "の中"
 
-#: frontend/src/metabase/home/components/Activity.jsx:335
+#: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
 msgstr "メトリクスを削除しました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:338
+#: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
 msgstr "パルスを作成しました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:341
+#: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
 msgstr "パルスを削除しました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:347
-#: frontend/src/metabase/home/components/Activity.jsx:378
+#: frontend/src/metabase/home/components/Activity.jsx:349
+#: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
 msgstr "フィルターを追加しました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:388
-#: frontend/src/metabase/home/components/Activity.jsx:419
+#: frontend/src/metabase/home/components/Activity.jsx:390
+#: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
 msgstr "フィルターが変更されました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:426
+#: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
 msgstr "フィルター{0}を削除しました"
 
-#: frontend/src/metabase/home/components/Activity.jsx:429
+#: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
 msgstr "参加しました！"
 
-#: frontend/src/metabase/home/components/Activity.jsx:529
+#: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
 msgstr "何も起こりませんでした"
 
-#: frontend/src/metabase/home/components/Activity.jsx:532
+#: frontend/src/metabase/home/components/Activity.jsx:534
 msgid "Save a question and get this baby going!"
 msgstr "質問を保存して次に進みましょう！"
 
@@ -3248,21 +3248,21 @@ msgstr "最近見たデータ"
 msgid "You haven't looked at any dashboards or questions recently"
 msgstr "最近ダッシュボードや質問を見ていないようです"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:99
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
 msgstr "{0}アイテムが選択されました"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:121
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:172
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
 msgstr "アーカイブを取り消す"
 
-#: frontend/src/metabase/home/containers/HomepageApp.jsx:74
-#: frontend/src/metabase/nav/containers/Navbar.jsx:331
+#: frontend/src/metabase/home/containers/HomepageApp.jsx:77
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
 msgstr "アクティビティ"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:28
+#: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
 msgstr "{0}の結果"
 
@@ -3327,6 +3327,7 @@ msgstr "アバターイメージURL"
 msgid "Common"
 msgstr "一般"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
@@ -3363,8 +3364,9 @@ msgstr "緯度"
 msgid "Longitude"
 msgstr "経度"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:149
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
 msgstr "番号"
@@ -3393,7 +3395,7 @@ msgstr "量"
 
 #: frontend/src/metabase/lib/core.js:120
 msgid "Income"
-msgstr "収入"
+msgstr "収益"
 
 #: frontend/src/metabase/lib/core.js:125
 msgid "Discount"
@@ -3461,7 +3463,7 @@ msgstr "スコア"
 
 #: frontend/src/metabase/lib/core.js:210
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:17
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
 msgstr "タイトル"
 
@@ -3518,8 +3520,9 @@ msgid "Metabase will never retrieve this field. Use this for sensitive or irrele
 msgstr "メタベースはこのフィールドを取得しなくなります。取得するとセキュリティ上問題があったり、無関係なフィールドに使いましょう"
 
 #: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:614
-#: frontend/src/metabase/visualizations/lib/utils.js:126
+#: frontend/src/metabase/lib/query.js:300
+#: frontend/src/metabase/visualizations/lib/utils.js:130
+#: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -3534,7 +3537,7 @@ msgstr "累積AE計数"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
-#: frontend/src/metabase/visualizations/lib/utils.js:127
+#: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
 msgstr "合計"
 
@@ -3543,7 +3546,7 @@ msgid "CumulativeSum"
 msgstr "累積和"
 
 #: frontend/src/metabase/lib/expressions/config.js:11
-#: frontend/src/metabase/visualizations/lib/utils.js:128
+#: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
 msgstr "ディスティンクト"
 
@@ -3552,34 +3555,34 @@ msgid "StandardDeviation"
 msgstr "標準偏差"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/visualizations/lib/utils.js:125
+#: frontend/src/metabase/visualizations/lib/utils.js:129
 msgid "Average"
 msgstr "平均"
 
 #: frontend/src/metabase/lib/expressions/config.js:14
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:25
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
 msgstr "最低"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
 msgstr "最高"
 
-#: frontend/src/metabase/lib/expressions/parser.js:384
+#: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
 msgstr "字句エラーが検出されました"
 
-#: frontend/src/metabase/lib/formatting.js:707
+#: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0}秒"
 
-#: frontend/src/metabase/lib/formatting.js:710
+#: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0}分"
@@ -3617,222 +3620,224 @@ msgstr "何を知りたいですか？"
 msgid "What do you want to find out?"
 msgstr "何を調べますか？"
 
-#: frontend/src/metabase/lib/query.js:612
-#: frontend/src/metabase/lib/schema_metadata.js:451
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:246
+#: frontend/src/metabase/lib/query.js:298
+#: frontend/src/metabase/lib/schema_metadata.js:458
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
 msgstr "ローデータ"
 
-#: frontend/src/metabase/lib/query.js:616
+#: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
 msgstr "累積AE計数"
 
-#: frontend/src/metabase/lib/query.js:619
+#: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
 msgstr "の平均"
 
-#: frontend/src/metabase/lib/query.js:624
+#: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
 msgstr "␣のディスティンクト値"
 
-#: frontend/src/metabase/lib/query.js:629
+#: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
 msgstr "の標準偏差"
 
-#: frontend/src/metabase/lib/query.js:634
+#: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
 msgstr "の合計"
 
-#: frontend/src/metabase/lib/query.js:639
+#: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
 msgstr "の累積和"
 
-#: frontend/src/metabase/lib/query.js:644
+#: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
 msgstr "の最高"
 
-#: frontend/src/metabase/lib/query.js:649
+#: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
 msgstr "の最低"
 
-#: frontend/src/metabase/lib/query.js:663
+#: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
 msgstr "グループ化された"
 
-#: frontend/src/metabase/lib/query.js:677
+#: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
 msgstr "フィルターされた"
 
-#: frontend/src/metabase/lib/query.js:706
+#: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
 msgstr "ソートされた"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
 msgstr "正"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
 msgstr "誤"
 
-#: frontend/src/metabase/lib/schema_metadata.js:305
+#: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
 msgstr "経度フィールドを選択する"
 
-#: frontend/src/metabase/lib/schema_metadata.js:306
+#: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
 msgstr "もっと上の緯度を入力する"
 
-#: frontend/src/metabase/lib/schema_metadata.js:307
+#: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
 msgstr "もっと左の経度を入力する"
 
-#: frontend/src/metabase/lib/schema_metadata.js:308
+#: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
 msgstr "もっと下の緯度を入力する"
 
-#: frontend/src/metabase/lib/schema_metadata.js:309
+#: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
 msgstr "もっと右の経度を入力する"
 
-#: frontend/src/metabase/lib/schema_metadata.js:345
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase-lib/lib/Dimension.js:505
+#: frontend/src/metabase-lib/lib/Dimension.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:351
+#: frontend/src/metabase/lib/schema_metadata.js:371
 #: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:387
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
 msgstr "である"
 
-#: frontend/src/metabase/lib/schema_metadata.js:346
-#: frontend/src/metabase/lib/schema_metadata.js:366
-#: frontend/src/metabase/lib/schema_metadata.js:376
-#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/lib/schema_metadata.js:352
+#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:396
+#: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
 msgstr "ではない"
 
-#: frontend/src/metabase/lib/schema_metadata.js:347
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:369
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:353
+#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
 msgstr "空"
 
-#: frontend/src/metabase/lib/schema_metadata.js:348
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:370
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:402
+#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
 msgstr "空ではない"
 
-#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
 msgstr "同等"
 
-#: frontend/src/metabase/lib/schema_metadata.js:355
+#: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
 msgstr "同等ではない"
 
-#: frontend/src/metabase/lib/schema_metadata.js:356
+#: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
 msgstr "より大きい"
 
-#: frontend/src/metabase/lib/schema_metadata.js:357
+#: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
 msgstr "より小さい"
 
-#: frontend/src/metabase/lib/schema_metadata.js:358
-#: frontend/src/metabase/lib/schema_metadata.js:384
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:285
+#: frontend/src/metabase/lib/schema_metadata.js:364
+#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "間"
 
-#: frontend/src/metabase/lib/schema_metadata.js:359
+#: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
 msgstr "以上"
 
-#: frontend/src/metabase/lib/schema_metadata.js:360
+#: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
 msgstr "以下"
 
-#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
 msgstr "含む"
 
-#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
 msgstr "含まない"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
 msgstr "で始まる"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
 msgstr "で終わる"
 
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:264
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "前"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:271
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "後"
 
-#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
 msgstr "中"
 
-#: frontend/src/metabase/lib/schema_metadata.js:453
+#: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "回答内の行を含む表のみ、他操作なし"
 
-#: frontend/src/metabase/lib/schema_metadata.js:459
+#: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
 msgstr "行のカウント"
 
-#: frontend/src/metabase/lib/schema_metadata.js:461
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
 msgstr "回答の全行数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
 msgstr "の合計"
 
-#: frontend/src/metabase/lib/schema_metadata.js:469
+#: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
 msgstr "列の全値の合計"
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
 msgstr "の平均"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
 msgstr "列の全値の平均"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
 msgstr "ディスティンクト値"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "回答の全行のうち固有値の列数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:491
+#: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
 msgstr "累積合計"
 
@@ -3840,7 +3845,7 @@ msgstr "累積合計"
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "列の全値の合計\\\\ne.x. 経年の全収入"
 
-#: frontend/src/metabase/lib/schema_metadata.js:499
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
 msgstr "行の累積AE計数"
 
@@ -3848,105 +3853,105 @@ msgstr "行の累積AE計数"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "行数の合計\\\\ne.x.経年の販売数合計"
 
-#: frontend/src/metabase/lib/schema_metadata.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
 msgstr "...の標準偏差"
 
-#: frontend/src/metabase/lib/schema_metadata.js:509
+#: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "回答の全行の間で列の値がどれくらい異なるかを表す数値"
 
-#: frontend/src/metabase/lib/schema_metadata.js:515
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
 msgstr "...の最低"
 
-#: frontend/src/metabase/lib/schema_metadata.js:517
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
 msgstr "列の最低値"
 
-#: frontend/src/metabase/lib/schema_metadata.js:523
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
 msgstr "...の最高"
 
-#: frontend/src/metabase/lib/schema_metadata.js:525
+#: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
 msgstr "列の最高値"
 
-#: frontend/src/metabase/lib/schema_metadata.js:533
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
 msgstr "ディメンション別に分割する"
 
-#: frontend/src/metabase/lib/settings.js:93
+#: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
 msgstr "小文字"
 
-#: frontend/src/metabase/lib/settings.js:95
+#: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
 msgstr "大文字"
 
-#: frontend/src/metabase/lib/settings.js:97
+#: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "数字"
 
-#: frontend/src/metabase/lib/settings.js:99
+#: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
 msgstr "特殊文字"
 
-#: frontend/src/metabase/lib/settings.js:105
+#: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
 msgstr "でなければならない"
 
-#: frontend/src/metabase/lib/settings.js:105
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:120
+#: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
 msgstr "文字数"
 
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
 msgstr "でなければならない"
 
-#: frontend/src/metabase/lib/settings.js:122
+#: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
 msgstr "含む"
 
-#: frontend/src/metabase/lib/utils.js:92
+#: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
 msgstr "0"
 
-#: frontend/src/metabase/lib/utils.js:93
+#: frontend/src/metabase/lib/utils.js:86
 msgid "one"
 msgstr "1"
 
-#: frontend/src/metabase/lib/utils.js:94
+#: frontend/src/metabase/lib/utils.js:87
 msgid "two"
 msgstr "2"
 
-#: frontend/src/metabase/lib/utils.js:95
+#: frontend/src/metabase/lib/utils.js:88
 msgid "three"
 msgstr "3"
 
-#: frontend/src/metabase/lib/utils.js:96
+#: frontend/src/metabase/lib/utils.js:89
 msgid "four"
 msgstr "4"
 
-#: frontend/src/metabase/lib/utils.js:97
+#: frontend/src/metabase/lib/utils.js:90
 msgid "five"
 msgstr "5"
 
-#: frontend/src/metabase/lib/utils.js:98
+#: frontend/src/metabase/lib/utils.js:91
 msgid "six"
 msgstr "6"
 
-#: frontend/src/metabase/lib/utils.js:99
+#: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
 msgstr "7"
 
-#: frontend/src/metabase/lib/utils.js:100
+#: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
 msgstr "8"
 
-#: frontend/src/metabase/lib/utils.js:101
+#: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
 msgstr "9"
 
@@ -4020,6 +4025,7 @@ msgstr "時間"
 msgid "Date range, relative date, time of day, etc."
 msgstr "時間範囲、相対日付、時間等"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
@@ -4042,7 +4048,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "カテゴリー、タイプ、モデル、レーティング等"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
-#: frontend/src/metabase/user/components/UserSettings.jsx:54
+#: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
 msgstr "アカウント設定"
 
@@ -4054,56 +4060,56 @@ msgstr "管理画面から離れる"
 msgid "Logs"
 msgstr "ログ"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:64
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
 msgstr "ヘルプ"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:67
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
 msgstr "Metabaseについて"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:73
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
 msgstr "サインアウト"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:98
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
 msgstr "ご利用ありがとうございました"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
 msgstr "バージョンをご利用中です"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
 msgstr "構築された"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:124
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
 msgstr "の商標です"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:126
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
 msgstr "カリフォルニアのサンフランシスコで構築されています"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:194
+#: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
 msgstr "Metabase管理者"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:300
+#: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
 msgstr "照会する"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:309
+#: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
 msgstr "新しいダッシュボード"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:315
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/nav/containers/Navbar.jsx:361
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
 msgstr "新しいパルス"
 
@@ -4111,16 +4117,16 @@ msgstr "新しいパルス"
 msgid "Reference"
 msgstr "参照"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:83
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
 msgstr "どのメトリクスですか？"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:110
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "チームの共通のメトリクスを定義することで、さらに簡単に質問することができます"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:113
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
 msgstr "メトリクスの作成方法"
 
@@ -4132,8 +4138,8 @@ msgstr "トレンドや変化を理解するため、地図やピボットされ
 msgid "Custom"
 msgstr "カスタム"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:150
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:517
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
 msgstr "新しい質問"
 
@@ -4141,22 +4147,22 @@ msgstr "新しい質問"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "トレンドやリストを表示したり、独自のメトリクスを作成するには、簡単な質問ビルダーを使用してください。"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:161
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "ネイティブクエリ"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:162
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "複雑な質問については、独自のSQLまたはネイティブクエリを記述することができます。"
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:240
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
 msgstr "デフォルト値を選択する"
 
-#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:149
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
 msgstr "フィルターをアップデートする"
 
@@ -4164,14 +4170,14 @@ msgstr "フィルターをアップデートする"
 #: frontend/src/metabase/lib/query_time.js:123
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:9
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Today"
 msgstr "本日"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
 msgstr "昨日"
 
@@ -4183,7 +4189,7 @@ msgstr "過去7日"
 msgid "Past 30 days"
 msgstr "過去30日"
 
-#: frontend/src/metabase/lib/query_time.js:195
+#: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:29
 #: src/metabase/api/table.clj
@@ -4191,7 +4197,7 @@ msgid "Week"
 msgid_plural "Weeks"
 msgstr[0] "週"
 
-#: frontend/src/metabase/lib/query_time.js:197
+#: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:30
 #: src/metabase/api/table.clj
@@ -4199,7 +4205,7 @@ msgid "Month"
 msgid_plural "Months"
 msgstr[0] "月"
 
-#: frontend/src/metabase/lib/query_time.js:201
+#: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:31
 #: src/metabase/api/table.clj
@@ -4248,6 +4254,7 @@ msgstr "値を入力する..."
 msgid "Enter a default value..."
 msgstr "デフォルト値を入力する..."
 
+#: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "エラーが発生しました"
@@ -4288,24 +4295,24 @@ msgstr "公開"
 msgid "Code"
 msgstr "コード"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:70
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
 msgstr "スタイル"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
 msgstr "この埋め込みのユーザーはどのパラメータを使用できますか？"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:83
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
 msgstr "この{0}には設定するパラメータがまだありません。"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
 msgstr "編集可能"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
 msgstr "ロックされた"
 
@@ -4313,19 +4320,19 @@ msgstr "ロックされた"
 msgid "Preview Locked Parameters"
 msgstr "ロックされたパラメーターをプレビューする"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:115
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
 msgstr "ロックされたパラメータにいくつかの値を入力してみてください。 これを実際に使用する場合には、サーバーは署名トークンに実際の値を提供する必要があります。"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
 msgstr "危険ゾーン"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
 msgstr "この{0}への埋め込みを無効化します"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:128
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
 msgstr "非公開"
 
@@ -4365,64 +4372,64 @@ msgstr "さらに{0}"
 msgid "examples on GitHub"
 msgstr "GitHubの例"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:72
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
 msgstr "共有を有効化する"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
 msgstr "公開リンクを無効化しますか？"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:77
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
 msgstr "リンクが作動しなくなる可能性があります。再度有効化することはできますが、異なるリンクが作成されます"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
 msgstr "リンクを公開する"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:118
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
 msgstr "Metabaseアカウントを保有していない方に下記URLを利用して{0}を共有する"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:158
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
 msgstr "公開埋め込み"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:159
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
 msgstr "このスニペットをコピーして貼り付けることで、ブログ投稿やウェブページにこの{0}を埋め込むことができます："
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:176
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
 msgstr "アプリケーションへ{0}を埋め込む"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:177
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
 msgstr "アプリケーションサーバーコードと統合することで、特定のユーザー、顧客、組織などに限定された安全な統計情報{0}を提供することができます。"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
 msgstr "添付を削除する"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:95
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
 msgstr "結果を添付する"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
 msgstr "この質問は添付ファイルとして追加されます"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:128
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
 msgstr "この質問はパルスには含まれません"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:92
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
 msgstr "このクエスチョンは{0} {1}にメールされません"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:94
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:376
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
 msgstr[0] "{0}アドレス"
@@ -4431,39 +4438,39 @@ msgstr[0] "{0}アドレス"
 msgid "Slack channel {0} will no longer get this pulse {1}"
 msgstr "Slackチャンネル{0}からは、このパルス{1}を取得できません"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:110
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
 msgstr "チャンネル{0}からは、このパルス{1}を受信できません"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
 msgstr "パルスを編集する"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:131
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
 msgstr "パルスとは？"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:141
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
 msgstr "了解しました"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
 msgstr "このデータはどちらに保存しますか？"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:173
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
 msgstr "アーカイブ取消中..."
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
 msgstr "アーカイブ取消が失敗しました"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
 msgstr "アーカイブが取り消されました"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
 msgstr "パルスを作成する"
 
@@ -4473,7 +4480,7 @@ msgstr "添付"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:673
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
 msgstr "警告"
 
@@ -4494,6 +4501,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "パルスを小さく保ち、チーム全体にとって使いやすく処理することをお勧めします。"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
+#: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
 msgstr "データを選ぶ"
 
@@ -4509,47 +4517,47 @@ msgstr "メール"
 msgid "Slack messages"
 msgstr "Slackメッセージ"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "送信しました"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:222
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0}が送信されます"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:224
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "メッセージ"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "今すぐメールを送信する"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:241
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "今すぐ{0}に送信する"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "送信中..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:244
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "送信に失敗しました"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "パルスの結果が存在しないため送信できませんでした"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:248
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "パルスが送信されました"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:287
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0}は管理者が設定する必要があります"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:302
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
 msgstr "Slack"
 
@@ -4598,21 +4606,21 @@ msgid "Before {0}"
 msgstr "{0}前"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:295
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "空"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:301
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "空ではない"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:213
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "全期間"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:154
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
 msgstr "適用する"
 
@@ -4678,17 +4686,17 @@ msgstr "分布"
 msgid "View details"
 msgstr "詳細を見る"
 
-#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:54
+#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
 msgstr "{0}の{1}を見る"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:42
 msgid "Ascending"
-msgstr "上昇"
+msgstr "昇順"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:50
 msgid "Descending"
-msgstr "下降"
+msgstr "降順"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js:47
 msgid "over time"
@@ -4702,22 +4710,21 @@ msgstr "平均"
 msgid "Distincts"
 msgstr "Distinct"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:32
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
-msgstr[0] "この{0}を見る\n"
-"Plural：これらの{0}を見る"
+msgstr[0] "この{0}を見る"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:225
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
 msgstr "拡大する"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:19
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
 msgstr "カスタムエクスプレッション"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
 msgstr "共通のメトリクス"
 
@@ -4725,7 +4732,7 @@ msgstr "共通のメトリクス"
 msgid "Metabasics"
 msgstr "Metabasics"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
 msgstr "名前（任意）"
 
@@ -4737,31 +4744,31 @@ msgstr "集約を選択する"
 msgid "Set up your own alert"
 msgstr "アラートを設定する"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:140
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
 msgstr "購読解除中..."
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:145
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
 msgstr "購読解除に失敗しました"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:204
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
 msgstr "購読解除する"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:235
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
 msgstr "チャンネルがありません"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:263
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
 msgstr "購読解除しました"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:335
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
 msgstr "{0}のアラートを受け取る設定になっています"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
 msgstr "{0}アラートを設定しました。"
 
@@ -4817,147 +4824,147 @@ msgstr "アラートを編有する"
 msgid "Edit alert"
 msgstr "アラートを編集する"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:374
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
 msgstr "このアラートは{0}にメール送信されません"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:382
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
 msgstr "Slackチャンネル{0}では、このアラートを取得できません"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:386
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
 msgstr "チャンネル{0}では、このアラートを受信できません"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:403
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
 msgstr "このアラートを削除する"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:405
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
 msgstr "このアラートを削除する。この操作はやり直しできませんので、ご注意ください"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:413
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
 msgstr "このアラートを削除しますか？"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:497
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
 msgstr "線が...のときアラートする"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:498
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
 msgstr "進捗バーが...のときアラートする"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
 msgstr "目標値を超える"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
 msgstr "目標に到達する"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
 msgstr "目標値を下回る"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
 msgstr "目標を下回る"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:512
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
 msgstr "最初に超えたときのみ、または超えたときは毎回"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:513
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
 msgstr "最初に目標に到達したときのみ、または目標に到達したときは毎回"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
 msgstr "最初のみ"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:516
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
 msgstr "毎回"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:619
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
 msgstr "アラートをどこに送信しますか？"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:630
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
 msgstr "にアラートをメール送信する"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:672
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
 msgstr "{0} 2行以上のグラフでは目標ベースのアラートがサポートされていないため、図に{1}があるたびにアラートが送信されます。"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
 msgstr "結果"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:679
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
 msgstr "{0}このタイプのアラートは、保存された質問が{1}結果を返さない場合でも、いつ実行したかを知りたいときに最も便利です。"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:680
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
 msgstr "ヒント"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
 msgstr "通常"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:57
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
 msgstr "セグメントまたは表を選ぶ"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
 msgstr "データベースを選択する"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:88
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
 msgstr "選択する..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:128
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
 msgstr "表を選択する"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:793
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
 msgstr "このデータベースにはテーブルが見つかりませんでした"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:830
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
 msgstr "質問がありませんか？"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:834
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
 msgstr "ネストしたクエリについてもっと調べる"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:868
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
 msgstr "フィールド"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:946
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
 msgstr "セグメントが見つかりませんでした"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:969
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
 msgstr "セグメントを探す"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:46
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
 msgstr "少く表示"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:56
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
 msgstr "さらに表示"
 
@@ -4966,60 +4973,65 @@ msgid "Pick a field to sort by"
 msgstr "ソートするフィールドを選ぶ"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
 msgstr "ソート"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
 msgstr "行数制限"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:69
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
 msgstr "不明なフィールド"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
 msgstr "フィールド"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:114
+#: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
 msgstr "一致"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
+#: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "回答を絞るためにフィルターを追加する"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:284
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
 msgstr "グルーピングを追加する"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:322
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:102
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:113
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:152
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:194
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:59
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:68
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:75
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:225
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:231
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:237
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:70
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:75
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:64
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:89
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:131
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:176
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:302
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:308
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:314
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "データ"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:352
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
 msgstr "フィルターされた"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:369
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
 msgstr "閲覧"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:386
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
 msgstr "グループ化された"
 
@@ -5027,23 +5039,23 @@ msgstr "グループ化された"
 msgid "None"
 msgstr "なし"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:345
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
 msgstr "この質問は{0}で書かれました"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:353
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
 msgstr "エディターを非表示にする"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:354
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
 msgstr "クエリを非表示にする"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
 msgstr "エディターを表示する"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:360
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
 msgstr "クエリを表示する"
 
@@ -5064,15 +5076,15 @@ msgstr "このデータをダウンロードする"
 msgid "Warning"
 msgstr "警告"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:52
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
 msgstr "行数が多いため、ダウンロードに時間がかかる場合があります"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:53
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
 msgstr "最大ダウンロードサイズは100万行です"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:232
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
 msgstr "質問を編集する"
 
@@ -5088,17 +5100,17 @@ msgstr "キャンセル"
 msgid "Move question"
 msgstr "質問を移動する"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:283
+#: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
 msgstr "これはどのコレクションに保存しますか？"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:313
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:110
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
+#: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
 msgstr "変数"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:432
+#: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
 msgstr "データについて詳しく見る"
 
@@ -5142,11 +5154,11 @@ msgstr "この質問の{0}"
 msgid "Convert this question to {0}"
 msgstr "この質問を{0}に転換する"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:122
+#: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
 msgstr "この質問は更新に約{0}かかります"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:131
+#: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
 msgstr "{0}をアップデートしました"
 
@@ -5163,11 +5175,11 @@ msgstr "最初の{0} {1}を表示する"
 msgid "Showing {0} {1}"
 msgstr "{0} {1}を表示する"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:281
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
 msgstr "実験中"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:294
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
 msgstr "お見せしたいものがあります。データを入力し、 是非クエリを実行してください！"
 
@@ -5175,7 +5187,7 @@ msgstr "お見せしたいものがあります。データを入力し、 是�
 msgid "How do I use this thing?"
 msgstr "どのように使いますか？"
 
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:28
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
 msgstr "回答を得る"
 
@@ -5203,39 +5215,39 @@ msgstr "申し訳ありません、問題が発生しました"
 msgid "Group time by"
 msgstr "で時間をグループ化する"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:46
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
 msgstr "質問に時間がかかりすぎました"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:47
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
 msgstr "データベースから時間内に回答を得られなかったため、動作を終了しました。時間をおいて再度お試しいただくか、問題が続く場合は管理者にメールでお問い合わせください。"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:55
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
 msgstr "サーバーの問題が発生しています"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:56
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
 msgstr "数分後にページを再読み込みしてください。問題が続く場合は、管理者へお問い合わせください。"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:88
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
 msgstr "質問で問題が発生しました"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:89
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
 msgstr "これは無効な選択または入力値が無効であるために発生することがあります。 入力値を再度確認して、クエリを再試行してください。"
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:60
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
 msgstr "お探しの回答ですか？そうではない場合は、回答が特定されすぎないように、フィルタを削除または変更してください。"
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
 msgstr "結果がある場合は、{0}もできます。"
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:68
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
 msgstr "アラートを受け取る"
 
@@ -5243,11 +5255,11 @@ msgstr "アラートを受け取る"
 msgid "Back to last run"
 msgstr "最後の実行に戻る"
 
-#: frontend/src/metabase/query_builder/components/VisualizationSettings.jsx:100
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
 msgstr "ビジュアライゼーション"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:96
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
 msgstr "まだ説明がありません"
 
@@ -5259,7 +5271,7 @@ msgstr "現在の質問で使用する"
 msgid "Potentially useful questions"
 msgstr "役立つかもしれない質問"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:166
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
 msgstr "{0}でグループ化する"
 
@@ -5272,14 +5284,14 @@ msgstr "{0}の全値の合計"
 msgid "All distinct values of {0}"
 msgstr "{0}の全ディスティンクト値"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:187
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
 msgstr "{1}でグループ化された{0}の数字"
 
-#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5295,34 +5307,34 @@ msgstr "データ一覧"
 msgid "Learn more about your data structure to ask more useful questions"
 msgstr "さらに役立つ質問をするためにデータ構成を詳しく知る"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:58
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:84
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
 msgstr "質問作成前に表メタデータが見つかりませんでした"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:80
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
 msgstr "{0}を見"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:94
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
 msgstr "メトリクスの定義"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:118
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
 msgstr "{0}でフィルターをかける"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:127
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
 msgstr "{0}の数字"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
 msgstr "全ての{0}を見る"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:148
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
 msgstr "セグメントの定義"
 
@@ -5334,7 +5346,7 @@ msgstr "テーブルの読み込み中にエラーが発生しました"
 msgid "See the raw data for {0}"
 msgstr "{0}のローデータを見る"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:180
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
 msgstr "さらに"
 
@@ -5346,24 +5358,24 @@ msgstr "無効な表現"
 msgid "unknown error"
 msgstr "不明なエラー"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:46
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
 msgstr "フィールド計算式"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:57
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "これは、スプレッドシートプログラムで数式を書くようなものだとお考えください。数字、この表のフィールド、+などの数学記号、その他一部の機能を使用できます。そのため、Subtotal - Costのようなものを入力することができます。"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
 msgstr "詳しく見る"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:66
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
 msgstr "名前を付ける"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:72
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
 msgstr "分かりやすい説明"
 
@@ -5415,7 +5427,8 @@ msgstr "正"
 msgid "false"
 msgstr "誤"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
 msgstr "フィルターを追加する"
 
@@ -5423,26 +5436,26 @@ msgstr "フィルターを追加する"
 msgid "Item"
 msgstr "アイテム"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:221
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
 msgstr "前回"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:252
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
 msgstr "現在"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:278
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
-msgstr "で"
+msgstr "オン"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx:47
 msgid "Enter desired number"
 msgstr "希望の数字を入力する"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:100
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
 msgstr "空"
 
@@ -5466,35 +5479,35 @@ msgstr "コンマ(,)で区切ることで、複数の値を入力できます"
 msgid "Enter desired text"
 msgstr "希望のテキストを入力する"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
 msgstr "試してみる"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
 msgstr "何に使いますか？"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
 msgstr "ネイティブクエリの変数を用いることで、フィルタウィジェットまたはURLを使用したクエリの値を置き換えることができます。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
 msgstr "{0}は、このSQLテンプレートで変数名 \"variable_name\"を作成します。 サイドパネルに変数を指定すると、その動作が変わります。 \"フィールドフィルター\"以外の全ての変数タイプは、この質問に自動的にフィルタウィジェットを配置します。 フィールドフィルタでは、これはオプションです。 このフィルタウィジェットが入力されると、その値がSQLテンプレートの変数に置き換えられます。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:121
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
 msgstr "フィルターを探す"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:123
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "変数に \"フィールドフィルター\"タイプを指定すると、SQLカードをダッシュボードフィルタウィジェットにリンクしたり、SQL質問にさらに多くのタイプのフィルタウィジェットを使用することができます。 フィールドフィルター変数は、既存の列にフィルタを追加するときにGUIクエリビルダによって生成されたものと同様のSQLを挿入します。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:126
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
 msgstr "フィールドフィルター変数を追加するときは、特定のフィールドにマップする必要があります。 質問にフィルタウィジェットを表示させるか選択できますが、そうでない場合でも、この質問をダッシュボードに追加するときに、フィールドフィルタ変数をダッシュボードフィルタにマッピングすることが可能です。 フィールドフィルターは \"WHERE\"節の中で使用する必要があります。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:130
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
 msgstr "選択条項"
 
@@ -5502,59 +5515,61 @@ msgstr "選択条項"
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
 msgstr "{0}を囲む括弧は、テンプレート内に任意の句を作成します。 \"変数\"が設定されている場合は、節全体がテンプレートに配置されます。 そうでない場合、節全体が無視されます。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:142
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
 msgstr "複数の任意の句を使用するには、最低1つの任意でないWHERE句と、その後に「AND」で始まる任意の句を含めてください。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
 msgstr "全文を読む"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:127
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
 msgstr "フィルターラベル"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:139
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
 msgstr "値タイプ"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:143
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
 msgstr "テキスト"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:150
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:119
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
 msgstr "日付"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
 msgstr "フィールドフィルター"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:157
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
 msgstr "マップするためのフィールド"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
 msgstr "フィルターウィジェットタイプ"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:201
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
 msgstr "必要ですか？"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:211
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
 msgstr "デフォルトのフィルターウィジェット値"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:46
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
 msgstr "この質問をアーカイブしますか？"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:57
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "この質問は関連したダッシュボードやパルスから削除されます"
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:136
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
 msgstr "質問"
 
@@ -5571,21 +5586,21 @@ msgstr "このページを編集中です"
 msgid "See this {0}"
 msgstr "この{0}を見る"
 
-#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:120
+#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
 msgstr "のサブセット"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:68
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
 msgstr "フィールドタイプを選択する"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:57
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
 msgstr "フィールドタイプがありません"
 
@@ -5594,16 +5609,16 @@ msgid "by"
 msgstr "で"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
-#: frontend/src/metabase/reference/databases/FieldList.jsx:152
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
+#: frontend/src/metabase/reference/databases/FieldList.jsx:155
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
 msgstr "フィールドタイプ"
 
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:72
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
 msgstr "外部キーを選択する"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:53
+#: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
 msgstr "{0}計算式を見る"
 
@@ -5620,12 +5635,12 @@ msgid "Nothing important yet"
 msgstr "重要なデータはまだありません"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:168
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:233
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:211
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:215
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:219
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:229
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:236
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:214
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
 msgstr "興味深いデータはまだありません"
 
@@ -5634,12 +5649,12 @@ msgid "Things to be aware of about this {0}"
 msgstr "この{0}関して知っておくべきこと"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:178
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:243
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:221
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:225
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:229
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:239
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:246
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:224
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
 msgstr "知っておくべきことはまだありません"
 
@@ -5701,15 +5716,15 @@ msgstr "変更理由"
 msgid "Leave a note to explain what changes you made and why they were required"
 msgstr "変更箇所と変更理由を記入してください"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:166
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
 msgstr "なぜこのデータベースは興味深いですか？"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:176
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
 msgstr "このデータベースに関して知っておくべきこと"
 
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:46
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
 msgstr "データベースとテーブル"
@@ -5717,42 +5732,42 @@ msgstr "データベースとテーブル"
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:41
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:170
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:173
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:34
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:184
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:187
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:30
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:188
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:187
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:191
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:190
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
 msgstr "詳細"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
-#: frontend/src/metabase/reference/databases/TableList.jsx:111
+#: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
 msgstr "{0}のテーブル"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:222
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:200
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:218
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:203
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
 msgstr "データベース上の実際の名前"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:231
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:227
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
 msgstr "なぜこのフィールドは興味深いですか？"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:241
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:237
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
 msgstr "このフィールドに関して知っておくべきこと"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:253
-#: frontend/src/metabase/reference/databases/FieldList.jsx:155
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:249
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
+#: frontend/src/metabase/reference/databases/FieldList.jsx:158
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
 msgstr "データタイプ"
 
@@ -5761,13 +5776,13 @@ msgstr "データタイプ"
 msgid "Fields in this table will appear here as they're added"
 msgstr "この表のフィールドは追加されるとここに表示されます"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:134
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:135
+#: frontend/src/metabase/reference/databases/FieldList.jsx:137
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
 msgstr "{0}のフィールド"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:149
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:150
+#: frontend/src/metabase/reference/databases/FieldList.jsx:152
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
 msgstr "フィールド名"
 
@@ -5791,7 +5806,10 @@ msgstr "データベースは一度管理者が追加するとここに表示さ
 msgid "Connect a database"
 msgstr "データベースを繋ぐ"
 
+#. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
+#. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
+#: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
 msgstr "{0}のカウント"
 
@@ -5799,11 +5817,11 @@ msgstr "{0}のカウント"
 msgid "See raw data for {0}"
 msgstr "{0}のローデータを見る"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:209
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
 msgstr "なぜこの表は興味深いですか？"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:219
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
 msgstr "この表に関して知っておくべきこと"
 
@@ -5815,16 +5833,16 @@ msgstr "このデータベースの表は追加されるとここに表示れま
 msgid "Questions about this table will appear here as they're added"
 msgstr "この表に関する質問は追加されるとここに表示されます"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:71
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:75
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:74
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
 msgstr "{0}に関する質問"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
 msgstr "{1}で{0}を作成しました"
 
@@ -5836,151 +5854,152 @@ msgstr "この表のフィールド"
 msgid "Questions about this table"
 msgstr "この表に関する質問"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:157
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
 msgstr "チームとデータを共有する"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:159
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
 msgstr "トップにくるダッシュボード、メトリクス、セグメントを選択し、チームに重要事項を提示しましょう"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:165
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
 msgstr "開始する"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:173
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
 msgstr "最重要ダッシュボード"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:188
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
 msgstr "注視すべき数字"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:213
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
 msgstr "メトリクスは企業が重視する数字です。ビジネスが上手くいっているかどうかを示すものです。"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:221
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
 msgstr "全メトリクスを見る"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:235
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
 msgstr "セグメントと表"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
+#: frontend/src/metabase/home/containers/SearchApp.jsx:83
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
 msgstr "表"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:262
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
 msgstr "セグメントや表は、会社データの基礎的要素です。 表はローデータをまとめた情報であり、セグメントは{0}など特定の意味を持つ特定の情報です。"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:267
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
 msgstr "表は、会社データの基礎的要素です。"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:277
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
 msgstr "全セグメントを見る"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:293
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
 msgstr "全ての表を見る"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:301
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
 msgstr "データに関して他に知っておくべきこと"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
 msgstr "詳細を見る"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:307
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
 msgstr "他の表や情報をもっと見ることで、自身のデータをより詳しく知ることができます。時間がかかるかもしれませんが、名前やその意味について理解を深めることができるでしょう。"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:313
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
 msgstr "データを調査する"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:321
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
 msgstr "質問はありますか？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:326
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
 msgstr "{0}に問い合わせる"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:248
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
 msgstr "新しいユーザーをヘルプする"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:251
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
 msgstr "スタートガイドは、ダッシュボード、メトリクス、セグメントや表等の重要事項に焦点を当て、ユーザーが実際にデータを扱い始める前に知っておくべきことを説明しています。"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:258
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
 msgstr "チームに重要なダッシュボードはありますか？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:260
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
 msgstr "今すぐダッシュボードを作成する"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:266
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
 msgstr "最重要ダッシュボードはどれですか？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:285
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
 msgstr "よく参照するメトリクスはありますか？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:287
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
 msgstr "メトリクスの定義づけ方法を確認する"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:300
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
 msgstr "よく参照するメトリクス3〜5個は何ですか？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:344
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
-msgstr "他メトリクスを追加する"
+msgstr "他のメトリクスを追加する"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:357
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
 msgstr "よく参照するセグメントや表はありますか"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:359
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
 msgstr "セグメントの作成方法を確認する"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:372
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
 msgstr "オーディエンスに役立つであろう、よく参照するセグメントや表3〜5個は何ですか？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:418
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
-msgstr "他セグメントや表を追加する"
+msgstr "他のセグメントや表を追加する"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:427
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
 msgstr "データへのアクセスを開始する前に、ユーザーが理解し知っておくべきことはありますか？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:433
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
 msgstr "データへのアクセスを開始する前に、ユーザーが知っておくべきことは何ですか？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:437
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
 msgstr "例：データのプライバシーと使用に関する危険性や誤解、データウェアハウスのパフォーマンスに関する情報、法的通知など"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
 msgstr "このガイドで不明点があった際にユーザーがコンタクトできる方はいますか？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:457
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
 msgstr "このデータで不明点があった際にユーザーは誰にコンタクトすべきですか？"
 
@@ -5989,39 +6008,39 @@ msgstr "このデータで不明点があった際にユーザーは誰にコン
 msgid "Please enter a revision message"
 msgstr "履歴メッセージを入力してください"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:213
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
 msgstr "なぜこのメトリクスは興味深いですか？"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:223
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
 msgstr "このメトリクスに関して知っておくべきこと"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:233
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
 msgstr "このメトリクスの計算方法"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:235
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
 msgstr "計算方法はまだありません"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:293
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
 msgstr "このメトリクスをグループ化する他のフィールド"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:294
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
 msgstr "このメトリクスをグループ化するフィールド"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:23
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "メトリクスはチームが気にかける公式な数字です"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
 msgstr "メトリクスは管理者が作成次第ここに表示されます"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
 msgstr "メトリクスの作成方法を詳しく見る"
 
@@ -6033,9 +6052,9 @@ msgstr "このメトリクスに関する質問は追加されるとここに表
 msgid "There are no revisions for this metric"
 msgstr "このメトリクスには履歴がありません"
 
-#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:88
-#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
-#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:88
+#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
+#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
+#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
 msgstr "{0}の履歴"
 
@@ -6043,27 +6062,27 @@ msgstr "{0}の履歴"
 msgid "X-ray this metric"
 msgstr "このメトリクスを自動探査(X-ray)する"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:217
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
 msgstr "なぜこのセグメントは興味深いですか？"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:227
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
 msgstr "このセグメントに関して知っておくべきこと"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
 msgstr "セグメントは表のサブセットです"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "共通のセグメントについて定義するとチームがより質問しやすくなります"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
 msgstr "セグメントは管理者が作成次第ここに表示されます"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
 msgstr "セグメントの作成方法について詳しく見る"
 
@@ -6091,7 +6110,7 @@ msgstr "このセグメントを自動探査(X-ray)する"
 msgid "Login"
 msgstr "ログイン"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:130
+#: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
 msgstr "検索"
@@ -6108,101 +6127,101 @@ msgstr "新しい質問"
 msgid "Select the type of Database you use"
 msgstr "使用するデータベースタイプを選択する"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:141
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
 msgstr "データを追加する"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:145
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
 msgstr "あとでデータを追加する"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
 msgstr "{0}に接続中"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:165
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
 msgstr "ユーザー名やパスワード等データベースに関する情報が必要です。"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:196
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
 msgstr "あとでデータを追加する"
 
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:41
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
 msgstr "自動スキャンを設定する"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:53
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
 msgstr "データ使用の優先度"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
 msgstr "ご協力ありがとうございます"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:57
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
 msgstr "Usage eventに関する情報は収集いたしません"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:76
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Metabaseサービスを向上させるため、Google Analyticsを通じてデータ使用に関する情報を収集いたします"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
 msgstr "収集する情報とその理由についてはこちらをご確認ください"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:98
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Metabaseが匿名の情報収集をすることに同意する"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0}はデータや質問結果に関する情報を収集します"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:106
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
 msgstr "しない"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
 msgstr "情報収集は全て匿名です"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "情報収集による設定は管理者設定からいつでも変更することができます"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:45
+#: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
 msgstr "お困りの場合"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:52
+#: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
 msgstr "スタートガイド"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:53
+#: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
 msgstr "クリックするだけ"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:95
+#: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
-msgstr "Metabseへようこそ"
+msgstr "Metabaseへようこそ"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:96
+#: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "すべて正常に動作しています。使用を開始し、データを接続して回答を探しましょう。"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:100
+#: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
 msgstr "開始しましょう"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:145
+#: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
 msgstr "準備ができました！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:156
+#: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
-msgstr "Metabseを使い始める"
+msgstr "Metabaseを使い始める"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:155
 msgid "What should we call you?"
@@ -6217,7 +6236,7 @@ msgid "Create a password"
 msgstr "パスワードを作成する"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:116
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
 msgstr "Shhh..."
 
@@ -6410,11 +6429,11 @@ msgstr "Googleメールアドレスでサインインする"
 msgid "User Details"
 msgstr "ユーザー詳細"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:275
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
 msgstr "デフォルトに戻す"
 
-#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:133
+#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
 msgstr "不明なマップ"
 
@@ -6426,24 +6445,24 @@ msgstr "グリッドマップには経度/緯度がビニングされている�
 msgid "more"
 msgstr "さらに"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:101
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
 msgstr "X軸、Y軸にどのフィールドを使用しますか？"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:103
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:60
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
 msgstr "フィールドを選択する"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:204
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
 msgstr "デフォルトビューとして保存する"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
 msgstr "フィルターにボックスを描く"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
 msgstr "フィルターをキャンセルする"
 
@@ -6451,7 +6470,7 @@ msgstr "フィルターをキャンセルする"
 msgid "Pin Map"
 msgstr "マップを固定する"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:303
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
 msgstr "解除する"
 
@@ -6459,31 +6478,31 @@ msgstr "解除する"
 msgid "Rows {0}-{1} of {2}"
 msgstr "{2}の行{0}〜{1}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:189
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
 msgstr "{0}行に切り捨てされたデータ"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:364
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
 msgstr "ビジュアライゼーションが見つかりませんでした"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:371
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
 msgstr "このデータでは図が表示できません"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:469
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
 msgstr "結果が見つかりませんでした"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:490
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
 msgstr "待機中..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:493
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
 msgstr "通常約{0}かかります"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:499
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
 msgstr "（通常のダッシュボード処理より時間がかかっています）"
 
@@ -6499,11 +6518,11 @@ msgstr "フィールドを選択する"
 msgid "error"
 msgstr "エラー"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:126
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
 msgstr "順番を変えるにはクリックしてドラッグしてください"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:139
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
 msgstr "以下リストからフィールドを追加する"
 
@@ -6593,7 +6612,7 @@ msgid "Highlight the whole row"
 msgstr "全行をハイライトする"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:98
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "色"
 
@@ -6658,20 +6677,20 @@ msgstr "この識別子を用いたビジュアライゼーションはすでに
 msgid "No visualization for {0}"
 msgstr "{0}のビジュアライゼーションがありません"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:75
+#: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
 msgstr "「{0]」は属性のないフィールドです。X軸上に複数の値がある場合、値は合計値となります。"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:91
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
 msgstr "この図タイプでは最低2列が必要です"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:96
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
 msgstr "この図タイプは、{0}個以上のデータをサポートしていません。"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:51
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:297
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
 msgstr "目標値"
 
@@ -6709,25 +6728,25 @@ msgstr "編集設定"
 msgid "xValues missing!"
 msgstr "x値がありません"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:114
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "X軸"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:140
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
 msgstr "ブレークアウトのシリーズを追加する"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:153
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Y軸"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:178
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
 msgstr "別のシリーズを追加する..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:195
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
 msgstr "吹き出しサイズ"
 
@@ -6741,7 +6760,7 @@ msgid "Curve"
 msgstr "曲線"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:69
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
 msgstr "ステップ"
 
@@ -6749,27 +6768,27 @@ msgstr "ステップ"
 msgid "Show point markers on lines"
 msgstr "線上にポイントマーカーを表示する"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:235
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
 msgstr "スタック中"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:239
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
 msgstr "スタックしない"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:240
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
 msgstr "スタック"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:241
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
 msgstr "スタック - 100%"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:300
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
 msgstr "目標値を表示する"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:306
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
 msgstr "目標値"
 
@@ -6789,126 +6808,126 @@ msgstr "なし"
 msgid "Linear Interpolated"
 msgstr "線形補間"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:371
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
 msgstr "X軸目盛"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
 msgstr "時系列"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:391
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:409
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:381
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
 msgstr "線形"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:410
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:383
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
 msgstr "累乗"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:384
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
 msgstr "ログ"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:396
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
 msgstr "ヒストグラム"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:398
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
 msgstr "序数"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:404
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
 msgstr "Y軸目盛"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:417
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
 msgstr "X軸線とマークを表示する"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:423
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
 msgstr "コンパクト"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:424
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
 msgstr "45°回転"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
 msgstr "90°回転"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
 msgstr "Y軸線とマークを表示する"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
 msgstr "自動Y軸範囲"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
 msgstr "必要に応じて分割したY軸を使用する"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
 msgstr "X軸にラベルを表示する"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:501
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
 msgstr "X軸ラベル"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:510
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
 msgstr "Y軸のラベルを表示する"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:516
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
 msgstr "Y軸ラベル"
 
-#: frontend/src/metabase/visualizations/lib/utils.js:129
+#: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
 msgstr "標準偏差"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:275
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:17
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:256
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
 msgstr "範囲"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
 msgstr "範囲図"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:276
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:16
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:257
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
 msgstr "棒"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
 msgstr "棒グラフ"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
 msgstr "どのフィールドを利用しますか？"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
 msgstr "ファネル"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:76
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:76
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "測定"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
 msgstr "ファネルタイプ"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:88
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
 msgstr "棒グラフ"
 
@@ -6916,141 +6935,141 @@ msgstr "棒グラフ"
 msgid "line chart"
 msgstr "折れ線グラフ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:224
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "図設定で緯度と経度を選択してください"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
 msgstr "地域マップを選択してください"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 msgid "Please select region and metric columns in the chart settings."
 msgstr "図設定で地域とメトリクス列を選択してください"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:38
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "マップ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:53
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
 msgstr "マップタイプ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:57
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:149
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
 msgstr "地域マップ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
 msgstr "ピンマップ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
 msgstr "ピンタイプ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
 msgstr "タイル"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
 msgstr "マーカー"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
 msgstr "緯度"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
 msgstr "経度"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:142
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:168
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
 msgstr "メトリクスフィールド"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
 msgstr "地域フィールド"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
 msgstr "半径"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:198
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
 msgstr "ぼかし"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
 msgstr "最小不透明度"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
 msgstr "最大ズーム"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:175
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
 msgstr "関係は見つかりませんでした"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:213
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
 msgstr "{0}経由"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:290
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
 msgstr "この{0}は接続していません"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:47
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
 msgstr "オブジェクト詳細"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
 msgstr "オブジェクト"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
 msgstr "合計"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "どの列を使用しますか？"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:44
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "円"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "ディメンション"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:81
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "凡例"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:86
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "凡例にパーセンテージを表示する"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:92
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "最小パーセンテージ"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:146
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
 msgstr "目標値に到達しました"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:148
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
 msgstr "目標値を達成しました"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
 msgstr "目標値{0}"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
 msgstr "ビジュアライゼーションには数字が必要です。"
 
@@ -7058,9 +7077,9 @@ msgstr "ビジュアライゼーションには数字が必要です。"
 msgid "Progress"
 msgstr "プログレス"
 
-#: frontend/src/metabase/entities/collections.js:108
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:176
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:57
+#: frontend/src/metabase/entities/collections.js:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "色"
 
@@ -7072,7 +7091,7 @@ msgstr "行グラフ"
 msgid "row chart"
 msgstr "行グラフ"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:357
+#: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
 msgstr "桁区切りスタイル"
 
@@ -7080,15 +7099,15 @@ msgstr "桁区切りスタイル"
 msgid "Number of decimal places"
 msgstr "小数点以下の桁数"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:381
+#: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
 msgstr "接頭辞をつける"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:385
+#: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
 msgstr "接尾辞をつける"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:374
+#: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
 msgstr "掛ける"
 
@@ -7100,7 +7119,7 @@ msgstr "散布"
 msgid "scatter plot"
 msgstr "散布図"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:78
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
 msgstr "表をピボットする"
 
@@ -7109,7 +7128,8 @@ msgid "Visible fields"
 msgstr "表示されるフィールド"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-msgid "Write here, and use Markdown if you''d like"
+#, fuzzy
+msgid "Write here, and use Markdown if you'd like"
 msgstr "書き込みをし、ご自由にMarkdownをご利用ください"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
@@ -7150,12 +7170,12 @@ msgstr "右"
 msgid "Show background"
 msgstr "背景を表示する"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:553
+#: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0}ビン"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:559
+#: frontend/src/metabase-lib/lib/Dimension.js:731
 msgid "Auto binned"
 msgstr "自動ビニングされた"
 
@@ -7423,26 +7443,26 @@ msgstr "自動ビン"
 msgid "Don''t bin"
 msgstr "ビニングしない"
 
-#: frontend/src/metabase/lib/query_time.js:193 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "日"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
-#: frontend/src/metabase/lib/query_time.js:189 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "分"
 
-#: frontend/src/metabase/lib/query_time.js:191 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "時間"
 
-#: frontend/src/metabase/lib/query_time.js:199 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
-msgstr[0] "4分の1"
+msgstr[0] "四半期"
 
 #: src/metabase/api/table.clj
 msgid "Minute of Hour"
@@ -7505,7 +7525,7 @@ msgid "Bin every 20 degrees"
 msgstr "20度ごとにビニングする"
 
 #. returns `true` if successful -- see JavaDoc
-#: src/metabase/api/tiles.clj src/metabase/pulse/render.clj
+#: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
 msgstr "最適なイメージライターが見つかりませんでした"
 
@@ -7577,10 +7597,12 @@ msgstr "累積和"
 msgid "{0} and {1}"
 msgstr "{0}と{1}"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{1}の{0}"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
 msgstr "{1}で{0}"
@@ -7593,9 +7615,11 @@ msgstr "{1}セグメントの{0}"
 msgid "{0} segment"
 msgstr "{0}セグメント"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
-msgstr "{0}メトリクス"
+msgid_plural "{0} metrics"
+msgstr[0] "{0}メトリクス"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
@@ -7769,11 +7793,11 @@ msgstr "Metabaseをシャットダウン中..."
 
 #: src/metabase/core.clj
 msgid "Metabase Shutdown COMPLETE"
-msgstr "Metabseのシャットダウンが完了しました"
+msgstr "Metabaseのシャットダウンが完了しました"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase version {0} ..."
-msgstr "Metabseバージョン{0}を起動中..."
+msgstr "Metabaseバージョン{0}を起動中..."
 
 #: src/metabase/core.clj
 msgid "System timezone is ''{0}'' ..."
@@ -7782,7 +7806,7 @@ msgstr "システムタイムゾーンは\"{0}\"です"
 #. startup database.  validates connection & runs any necessary migrations
 #: src/metabase/core.clj
 msgid "Setting up and migrating Metabase DB. Please sit tight, this may take a minute..."
-msgstr "Metabse DBを移動設定中。これには時間がかかることがあります。"
+msgstr "Metabase DBを移動設定中。これには時間がかかることがあります。"
 
 #: src/metabase/core.clj
 msgid "Looks like this is a new installation ... preparing setup wizard"
@@ -7794,7 +7818,7 @@ msgstr "Metabaseの初期化が完了しました"
 
 #: src/metabase/server.clj
 msgid "Launching Embedded Jetty Webserver with config:"
-msgstr "configで埋め込みJetty Webserverを起動中："
+msgstr "埋め込みJetty Webserverを起動中 設定:"
 
 #: src/metabase/server.clj
 msgid "Shutting Down Embedded Jetty Webserver"
@@ -7802,7 +7826,7 @@ msgstr "埋め込みJetty Webserverをシャットダウン中"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase in STANDALONE mode"
-msgstr "MetabseをSTANDALONEモードで起動中"
+msgstr "MetabaseをSTANDALONEモードで起動中"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization FAILED"
@@ -7851,7 +7875,7 @@ msgstr "データベース接続を確認..."
 
 #: src/metabase/db.clj
 msgid "Running Database Migrations..."
-msgstr "Database移行を実行中"
+msgstr "データベース移行を実行中"
 
 #: src/metabase/db.clj
 msgid "Database Migrations Current ... "
@@ -7953,7 +7977,7 @@ msgstr "デフォルトの（管理者）データベースユーザーを使用
 
 #: src/metabase/driver/sparksql.clj
 msgid "Error: metabase.driver.FixedHiveDriver is registered, but JDBC does not seem to be using it."
-msgstr "エラー：metabase.driver.FixedHiveDriverは登録されていますが、JDBCがそれを使用していないようです。"
+msgstr "エラー: metabase.driver.FixedHiveDriverは登録されていますが、JDBCがそれを使用していないようです。"
 
 #: src/metabase/driver/sparksql.clj
 msgid "Found metabase.driver.FixedHiveDriver."
@@ -8176,6 +8200,7 @@ msgid "Cannot save Question: source query has circular references."
 msgstr "質問が保存できません：ソースクエリに循環参照があります"
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
+#: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
 msgstr "カード{0}は存在しません。"
@@ -8331,7 +8356,7 @@ msgstr "「MetaBot」グループへユーザーを追加したりユーザー�
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'All Users' group."
-msgstr "「全ユーザー」グループへユーザーを追加したりユーザーを削除することはできません"
+msgstr "'All Users'グループへユーザーを追加したりユーザーを削除することはできません"
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the 'Admin' group!"
@@ -8449,11 +8474,11 @@ msgstr "Metabaseの利用可能なバージョンに関する情報"
 
 #: src/metabase/public_settings.clj
 msgid "The name used for this instance of Metabase."
-msgstr "Metabseのこのインスタンスに使用されている名前"
+msgstr "Metabaseのこのインスタンスに使用されている名前"
 
 #: src/metabase/public_settings.clj
 msgid "The base URL of this Metabase instance, e.g. \"http://metabase.my-company.com\"."
-msgstr "このMetabseインスタンスのベースURL、例：\"http://metabase.my-company.com\""
+msgstr "このMetabaseインスタンスのベースURL、例：\"http://metabase.my-company.com\""
 
 #: src/metabase/public_settings.clj
 msgid "The default language for this Metabase instance."
@@ -8469,7 +8494,7 @@ msgstr "問題が発生した場合に、ユーザーが参照すべきメール
 
 #: src/metabase/public_settings.clj
 msgid "Enable the collection of anonymous usage data in order to help Metabase improve."
-msgstr "Metabseのサービス向上のため、匿名の使用状況データの収集を許可する。"
+msgstr "Metabaseのサービス向上のため、匿名の使用状況データの収集を許可する。"
 
 #: src/metabase/public_settings.clj
 msgid "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox."
@@ -8577,7 +8602,7 @@ msgstr "認識できないチャンネルタイプ{0}"
 msgid "Error sending notification!"
 msgstr "通知送信中にエラーが発生しました！"
 
-#: src/metabase/pulse/color.clj
+#: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
 msgstr "\"{0]\"にJSカラーセレクタが見つかりません。"
 
@@ -8884,43 +8909,43 @@ msgstr "データ権限"
 msgid "Collection permissions"
 msgstr "コレクション権限"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:56
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
 msgstr "全てのコレクション権限を見る"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:25
+#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
 msgstr "サブコレクションを変更することもできます"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:282
+#: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
 msgstr "このコレクションとコンテンツを編集することができます"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:289
+#: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
 msgstr "このコレクション内のアイテムを見ることができます"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:749
+#: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
 msgstr "コレクションアクセス"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:825
+#: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "このグループには、コレクション内の最低一つのサブコレクションの閲覧権限があります"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:830
+#: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "このグループは、このコレクションの最低1つのサブコレクションを編集する権限があります"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
 msgstr "サブコレクションを見る"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:211
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
 msgstr "記憶する"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:95
+#: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
 msgstr "このスキーマを自動探査(X-ray)する"
 
@@ -8952,31 +8977,32 @@ msgstr "\"{0}\"にダッシュボード、質問、コレクションを保存�
 msgid "Access dashboards, questions, and collections in \"{0}\""
 msgstr "\"{0}\"のダッシュボード、質問、コレクションにアクセスする"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:221
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
 msgstr "比較"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:229
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
 msgstr "ズームアウト"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:233
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
 msgstr "関連"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:293
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
 msgstr "さらに自動探査(X-ray)"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:46
+#: frontend/src/metabase/home/containers/SearchApp.jsx:40
+#: src/metabase/pulse/render/body.clj
 msgid "No results"
 msgstr "結果がありません"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:47
+#: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
 msgstr "検索結果が見つかりませんでした"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:111
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
 msgstr "メトリクスがありません"
 
@@ -9018,7 +9044,7 @@ msgstr "権限を付与できませんでした：{0}"
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
 msgstr "暗号化された文字列を復号化できません。 MB_ENCRYPTION_SECRET_KEYを変更または設定しましたか？"
 
-#: frontend/src/metabase/entities/collections.js:164
+#: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
 msgstr "全てのパーソナルコレクション"
 
@@ -9182,24 +9208,24 @@ msgstr "該当なし"
 msgid "Windows domain"
 msgstr "ウィンドウズドメイン"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:509
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:515
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:490
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:499
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
 msgstr "ラベル"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:329
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
 msgstr "メンバーを追加する"
 
-#: frontend/src/metabase/entities/collections.js:115
+#: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
 msgstr "保存先のコレクション"
 
 #: frontend/src/metabase/lib/groups.js:4
 msgid "All Users"
-msgstr "全てのユーザー"
+msgstr "All Users"
 
 #: frontend/src/metabase/lib/groups.js:5
 msgid "Administrators"
@@ -9214,43 +9240,43 @@ msgid "Sharing"
 msgstr "共有"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:234
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:270
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:299
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:305
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:313
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:321
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:218
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:251
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:280
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:286
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:294
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:302
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:80
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:85
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:91
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:97
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:50
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:56
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
 msgstr "表示"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:370
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:416
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:431
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:487
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:358
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:406
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:447
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
 msgstr "軸"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:222
-#: frontend/src/metabase/admin/settings/selectors.js:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
+#: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
-msgstr "フォーマット中"
+msgstr "書式"
 
 #: frontend/src/metabase/containers/Overworld.jsx:102
 msgid "Try these x-rays based on your data."
@@ -9280,20 +9306,20 @@ msgstr "自動探査(X-ray)"
 msgid "Compare to the rest"
 msgstr "残りと比較する"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:244
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "JVMのタイムゾーンを使う"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
 msgstr "もしほとんどのクエリで手動でタイムゾーンのキャストをしていない限り、この設定はそのままにしておくことをおすすめします"
 
-#: frontend/src/metabase/containers/Overworld.jsx:310
+#: frontend/src/metabase/containers/Overworld.jsx:312
 msgid "Your team's most important dashboards go here"
 msgstr "あなたのチームの最も重要なダッシュボードがここに表示されます"
 
-#: frontend/src/metabase/containers/Overworld.jsx:311
+#: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
 msgstr "他の人も閲覧できるようこの場所に表示させるため、ダッシュボードを{0}でピン留めする"
 
@@ -9309,32 +9335,32 @@ msgstr "JVMのタイムゾーンを使う"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "あなたがデータ分析を簡単にできるようテーブルとフィールドを解析中です・・"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
 msgstr "ヒント: "
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:258
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
 msgstr "通貨単位を選択"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:318
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
 msgstr "フィールドタイプ"
 
 #: frontend/src/metabase/admin/routes.jsx:109
-#: frontend/src/metabase/nav/containers/Navbar.jsx:224
+#: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
 msgstr "トラブルシューティング"
 
-#: frontend/src/metabase/admin/settings/selectors.js:96
+#: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
 msgstr "X-ray機能を有効化"
 
-#: frontend/src/metabase/admin/settings/selectors.js:323
+#: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
 msgstr "書式オプション"
 
-#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:19
+#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
 msgstr "タスク詳細"
 
@@ -9374,7 +9400,7 @@ msgstr "通貨"
 msgid "Pick a user or channel..."
 msgstr "ユーザーかチャンネルを選択"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
+#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
 msgstr "フォーマット設定はありません"
 
@@ -9460,7 +9486,7 @@ msgstr "日付の区切り文字"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:215
 msgid "Abbreviate names of days and months"
-msgstr ""
+msgstr "日と月の略称"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:225
 msgid "Show the time"
@@ -9482,31 +9508,31 @@ msgstr "HH:MM:SS.MS"
 msgid "Time style"
 msgstr "時刻の形式"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:299
+#: frontend/src/metabase/visualizations/lib/settings/column.js:300
 msgid "Unit of currency"
 msgstr "通貨単位"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:319
+#: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
 msgstr "通貨単位の表示形式"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:337
+#: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
 msgstr "通貨単位の表示場所"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:370
+#: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
 msgstr "小数点の最小桁数"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:271
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
 msgstr "積み上げグラフ形式"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:314
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:322
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
 msgstr "傾向線を表示"
 
@@ -9535,7 +9561,7 @@ msgstr "折れ線＋棒"
 msgid "line and bar chart"
 msgstr "折れ線＋棒グラフ"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:72
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
 msgstr ""
 
@@ -9544,76 +9570,77 @@ msgstr ""
 msgid "Gauge"
 msgstr "ゲージ"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 #, fuzzy
 msgid "Gauge ranges"
 msgstr "ゲージの範囲"
 
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
 msgstr "表示するフィールド"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:121
+#. 「前{0}」はどうでしょう。前日、前月、…
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
-msgstr "最後の {0}"
+msgstr "前{0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:185
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:52
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
 msgstr "時間経過と共にどのように変化したか見るため時間のフィールドでグルーピング"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
 msgstr "＋ーで色を分けますか？"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
 msgstr "ピボット項目"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:107
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
 msgstr "セル項目"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:123
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
 msgstr "表示列"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:143
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
 msgstr "条件付き書式"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
 msgstr "項目名"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
 msgstr "ミニバーを表示"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:183
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
 msgstr "リンク"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:187
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
 msgstr "メールアドレス"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
 msgstr "イメージ"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:195
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
 msgstr "自動"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:200
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
 msgstr "リンクあるいは画像として表示"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
 msgstr "リンクテキスト"
 
@@ -9877,7 +9904,7 @@ msgstr "クエリの処理エラー"
 msgid "No native form returned."
 msgstr ""
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
 msgstr "データベースドライバから不正な応答: ステータスを確認できません"
 
@@ -9949,7 +9976,7 @@ msgstr "カード {0} から取得されたソースクエリ"
 
 #: src/metabase/query_processor/middleware/mbql_to_native.clj
 msgid "Error transforming MBQL query to native:"
-msgstr ""
+msgstr "MBQLクエリーからネイティブクエリーに変換中にエラーが起こりました:"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Cannot run query: could not find source table {0}."
@@ -9961,15 +9988,15 @@ msgstr ""
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Query Processor store is not initialized."
-msgstr ""
+msgstr "エラー: クエリー処理ストアが初期化されていません。"
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Table {0} is not present in the Query Processor Store."
-msgstr ""
+msgstr "エラー: テーブル{0}がクエリー処理ストアに存在しません。"
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Field {0} is not present in the Query Processor Store."
-msgstr ""
+msgstr "エラー: フィールド{0}がクエリー処理ストアに存在しません。"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were {0}deleted"
@@ -10074,7 +10101,7 @@ msgstr "[[this]] の概要"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Bottom 5 per category"
-msgstr "カテゴリごとの下位5位"
+msgstr "カテゴリーごとの下位5位"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Number of orders"
@@ -10122,7 +10149,7 @@ msgstr "時間帯ごとのイベント"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Singleton]]"
-msgstr ""
+msgstr "[[Singleton]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
@@ -10181,7 +10208,7 @@ msgstr "国ごとの [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Income per state"
-msgstr "状態ごとの収入"
+msgstr "州ごとの収益"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[GenericCategoryMedium]]"
@@ -10297,7 +10324,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average income per state"
-msgstr "状態ごとの平均収益"
+msgstr "州ごとの平均収益"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -10349,7 +10376,7 @@ msgstr "[[this]] の比較と相関"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income"
-msgstr "全収益"
+msgstr "総収益"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income per month"
@@ -10369,7 +10396,7 @@ msgstr "[[Timestamp]] 別の [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30 days"
-msgstr "過去30日でのソースごとのユーザー"
+msgstr "過去30日のソースごとのユーザー"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the month"
@@ -10381,11 +10408,11 @@ msgstr "平均値引率"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Autogenerated metrics about [[GenericTable]]."
-msgstr ""
+msgstr "[[GenericTable]]に関して自動生成されたメトリクス"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per day of the month"
-msgstr ""
+msgstr "その年の日ごとの [[this]]"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions in each country"
@@ -10393,7 +10420,7 @@ msgstr "国別の総セッション数"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per month of the year"
-msgstr ""
+msgstr "その年の月ごとのトランザクション数"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per product"
@@ -10427,11 +10454,11 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "[[this]] per product"
-msgstr ""
+msgstr "製品ごとの [[this]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per month of the year"
-msgstr ""
+msgstr "その年の月ごとの [[this]]"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per country"
@@ -10444,7 +10471,7 @@ msgstr ""
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per state"
-msgstr "状態ごとの売上"
+msgstr "州ごとの売上"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by [[GenericNumber]]"
@@ -10468,7 +10495,7 @@ msgstr "曜日別の [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Days of the month when [[this.short-name]] joined"
-msgstr ""
+msgstr "その月の[[this.short-name]]が参加した日"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Heres an overview of the people in your [[this]]"
@@ -10495,7 +10522,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per state"
-msgstr ""
+msgstr "州ごとの [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Weekdays when [[this.short-name]] joined"
@@ -10507,7 +10534,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Total income by month"
-msgstr ""
+msgstr "月別の総収益"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "A breakdown of your [[this]] over time, and its min, max, average and more."
@@ -10515,7 +10542,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average quantity per state"
-msgstr ""
+msgstr "ソースごとの平均数量"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare by across different numbers"
@@ -10523,7 +10550,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "New users per country in the last 30 days"
-msgstr ""
+msgstr "過去30日の国ごとの新規ユーザー"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions over time"
@@ -10543,7 +10570,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per quarter of the year"
-msgstr ""
+msgstr "その年の四半期ごとのトランザクション数"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "By coordinates"
@@ -10567,7 +10594,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "New [[this.short-name]] in the last 30 days"
-msgstr ""
+msgstr "過去30日の新しい[[this.short-name]] "
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions by desktop, mobile, or tablet"
@@ -10579,7 +10606,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average income per source"
-msgstr "ソースごとの平均収入"
+msgstr "ソースごとの平均収益"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by day of week"
@@ -10613,11 +10640,11 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales in the last 30 days"
-msgstr "直近30日間における売り上げトップ10の州"
+msgstr "過去30日の売上トップ10の州"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales"
-msgstr "売り上げトップ10の州"
+msgstr "売上トップ10の州"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Timestamp]]"
@@ -10629,11 +10656,11 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales"
-msgstr "売り上げトップ10の国"
+msgstr "売上トップ10の国"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by state"
-msgstr ""
+msgstr "州別の売上"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Where most of your sessions originate from"
@@ -10649,7 +10676,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity"
-msgstr ""
+msgstr "国ごとの平均数量"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per source"
@@ -10657,7 +10684,7 @@ msgstr "ソースごとの売上"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average income per country"
-msgstr "国別の平均収入"
+msgstr "国別の平均収益"
 
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
@@ -10776,8 +10803,9 @@ msgid "Total [[this.short-name]]"
 msgstr ""
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
+#, fuzzy
 msgid "Some metrics we found about your transactions."
-msgstr ""
+msgstr "あなたのトランザクションに関して、あるメトリクスを見つけました。"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "How your different products are performing."
@@ -10798,12 +10826,13 @@ msgid "How they compare across time"
 msgstr ""
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
+#, fuzzy
 msgid "Average transaction income per month"
-msgstr ""
+msgstr "月ごとの平均トランザクション収益"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity per month"
-msgstr ""
+msgstr "月ごとの平均数量"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "Seasonal patterns in the [[this]]"
@@ -10819,7 +10848,7 @@ msgstr "ソースごとの注文と収益"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per hour of the day"
-msgstr ""
+msgstr "その日の時間ごとのトランザクション数"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where most of your traffic is coming from."
@@ -10835,7 +10864,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount per month"
-msgstr ""
+msgstr "月ごとの平均割引"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
@@ -10852,7 +10881,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by source"
-msgstr "ソースごとの売上"
+msgstr "ソース別の売上"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales for each product category"
@@ -10872,7 +10901,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average quantity per country"
-msgstr ""
+msgstr "国別平均数量"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryLarge]]"
@@ -10901,7 +10930,7 @@ msgstr ""
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per state"
-msgstr ""
+msgstr "州ごとの [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
@@ -10922,11 +10951,11 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average quantity per source"
-msgstr ""
+msgstr "ソース別平均数量"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Top 5 per category"
-msgstr ""
+msgstr "カテゴリーごとの上位5位"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the week"
@@ -10958,7 +10987,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by month"
-msgstr "月別の売り上げ"
+msgstr "月別の売上"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] is distributed across categories"
@@ -11057,7 +11086,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Income per country"
-msgstr ""
+msgstr "国別の収益"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Heres a closer look at your [[this]] per country"
@@ -11105,7 +11134,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per month"
-msgstr "月別の売り上げ"
+msgstr "月ごとの売上"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[GenericNumber]] by join date"
@@ -11243,13 +11272,13 @@ msgstr ""
 msgid "Values greater than {1} are not allowed."
 msgstr "{1} より大きな値は指定できません。"
 
-#: src/metabase/query_processor/middleware/resolve_database.clj
+#: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
 msgstr "データベース {0} は存在しません。"
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Database is not present in the Query Processor Store."
-msgstr ""
+msgstr "エラー: データベース{0}がクエリー処理ストアに存在しません。"
 
 #: src/metabase/util/embed.clj
 msgid "Invalid embedding-secret-key! Secret key must be a hexadecimal-encoded 256-bit key (i.e., a 64-character string)."
@@ -11292,13 +11321,13 @@ msgstr ""
 msgid "View triggers"
 msgstr ""
 
-#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:82
+#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
-msgstr ""
+msgstr "スケジューラ情報"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:20
 msgid "Priority"
-msgstr ""
+msgstr "優先度"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:21
 msgid "Last Fired"
@@ -11306,51 +11335,51 @@ msgstr ""
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:22
 msgid "Next Fire Time"
-msgstr ""
+msgstr "次回実行時間"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:23
 msgid "Start Time"
-msgstr ""
+msgstr "開始時間"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:24
 msgid "End Time"
-msgstr ""
+msgstr "終了時間"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:25
 msgid "Final Fire Time"
-msgstr ""
+msgstr "最終実行時間"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:26
 msgid "May Fire Again?"
 msgstr ""
 
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:75
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
 msgstr ""
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:25
 msgid "Tasks"
-msgstr ""
+msgstr "タスク"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:30
 msgid "Jobs"
-msgstr ""
+msgstr "ジョブ"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
 msgstr ""
 
-#: frontend/src/metabase/components/EntityItem.jsx:55
+#: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
-msgstr ""
+msgstr "このアイテムを複製する"
 
-#: frontend/src/metabase/components/EntityItem.jsx:61
+#: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
-msgstr ""
+msgstr "このアイテムをアーカイブする"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:330
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
-msgstr ""
+msgstr "ダッシュボードを複製する"
 
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:16
 msgid "Duplicate \"{0}\""
@@ -11398,54 +11427,55 @@ msgstr ""
 msgid "{0} {1} from now"
 msgstr ""
 
-#: frontend/src/metabase/lib/query_time.js:187
+#: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:203
+#: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:205
+#: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:207
+#: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:209
+#: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:211
+#: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:213
+#: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:215
+#: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:217
+#: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] ""
 
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:79
+#: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] ""
@@ -11458,20 +11488,20 @@ msgstr ""
 msgid "This"
 msgstr ""
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:64
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
 msgstr ""
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:147
+#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:170
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
 msgstr ""
 
-#: frontend/src/metabase-lib/lib/Dimension.js:517
+#: frontend/src/metabase-lib/lib/Dimension.js:678
 msgid "by {0}"
 msgstr ""
 
@@ -11545,11 +11575,11 @@ msgstr ""
 
 #: src/metabase/driver.clj
 msgid "Registered abstract driver {0}"
-msgstr ""
+msgstr "抽象ドライバー {0} を登録しました"
 
 #: src/metabase/driver.clj
 msgid "Registered driver {0}"
-msgstr ""
+msgstr "ドライバー {0} を登録しました"
 
 #: src/metabase/driver.clj
 msgid "(parents: {0})"
@@ -11557,11 +11587,11 @@ msgstr ""
 
 #: src/metabase/driver.clj
 msgid "Initializing driver {0}..."
-msgstr ""
+msgstr "ドライバー{0}の初期化中です..."
 
 #: src/metabase/driver.clj
 msgid "Reason:"
-msgstr ""
+msgstr "理由:"
 
 #: src/metabase/driver.clj
 msgid "Invalid driver feature: {0}"
@@ -11573,7 +11603,7 @@ msgstr ""
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing connection pool for database {0} ..."
-msgstr ""
+msgstr "データベース {0} へのコネクションプールを切断中です..."
 
 #: src/metabase/driver/util.clj
 msgid "Error loading namespace"
@@ -11581,7 +11611,7 @@ msgstr ""
 
 #: src/metabase/events.clj
 msgid "Starting events listener:"
-msgstr ""
+msgstr "イベントリスナーを開始しています:"
 
 #: src/metabase/events.clj
 msgid "Unexpected error listening on events"
@@ -11589,7 +11619,7 @@ msgstr ""
 
 #: src/metabase/events/sync_database.clj
 msgid "Error syncing Database {0}"
-msgstr ""
+msgstr "データベース {0} の同期に失敗しました"
 
 #: src/metabase/events/sync_database.clj
 msgid "Failed to process sync-database event."
@@ -11629,15 +11659,15 @@ msgstr ""
 
 #: src/metabase/plugins.clj
 msgid "Metabase does not have permissions to write to plugins directory {0}"
-msgstr ""
+msgstr "Metabaseはプラグインディレクトリへの書き込み権限を持っていません"
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot use the plugins directory {0}"
-msgstr ""
+msgstr "Metabaseはプラグインディレクトリ {0} を使用できません"
 
 #: src/metabase/plugins.clj
 msgid "Please make sure the directory exists and that Metabase has permission to write to it."
-msgstr ""
+msgstr "ディレクトリが存在するか、Metabaseに書き込み権限があるか確認してください。"
 
 #: src/metabase/plugins.clj
 msgid "You can change the directory Metabase uses for modules by setting the environment variable MB_PLUGINS_DIR."
@@ -11657,7 +11687,7 @@ msgstr ""
 
 #: src/metabase/plugins.clj
 msgid "Failied to initialize plugin {0}"
-msgstr ""
+msgstr "プラグイン {0} の初期化に失敗しました"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in {0}..."
@@ -11681,7 +11711,7 @@ msgstr ""
 
 #: src/metabase/plugins/classloader.clj
 msgid "Added URL {0} to classpath"
-msgstr ""
+msgstr "URL {0} をクラスパスに追加しました"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin {0} declares a dependency that Metabase does not understand: {1}"
@@ -11693,15 +11723,15 @@ msgstr ""
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Metabase cannot initialize plugin {0} due to required dependencies."
-msgstr ""
+msgstr "必要な依存性を満たしていないため、Metabaseはプラグイン{0}を初期化できません。"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Class not found: {0}"
-msgstr ""
+msgstr "クラスが見つかりません: {0}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin ''{0}'' depends on plugin ''{1}''"
-msgstr ""
+msgstr "プラグイン ''{0}'' はプラグイン ''{1}'' に依存しています。"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "{0} dependency {1} satisfied? {2}"
@@ -11759,43 +11789,43 @@ msgstr ""
 #. finally, register the Metabase driver
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Registering lazy loading driver {0}..."
-msgstr ""
+msgstr "遅延ロードドライバー {0} の登録中です..."
 
 #: src/metabase/pulse.clj
 msgid "Error running query for Card {0}"
-msgstr ""
+msgstr "カード {0} のクエリー実行中にエラー"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
-msgstr ""
+msgstr "先週"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This week"
-msgstr ""
+msgstr "今週"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
-msgstr ""
+msgstr "先月"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This month"
-msgstr ""
+msgstr "今月"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
 msgstr ""
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
 msgstr ""
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
-msgstr ""
+msgstr "昨年"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This year"
-msgstr ""
+msgstr "今年"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "*driver* is unbound."
@@ -11843,11 +11873,11 @@ msgstr ""
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler {0}"
-msgstr ""
+msgstr "Quartzスケジューラ {0} を停止中です"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler {0}"
-msgstr ""
+msgstr "Quartzスケジューラ {0} を開始中です"
 
 #: src/metabase/task.clj
 msgid "Error loading tasks namespace {0}"
@@ -11857,11 +11887,11 @@ msgstr ""
 #. namespaces we can log it
 #: src/metabase/task.clj
 msgid "Initializing task {0}"
-msgstr ""
+msgstr "タスク {0} を初期化しています"
 
 #: src/metabase/task.clj
 msgid "Error initializing task {0}"
-msgstr ""
+msgstr "タスク {0} の初期化中にエラーが発生しました"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Problem sending abandonment email"
@@ -11913,7 +11943,7 @@ msgstr "バージョン情報の取得に失敗しました"
 
 #: src/metabase/util.clj
 msgid "Maximum memory available to JVM: {0}"
-msgstr ""
+msgstr "JVMに割り当てられる最大メモリ量: {0}"
 
 #: src/metabase/util.clj
 msgid "Not something with an ID: {0}"
@@ -12040,77 +12070,77 @@ msgid "[[CreateDate]] by quarter of the year"
 msgstr ""
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:200
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
-msgstr ""
+msgstr "ユーザーを編集"
 
 #: frontend/src/metabase/admin/people/containers/NewUserModal.jsx:13
 msgid "New user"
-msgstr ""
+msgstr "新規ユーザー"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
-msgstr ""
+msgstr "パスワードをリセットする"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:209
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
-msgstr ""
+msgstr "ユーザーを無効化"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:47
 msgid "Reactivate {0}?"
-msgstr ""
+msgstr "{0}を再有効化しますか？"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:63
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
 msgstr ""
 
-#: frontend/src/metabase/entities/collections.js:21
+#: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
-msgstr ""
+msgstr "コレクション"
 
-#: frontend/src/metabase/entities/collections.js:22
+#: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
-msgstr ""
+msgstr "コレクション"
 
-#: frontend/src/metabase/entities/dashboards.js:29
+#: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
-msgstr ""
+msgstr "ダッシュボード"
 
-#: frontend/src/metabase/entities/dashboards.js:30
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
-msgstr ""
+msgstr "ダッシュボード"
 
-#: frontend/src/metabase/entities/users.js:125
+#: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
 msgstr ""
 
-#: frontend/src/metabase/entities/users.js:126
-#: frontend/src/metabase/entities/users.js:133
+#: frontend/src/metabase/entities/users.js:38
+#: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
-msgstr ""
+msgstr "100文字以下でなければなりません"
 
-#: frontend/src/metabase/entities/users.js:132
+#: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
-msgstr ""
+msgstr "姓は必須です"
 
-#: frontend/src/metabase/entities/users.js:138
+#: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
-msgstr ""
+msgstr "Emailアドレスは必須です"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:90
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
-msgstr ""
+msgstr "アーカイブしたアイテムはここに現れます"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:16
 msgid "No description"
-msgstr ""
+msgstr "説明がありません"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:175
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
 msgstr ""
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:183
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
 msgstr ""
 
@@ -12136,11 +12166,11 @@ msgstr ""
 
 #: src/metabase/api/metric.clj
 msgid "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id."
-msgstr ""
+msgstr "DELETE /api/metric/:idは推奨されていません。 代わりに、'archived'値をPUT /api/metric/:idで変更してください。"
 
 #: src/metabase/api/segment.clj
 msgid "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id."
-msgstr ""
+msgstr "DELETE /api/segment/:idは推奨されていません。 代わりに、'archived'値をPUT /api/segment/:idで変更してください。"
 
 #: src/metabase/api/user.clj
 msgid "Value of is_superuser must correspond to presence of Admin group ID in group_ids."
@@ -12152,7 +12182,7 @@ msgstr ""
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected output in async API response"
-msgstr ""
+msgstr "非同期APIのレスポンスが予想外の出力です"
 
 #: src/metabase/async/api_response.clj
 msgid "starting streaming response"
@@ -12164,11 +12194,11 @@ msgstr ""
 
 #: src/metabase/async/api_response.clj
 msgid "Async response finished, closing channels."
-msgstr ""
+msgstr "非同期通信が終了しました。チャネルをクローズします。"
 
 #: src/metabase/async/api_response.clj
 msgid "No response after waiting {0}. Canceling request."
-msgstr ""
+msgstr "{0} 待ちましたが応答がありません。問い合わせをキャンセルします"
 
 #: src/metabase/async/api_response.clj
 msgid "Input channel unexpectedly closed."
@@ -12200,15 +12230,15 @@ msgstr ""
 
 #: src/metabase/async/util.clj
 msgid "Running {0} on separate thread..."
-msgstr ""
+msgstr "{0}を複数のスレッドで実行中..."
 
 #: src/metabase/async/util.clj
 msgid "Caught error running {0}"
-msgstr ""
+msgstr "{0}の実行中にエラーが発生しました"
 
 #: src/metabase/async/util.clj
 msgid "Request canceled, canceling future"
-msgstr ""
+msgstr "リクエストがキャンセルされたため、フューチャーをキャンセルしています"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing old connection pool for database {0} ..."
@@ -12224,7 +12254,7 @@ msgstr ""
 
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
-msgstr ""
+msgstr "カード {0} が見つかりません"
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Exception in API call"
@@ -12232,11 +12262,11 @@ msgstr ""
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Request canceled before finishing."
-msgstr ""
+msgstr "問い合わせは終了前にキャンセルされました"
 
 #: src/metabase/middleware/json.clj
 msgid "Metabase only supports JSON requests."
-msgstr ""
+msgstr "MetabaseはJSONリクエストのみをサポートしています"
 
 #: src/metabase/middleware/json.clj
 msgid "Make sure you set a 'Content-Type: application/json' header."
@@ -12304,21 +12334,780 @@ msgstr ""
 
 #: src/metabase/models/user.clj
 msgid "Adding User {0} to All Users permissions group..."
-msgstr ""
+msgstr "ユーザ {0} をAll Users権限グループに追加しています..."
 
 #: src/metabase/models/user.clj
 msgid "Adding User {0} to Admin permissions group..."
-msgstr ""
+msgstr "ユーザー {0} を管理者権限グループに追加しています..."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
 msgstr ""
 
-#: src/metabase/query_processor/async.clj
+#: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
 msgstr ""
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
+msgstr "{0} ミリ秒後にタイムアウトしました。"
+
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
+msgid "Misfire Instruction"
+msgstr ""
+
+#: frontend/src/metabase/components/ArchiveModal.jsx:31
+msgid "Archive this?"
+msgstr ""
+
+#: frontend/src/metabase/components/BrowseApp.jsx:244
+msgid "Learn about our data"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
+msgid "Use DNS SRV when connecting"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
+msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
+"an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
+"leave this disabled."
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
+msgid "Automatically run queries when doing simple filtering and summarizing"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr ""
+
+#: frontend/src/metabase/containers/Overworld.jsx:247
+msgid "Learn about this database"
+msgstr "このデータベースについて詳細を見る"
+
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+msgid "Archive this dashboard?"
+msgstr ""
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:113
+msgid "All results"
+msgstr ""
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:180
+msgid "Our Analytics"
+msgstr ""
+
+#: frontend/src/metabase/lib/schema_metadata.js:500
+msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
+msgstr ""
+
+#: frontend/src/metabase/lib/schema_metadata.js:508
+msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
+msgstr ""
+
+#: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
+msgid "Filter"
+msgstr ""
+
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+msgid "record"
+msgid_plural "records"
+msgstr[0] ""
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:346
+msgid "Browse Data"
+msgstr ""
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:376
+msgid "Write SQL"
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
+msgid "Simple question"
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
+msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
+msgid "Custom question"
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
+msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+msgid "Basic Metrics"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+msgid "Custom…"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
+msgid "Add grouping"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
+msgid "Pick a limit"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
+msgid "Show maximum"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
+msgid "Get Preview"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
+msgid "Back to previous results"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
+msgid "Sample values"
+msgstr "サンプル値"
+
+#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
+msgid "Visualize"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
+msgid "Join data"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
+msgid "Custom column"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
+msgid "Summarize"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
+msgid "Aggregate"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
+msgid "Breakout"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
+msgid "Pick the metric you want to see"
+msgstr "見たいメトリクスを選択してください"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
+#: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
+msgid "Pick a column to group by"
+msgstr "集約するためのキー列を選択してください"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
+msgid "Pick your starting data"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select None"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select All"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
+msgid "Pick a table..."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
+msgid "Enter a limit"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
+msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
+msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
+msgid "View the native query"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
+msgid "Native query for this question"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
+msgid "Convert this question to a native query"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
+msgid "SQL for this question"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
+msgid "Convert this question to SQL"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
+msgid "Get alerts"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
+msgid "{0} breakout"
+msgid_plural "{0} breakouts"
+msgstr[0] ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
+msgid "Hide filters"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
+msgid "Show filters"
+msgstr "フィルターを表示する"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
+msgid "Started from"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
+msgid "{0} row"
+msgid_plural "{0} rows"
+msgstr[0] ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
+msgid "Show all rows"
+msgstr "全ての行を表示する"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
+msgid "Show {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
+msgid "Showing first {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
+msgid "Showing {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
+msgid "Summarized"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Hide editor"
+msgstr "エディタを非表示にする"
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Show editor"
+msgstr "エディタを表示する"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
+msgid "Pick the metric you'd like to see"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
+msgid "{0} options"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
+msgid "Choose a visualization"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
+msgid "Filter by"
+msgstr "フィルタ項目"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+msgid "Summarize by"
+msgstr "集約方法"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+msgid "Group by"
+msgstr "集約キー"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+msgid "Add a metric"
+msgstr "メトリクスを追加する"
+
+#: frontend/src/metabase/user/components/UserSettings.jsx:57
+msgid "Profile"
+msgstr "プロフィール"
+
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:548
+msgid "This is usually pretty fast but seems to be taking a while right now."
+msgstr "これはたいていの場合はとても速いですが、現在は時間がかかっているようです。"
+
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
+msgid "Combo"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
+msgid "Row"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
+msgid "Trend"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:129
+msgid "Boolean"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+msgid "Unknown Segment"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+msgid "Unknown Filter"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
+msgid "Left outer join"
+msgstr "左外部結合"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
+msgid "Right outer join"
+msgstr "右外部結合"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
+msgid "Inner join"
+msgstr "内部結合"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
+msgid "Full outer join"
+msgstr "完全外部結合"
+
+#: src/metabase/api/card.clj
+msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
+msgstr ""
+
+#: src/metabase/api/session.clj
+msgid "Problem connecting to LDAP server, will fall back to local authentication"
+msgstr ""
+
+#: src/metabase/api/setup.clj
+msgid "Cannot create Database: cannot find driver {0}."
+msgstr ""
+
+#: src/metabase/api/tiles.clj
+msgid "Query failed"
+msgstr "クエリが失敗しました"
+
+#: src/metabase/async/util.clj
+msgid "Warning: {0} returned `nil`"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing result to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing exception to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Request canceled, canceling future."
+msgstr ""
+
+#: src/metabase/cmd/load_from_h2.clj
+msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
+msgstr "MetabaseはH2からPostgresまたはMySQL/MariaDBへのデータ移行のみをサポートしています。"
+
+#: src/metabase/db.clj
+msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "Application database setup"
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Could not find {0} driver."
+msgstr "{0}のドライバーが見つかりませんでした"
+
+#: src/metabase/driver.clj
+msgid "Abstract drivers cannot derive from concrete parent drivers."
+msgstr ""
+
+#: src/metabase/driver/mysql.clj
+msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifer."
+msgstr ""
+
+#: src/metabase/driver/sql_jdbc/execute.clj
+msgid "Client closed connection, canceling query"
+msgstr ""
+
+#: src/metabase/integrations/ldap.clj
+msgid "{0} is not a valid DN."
+msgstr ""
+
+#: src/metabase/middleware/log.clj
+msgid "Error logging API request"
+msgstr ""
+
+#: src/metabase/middleware/misc.clj
+msgid "Failed to set site-url"
+msgstr ""
+
+#: src/metabase/models/database.clj
+msgid "Error destroying thread pool for DB."
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/models/task_history.clj src/metabase/sync/util.clj
+msgid "Error saving task history"
+msgstr ""
+
+#: src/metabase/plugins.clj
+msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
+msgstr "spark-deps.jarはMetabase 0.32.0以降では必要ありません。pluginsディレクトリから削除して構いません。"
+
+#: src/metabase/plugins/classloader.clj
+msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
+msgstr ""
+
+#: src/metabase/plugins/files.clj
+msgid "Failed to copy file"
+msgstr "ファイルのコピーに失敗しました"
+
+#: src/metabase/public_settings.clj
+msgid "Invalid site URL: {0}"
+msgstr "無効なサイトURL: {0}"
+
+#: src/metabase/public_settings.clj
+msgid "site-url is invalid; returning nil for now. Will be reset on next request."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "More results have been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "This question has been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "We were unable to display this Pulse."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "Please view this card in Metabase."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "An error occurred while displaying this card."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Can only determine expected columns for MBQL queries."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "No columns returned."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
+msgstr "{0}を解決できません: フィールドが存在しないか、テーブルな異なるデータベースに属しています"
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot find Table ID for {0}"
+msgstr "{0}に対するテーブルIDが見つかりません"
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "No matching info found."
+msgstr "合致する情報が見つかりません"
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Could not resolve {0}"
+msgstr "{0}を解決できませんでした"
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Invalid fk-> clause: nowhere to add corresponding join."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "{0} driver does not support foreign keys."
+msgstr "{0}ドライバーは外部キーをサポートしていません"
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Query processor error: number of columns returned by driver does not match results."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Expected {0} columns, but first row of resuls has {1} columns."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "No expression named {0} found. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Distinct values of {0}"
+msgstr "{0}の異なる値"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Average of {0}"
+msgstr "{0}の平均値"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0}"
+msgstr "{0}の合計値"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "SD of {0}"
+msgstr "{0}の標準偏差"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Min of {0}"
+msgstr "{0}の最小値"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Max of {0}"
+msgstr "{0}の最大値"
+
+#. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0} matching condition"
+msgstr "条件に合致する{0}の合計値"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Share of rows matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Count of rows matching condition"
+msgstr "条件に合致する行の数"
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Request already canceled, will not run synchronous QP code."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unexpectedly got `nil` Query Processor response."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Got InterruptedException. Canceling query."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Query timed out after %s"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Creating new query thread pool for Database {0}"
+msgstr "データベース{0}に対する新しいクエリスレッドプールを作成中です"
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Destroying query thread pool for Database {0}"
+msgstr "データベース{0}に対するクエリスレッドプールを削除中です"
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Request canceled, canceling pending query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: query is missing source-metadata"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Using query processor cache backend: {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/expand_macros.clj
+msgid "Invalid metric: {0} reason: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unknown error"
+msgstr "未知のエラー"
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unexpected nil response from query processor."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Query canceled"
+msgstr "クエリがキャンセルされました"
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: Database {0} does not exist."
+msgstr "クエリに対するドライバを解決することができません: データベース{0}が存在しません。"
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_source_table.clj
+msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Cannot store Tables or Fields before Database is stored."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Attempting to fetch second Database. Queries can only reference one Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
+msgstr "テーブル{0}のフェッチに失敗しました: テーブルが存在しないか、テーブルが異なるデータベースに属しています。"
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
+msgstr "フィールド{0}のフェッチに失敗しました: フィールドが存在しないか、フィールドが異なるデータベースに属しています。"
+
+#: src/metabase/routes/index.clj
+msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Sample dataset DB file ''{0}'' cannot be found."
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Loading sample dataset..."
+msgstr "サンプルデータセットをロードしています..."
+
+#: src/metabase/sample_data.clj
+msgid "Failed to load sample dataset"
+msgstr "サンプルデータセットのロードに失敗しました"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Found new tables:"
+msgstr "新しいテーブルが見つかりました:"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Marking tables as inactive:"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Updating description for tables:"
+msgstr ""
+
+#: src/metabase/task.clj
+msgid "Rescheduling job {0}"
+msgstr ""
+
+#: src/metabase/task.clj
+msgid "Error rescheduling job"
+msgstr ""
+
+#: src/metabase/task/send_pulses.clj
+msgid "Starting Pulse Execution: {0}"
+msgstr ""
+
+#: src/metabase/task/send_pulses.clj
+msgid "Finished Pulse Execution: {0}"
+msgstr ""
+
+#: src/metabase/task/sync_databases.clj
+msgid "Failed to schedule tasks for Database {0}"
+msgstr "データベース{0}に対する定期タスクのスケジューリングに失敗しました"
+
+#: src/metabase/util/schema.clj
+msgid "All elements must be distinct."
+msgstr "全ての項目が一意でなければなりません"
+
+#: 
+msgctxt "Modal for selecting columns in source data or when doing a join."
+msgid "Pick the columns you want to include"
+msgstr "含めたい列を選択してください"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr "これを有効にすることにより、ユーザが図や表を見るときに要約やフィルターボタンを利用して簡単な探索を行った場合に、Metabaseが自動的にクエリを実行するようになります。このデータベースへのクエリが遅い場合は、この設定を無効にすることができます。この設定によってドリルスルーやSQLクエリが影響を受けることはありません。"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
+msgid "Change join type"
+msgstr "JOINの形式を変える"
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifier."
+msgstr ""
+
+#: src/metabase/integrations/common.clj
+msgid "Error adding User {0} to Group {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Infinite loop detected: recursively preprocessed query {0} times."
+msgstr "無限ループが検知されました: クエリに対する再帰的な前処理が{0}回行われました。"
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Error determining expected columns for query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr ""
 

--- a/locales/nb.po
+++ b/locales/nb.po
@@ -28,18 +28,19 @@ msgstr "Utforsk disse dataene"
 msgid "Select a database type"
 msgstr "Velg en databasetype"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:75
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:401
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:71
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:182
+#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:410
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:74
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:203
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:180
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:197
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:193
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:171
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:180
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:164
 msgid "Save"
 msgstr "Lagre"
@@ -60,7 +61,7 @@ msgid "This is a lightweight process that checks for\n"
 msgstr "Dette er en lett prosess som sjekker for oppdatering i database skjemaet. I de fleste tilfeller holder det med synkronisering hver time."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:184
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
 msgid "Scan"
 msgstr "Skann"
 
@@ -75,235 +76,237 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase kan skanne verdiene i hvert felt i denne databasen for og aktivere sjekkboks filtere i infotavler og spørsmål. Dette er en ressurs krevende prosess, spesielt for veldig store databaser"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:159
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Når skal Metabase automatisk skanne og mellomlagre feltverdier?"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:164
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
 msgstr "Regelmessig, etter en tidsplan"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:195
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
 msgstr "Bare når du legger til en ny filter-widget"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:199
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
 msgstr "Når en bruker legger til nye filter på en infotavle eller et SQL spørsmål, vil Metabase skanne feltene som er tilknyttet til det filteret for å vise liste over mulige filterverdier."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:210
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
 msgid "Never, I'll do this manually if I need to"
 msgstr "Aldri, jeg vil gjøre det manuelt hvis jeg trenger"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:222
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:222
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:426
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
 msgid "Saving..."
 msgstr "Lagrer..."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:39
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
 msgid "Server error encountered"
 msgstr "En tjenerfeil har oppstått"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:58
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
 msgstr "Slett denne databasen?"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
 msgstr "Alle dine lagrede spørsmål, beregninger og segmenter"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:67
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
 msgstr "Dette kan ikke angres"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
 msgstr "Hvis du er sikker, vennligst skriv"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:53
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
 msgstr "SLETT"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:71
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
-msgstr "I denne boksen:"
+msgstr "i denne boksen:"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:82
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:50
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:93
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:58
-#: frontend/src/metabase/admin/permissions/selectors.js:160
-#: frontend/src/metabase/admin/permissions/selectors.js:170
-#: frontend/src/metabase/admin/permissions/selectors.js:185
-#: frontend/src/metabase/admin/permissions/selectors.js:224
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:355
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:181
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:247
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:61
+#: frontend/src/metabase/admin/permissions/selectors.js:163
+#: frontend/src/metabase/admin/permissions/selectors.js:173
+#: frontend/src/metabase/admin/permissions/selectors.js:188
+#: frontend/src/metabase/admin/permissions/selectors.js:227
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:202
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:268
+#: frontend/src/metabase/components/ArchiveModal.jsx:35
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
-#: frontend/src/metabase/components/form/StandardForm.jsx:61
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:196
+#: frontend/src/metabase/components/form/StandardForm.jsx:62
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:198
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:289
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:162
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:153
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:38
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:189
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:24
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:48
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:41
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:92
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:259
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:88
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:121
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:132
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
 msgstr "Slett"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:128
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:74
-#: frontend/src/metabase/admin/permissions/selectors.js:320
-#: frontend/src/metabase/admin/permissions/selectors.js:327
-#: frontend/src/metabase/admin/permissions/selectors.js:423
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
+#: frontend/src/metabase/admin/permissions/selectors.js:323
+#: frontend/src/metabase/admin/permissions/selectors.js:330
+#: frontend/src/metabase/admin/permissions/selectors.js:426
 #: frontend/src/metabase/admin/routes.jsx:53
-#: frontend/src/metabase/nav/containers/Navbar.jsx:214
+#: frontend/src/metabase/nav/containers/Navbar.jsx:243
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
 msgstr "Databaser"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:129
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
 msgstr "Legg til database"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
-msgstr "Forbindelse"
+msgstr "Tilkobling"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:61
 msgid "Scheduling"
 msgstr "Planlegging"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:78
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:84
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:26
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:221
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
 msgstr "Lagre endringer"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:185
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:38
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:38
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
 msgstr "Handlinger"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:193
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
 msgstr "Synkroniser database skjemaer nå"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:194
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:206
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:109
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
 msgstr "Starter..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:195
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
 msgstr "Feilet ved synkronsering"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
 msgstr "Synkronisering utløst!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:205
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
 msgstr "Skanne felter verdier på nytt"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:207
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
 msgstr "Skanning feilet ved start"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
 msgstr "Skanning påbegynt!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:215
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:401
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
 msgstr "Faresone"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:221
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
 msgstr "Forkast lagrede feltverdier"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
 msgstr "Fjern denne databasen"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:73
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
 msgstr "Legg til database"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:85
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:36
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:36
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:122
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:32
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:399
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:446
 #: frontend/src/metabase/containers/EntitySearch.jsx:26
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:218
-#: frontend/src/metabase/entities/collections.js:93
-#: frontend/src/metabase/entities/dashboards.js:145
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:461
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:81
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:220
+#: frontend/src/metabase/entities/collections.js:94
+#: frontend/src/metabase/entities/dashboards.js:142
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
 msgstr "Navn"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:86
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
 msgstr "Motor"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:115
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
 msgstr "Sletter..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:145
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
 msgstr "Laster..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:161
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
 msgstr "Hent eksempel-datasettet tilbake"
 
@@ -320,9 +323,9 @@ msgid "Successfully saved!"
 msgstr "Lagring vellykket!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:177
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:197
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
 msgstr "Rediger"
@@ -331,86 +334,90 @@ msgstr "Rediger"
 msgid "Revision History"
 msgstr "Revisjonshistorikk"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
 msgstr "Arkiver denne {0}?"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
 msgstr "Lagrede spørsmål og andre ting som avhenger av denne {0} vil fortsette å virke, men denne {1} vil ikke lenger være mulig å velge fra spørrings-byggeren."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
 msgstr "Hvis du er usikker på om du vil arkivere denne {0}, vennligst skriv en kort forklaring på hvorfor den blir arkivert:"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
 msgstr "Dette vil vises i aktivitetsstrømmen og i en e-post som vil bli sendt til alle på ditt lag som lager noe som bruker denne {0}."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
 msgstr "Arkiver"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
 msgstr "Kaster..."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
 msgstr "Feilet"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
 msgstr "Suksess"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:91
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
+#: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Forhåndsvisning"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
 msgstr "Ingen kolonnebeskrivelse enda"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:135
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
 msgstr "Velg en feltsynlighet"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:210
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
 msgstr "Ingen spesiell type"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:211
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:148
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
 msgstr "Andre"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:231
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Velg en spesiell type"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:277
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
 msgstr "Velg ett mål"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:77
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:89
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:106
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:122
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
 msgstr "Kolonner"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Kolonne"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:121
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:306
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
 msgstr "Synlighet"
 
@@ -418,53 +425,53 @@ msgstr "Synlighet"
 msgid "Type"
 msgstr "Type"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
 msgstr "Nåværende database:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
 msgstr "Vis opprinnelige skjema"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:45
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
 msgstr "Datatype"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
 msgstr "Tillegsinfo"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
 msgstr "Fins ett skjema"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:51
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "{0} skjema"
 msgstr[1] "{0} skjemaer"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
 msgstr "Hvorfor skjule?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
 msgstr "Teknisk data"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
 msgstr "Irrelevant"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
 msgid "Queryable"
 msgstr "Spørbar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:91
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
 msgstr "Skjul"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
 msgstr "Ingen tabell beskrivelse enda"
 
@@ -472,65 +479,67 @@ msgstr "Ingen tabell beskrivelse enda"
 msgid "Metadata Strength"
 msgstr "Metadata styrke"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "[0} Spørbar Tabell"
 msgstr[1] "[0} Spørbare Tabeller"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:96
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} skjult tabell"
 msgstr[1] "{0} skjulte tabeller"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
 msgstr "Find en tabell"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
 msgstr "Skjemaer"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:24
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:137
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:68
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:56
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:190
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
 msgstr "Indikatorer"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
 msgstr "Legg til en indikator"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:37
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Definisjon"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Lag indikatorer som vises i nedtrekksmenyen i spørsmålsbyggeren"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:24
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:930
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:952
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:56
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segmenter"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
 msgstr "Legg til segment"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Lag segmenter som vises i nedfelsmenyen i spørsmål byggeren"
 
@@ -558,53 +567,53 @@ msgstr "edited the "
 msgid "made some changes"
 msgstr "gjorde noen endringer"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
-#: frontend/src/metabase/home/components/Activity.jsx:80
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:332
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/home/components/Activity.jsx:82
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
 msgstr "Du"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
 msgstr "Datamodell"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
 msgstr " Historie"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:48
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
 msgstr "Revisjons historie for"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:239
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
 msgstr "{0} - felt instillinger"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
 msgstr "Hvor dette feltet vil dukke opp i Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:329
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filtrering på dette feltet"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Når dette feltet brukes i ett filter, hvilken metode skal brukes for å legge inn filtreringsverdi?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:453
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Ingen beskrivelse for dette feltet enda"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:379
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
 msgstr "Opprinnelig verdi"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:380
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
 msgid "Mapped value"
 msgstr "Kartlagt verdi"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:423
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
 msgstr "Legg inn verdi"
 
@@ -621,7 +630,7 @@ msgid "Custom mapping"
 msgstr "Tilpasset kartlegging"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:155
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
 msgid "Unrecognized mapping type"
 msgstr "Ukjent kartleggingstype"
 
@@ -629,23 +638,23 @@ msgstr "Ukjent kartleggingstype"
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Det gjeldende feltet er ikke en fremmednøkkel eller måltabellen mangler FK-metadata."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:187
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
 msgstr "Valgt felt er ikke en fremmed nøkkel"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:347
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
 msgstr "Vis verdier"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:348
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Velg å vise originalverdien fra databasen, eller å vise tilhørende eller egendefinert informasjon."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:268
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
 msgstr "Velg ett felt"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:289
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
 msgstr "Vennligst velg en kolonne til visning"
 
@@ -653,16 +662,16 @@ msgstr "Vennligst velg en kolonne til visning"
 msgid "Tip:"
 msgstr "Tips:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Du vil kanskje oppdatere feltnavnet sånn at det fortsatt gir mening dersom du har valgt å bruke verdien fra et annet felt."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:364
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:102
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
 msgstr "Mellomlagret felt verdier"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:365
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase kan skanne verdiene for dette feltet for å aktivere avhukingsfilter i infotavler og spørsmål."
 
@@ -671,167 +680,168 @@ msgid "Re-scan this field"
 msgstr "Skan feltet på nytt"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
 msgstr "Kast mellomlagrede feltverdier"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:118
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
 msgstr "Mislyktes å kaste verdier"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard triggered!"
 msgstr "Kasting utløst!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:105
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Velg en hvilken som helst tabell for å se tabellens skjema og for å legge til eller endre metadata."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:37
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:34
-#: frontend/src/metabase/entities/collections.js:96
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "Navn er påkrevd"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:40
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
 msgstr "Beskrivelse er påkrevd"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:44
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:41
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
 msgstr "Revisjonsmelding er påkrevd"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:50
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
 msgstr "Aggregering er påkrevd"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
 msgstr "Rediger din indikator"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
 msgstr "Opprett din indikator"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:115
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Gjør endringer i din indikator og legg igjen en forklaring."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Du kan lage lagrede indikatorer for å legge til en navngitt indikator i denne tabellen. Lagrede indikatorer inkluderer den aggregerte typen, det aggregerte feltet, og alternativt alle filtre du velger å legge til. Som et eksempel; du vil kanskje bruke dette for å lage noe sånt som den offisielle måten å beregne \"gjennomsnittlig pris\" for en ordre-tabell."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
 msgstr "Resultat: "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
 msgstr "Gi navn til din indikator"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
 msgstr "Gi indikatoren din et navn for å hjelpe andre med å finne den."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:162
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
 msgstr "Noe beskrivende men ikke for langt"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
 msgstr "Beskriv din indikator"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Gi din indikator en beskrivelse for å hjelpe andre med å forså hva den handler om."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Dette er et bra sted å være mer spesifikk om mindre åpenbare indikator-regler."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:179
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
 msgstr "Grunn Til Endringer"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:177
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Legg igjen en beskjed for å forklare hva slags endringer du gjorde og hvorfor de måtte gjøres."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Dette vil vises i revisjonshistorikken for denne indikatoren for å hjelpe alle med å huske hvorfor ting ble forandret."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
 msgstr "Minst ett filter er påkrevd"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
 msgstr "Rediger ditt segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
 msgstr "Opprett ditt segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:121
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Gjør endringer i ditt segment og legg igjen en forklaring."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Velg og legg til filtere for å lage ditt nye segment for {0}-tabellen"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
 msgstr "Navngi ditt segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:162
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
 msgstr "Gi segmentet ditt et navn for å gjøre det enklere for andre å finne det"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:170
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
 msgstr "Beskriv ditt segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Gi ditt segment en beskrivelse for å hjelpe andre med å forstå hva det dreier seg om."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:175
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Dette er et bra sted å være mer spesifikk om mindre åpenbare segmenteringsregler"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:185
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Dette vil vises i revisjonshistorikken for dette segmentet for å hjelpe alle å huske hvorfor ting ble endret"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:266
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:87
-#: frontend/src/metabase/nav/containers/Navbar.jsx:199
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:269
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:91
+#: frontend/src/metabase/nav/containers/Navbar.jsx:228
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
 msgstr "Innstillinger"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:103
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase kan skanne verdiene i denne tabellen for å lage avkrysningsboks-filtere på infotavlene og i spørsmålene."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:108
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
 msgstr "Skan denne tabellen på nytt"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:253
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
 msgstr "Legg til"
 
@@ -840,20 +850,22 @@ msgstr "Legg til"
 msgid "Not a valid formatted email address"
 msgstr "Ikke ett gyldig format på e-post adresse"
 
+#: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:100
 msgid "First name"
 msgstr "Fornavn"
 
+#: frontend/src/metabase/entities/users.js:42
 #: frontend/src/metabase/setup/components/UserStep.jsx:203
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:117
 msgid "Last name"
 msgstr "Etternavn"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:77
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:158
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:161
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:470
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:481
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
@@ -867,34 +879,35 @@ msgstr "Tillatelsesgrupper"
 msgid "Make this user an admin"
 msgstr "Gjør denne bruker til administrator"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:32
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
 msgstr "Alle brukere tilhører {0}-gruppen og kan ikke fjernes fra den. Innstilling av rettigheter for denne gruppen er en bra måte å være sikker på at du vet hva nye Metabase-brukere i denne gruppen har lov til å se."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:41
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
 msgstr "Dette er en spesiell gruppe, og dens medlemmer kan se alt i denne Metabase-instansen. Medlemmer av denne gruppen kan også gjøre endringer i administrasjonspanelet, inkludert endring av tillatelser! Så, vær forsiktig når du legger til brukere i denne gruppen."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:45
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
 msgstr "For å sikre at du ikke blir låst ute av Metabase, må det alltid være igjen en bruker i denne gruppen."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
 msgstr "Medlemmer"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:124
-#: frontend/src/metabase/admin/settings/selectors.js:113
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
+#: frontend/src/metabase/admin/settings/selectors.js:110
+#: frontend/src/metabase/entities/users.js:50
 #: frontend/src/metabase/lib/core.js:55
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
 msgstr "E-post"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:203
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
 msgstr "En gruppe er kun like bra som sine medlemmer."
 
@@ -905,8 +918,8 @@ msgid "Admin"
 msgstr "Administrator"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:237
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:290
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
 msgstr "og"
 
@@ -936,13 +949,13 @@ msgstr "Er du sikker? Alle medlemmer av denne gruppen vil miste tilganger fra de
 "Denne kan ikke bli gjennopprettet."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
 msgstr "Ja"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
 msgstr "Nei"
 
@@ -961,10 +974,11 @@ msgstr "Fjern gruppe"
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:107
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:327
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:395
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:265
+#: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
 msgstr "Ferdig"
 
@@ -974,9 +988,9 @@ msgstr "Gruppenavn"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:131
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:88
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
 msgstr "Grupper"
 
@@ -1005,9 +1019,9 @@ msgid "Deactivate"
 msgstr "Deaktiver"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:93
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
-#: frontend/src/metabase/nav/containers/Navbar.jsx:204
+#: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
 msgstr "Folk"
 
@@ -1047,7 +1061,6 @@ msgid "We've re-sent {0}'s invite"
 msgstr "Vi har sendt ut invitasjon på nytt til {0}"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
-#: frontend/src/metabase/tutorial/Tutorial.jsx:253
 msgid "Okay"
 msgstr "Okei"
 
@@ -1079,13 +1092,13 @@ msgstr "De vil kunne logge inn igjen, de vil da bli plassert tilbake i gruppene 
 msgid "Reset {0}'s password?"
 msgstr "Tilbakestill {0} sitt passord?"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:77
+#: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
 msgstr "Tilbakestill"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:44
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
 msgstr "Er du sikker du vil gjøre dette?"
 
@@ -1101,76 +1114,78 @@ msgstr "Her er ett midlertidig passord de kan bruke for å logge inn og bytte pa
 msgid "We've sent them an email with instructions for creating a new password."
 msgstr "Vi har sendt dem en e-post med instruksjoner for å lage ett nytt passord."
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:101
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
 msgstr "Aktiv"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:127
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
 msgstr "Deaktivert"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:115
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
 msgstr "Legg til noen"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
 msgstr "Siste innlogging"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:153
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
 msgstr "Meldt inn via Google"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:158
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
 msgstr "Meldt inn via LDAP"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:170
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
 msgstr "Reaktiver denne kontoen"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:193
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
 msgstr "Aldri"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:27
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
 msgstr[0] "{0} tabell"
 msgstr[1] "{0} tabeller"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:45
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
 msgstr " vil bli "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:48
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
 msgstr "gitt tilgang til"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:53
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
 msgstr " og "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:56
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
 msgstr "nektet tilgang til"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:70
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
 msgstr " vil ikke lenger kunne "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:71
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
 msgstr "vil nå kunne "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:79
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
 msgstr " lokal spørring for "
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
-#: frontend/src/metabase/nav/containers/Navbar.jsx:219
+#: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
 msgstr "Tillatelser"
 
@@ -1195,15 +1210,15 @@ msgstr "Ingen endringer i tillatelser vil bli gjort."
 msgid "You've made changes to permissions."
 msgstr "Du har gjort endringer med tilganger"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:52
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
 msgstr "Tilganger for denne samlingen"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
 msgstr "Du har ulagrede endringer"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:54
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
 msgstr "Vil du gå bort fra siden uten å lagre endringene?"
 
@@ -1223,119 +1238,119 @@ msgstr "Hver Metabase bruker tilhører i \"alle brukere\" gruppen. Hvis du vil b
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
 msgstr "MetaBot er Metabase sin Slack-bot. Du kan velge hva den skal ha tilgang til her."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:119
+#: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
 msgstr "Gruppen {0} kan ha tilgang til et annet sett av {1} enn denne gruppen, som kan gi gruppen tilgang til noe av {2}"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:124
+#: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
 msgstr "\"{0}\"-gruppen har et høyere nivå av adgang enn dette, det vil overstyre denne innstillingen. Du bør begrense eller fjerne \"{1}\"-gruppens tilgang til denne ressursen."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
 msgstr "Grense"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
 msgstr "Fjern"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:156
+#: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
 msgstr "tilgang selv om \"{0}\" har høyere tilgangsnivå?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:258
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
 msgstr "Tilgangsgrense"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:223
-#: frontend/src/metabase/admin/permissions/selectors.js:266
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:226
+#: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
 msgstr "Fjern tilgang"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:168
+#: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
 msgstr "Bytt tilgang til denne databasen til begrenset?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:169
+#: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
 msgstr "Bytt"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:182
+#: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
 msgstr "Tillatt direkte spørringer?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:183
+#: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
 msgstr "Dette vil også endre denne gruppens data tilgang til ubegrenset for denne databasen."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:184
+#: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
 msgstr "Tillatt"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:221
+#: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
 msgstr "Fjern tilgang til alle tabeller?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:222
+#: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
 msgstr "Dette vil også fjerne denne gruppens tilgang til rå spørringer for denne databasen."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:251
+#: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
 msgstr "Gi ubegrenset tilgang"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:252
+#: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
 msgstr "Ubegrenset tilgang"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:259
+#: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
 msgstr "Begrenset tilgang"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:267
+#: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
 msgstr "Ingen tilgang"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:273
+#: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
 msgstr "Skriv rå spørringer"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:274
+#: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
 msgstr "Kan skrive direkte spørringer"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:281
+#: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
 msgstr "Organiser samlingen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:288
+#: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
 msgstr "Vis samling"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:331
-#: frontend/src/metabase/admin/permissions/selectors.js:427
-#: frontend/src/metabase/admin/permissions/selectors.js:524
+#: frontend/src/metabase/admin/permissions/selectors.js:334
+#: frontend/src/metabase/admin/permissions/selectors.js:430
+#: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
 msgstr "Tilgang til data"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:492
-#: frontend/src/metabase/admin/permissions/selectors.js:649
-#: frontend/src/metabase/admin/permissions/selectors.js:654
+#: frontend/src/metabase/admin/permissions/selectors.js:495
+#: frontend/src/metabase/admin/permissions/selectors.js:652
+#: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
 msgstr "Vis tabeller"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:590
+#: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
 msgstr "SQL spørsmål"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:660
+#: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
 msgstr "Vis skjemaer"
 
 #: frontend/src/metabase/admin/routes.jsx:59
-#: frontend/src/metabase/nav/containers/Navbar.jsx:209
+#: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
 msgstr "Datamodell"
 
@@ -1344,31 +1359,31 @@ msgstr "Datamodell"
 msgid "Sign in with Google"
 msgstr "Loginn med Google"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:13
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
 msgstr "Tillat brukere med eksisterende Metabase konto å logge inn med en Google konto som tilsvarer deres e-postadresse i tillegg til Metabase brukernavn og passord."
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:17
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
 msgstr "Konfigurer"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
-#: frontend/src/metabase/admin/settings/selectors.js:207
+#: frontend/src/metabase/admin/settings/selectors.js:204
 msgid "LDAP"
 msgstr "LDAP"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:25
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 #, fuzzy
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
 msgstr "Tillat brukere innenfor din LDAP katalog til å logge inn på Metabase med deres LDAP konto, i tillegg til at Metabase kan tildele Metabase grupper som tilsvarer LDAP grupper."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
-#: frontend/src/metabase/admin/settings/selectors.js:160
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
 msgstr "Det er ikke en gyldig e-postadresse"
 
@@ -1406,7 +1421,7 @@ msgstr "Rens"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:202
+#: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
 msgstr "Autentisering"
 
@@ -1471,21 +1486,21 @@ msgid "Once you're there, give it a name and click {0}. Then copy and paste the 
 msgstr "Når du er der, gi den ett navn og klikk på {0}.\n"
 "Kopier og lim inn Bot API nøkkel i understående felt. Når du er ferdig, lag en \"metabase_files\" kanal i Slack. Metabase trenger denne til å laste opp grafer."
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:90
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
 msgstr "Du bruker Metabase {0} som er den siste og beste!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:99
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0} er tilgjengelig. Du bruker {1}"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:112
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
 msgstr "Oppdater"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:116
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
 msgstr "Hva som blir endret:"
 
@@ -1498,80 +1513,80 @@ msgstr "Legg til kart"
 msgid "URL"
 msgstr "Nettlink"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:199
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
 msgstr "Slett tilpasset kart"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:327
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:40
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:181
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
 msgstr "Slett"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:226
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:187
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:241
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:246
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
 msgstr "Velg..."
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:241
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
 msgstr "Prøve verdier:"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
 msgstr "Legg til nytt kart"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
 msgstr "Endre kart"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:280
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
 msgstr "Hva vil du kalle dette kartet?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
 msgstr "Eksempel Norge, Europa, Månen"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:292
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
 msgstr "Nettlink for GeoJSON fil du vil bruke"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:298
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
 msgstr "Eksempel https://min-mb-tjener.no/kart/mitt-kart.json"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:33
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
 msgstr "Oppdater"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
 msgstr "Last inn"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:315
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
 msgstr "Hvilken verdi spesifiserer regionale identifikatorer?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:324
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
 msgstr "Hvilken verdi spesifiserer regionens visningsnavn?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:345
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
 msgstr "Last inn en GeoJSON-fil for å se en forhåndsvisning"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
 msgstr "Lagre kart"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
 msgstr "Legg til kart"
 
@@ -1583,11 +1598,11 @@ msgstr "Bruk innebygging"
 msgid "By enabling embedding you're agreeing to the embedding license located at"
 msgstr "Ved å aktivere innebygging er du enig med innebygging lisensen som fins her"
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:19
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
 msgstr "Kort oppsummert, når du bygger inn grafer eller infotavler fra Metabase i din egen applikasjon, så blir ikke den applikasjonen underlagt \"Affero General Publicus Lovende\" som dekker resten av Metabase, så lenge Metabase-logoen og teksten \"Powered by Metabase\" er synlig på alle innbygginger. Du burde uansett lese selve lisensen lenket til ovenfor ettersom det er den faktiske lisensen som du godtar ved å aktivere denne funksjonen."
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:32
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
 msgstr "Aktiver"
 
@@ -1611,25 +1626,25 @@ msgstr "Kjøp en nøkkel"
 msgid "Enter a token"
 msgstr "Legg inn en nøkkel"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:134
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
 msgstr "Rediger tilordninger"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:140
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
 msgstr "Grupper tilordninger"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:147
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
 msgstr "Lag en tilordning"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
 msgstr "Tilordninger tillater Metabase å automatisk legge til og fjerne brukere fra grupper basert på medlemsinformasjonen i LDAP-tjeneren. Medlemskap i Admin-gruppen kan gies gjennom tilordningene, men vil ikke automatisk fjernes som sikring mot å bli låst ute."
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
 msgstr "Unikt navn"
 
@@ -1641,44 +1656,44 @@ msgstr "Offentlig link"
 msgid "Revoke Link"
 msgstr "Tilbakekall linken"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:121
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
 msgstr "Deaktiver nettlinken?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:122
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
 msgstr "De vil ikke fungere lenger, og de kan ikke tilbakekalles, men du kan lage nye nettlinker."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 #, fuzzy
 msgid "Public Dashboard Listing"
 msgstr "Offentlig oppføring av infotavle"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:152
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
 msgstr "Ingen infotavler har blitt offentlig publisert enda."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:160
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
 msgstr "Offentlig kortvisning"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:163
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
 msgstr "Ingen spørsmål har blitt offentlig publisert enda "
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:172
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
 msgstr "Innebygd visning av infotavle"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
 msgstr "Ingen infotavler har blitt bygget inn som en del av en annen side enda."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:183
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
 msgstr "Innebygd kortvisning"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:184
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
 msgstr "Ingen spørsmål har blitt innebygd enda."
 
@@ -1699,18 +1714,17 @@ msgid "Generate Key"
 msgstr "Lag nøkkel"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:78
-#: frontend/src/metabase/admin/settings/selectors.js:87
+#: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
 msgstr "Aktivert"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:83
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:103
+#: frontend/src/metabase/admin/settings/selectors.js:82
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Deaktivert"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:116
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
 msgstr "Ukjent innstilling {0}"
 
@@ -1718,7 +1732,7 @@ msgstr "Ukjent innstilling {0}"
 msgid "Setup"
 msgstr "Oppsett"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
 msgstr "Generelt"
@@ -1747,11 +1761,11 @@ msgstr "Database standard"
 msgid "Select a timezone"
 msgstr "Velg en tidssone"
 
-#: frontend/src/metabase/admin/settings/selectors.js:55
+#: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Ikke alle databaser støtter tidssoner, hvilket gjør at denne innstillingen ikke vil ta effekt."
 
-#: frontend/src/metabase/admin/settings/selectors.js:60
+#: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
 msgstr "Språk"
 
@@ -1759,204 +1773,204 @@ msgstr "Språk"
 msgid "Select a language"
 msgstr "Velg ett språk"
 
-#: frontend/src/metabase/admin/settings/selectors.js:70
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
 msgstr "Anonym sporing"
 
-#: frontend/src/metabase/admin/settings/selectors.js:75
+#: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
 msgstr "Vennlig tabell og feltnavn"
 
-#: frontend/src/metabase/admin/settings/selectors.js:81
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Erstatt understrek og bindestreker med mellomrom"
 
-#: frontend/src/metabase/admin/settings/selectors.js:91
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
 msgstr "Aktiver nøstede spørringer"
 
-#: frontend/src/metabase/admin/settings/selectors.js:102
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
 msgstr "Oppdateringer"
 
-#: frontend/src/metabase/admin/settings/selectors.js:107
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
 msgstr "Sjekk etter oppdateringer"
 
-#: frontend/src/metabase/admin/settings/selectors.js:118
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
 msgstr "SMTP vert"
 
-#: frontend/src/metabase/admin/settings/selectors.js:126
+#: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
 msgstr "SMTP port"
 
-#: frontend/src/metabase/admin/settings/selectors.js:130
-#: frontend/src/metabase/admin/settings/selectors.js:230
+#: frontend/src/metabase/admin/settings/selectors.js:127
+#: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
 msgstr "Det er ikke ett gyldig port nummer"
 
-#: frontend/src/metabase/admin/settings/selectors.js:134
+#: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
 msgstr "SMTP sikkerhet"
 
-#: frontend/src/metabase/admin/settings/selectors.js:142
+#: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
 msgstr "SMTP brukernavn"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
 msgstr "SMTP passord"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
 msgstr "Fra e-postadresse"
 
-#: frontend/src/metabase/admin/settings/selectors.js:170
+#: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
 msgstr "Slack API nøkkel"
 
-#: frontend/src/metabase/admin/settings/selectors.js:172
+#: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
 msgstr "Legg inn nøkkelen du fikk fra Slack"
 
-#: frontend/src/metabase/admin/settings/selectors.js:189
+#: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
 msgstr "Singel innlogging"
 
-#: frontend/src/metabase/admin/settings/selectors.js:213
+#: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
 msgstr "LDAP autorisering"
 
-#: frontend/src/metabase/admin/settings/selectors.js:219
+#: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
 msgstr "LDAP vert"
 
-#: frontend/src/metabase/admin/settings/selectors.js:227
+#: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
 msgstr "LDAP port"
 
-#: frontend/src/metabase/admin/settings/selectors.js:234
+#: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
 msgstr "LDAP sikkerhet"
 
-#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
 msgstr "Brukernavn eller DN"
 
-#: frontend/src/metabase/admin/settings/selectors.js:247
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:188
-#: frontend/src/metabase/user/components/UserSettings.jsx:72
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:191
+#: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
 msgstr "Passord"
 
-#: frontend/src/metabase/admin/settings/selectors.js:252
+#: frontend/src/metabase/admin/settings/selectors.js:249
 #, fuzzy
 msgid "User search base"
 msgstr "Bruker søkebase"
 
-#: frontend/src/metabase/admin/settings/selectors.js:258
+#: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
 msgstr "Brukerfilter"
 
-#: frontend/src/metabase/admin/settings/selectors.js:264
+#: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
 msgstr "Sjekk dine parenteser"
 
-#: frontend/src/metabase/admin/settings/selectors.js:270
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
 msgstr "E-post attributter"
 
-#: frontend/src/metabase/admin/settings/selectors.js:275
+#: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
 msgstr "Fornavn attributter"
 
-#: frontend/src/metabase/admin/settings/selectors.js:280
+#: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
 msgstr "Etternavn attributter"
 
-#: frontend/src/metabase/admin/settings/selectors.js:285
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
 msgstr "Synkroniser gruppe medlemskap"
 
-#: frontend/src/metabase/admin/settings/selectors.js:291
+#: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
 msgstr "Gruppesøkebase"
 
-#: frontend/src/metabase/admin/settings/selectors.js:300
+#: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
 msgstr "Kart"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
 msgstr "URL til tjener for kartfliser"
 
-#: frontend/src/metabase/admin/settings/selectors.js:306
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase bruker OpenStreetMaps som standard"
 
-#: frontend/src/metabase/admin/settings/selectors.js:311
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
 msgstr "Egendefinerte kart"
 
-#: frontend/src/metabase/admin/settings/selectors.js:312
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Legg til din egen GeoJSON fil for å aktivere forskjellige regionale kartvisualiseringer"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
 msgstr "Offentlig deling"
 
-#: frontend/src/metabase/admin/settings/selectors.js:336
+#: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
 msgstr "Aktiver offentlig deling"
 
-#: frontend/src/metabase/admin/settings/selectors.js:341
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
 msgstr "Delte infotavler"
 
-#: frontend/src/metabase/admin/settings/selectors.js:347
+#: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
 msgstr "Delte spørsmål"
 
-#: frontend/src/metabase/admin/settings/selectors.js:354
+#: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
 msgstr "Innebygd i andre applikasjoner"
 
-#: frontend/src/metabase/admin/settings/selectors.js:381
+#: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Aktiver innebygging av Metabase i andre applikasjoner"
 
-#: frontend/src/metabase/admin/settings/selectors.js:391
+#: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
 msgstr "Hemmelig innebyggingsnøkkel"
 
-#: frontend/src/metabase/admin/settings/selectors.js:397
+#: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
 msgstr "Innebygde infotavler"
 
-#: frontend/src/metabase/admin/settings/selectors.js:403
+#: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
 msgstr "Innebygde spørsmål"
 
-#: frontend/src/metabase/admin/settings/selectors.js:410
+#: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
 msgstr "Mellomlagring"
 
-#: frontend/src/metabase/admin/settings/selectors.js:415
+#: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
 msgstr "Aktiver mellomlagring"
 
-#: frontend/src/metabase/admin/settings/selectors.js:420
+#: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
 msgstr "Minimum spørringstid"
 
-#: frontend/src/metabase/admin/settings/selectors.js:427
+#: frontend/src/metabase/admin/settings/selectors.js:424
 #, fuzzy
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Mellomlagre Time-To-Live (TTL) multiplikator"
 
-#: frontend/src/metabase/admin/settings/selectors.js:434
+#: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
 msgstr "Maks mellomlagrings oppføringsstørrelse"
 
@@ -1972,11 +1986,11 @@ msgstr "Dine varsler er oppdatert."
 msgid "The alert was successfully deleted."
 msgstr "Varselen ble vellykket slettet."
 
-#: frontend/src/metabase/auth/auth.js:33
+#: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
 msgstr "Vennligst skriv inn en gyldig e-postadresse."
 
-#: frontend/src/metabase/auth/auth.js:116
+#: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
@@ -2018,90 +2032,87 @@ msgstr "Send e-post for tilbskestilling av passord"
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Sjekk din e-post konto for instruksjoner på hvordan du skal tilbakestille passordet."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:128
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
 msgstr "Logg inn på Metabase"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:138
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
 msgstr "ELLER"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:157
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
 msgstr "Brukernavn eller e-postadresse"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:217
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
 msgstr "Logg inn"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:230
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
 msgstr "Jeg har dessverre glemt passordet mitt"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
 msgstr "Be om en ny tilbakestillingsepost"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:120
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
 msgstr "Oops, nettlinken har utløpt"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:122
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
 msgstr "På grunn av sikkerhetsmessige grunner, passord tilbakestillingslinker utgår etter en liten stund. Hvis du fortsatt trenger å tilbakestille passordet, kan du {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:147
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
 msgstr "Nytt passord"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:149
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
 msgstr "For å holde dataen trygg er passordet {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:163
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
 msgstr "Lag ett nytt passord"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:170
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:141
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
 msgstr "Forsikre deg om at det er sikkert som instruksjonene over"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:184
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:150
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
 msgstr "Bekreft nytt passord"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:191
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:159
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
 msgstr "Forsikre deg om at det er likt som det du akkurat skrev inn"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:216
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
 msgstr "Passordet ditt har blitt tilbakestilt."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:222
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:227
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
 msgstr "Logg inn med ditt nye passord"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:182
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:251
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Lagring feilet"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:183
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:129
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:225
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:252
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
 msgstr "Lagret"
 
@@ -2109,24 +2120,22 @@ msgstr "Lagret"
 msgid "Ok"
 msgstr "Ok"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:38
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
 msgstr "Arkiver denne samlingen?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:43
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Infotavlene, samlingene og pulsene i denne samlingen vil også bli arkivert."
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
-#: frontend/src/metabase/components/CollectionLanding.jsx:624
+#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: frontend/src/metabase/components/CollectionLanding.jsx:620
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:47
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:195
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:200
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:40
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:53
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
 msgstr "Arkiv"
@@ -2135,28 +2144,27 @@ msgstr "Arkiv"
 msgid "This {0} has been archived"
 msgstr "{0} har blitt arkiverr"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:715
+#: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
 msgstr "Se arkivet"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:43
+#: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
 msgstr "Dearkiver {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:70
-#: frontend/src/metabase/components/BrowseApp.jsx:132
-#: frontend/src/metabase/components/BrowseApp.jsx:225
+#: frontend/src/metabase/components/BrowseApp.jsx:39
+#: frontend/src/metabase/components/BrowseApp.jsx:102
+#: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
 msgstr "Vår data"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:169
+#: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
 msgstr "Kjør X-ray på denne tabellen"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:183
-#: frontend/src/metabase/containers/Overworld.jsx:246
+#: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
 msgstr "Lær mer om denne tabellen"
 
@@ -2174,31 +2182,31 @@ msgstr "Lagret!"
 msgid "Saving failed."
 msgstr "Lagring feilet."
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
 msgstr "Sø"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
 msgstr "Ma"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
 msgstr "Ti"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
 msgstr "On"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
 msgstr "To"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
 msgstr "Fr"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
 msgstr "Lø"
 
@@ -2244,62 +2252,62 @@ msgstr "Pulser lar deg sende ut de siste dataene til ditt lag regelmessig via e-
 msgid "Questions are a saved look at your data."
 msgstr "Spørsmål er en lagret visning av dataene dine."
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:287
+#: frontend/src/metabase/components/CollectionLanding.jsx:286
 #, fuzzy
 msgid "Pins"
 msgstr "Festet"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:341
+#: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
 msgstr "Dra noe hit for og feste det til toppen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:737
-#: frontend/src/metabase/components/CollectionLanding.jsx:353
-#: frontend/src/metabase/home/containers/SearchApp.jsx:35
-#: frontend/src/metabase/home/containers/SearchApp.jsx:92
+#: frontend/src/metabase/admin/permissions/selectors.js:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:352
+#: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
 msgstr "Samlinger"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:432
-#: frontend/src/metabase/components/CollectionLanding.jsx:455
+#: frontend/src/metabase/components/CollectionLanding.jsx:431
+#: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
 msgstr "Dra hit for og fjerne festet"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:490
+#: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
 msgstr[0] "{0} element valgt"
 msgstr[1] "{0} elementer valgt"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:522
+#: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
 msgstr "Flytt {0} elementer"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:523
+#: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
 msgstr "Flytt \"{0}\"?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:631
+#: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
 msgstr "Flytt"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:692
+#: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
 msgstr "Rediger denne samlingen"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:700
+#: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
 msgstr "Arkiver denne samlingen"
 
-#: frontend/src/metabase/components/CollectionList.jsx:64
-#: frontend/src/metabase/entities/collections.js:155
+#: frontend/src/metabase/components/CollectionList.jsx:67
+#: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
 msgstr "Min personlige samling"
 
-#: frontend/src/metabase/components/CollectionList.jsx:106
+#: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
 msgstr "Ny samling"
 
@@ -2307,11 +2315,11 @@ msgstr "Ny samling"
 msgid "Copied!"
 msgstr "Kopiert!"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:216
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Bruk en SSH-tunnel for database tilkoblinger"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
@@ -2319,75 +2327,76 @@ msgstr "Noen databaseinstallasjoner kan kun kobles til gjennom en SSH bastion-ve
 "Dette alternativet gir også et ekstra lag med sikkerhet når VPN ikke er tilgjengelig.\n"
 "Det er vanligvis treigere enn en direkte tilkobling."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:271
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Dette er en stor database, så la meg velge når Metabase synkroniserer og skanner."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:273
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Som standard kjører Metabase en lettvekts-synkronisering hver time og en intensiv daglig skann av feltverdier.\n"
 "Hvis du har en stor database anbefaler vi at du slår på dette og følger med på når og hvor ofte feltverdi-skanningen skjer."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:289
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} for å generere en Klient ID og en Klient Hemmelighet for ditt prosjekt."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:291
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:353
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
 msgstr "Klikk her"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Velg \"Annet\" som applikasjonstype. Gi den det navnet du vil."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:316
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
 msgstr "{0} for å få en autentiseringskode"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:328
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
 msgstr "Med Google Drive tillatelse"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:348
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "For å bruke Metabase med disse dataene må du aktivere API tilgang i Google Developers Console. "
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:351
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} for å gå til konsollen hvis du ikke allerede har gjort det."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
 msgstr "Hvordan vil du referere til denne databasen?"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:427
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:237
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:188
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:74
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:194
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:79
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
 msgstr "Neste"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:52
+#: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
 msgstr "Slett denne {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:43
+#: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
 msgstr "Fest dette elementet"
 
-#: frontend/src/metabase/components/EntityItem.jsx:49
+#: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
 msgstr "Flytt dette elementet"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
 msgstr "Rediger dette spørsmålet"
 
@@ -2400,6 +2409,7 @@ msgstr "Handlingstype"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
 msgstr "Vis revisjonshistorikk"
 
@@ -2415,8 +2425,7 @@ msgstr "Arkiver handling"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:329
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:342
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
 msgstr "Legg til infotavle"
 
@@ -2440,13 +2449,12 @@ msgstr "Andre handlingstyper"
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:449
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:454
 msgid "Get alerts about this"
 msgstr "Få varsler om dette"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
 msgstr "Vis SQL'en"
 
@@ -2466,44 +2474,44 @@ msgstr "Her er hele feilmeldingen"
 msgid "Hi, Metabot here."
 msgstr "Hei, MetaBot her."
 
-#: frontend/src/metabase/components/ExplorePane.jsx:95
+#: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
 msgstr "Basert på skjemaet"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:174
+#: frontend/src/metabase/components/ExplorePane.jsx:173
 #, fuzzy
 msgid "A look at your"
 msgstr "En kikk på din"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:234
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
 msgstr "Søk i listen"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:238
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
 msgstr "Søk med {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
 msgstr " eller skriv inn en ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
 msgstr "Skriv inn en ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
 msgstr "Skriv inn et tall"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:248
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
 msgstr "Skriv inn tekst"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:355
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
 msgstr "Ingen funn på {0}."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:363
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Inkluderer hver mulighet i filteret ditt vil mest sannsynlig ikke gjøre mye."
 
@@ -2519,17 +2527,17 @@ msgstr "Vi har støtt på en feil. Du kan prøve å oppdatere siden, eller bare 
 #: frontend/src/metabase/components/HeaderBar.jsx:45
 #: frontend/src/metabase/components/ListItem.jsx:37
 #: frontend/src/metabase/reference/components/Detail.jsx:47
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:158
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:213
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:191
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:205
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:209
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:209
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:161
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:216
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:194
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:208
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
 msgstr "Ingen beskrivelse enda"
 
 #: frontend/src/metabase/components/Header.jsx:112
-#: frontend/src/metabase/entities/containers/EntityForm.jsx:43
+#: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
 msgstr "Ny {0}"
 
@@ -2537,54 +2545,53 @@ msgstr "Ny {0}"
 msgid "Asked by {0}"
 msgstr "Spurt av {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:13
+#: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
 msgstr "Idag, "
 
-#: frontend/src/metabase/components/HistoryModal.jsx:15
+#: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
 msgstr "Igår, "
 
-#: frontend/src/metabase/components/HistoryModal.jsx:68
+#: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
 msgstr "Første revisjon"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:70
+#: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
 msgstr "Reversert til en tidligere revisjon og {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:82
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:289
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:379
-#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
+#: frontend/src/metabase/components/HistoryModal.jsx:42
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
+#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
 msgstr "Revisjonshistorikk"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:90
+#: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
 msgstr "Når"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:91
+#: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
 msgstr "Hvem"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:92
+#: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
 msgstr "Hva"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:113
+#: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
 msgstr "Tilbakestilt"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:114
+#: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
 msgstr "Reverserer..."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:115
+#: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
 msgstr "Reversering feilet"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:116
+#: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
 msgstr "Reversert"
 
@@ -2593,26 +2600,24 @@ msgid "Everything"
 msgstr "Alt"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
-#: frontend/src/metabase/home/containers/SearchApp.jsx:69
 msgid "Dashboards"
 msgstr "Infotavler"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
-#: frontend/src/metabase/home/containers/SearchApp.jsx:115
 msgid "Questions"
 msgstr "Spørsmål"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:321
+#: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
 msgstr "Pulser"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:103
+#: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
 msgstr "Tilbake"
 
-#: frontend/src/metabase/components/ListSearchField.jsx:18
+#: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
 msgstr "Finn..."
 
@@ -2649,14 +2654,14 @@ msgid "Temporary Password"
 msgstr "Midlertidig passord"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
 msgstr "Skjul"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:412
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
 msgstr "Vis"
 
@@ -2721,7 +2726,7 @@ msgstr "Femtende (midten)"
 msgid "Calendar Day"
 msgstr "Kalenderdag"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:210
+#: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
 msgstr "din Metabase tidssone"
 
@@ -2750,11 +2755,11 @@ msgid "A component used to make a selection"
 msgstr "En komponent bruker dette valget"
 
 #: frontend/src/metabase/components/Select.info.js:20
-#: frontend/src/metabase/components/Select.info.js:28
+#: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
 msgstr "Valgt"
 
-#: frontend/src/metabase/components/Select.jsx:297
+#: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
 msgstr "Ingenting å velge"
 
@@ -2767,7 +2772,7 @@ msgid "Unknown error encountered"
 msgstr "Ukjent feil oppstod"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/nav/containers/Navbar.jsx:304
+#: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
 msgstr "Lag"
 
@@ -2776,13 +2781,11 @@ msgid "Create dashboard"
 msgstr "Lag infotavle"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:331
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:60
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
 msgstr "Tabell"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:306
 msgid "Database"
 msgstr "Database"
 
@@ -2790,22 +2793,20 @@ msgstr "Database"
 msgid "Creator"
 msgstr "Skaper"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:238
+#: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
 msgstr "Ingen resultater funnet"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:239
+#: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
 msgstr "Prøv å justere dine filter for å finne hva du leter etter."
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:258
+#: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
 msgstr "Vis med"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:494
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:84
-#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:69
-#: frontend/src/metabase/tutorial/TutorialModal.jsx:34
+#: frontend/src/metabase/containers/EntitySearch.jsx:495
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
 msgstr "av"
 
@@ -2818,13 +2819,13 @@ msgid "Once you connect your own data, I can show you some automatic exploration
 msgstr "Når du kobler til dine data, kan jeg gjøre en automatisk utforsking kalt X-ray. Her er noen eksempler med test-data."
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
-#: frontend/src/metabase/containers/Overworld.jsx:299
+#: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
 msgstr "Start her"
 
-#: frontend/src/metabase/containers/Overworld.jsx:294
-#: frontend/src/metabase/entities/collections.js:147
+#: frontend/src/metabase/containers/Overworld.jsx:296
+#: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
 msgstr "Vår analyse"
@@ -2833,53 +2834,53 @@ msgstr "Vår analyse"
 msgid "Browse all items"
 msgstr "Bla gjennom alle elementer"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:165
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
 msgstr "Erstatt eller lagre som ny?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:173
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
 msgstr "Erstatt det opprinnelige spørsmålet, \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:178
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
 msgstr "Lagre som nytt spørsmål"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:187
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
 msgstr "Først, lagre spørsmålet ditt"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:188
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
 msgstr "Lagre spørsmålet"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:224
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
 msgstr "Hva er navnet på kortet ditt?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:232
-#: frontend/src/metabase/entities/collections.js:101
-#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:234
+#: frontend/src/metabase/entities/collections.js:102
+#: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/lib/core.js:50 frontend/src/metabase/lib/core.js:205
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:156
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:211
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:203
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:207
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:207
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:24
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:159
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:214
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:192
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:206
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:210
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:238
-#: frontend/src/metabase/entities/dashboards.js:153
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
+#: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
 msgstr "Det er valgfritt, men veldig hjelpsomt"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:245
-#: frontend/src/metabase/entities/dashboards.js:157
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
+#: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "Hvilken samling skal denne være i?"
 
@@ -2891,7 +2892,7 @@ msgstr "modifiert"
 msgid "item"
 msgstr "element"
 
-#: frontend/src/metabase/containers/UndoListing.jsx:81
+#: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
 msgstr "Angre"
 
@@ -2915,15 +2916,15 @@ msgstr "Vi er ikke sikker på om dette spørsmålet kompatibelt"
 msgid "Archive Dashboard"
 msgstr "Arkiver infotavle"
 
-#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:20
+#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Forsikre deg om at noe i hver serie er valgt, ellers vil ikke filteret virke på dette kortet."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:300
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
 msgstr "Denne infotavlen ser ut til å være tom."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:301
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
 msgstr "Legg til ett spørsmål for og gjøre det nyttig!"
 
@@ -2943,59 +2944,58 @@ msgstr "Lukk fullskjerm"
 msgid "Enter fullscreen"
 msgstr "Åpne fullskjerm"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:181
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:183
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Lagrer..."
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:216
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
 msgstr "Legg til spørsmål"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:219
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
 msgstr "Legg et spørsmål til denne infotavlen"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:248
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
 msgstr "Legg til filter"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:254
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:78
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Parametere"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:275
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
 msgstr "Legg til en tekst boks"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
 msgstr "Flytt infotavlen"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:302
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
 msgstr "Rediger infotavle"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:306
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
 msgstr "Rediger visning av infotavle"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:369
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
 msgstr "Du redigerer en infotavle"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:374
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
 msgstr "Velg feltet som skal være filtrert for hvert kort"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:28
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
 msgstr "Flytt infotavle til..."
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:52
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
 msgstr "Infotavlen ble flyttet til {0}"
 
@@ -3010,7 +3010,7 @@ msgstr "Hva slags filter?"
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:179
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
 msgstr "Av"
 
@@ -3050,174 +3050,174 @@ msgstr "Fornyes om"
 msgid "Remove this question?"
 msgstr "Fjern dette spørsmålet?"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:71
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
 msgstr "Infotavlen ble lagret"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:745
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:76
+#: frontend/src/metabase/components/CollectionLanding.jsx:744
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
 msgstr "Se det"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:137
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
 msgstr "Lagre dette"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:170
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
 msgstr "Vis mer om dette"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:140
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
 msgstr "Dette kortet har ingen felter eller parametere som kan tilordnes denne parametertypen."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:142
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Verdiene i dette feltet overlapper ikke med verdiene i noen andre felt du har valgt."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:186
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
 msgstr "Ingen gyldige felt"
 
-#: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
 msgstr "Navn må være 100 tegn eller mindre"
 
-#: frontend/src/metabase/entities/collections.js:111
+#: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
 msgstr "Farge er påkrevd"
 
-#: frontend/src/metabase/entities/dashboards.js:146
+#: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
 msgstr "Hva er navnet på infotavlen din?"
 
-#: frontend/src/metabase/home/components/Activity.jsx:92
+#: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
 msgstr "gjorde noen superstilige ting som er vanskelig å beskrive"
 
-#: frontend/src/metabase/home/components/Activity.jsx:101
-#: frontend/src/metabase/home/components/Activity.jsx:116
+#: frontend/src/metabase/home/components/Activity.jsx:103
+#: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
 msgstr "laget en varsel om - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:126
-#: frontend/src/metabase/home/components/Activity.jsx:141
+#: frontend/src/metabase/home/components/Activity.jsx:128
+#: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
 msgstr "slettet en varsel om - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:152
+#: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
 msgstr "lagret et spørsmål om "
 
-#: frontend/src/metabase/home/components/Activity.jsx:165
+#: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
 msgstr "lagret et spørsmål"
 
-#: frontend/src/metabase/home/components/Activity.jsx:169
+#: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
 msgstr "slettet et spørsmål"
 
-#: frontend/src/metabase/home/components/Activity.jsx:172
+#: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
 msgstr "laget en infotavle"
 
-#: frontend/src/metabase/home/components/Activity.jsx:175
+#: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
 msgstr "slettet en infotavle"
 
-#: frontend/src/metabase/home/components/Activity.jsx:181
-#: frontend/src/metabase/home/components/Activity.jsx:196
+#: frontend/src/metabase/home/components/Activity.jsx:183
+#: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
 msgstr "la til et spørsmål til infotavlen - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:206
-#: frontend/src/metabase/home/components/Activity.jsx:221
+#: frontend/src/metabase/home/components/Activity.jsx:208
+#: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
 msgstr "fjernet et spørsmål fra infotavlen - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:231
-#: frontend/src/metabase/home/components/Activity.jsx:238
+#: frontend/src/metabase/home/components/Activity.jsx:233
+#: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
 msgstr "mottok de siste dataene fra"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:621
-#: frontend/src/metabase/home/components/Activity.jsx:244
+#: frontend/src/metabase-lib/lib/Dimension.js:814
+#: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
 msgstr "Ukjent"
 
-#: frontend/src/metabase/home/components/Activity.jsx:251
+#: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
 msgstr "Hallo verden!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:252
+#: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
 msgstr "Metabase er oppe og kjører."
 
-#: frontend/src/metabase/home/components/Activity.jsx:258
-#: frontend/src/metabase/home/components/Activity.jsx:288
+#: frontend/src/metabase/home/components/Activity.jsx:260
+#: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
 msgstr "la til indikatoren"
 
-#: frontend/src/metabase/home/components/Activity.jsx:272
-#: frontend/src/metabase/home/components/Activity.jsx:362
+#: frontend/src/metabase/home/components/Activity.jsx:274
+#: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
 msgstr " til "
 
-#: frontend/src/metabase/home/components/Activity.jsx:282
-#: frontend/src/metabase/home/components/Activity.jsx:322
-#: frontend/src/metabase/home/components/Activity.jsx:372
-#: frontend/src/metabase/home/components/Activity.jsx:413
+#: frontend/src/metabase/home/components/Activity.jsx:284
+#: frontend/src/metabase/home/components/Activity.jsx:324
+#: frontend/src/metabase/home/components/Activity.jsx:374
+#: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
 msgstr " tabell"
 
-#: frontend/src/metabase/home/components/Activity.jsx:298
-#: frontend/src/metabase/home/components/Activity.jsx:328
+#: frontend/src/metabase/home/components/Activity.jsx:300
+#: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
 msgstr "gjorde endringer i indikatoren"
 
-#: frontend/src/metabase/home/components/Activity.jsx:312
-#: frontend/src/metabase/home/components/Activity.jsx:403
+#: frontend/src/metabase/home/components/Activity.jsx:314
+#: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
 msgstr " i "
 
-#: frontend/src/metabase/home/components/Activity.jsx:335
+#: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
 msgstr "fjernet indikatoren"
 
-#: frontend/src/metabase/home/components/Activity.jsx:338
+#: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
 msgstr "laget en puls"
 
-#: frontend/src/metabase/home/components/Activity.jsx:341
+#: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
 msgstr "slettet en puls"
 
-#: frontend/src/metabase/home/components/Activity.jsx:347
-#: frontend/src/metabase/home/components/Activity.jsx:378
+#: frontend/src/metabase/home/components/Activity.jsx:349
+#: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
 msgstr "la til filteret"
 
-#: frontend/src/metabase/home/components/Activity.jsx:388
-#: frontend/src/metabase/home/components/Activity.jsx:419
+#: frontend/src/metabase/home/components/Activity.jsx:390
+#: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
 msgstr "gjorde endringer til filteret"
 
-#: frontend/src/metabase/home/components/Activity.jsx:426
+#: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
 msgstr "fjernet filteret {0}"
 
-#: frontend/src/metabase/home/components/Activity.jsx:429
+#: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
 msgstr "ble med!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:529
+#: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
 msgstr "Hmm, det ser ikke ut til at noe har skjedd enda."
 
-#: frontend/src/metabase/home/components/Activity.jsx:532
+#: frontend/src/metabase/home/components/Activity.jsx:534
 #, fuzzy
 msgid "Save a question and get this baby going!"
 msgstr "Lagre ett spørsmål så du får fart på denne skuta!"
@@ -3266,21 +3266,21 @@ msgstr "Nylig vist"
 msgid "You haven't looked at any dashboards or questions recently"
 msgstr "Du har ikke sett på noen infotavler eller spørsmål nylig"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:99
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
 msgstr "{0} elementer valgt"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:121
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:172
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
 msgstr "Dearkiver"
 
-#: frontend/src/metabase/home/containers/HomepageApp.jsx:74
-#: frontend/src/metabase/nav/containers/Navbar.jsx:331
+#: frontend/src/metabase/home/containers/HomepageApp.jsx:77
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
 msgstr "Aktivitet"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:28
+#: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
 msgstr "Resultater for \"{0}\""
 
@@ -3345,6 +3345,7 @@ msgstr "Avatar bilde-URL"
 msgid "Common"
 msgstr "Vanlig"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
@@ -3381,8 +3382,9 @@ msgstr "Breddegrad"
 msgid "Longitude"
 msgstr "Lengdegrad"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:149
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
 msgstr "Nummer"
@@ -3479,7 +3481,7 @@ msgstr "Poengsum"
 
 #: frontend/src/metabase/lib/core.js:210
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:17
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
 msgstr "Tittel"
 
@@ -3536,8 +3538,9 @@ msgid "Metabase will never retrieve this field. Use this for sensitive or irrele
 msgstr "Metabase vil aldri hente dette feltet. Bruk dette for sensitiv eller irrelevant informasjon."
 
 #: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:614
-#: frontend/src/metabase/visualizations/lib/utils.js:126
+#: frontend/src/metabase/lib/query.js:300
+#: frontend/src/metabase/visualizations/lib/utils.js:130
+#: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -3552,7 +3555,7 @@ msgstr "KumulativTelling"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
-#: frontend/src/metabase/visualizations/lib/utils.js:127
+#: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
 msgstr "Sum"
 
@@ -3561,7 +3564,7 @@ msgid "CumulativeSum"
 msgstr "KumulativSum"
 
 #: frontend/src/metabase/lib/expressions/config.js:11
-#: frontend/src/metabase/visualizations/lib/utils.js:128
+#: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
 msgstr "Distrikt"
 
@@ -3570,35 +3573,35 @@ msgid "StandardDeviation"
 msgstr "StandardAvvik"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/visualizations/lib/utils.js:125
+#: frontend/src/metabase/visualizations/lib/utils.js:129
 msgid "Average"
 msgstr "Gjennomsnitt"
 
 #: frontend/src/metabase/lib/expressions/config.js:14
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:25
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
 msgstr "Min"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
 msgstr "Maks"
 
-#: frontend/src/metabase/lib/expressions/parser.js:384
+#: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
 msgstr "trist trist panda, leksikalske feil ble funnet"
 
-#: frontend/src/metabase/lib/formatting.js:707
+#: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} sekund"
 msgstr[1] "{0} sekunder"
 
-#: frontend/src/metabase/lib/formatting.js:710
+#: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minutt"
@@ -3637,222 +3640,224 @@ msgstr "Hva tenker du på?"
 msgid "What do you want to find out?"
 msgstr "Hva lurer du på?"
 
-#: frontend/src/metabase/lib/query.js:612
-#: frontend/src/metabase/lib/schema_metadata.js:451
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:246
+#: frontend/src/metabase/lib/query.js:298
+#: frontend/src/metabase/lib/schema_metadata.js:458
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
 msgstr "Rådata"
 
-#: frontend/src/metabase/lib/query.js:616
+#: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
 msgstr "Kumulativ telling"
 
-#: frontend/src/metabase/lib/query.js:619
+#: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
 msgstr "Gjennomsnittet av "
 
-#: frontend/src/metabase/lib/query.js:624
+#: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
 msgstr "Unike verdier av "
 
-#: frontend/src/metabase/lib/query.js:629
+#: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
 msgstr "Standardavviket av "
 
-#: frontend/src/metabase/lib/query.js:634
+#: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
 msgstr "Summen av "
 
-#: frontend/src/metabase/lib/query.js:639
+#: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
 msgstr "Kumulativ sum av "
 
-#: frontend/src/metabase/lib/query.js:644
+#: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
 msgstr "Største av "
 
-#: frontend/src/metabase/lib/query.js:649
+#: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
 msgstr "Minste av "
 
-#: frontend/src/metabase/lib/query.js:663
+#: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
 msgstr "Gruppert etter "
 
-#: frontend/src/metabase/lib/query.js:677
+#: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
 msgstr "Filtrert på "
 
-#: frontend/src/metabase/lib/query.js:706
+#: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
 msgstr "Sortert etter "
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
 msgstr "Sant"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
 msgstr "Usant"
 
-#: frontend/src/metabase/lib/schema_metadata.js:305
+#: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
 msgstr "Velg felt for lengdegrad"
 
-#: frontend/src/metabase/lib/schema_metadata.js:306
+#: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
 msgstr "Skriv inn øvre breddegrad"
 
-#: frontend/src/metabase/lib/schema_metadata.js:307
+#: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
 msgstr "Skriv inn venstre lengdegrad"
 
-#: frontend/src/metabase/lib/schema_metadata.js:308
+#: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
 msgstr "Skriv inn nedre breddegrad"
 
-#: frontend/src/metabase/lib/schema_metadata.js:309
+#: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
 msgstr "Skriv inn høyre lengdegrad"
 
-#: frontend/src/metabase/lib/schema_metadata.js:345
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase-lib/lib/Dimension.js:505
+#: frontend/src/metabase-lib/lib/Dimension.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:351
+#: frontend/src/metabase/lib/schema_metadata.js:371
 #: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:387
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
 msgstr "Er"
 
-#: frontend/src/metabase/lib/schema_metadata.js:346
-#: frontend/src/metabase/lib/schema_metadata.js:366
-#: frontend/src/metabase/lib/schema_metadata.js:376
-#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/lib/schema_metadata.js:352
+#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:396
+#: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
 msgstr "Er ikke"
 
-#: frontend/src/metabase/lib/schema_metadata.js:347
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:369
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:353
+#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
 msgstr "Er tom"
 
-#: frontend/src/metabase/lib/schema_metadata.js:348
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:370
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:402
+#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
 msgstr "Ikke tom"
 
-#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
 msgstr "Er lik"
 
-#: frontend/src/metabase/lib/schema_metadata.js:355
+#: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
 msgstr "Ikke lik"
 
-#: frontend/src/metabase/lib/schema_metadata.js:356
+#: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
 msgstr "Større enn"
 
-#: frontend/src/metabase/lib/schema_metadata.js:357
+#: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
 msgstr "Mindre enn"
 
-#: frontend/src/metabase/lib/schema_metadata.js:358
-#: frontend/src/metabase/lib/schema_metadata.js:384
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:285
+#: frontend/src/metabase/lib/schema_metadata.js:364
+#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Mellom"
 
-#: frontend/src/metabase/lib/schema_metadata.js:359
+#: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
 msgstr "Større eller lik"
 
-#: frontend/src/metabase/lib/schema_metadata.js:360
+#: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
 msgstr "Mindre eller lik"
 
-#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
 msgstr "Inneholder"
 
-#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
 msgstr "Inneholder ikke"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
 msgstr "Starter med"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
 msgstr "Slutter med"
 
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:264
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Før"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:271
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Etter"
 
-#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
 msgstr "Inni"
 
-#: frontend/src/metabase/lib/schema_metadata.js:453
+#: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Bare en tabell med rader i svaret, ingen flere operasjoner."
 
-#: frontend/src/metabase/lib/schema_metadata.js:459
+#: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
 msgstr "Antall rader"
 
-#: frontend/src/metabase/lib/schema_metadata.js:461
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
 msgstr "Totalt antall rader i svaret"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
 msgstr "Summen av ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:469
+#: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
 msgstr "Summen av alle verdiene i en kolonne."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
 msgstr "Gjennomsnittet av ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
 msgstr "Gjennomsnittet av alle verdiene i en kolonne"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
 msgstr "Antall unike verdier av ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Antall unike verdier i en kolonne blant alle radene i svaret."
 
-#: frontend/src/metabase/lib/schema_metadata.js:491
+#: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
 msgstr "Kumulativ sum av ..."
 
@@ -3860,7 +3865,7 @@ msgstr "Kumulativ sum av ..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Additiv sum av alle verdiene i en kolonne.\\\\nf.eks. total omsetning over tid."
 
-#: frontend/src/metabase/lib/schema_metadata.js:499
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
 msgstr "Kumulativ telling av rader"
 
@@ -3868,105 +3873,105 @@ msgstr "Kumulativ telling av rader"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Additiv telling av antall rader.\\\\nf.eks. antall salg over tid."
 
-#: frontend/src/metabase/lib/schema_metadata.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
 msgstr "Standardavvik for ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:509
+#: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Tall som uttrykker hvor mye verdiene i en kolonne varierer blant alle radene i svaret."
 
-#: frontend/src/metabase/lib/schema_metadata.js:515
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
 msgstr "Minste av ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:517
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
 msgstr "Minste verdi i kolonnen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:523
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
 msgstr "Største av ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:525
+#: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
 msgstr "Største verdi i kolonnen"
 
-#: frontend/src/metabase/lib/schema_metadata.js:533
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
 msgstr "Bryt ut etter dimensjon"
 
-#: frontend/src/metabase/lib/settings.js:93
+#: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
 msgstr "liten bokstav"
 
-#: frontend/src/metabase/lib/settings.js:95
+#: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
 msgstr "stor bokstav"
 
-#: frontend/src/metabase/lib/settings.js:97
+#: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "tall"
 
-#: frontend/src/metabase/lib/settings.js:99
+#: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
 msgstr "spesialtegn"
 
-#: frontend/src/metabase/lib/settings.js:105
+#: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
 msgstr "må være"
 
-#: frontend/src/metabase/lib/settings.js:105
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:120
+#: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
 msgstr "tegn lang"
 
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
 msgstr "Må være"
 
-#: frontend/src/metabase/lib/settings.js:122
+#: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
 msgstr "og inkludere"
 
-#: frontend/src/metabase/lib/utils.js:92
+#: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
 msgstr "null"
 
-#: frontend/src/metabase/lib/utils.js:93
+#: frontend/src/metabase/lib/utils.js:86
 msgid "one"
 msgstr "en"
 
-#: frontend/src/metabase/lib/utils.js:94
+#: frontend/src/metabase/lib/utils.js:87
 msgid "two"
 msgstr "to"
 
-#: frontend/src/metabase/lib/utils.js:95
+#: frontend/src/metabase/lib/utils.js:88
 msgid "three"
 msgstr "tre"
 
-#: frontend/src/metabase/lib/utils.js:96
+#: frontend/src/metabase/lib/utils.js:89
 msgid "four"
 msgstr "fire"
 
-#: frontend/src/metabase/lib/utils.js:97
+#: frontend/src/metabase/lib/utils.js:90
 msgid "five"
 msgstr "fem"
 
-#: frontend/src/metabase/lib/utils.js:98
+#: frontend/src/metabase/lib/utils.js:91
 msgid "six"
 msgstr "seks"
 
-#: frontend/src/metabase/lib/utils.js:99
+#: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
 msgstr "syv"
 
-#: frontend/src/metabase/lib/utils.js:100
+#: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
 msgstr "åtte"
 
-#: frontend/src/metabase/lib/utils.js:101
+#: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
 msgstr "ni"
 
@@ -4040,6 +4045,7 @@ msgstr "Tid"
 msgid "Date range, relative date, time of day, etc."
 msgstr "Datointervall, relativ dato, tid på dagen, osv."
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
@@ -4062,7 +4068,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Kategori, Type, Modell, Vurdering, osv."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
-#: frontend/src/metabase/user/components/UserSettings.jsx:54
+#: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
 msgstr "Kontoinnstillinger"
 
@@ -4074,56 +4080,56 @@ msgstr "Lukk admin"
 msgid "Logs"
 msgstr "Logger"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:64
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
 msgstr "Hjelp"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:67
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
 msgstr "Om Metabase"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:73
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
 msgstr "Logg ut"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:98
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
 msgstr "Takk for at du bruker"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
 msgstr "Du bruker versjon"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
 msgstr "Bygget den"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:124
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
 msgstr "er et varemerke for"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:126
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
 msgstr "og er bygget med omhu i San Francisco, California"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:194
+#: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
 msgstr "Metabase Admin"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:300
+#: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
 msgstr "Still et spørsmål"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:309
+#: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
 msgstr "Ny infotavle"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:315
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/nav/containers/Navbar.jsx:361
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
 msgstr "Ny puls"
 
@@ -4131,16 +4137,16 @@ msgstr "Ny puls"
 msgid "Reference"
 msgstr "Referanse"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:83
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
 msgstr "Hvilken indikator?"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:110
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Å definere vanlige indikatorer for ditt lag gjør det enklere å spørre spørsmål"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:113
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
 msgstr "Hvordan lage indikatorer"
 
@@ -4152,8 +4158,8 @@ msgstr "Se data over tid, som et kart, eller pivotert for å gjøre det enklere 
 msgid "Custom"
 msgstr "Egendefinert"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:150
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:517
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
 msgstr "Nytt spørsmål"
 
@@ -4161,22 +4167,22 @@ msgstr "Nytt spørsmål"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Bruke den enkle spørsmåls-byggeren for å se trender, liser over ting, eller for å lage dine egne indikatorer."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:161
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Lokal spørring"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:162
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "For mer kompliserte spørsmål, kan du skrive din egen SQL eller lokal spørring."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:240
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
 msgstr "Velg en standardverdi..."
 
-#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:149
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
 msgstr "Oppdater filter"
 
@@ -4184,14 +4190,14 @@ msgstr "Oppdater filter"
 #: frontend/src/metabase/lib/query_time.js:123
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:9
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Today"
 msgstr "I dag"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
 msgstr "I går"
 
@@ -4203,7 +4209,7 @@ msgstr "Siste 7 dager"
 msgid "Past 30 days"
 msgstr "Siste 30 dager"
 
-#: frontend/src/metabase/lib/query_time.js:195
+#: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:29
 #: src/metabase/api/table.clj
@@ -4212,7 +4218,7 @@ msgid_plural "Weeks"
 msgstr[0] "Uke"
 msgstr[1] "Uker"
 
-#: frontend/src/metabase/lib/query_time.js:197
+#: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:30
 #: src/metabase/api/table.clj
@@ -4221,7 +4227,7 @@ msgid_plural "Months"
 msgstr[0] "Måned"
 msgstr[1] "Måneder"
 
-#: frontend/src/metabase/lib/query_time.js:201
+#: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:31
 #: src/metabase/api/table.clj
@@ -4271,6 +4277,7 @@ msgstr "Skriv en verdi..."
 msgid "Enter a default value..."
 msgstr "Skriv en standardverdi..."
 
+#: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "En feil oppstod"
@@ -4311,24 +4318,24 @@ msgstr "Publiser"
 msgid "Code"
 msgstr "Kode"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:70
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
 msgstr "Stil"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
 msgstr "Hvilke parametere kan brukere av denne innbyggingen bruke?"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:83
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
 msgstr "Denne {0} har ikke noen parametere å konfigurere enda."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
 msgstr "Redigerbar"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
 msgstr "Låst"
 
@@ -4336,19 +4343,19 @@ msgstr "Låst"
 msgid "Preview Locked Parameters"
 msgstr "Forhåndsvis Låste Parametere"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:115
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
 msgstr "Prøv å sende noen verdier til dine låste parametere her. Tjeneren din må tilby de faktiske verdiene i den signerte tokenen når du bruker dette på ordentlig."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
 msgstr "Faresone"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
 msgstr "Dette vil deaktivere innbygging av denne {0}."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:128
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
 msgstr "Avpubliser"
 
@@ -4388,64 +4395,64 @@ msgstr "Mer {0}"
 msgid "examples on GitHub"
 msgstr "eksempler på GitHub"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:72
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
 msgstr "Aktiver deling"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
 msgstr "Deaktiver denne offentlige lenken?"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:77
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
 msgstr "Dette vil gjøre sånn at den gjeldende lenken slutter å fungere. Du kan re-aktivere den, men du vil da få en annen lenke."
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
 msgstr "Offentlig lenke"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:118
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
 msgstr "Del denne {0} med folk som ikke har en Metabase-konto ved å bruke nettadressen under:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:158
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
 msgstr "Offentlig innbygging"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:159
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
 msgstr "Bygg inn denne {0} i blogginnlegg eller nettside ved å kopiere og lime inn denne snutten:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:176
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
 msgstr "Bygg inn denne {0} i en applikasjon"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:177
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
 msgstr "Ved å integrere med koden til din applikasjonstjener, så kan du tilby sikker statistikk {0} begrenset til en spesifikk bruker, kunde, organisasjon, osv."
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
 msgstr "Fjern vedlegg"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:95
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
 msgstr "Legg ved fil med resultatene"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
 msgstr "Dette spørsmålet vil bli lagt til som vedlegg"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:128
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
 msgstr "Dette spørsmålet vil ikke bli inkludert i din Puls"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:92
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
 msgstr "Denne pulsen vil ikke lenger bli sendt til {0} {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:94
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:376
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
 msgstr[0] "{0} adresse"
@@ -4455,39 +4462,39 @@ msgstr[1] "{0} adresser"
 msgid "Slack channel {0} will no longer get this pulse {1}"
 msgstr "Slack-kanalen {0} vil ikke lenger motta denne pulsen {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:110
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
 msgstr "Kanalen {0} vil ikke lenger motta denne pulsen {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
 msgstr "Rediger puls"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:131
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
 msgstr "Hva er en Puls?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:141
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
 msgstr "Skjønner"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
 msgstr "Hvor skal disse dataene sendes?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:173
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
 msgstr "Pakker ut..."
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
 msgstr "Utpakking feilet"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
 msgstr "Pakket ut"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
 msgstr "Laget puls"
 
@@ -4497,7 +4504,7 @@ msgstr "Vedlegg"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:673
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
 msgstr "Varsko"
 
@@ -4518,6 +4525,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Vi anbefaler å holde pulsene små og fokuserte for å gjøre de enklere å fordøye og mer anvendelige for hele laget."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
+#: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
 msgstr "Velg dataene dine"
 
@@ -4533,47 +4541,47 @@ msgstr "E-poster"
 msgid "Slack messages"
 msgstr "Slack-meldinger"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Sendt"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:222
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} vil bli sendt"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:224
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Meldinger"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Send e-post nå"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:241
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Send til {0} nå"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Sender..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:244
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Sending feilet"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Sendte ikke, fordi pulsen ikke har noen resultater."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:248
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Puls sendt"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:287
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} må settes opp av en administrator"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:302
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
 msgstr "Slack"
 
@@ -4622,21 +4630,21 @@ msgid "Before {0}"
 msgstr "Før {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:295
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Er tom"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:301
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Ikke tom"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:213
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Hele tiden"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:154
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
 msgstr "Bruk"
 
@@ -4702,7 +4710,7 @@ msgstr "Distribusjon"
 msgid "View details"
 msgstr "Vis detaljer"
 
-#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:54
+#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
 msgstr "Vis denne {0}s {1}"
 
@@ -4726,22 +4734,22 @@ msgstr "Gjennomsnitt"
 msgid "Distincts"
 msgstr "Unike"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:32
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Vis denne {0}"
 msgstr[1] "Vis disse {0}"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:225
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
 msgstr "Forstørr"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:19
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
 msgstr "Egendefinert uttrykk"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
 msgstr "Vanlige indikatorer"
 
@@ -4749,7 +4757,7 @@ msgstr "Vanlige indikatorer"
 msgid "Metabasics"
 msgstr "Metabasics"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
 msgstr "Navn (valgfritt)"
 
@@ -4761,31 +4769,31 @@ msgstr "Velg en aggregering"
 msgid "Set up your own alert"
 msgstr "Sett opp ditt eget varsel"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:140
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
 msgstr "Stopper abonnement..."
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:145
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
 msgstr "Klarte ikke å stoppe abonnement"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:204
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
 msgstr "Stopp abonnement"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:235
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
 msgstr "Ingen kanal"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:263
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
 msgstr "Okei, du har meldt deg av"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:335
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
 msgstr "Du mottar {0}s varsler"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
 msgstr "{0} satte opp en varsel"
 
@@ -4841,147 +4849,147 @@ msgstr "Rediger varselet ditt"
 msgid "Edit alert"
 msgstr "Rediger varsel"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:374
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
 msgstr "Dette varselet vil ikke lenger bli sendt til {0}"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:382
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
 msgstr "Slack-kanalen {0} vil ikke lenger motta dette varselet."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:386
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
 msgstr "Kanalen {0} vil ikke lenger motta dette varselet."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:403
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
 msgstr "Slett dette varselet."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:405
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
 msgstr "Stopp levering og slett dette varselet. Det er ingen måte å angre dette, så vær forsiktig."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:413
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
 msgstr "Slett dette varselet?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:497
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
 msgstr "Varsle meg når linjen..."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:498
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
 msgstr "Varsle meg når fremdriftsindikatoren..."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
 msgstr "Går over mållinjen"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
 msgstr "Når målet"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
 msgstr "Går under mållinjen"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
 msgstr "Går under målet"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:512
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
 msgstr "Første gangen den krysser, eller hver gang?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:513
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
 msgstr "Første gangen den når målet, eller hver gang?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
 msgstr "Første gangen"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:516
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
 msgstr "Hver gang"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:619
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
 msgstr "Hvor vil du ha disse varslene sendt?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:630
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
 msgstr "Send e-postvarsel til:"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:672
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
 msgstr "{0} Måldrevne varseler støttes ikke enda for diagrammer med mer enn én linje, så dette varselet vil bli sendt når enn diagrammet har {1}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
 msgstr "resultater"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:679
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
 msgstr "{0} Denne typen varsel er mest nyttig når dine lagrede spørsmål ikke {1} returnerer noen resultater, men du vil vite når de gjør det."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:680
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
 msgstr "Tips"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
 msgstr "vanligvis"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:57
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
 msgstr "Velg et segment eller en tabell"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
 msgstr "Velg en database"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:88
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
 msgstr "Velg..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:128
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
 msgstr "Velg en tabell"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:793
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
 msgstr "Ingen tabeller funnet for denne databasen"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:830
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
 msgstr "Mangler det et spørsmål?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:834
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
 msgstr "Lær mer om nøstede spørringer"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:868
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
 msgstr "Felter"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:946
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
 msgstr "Ingen segmenter ble funnet."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:969
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
 msgstr "Finn et segment"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:46
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
 msgstr "Vis mindre"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:56
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
 msgstr "Vis mer"
 
@@ -4990,60 +4998,65 @@ msgid "Pick a field to sort by"
 msgstr "Velg et felt det skal sorteres etter"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
 msgstr "Sorter"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
 msgstr "Radgrense"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:69
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
 msgstr "Ukjent felt"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
 msgstr "felt"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:114
+#: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
 msgstr "Matcher"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
+#: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Legg til filter for å snevre inn svaret ditt"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:284
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
 msgstr "Legg til en gruppering"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:322
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:102
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:113
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:152
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:194
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:59
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:68
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:75
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:225
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:231
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:237
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:70
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:75
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:64
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:89
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:131
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:176
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:302
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:308
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:314
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Data"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:352
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
 msgstr "Filtrert etter"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:369
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
 msgstr "Vis"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:386
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
 msgstr "Gruppert Etter"
 
@@ -5051,23 +5064,23 @@ msgstr "Gruppert Etter"
 msgid "None"
 msgstr "Ingen"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:345
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
 msgstr "Dette spørsmålet er skrevet i {0}."
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:353
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
 msgstr "Skjul Redigeringsverktøy"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:354
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
 msgstr "Skjul Spørring"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
 msgstr "Åpne Redigeringsverktøy"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:360
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
 msgstr "Vis Spørring"
 
@@ -5088,15 +5101,15 @@ msgstr "Last ned disse dataene"
 msgid "Warning"
 msgstr "Advarsel"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:52
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
 msgstr "Ditt svar har veldig mange rader, så det kan ta en stund å laste ned."
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:53
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
 msgstr "Maks antall rader ved nedlasting er 1 million."
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:232
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
 msgstr "Rediger spørsmål"
 
@@ -5112,17 +5125,17 @@ msgstr "AVBRYT"
 msgid "Move question"
 msgstr "Flytt spørsmål"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:283
+#: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
 msgstr "Hvilken samling skal denne være i?"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:313
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:110
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
+#: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
 msgstr "Variabler"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:432
+#: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
 msgstr "Lær mer om dataene dine"
 
@@ -5166,11 +5179,11 @@ msgstr "{0} for dette spørsmålet"
 msgid "Convert this question to {0}"
 msgstr "Konverter dette spørsmålet til {0}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:122
+#: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
 msgstr "Dette spørsmålet vil ta cirka {0} å fornye"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:131
+#: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
 msgstr "Oppdatert {0}"
 
@@ -5188,11 +5201,11 @@ msgstr "Viser først {0} {1}"
 msgid "Showing {0} {1}"
 msgstr "Viser {0} {1}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:281
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
 msgstr "Vitenskap utføres"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:294
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
 msgstr "Hvis du gir meg noe data, så kan jeg vise deg noe kult. Kjør en spørring!"
 
@@ -5200,7 +5213,7 @@ msgstr "Hvis du gir meg noe data, så kan jeg vise deg noe kult. Kjør en spørr
 msgid "How do I use this thing?"
 msgstr "Hvordan bruker jeg denne?"
 
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:28
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
 msgstr "Få svar"
 
@@ -5228,39 +5241,39 @@ msgstr "Beklager. Noe gikk galt."
 msgid "Group time by"
 msgstr "Grupper tid ved"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:46
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
 msgstr "Spørsmålet ditt tok for lang tid å svare på"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:47
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
 msgstr "Vi fikk ikke ett svar fra din database i tid, så vi måtte stoppe. Du kan prøve igjen om ett minutt, hvis problemet fortsetter, kan du sende en e-post til administrator for å rapportere."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:55
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
 msgstr "Vi har for øyeblikket tjenerproblemer"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:56
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
 msgstr "Prøv oppdatere siden etter å ha ventet ett minutt eller to. Hvis problemet fortsetter, ta kontakt med administrator."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:88
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
-msgstr "Det var ett problem med spørsmålet ditt"
+msgstr "Det var et problem med spørsmålet ditt"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:89
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
 msgstr "For det meste skyldes dette et ugyldig valg eller feil inntastet verdi. Sjekk input en gang til og prøv spørringen din igjen."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:60
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
 msgstr "Dette kan være svaret du leter etter. Hvis ikke, prøv å fjern eller endre filterne for å gjøre det mindre spesifisert."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
 msgstr "Du kan også {0} når det er noen resultater."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:68
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
 msgstr "få en varsel"
 
@@ -5268,11 +5281,11 @@ msgstr "få en varsel"
 msgid "Back to last run"
 msgstr "Tilbake til siste kjøring"
 
-#: frontend/src/metabase/query_builder/components/VisualizationSettings.jsx:100
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
 msgstr "Visualisering"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:96
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
 msgstr "Ingen beskrivelse satt."
 
@@ -5284,7 +5297,7 @@ msgstr "Bruk til dette spørsmålet"
 msgid "Potentially useful questions"
 msgstr "Potensielt nyttige spørsmål"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:166
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
 msgstr "Grupper med {0}"
 
@@ -5297,14 +5310,14 @@ msgstr "Sum av alle verdier med {0}"
 msgid "All distinct values of {0}"
 msgstr "Alle distinkte verdier av {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:187
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
 msgstr "Nummer av {0} gruppert med {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5320,34 +5333,34 @@ msgstr "Datareferanse"
 msgid "Learn more about your data structure to ask more useful questions"
 msgstr "Lær mer om din datastruktur for å spørre nyttigere spørsmål"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:58
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:84
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
 msgstr "Kunne ikke å finne tabellmetadata i før opprettelsen av nytt spørsmål"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:80
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
 msgstr "Se {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:94
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
 msgstr "Indikatordefinisjon"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:118
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
 msgstr "Filtrer med {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:127
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
 msgstr "Tall av {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
 msgstr "Se alle {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:148
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
 msgstr "Segmentdefinisjoner"
 
@@ -5359,7 +5372,7 @@ msgstr "En feil oppstod ved innlasting av tabell"
 msgid "See the raw data for {0}"
 msgstr "Se rådata for {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:180
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
 msgstr "Mer"
 
@@ -5371,24 +5384,24 @@ msgstr "Ugyldig uttrykk"
 msgid "unknown error"
 msgstr "ukjent feil"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:46
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
 msgstr "Felt formel"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:57
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Tenk på dette litt som å skrive en formel i et regneark: Du kan bruke tall, felter i denne tabellen, matematiske symboler som +, og noen funksjoner. Så du kan skrive noe sånt som Subtotal - Kostnad."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
 msgstr "Lær mer"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:66
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
 msgstr "Gi den ett navn"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:72
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
 msgstr "Noe fint og informativt"
 
@@ -5440,7 +5453,8 @@ msgstr "riktig"
 msgid "false"
 msgstr "feil"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
 msgstr "Legg til filter"
 
@@ -5448,15 +5462,15 @@ msgstr "Legg til filter"
 msgid "Item"
 msgstr "Element"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:221
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
 msgstr "Tidligere"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:252
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
 msgstr "Nåværende"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:278
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
@@ -5467,7 +5481,7 @@ msgid "Enter desired number"
 msgstr "Skriv inn ønsket tall"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:100
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
 msgstr "Tom"
 
@@ -5491,35 +5505,35 @@ msgstr "Du kan skrive inn flere verdier separert med komma"
 msgid "Enter desired text"
 msgstr "Skriv inn ønsket tekst"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
 msgstr "Prøv den"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
 msgstr "Hva er dette til?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
 msgstr "Variabler i lokale spørringer lar deg dynamisk erstatte verdier i spørringen ved bruk av filter eller gjennom nettlinken."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
 msgstr "{0} oppretter en variabel i denne SQL-malen kalt \"variable_name\". Variabler kan gies typer i sidepanelet, som endrer deres oppførsel. Alle variabeltyper annet enn \"feltfilter\" vil automatisk gjøre at en filterwidget blir plassert på dette spørsmålet; med feltfiltere, så er dette valgfritt. Når denne filterwidgeten er fylt inn, så vil dens verdi erstatte variabelen i SQL-malen."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:121
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
 msgstr "Felt filtere"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:123
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Ved å gi en variabel \"Felt Filter\"-typen så kan du lenke SQL-spørsmålskort til filter-widgetsene på infotavler, eller bruke flere typer filter-widgets på ditt SQL-spørsmål. En \"Felt Filter\"-variabel setter inn SQL tilsvarende det som den grafiske spørsmålsbyggeren gjør når det legges til filtere på eksisterende kolonner."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:126
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
 msgstr "Når du legger til en \"Felt Filter\"-variabel, så må du tilordne den til et spesifikt felt. Du kan deretter velge å vise en filter-widget på spørsmålet ditt, men selv om du ikke gjør det, så kan du nå tilordne \"Felt Filter\"-variabelen din til et infotavle-filter når du legger dette spørsmålet til en infotavle. Felt Filtere bør brukes inni en \"WHERE\"-klausul."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:130
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
 msgstr "Valgfrie klausuler"
 
@@ -5527,59 +5541,61 @@ msgstr "Valgfrie klausuler"
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
 msgstr "firkant-parenteser rundt en {0} lager en valgfri klausul i malen. Hvis \"variabel\" er satt, da blir hele klausulen satt inn i malen. Ellers så blir hele klausulen ignorert."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:142
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
 msgstr "For å bruke flere valgfrie klausuler kan du inkludere minst én ikke-valgfri WHERE-klausul etterfulgt av valgfrie klausuler som starter med \"AND\"."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
 msgstr "Les hele dokumentasjonen"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:127
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
 msgstr "Filter etikett"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:139
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
 msgstr "Variabel type"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:143
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
 msgstr "Tekst"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:150
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:119
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
 msgstr "Dato"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
 msgstr "Felt filter"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:157
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
 msgstr "Felt å koble til"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
 msgstr "Filter type"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:201
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
 msgstr "Påkrevd?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:211
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
 msgstr "Standard filter verdi"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:46
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
 msgstr "Arkiver spørsmålet?"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:57
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Dette spørsmålet vil bli slettet fra alle infotavler eller pulser den er i."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:136
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
 msgstr "Spørsmål"
 
@@ -5596,21 +5612,21 @@ msgstr "Du kan redigere denne siden"
 msgid "See this {0}"
 msgstr "Se dette {0}"
 
-#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:120
+#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
 msgstr "En underdel av"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:68
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
 msgstr "Velg en felt type"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:57
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
 msgstr "Ingen felt type"
 
@@ -5619,16 +5635,16 @@ msgid "by"
 msgstr "av"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
-#: frontend/src/metabase/reference/databases/FieldList.jsx:152
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
+#: frontend/src/metabase/reference/databases/FieldList.jsx:155
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
 msgstr "Felt type"
 
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:72
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
 msgstr "Velg en ukjent nøkkel"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:53
+#: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
 msgstr "Vis {0} formelen"
 
@@ -5645,12 +5661,12 @@ msgid "Nothing important yet"
 msgstr "Ingenting viktig enda"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:168
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:233
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:211
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:215
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:219
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:229
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:236
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:214
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
 msgstr "Ingenting interessant enda"
 
@@ -5659,12 +5675,12 @@ msgid "Things to be aware of about this {0}"
 msgstr "Ting å være klar over om denne {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:178
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:243
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:221
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:225
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:229
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:239
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:246
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:224
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
 msgstr "Ingenting å være klar over enda"
 
@@ -5726,15 +5742,15 @@ msgstr "Grunn til endring"
 msgid "Leave a note to explain what changes you made and why they were required"
 msgstr "Legg igjen et notat for å forklare endringene du gjorde og hvorfor de var nødvendige"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:166
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
 msgstr "Hvorfor denne databasen er interessant"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:176
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
 msgstr "Ting å være klar over om denne databasen"
 
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:46
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
 msgstr "Databaser og tabeller"
@@ -5742,42 +5758,42 @@ msgstr "Databaser og tabeller"
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:41
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:170
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:173
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:34
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:184
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:187
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:30
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:188
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:187
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:191
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:190
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
 msgstr "Detaljer"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
-#: frontend/src/metabase/reference/databases/TableList.jsx:111
+#: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
 msgstr "Tabeller i {0}"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:222
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:200
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:218
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:203
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
 msgstr "Reelt navn i database"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:231
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:227
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
 msgstr "Hvorfor er dette feltet interessant"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:241
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:237
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
 msgstr "Ting å være klar over om dette feltet"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:253
-#: frontend/src/metabase/reference/databases/FieldList.jsx:155
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:249
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
+#: frontend/src/metabase/reference/databases/FieldList.jsx:158
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
 msgstr "Datatype"
 
@@ -5786,13 +5802,13 @@ msgstr "Datatype"
 msgid "Fields in this table will appear here as they're added"
 msgstr "Felter i denne tabellen vil vises her når de blir lagt til"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:134
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:135
+#: frontend/src/metabase/reference/databases/FieldList.jsx:137
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
 msgstr "Felter i {0}"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:149
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:150
+#: frontend/src/metabase/reference/databases/FieldList.jsx:152
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
 msgstr "Feltnavn"
 
@@ -5816,7 +5832,10 @@ msgstr "Databasene vil vises her når en av administratorene har lagt til"
 msgid "Connect a database"
 msgstr "Koble til en database"
 
+#. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
+#. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
+#: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
 msgstr "Telling av {0}"
 
@@ -5824,11 +5843,11 @@ msgstr "Telling av {0}"
 msgid "See raw data for {0}"
 msgstr "Se rådata for {0}"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:209
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
 msgstr "Hvorfor er denne tabellen interessant"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:219
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
 msgstr "Ting å være klar over om denne tabellen"
 
@@ -5840,16 +5859,16 @@ msgstr "Tabellen i denne databasen vises her etter hvert som de blir lagt til"
 msgid "Questions about this table will appear here as they're added"
 msgstr "Spørsmål om denne tabellen vises her etter hvert som de blir lagt til"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:71
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:75
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:74
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
 msgstr "Spørsmål om {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
 msgstr "Laget {0} av {1}"
 
@@ -5861,151 +5880,152 @@ msgstr "Felter i denne tabellen"
 msgid "Questions about this table"
 msgstr "Spørsmål om denne tabellen"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:157
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
 msgstr "Hjelp ditt lag i gang med dataene dine."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:159
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
 msgstr "Vis ditt lag hva som er viktigst ved å velge din viktigste infotavle, indikatorer og segmenter."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:165
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
 msgstr "Gå igang"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:173
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
 msgstr "Vår viktigste infotavle"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:188
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
 msgstr "Tall vi følger med på"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:213
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
 msgstr "Indikatorer er viktige tall som din bedrift bryr seg om. De er ofte et mål på hvordan det går med bedriften."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:221
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
 msgstr "Se alle indikatorer"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:235
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
 msgstr "Segmenter og tabeller"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
+#: frontend/src/metabase/home/containers/SearchApp.jsx:83
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
 msgstr "Tabeller"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:262
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
 msgstr "Segmenter og tabeller er byggeklossene i din organisasjons data. Tabeller er samlinger av rå informasjon mens segmenter er spesifikke stykker med spesiell betydning, som for eksempel {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:267
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
 msgstr "Tabeller er byggeblokkene i bedriftens data."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:277
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
 msgstr "Se alle segmenter"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:293
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
 msgstr "Se alle tabeller"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:301
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
 msgstr "Andre ting å vite om dataene dine"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
 msgstr "Finn ut mer"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:307
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
 msgstr "En fin måte å bli kjent med dataene fine er å bruke litt tid på å utforske de forskjellige tabellene og annen informasjon som er tilgjengelig. Det kan ta litt tid, men etter hvert vil du begynne å kjenne igjen navn og hva ting betyr."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:313
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
 msgstr "Utforsk dataene våre"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:321
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
 msgstr "Har du spørsmål?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:326
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
 msgstr "Kontakt {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:248
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
 msgstr "Hjelp nye Metabase brukere finne veien igjennom."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:251
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
 msgstr "\"Kom igang\"-veilederen fremhever infotavlen, beregninger, segmenter, og de mest viktige tabellene, og informerer brukerne dine om ting de bør vite før de begynner å grave i dataene."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:258
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
 msgstr "Er det en viktig infotavle for ditt lag?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:260
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
 msgstr "Lag en infotavle nå"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:266
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
 msgstr "Hva er din viktigste infotavle?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:285
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
 msgstr "Har du noen ofte brukte indikatorer?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:287
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
 msgstr "Lær hvordan man definerer en indikator"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:300
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
 msgstr "Hva er de 3-5 mest brukte indikatorene?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:344
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
 msgstr "Legg til enda en indikator"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:357
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
 msgstr "Har du noen segmenter eller tabeller som det ofte refereres til?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:359
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
 msgstr "Lær hvordan man lager ett segment"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:372
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
 msgstr "Hva er 3-5 segmenter eller tabeller som det ofte henvises til og som vil være nyttige for dette publikumet?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:418
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
 msgstr "Legg til nytt segment eller tabell"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:427
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
 msgstr "Er det noe brukerne dine burde forstå eller vite om før de begynner å se på dataene?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:433
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
 msgstr "Hva burde en bruker vite før de begynner å se på datene? "
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:437
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
 msgstr "F.eks., forventninger rundt personvern og bruk av data, vanlige fallgruver eller misforståelser, informasjon om ytelsen til datavarehuset, juridiske merknader, osv."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
 msgstr "Er det noen som brukere kan kontakte for å få hjelp dersom de har noen spørsmål angående denne veilederen?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:457
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
 msgstr "Hvem skal brukere kontakte for å få hjelp dersom de har noen spørsmål om disse dataene?"
 
@@ -6014,39 +6034,39 @@ msgstr "Hvem skal brukere kontakte for å få hjelp dersom de har noen spørsmå
 msgid "Please enter a revision message"
 msgstr "Vennligst oppgi en revisjonsmelding"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:213
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
 msgstr "Hvorfor denne indikatoren er interessant"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:223
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
 msgstr "Ting å være klar over med denne indikatoren"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:233
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
 msgstr "Hvordan denne indikatoren er beregnet"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:235
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
 msgstr "Ingenting om hvordan det er beregnet enda"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:293
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
 msgstr "Andre felter du kan gruppere denne indikatoren etter"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:294
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
 msgstr "Felter du kan gruppere denne indikatoren etter"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:23
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Indikatorer er de offisielle tallene som ditt lag bryr seg om"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Indikatorer vil dukke opp her når administratorene har laget noen"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
 msgstr "Lær mer om hvordan man lager indikatorer"
 
@@ -6058,9 +6078,9 @@ msgstr "Spørsmål om denne indikatoren vil dukke opp her ettersom de blir lagt 
 msgid "There are no revisions for this metric"
 msgstr "Det er ingen revisjoner for denne indikatoren"
 
-#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:88
-#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
-#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:88
+#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
+#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
+#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
 msgstr "Revisjonshistorikk for {0}"
 
@@ -6069,27 +6089,27 @@ msgstr "Revisjonshistorikk for {0}"
 msgid "X-ray this metric"
 msgstr "Gjør en X-ray på denne indikatoren"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:217
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
 msgstr "Hvorfor dette Segmentet er interessant"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:227
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
 msgstr "Ting å være klar over når det gjelder dette Segmentet"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
 msgstr "Segmenter er interessante subsett av tabeller"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Å definere vanlige segmenter for ditt lag gjør det enda enklere å stille spørsmål"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
 msgstr "Segmenter vil vises her når en administrator har laget noen"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
 msgstr "Lær hvordan man lager segmenter"
 
@@ -6117,7 +6137,7 @@ msgstr "Gjør en X-ray av dette segmentet"
 msgid "Login"
 msgstr "Logg inn"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:130
+#: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
 msgstr "Søk"
@@ -6134,99 +6154,99 @@ msgstr "Nytt spørsmål"
 msgid "Select the type of Database you use"
 msgstr "Velg hvilken database type du bruker"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:141
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
 msgstr "Legg til dataene din"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:145
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
 msgstr "Jeg vil legge til data senere"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
 msgstr "Kobler til {0}"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:165
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
 msgstr "Du trenger noe informasjon om databasen din, som for eksempel brukernavn og passord. Hvis du ikke har det akkurat nå, så kommer Metabase med et eksempel-datasett som du kan begynne med."
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:196
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
 msgstr "Jeg vil legge til data senere"
 
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:41
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
 msgstr "Kontroller automatisk skanninger"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:53
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
 msgstr "Innstillinger for bruk av data"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
 msgstr "Takk for hjelpen"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:57
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
 msgstr "Vi vil ikke samle inn noen brukshendelser"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:76
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "For å kunne hjelpe oss med å forbedre Metabase, så vil vi gjerne samle inn enkelte data for bruk gjennom Google Analytics"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
 msgstr "Her er en liste over det vi sporer og hvorfor."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:98
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Tillat Metabase å samle inn bruksdata anonymt"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} samler alt om dine data eller resultat på spørsmål."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:106
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
 msgstr "aldri"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
 msgstr "All innsamling av data er anonymt."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Samling kan skrus av når som helst i admin-innstillingene"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:45
+#: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
 msgstr "Hvis du føler at du sitter fast"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:52
+#: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
 msgstr "vår oppstartsguide"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:53
+#: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
 msgstr "er bare ett klikk unna"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:95
+#: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
 msgstr "Velkommen til Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:96
+#: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Ser ut som alt virker. La oss bli kjent, koble til dataene din og start med å finne noen svar!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:100
+#: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
 msgstr "Lå oss starte"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:145
+#: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
 msgstr "Alt er klart og satt opp!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:156
+#: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
 msgstr "Ta meg med til Metabase"
 
@@ -6243,7 +6263,7 @@ msgid "Create a password"
 msgstr "Lag ett nytt passord"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:116
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
 msgstr "Hyyysj..."
 
@@ -6437,11 +6457,11 @@ msgstr "Logg inn med Google E-postadresse"
 msgid "User Details"
 msgstr "Brukerdetaljer"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:275
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
 msgstr "Tilbakestill til standard"
 
-#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:133
+#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
 msgstr "ukjent kart"
 
@@ -6453,24 +6473,24 @@ msgstr "Rutekartet krever grupperte lengdegrader/breddegrader."
 msgid "more"
 msgstr "mer"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:101
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
 msgstr "Hvilke felter vil du bruke for X- og Y-aksene?"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:103
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:60
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
 msgstr "Velg felt"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:204
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
 msgstr "Lagre som standardvisning"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
 msgstr "Tegn en boks for å filtrere"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
 msgstr "Avbryt filter"
 
@@ -6478,7 +6498,7 @@ msgstr "Avbryt filter"
 msgid "Pin Map"
 msgstr "Kartnål-kart"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:303
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
 msgstr "Ikke satt"
 
@@ -6486,31 +6506,31 @@ msgstr "Ikke satt"
 msgid "Rows {0}-{1} of {2}"
 msgstr "Rader {0}-{1} av {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:189
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
 msgstr "Data redusert til {0} rader."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:364
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
 msgstr "Kunne ikke finne visualisering"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:371
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
 msgstr "Kunne ikke vise grafen med denne dataen."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:469
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
 msgstr "Ingen resultater!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:490
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
 msgstr "Venter fortsatt..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:493
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
 msgstr "Dette tar vanligvis gjennomsnittlig {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:499
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
 msgstr "(dette er litt for langt for en infotavle)"
 
@@ -6526,11 +6546,11 @@ msgstr "Velg ett felt"
 msgid "error"
 msgstr "feil"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:126
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
 msgstr "Klikk og dra for å endre rekkefølgen"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:139
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
 msgstr "Legg til felter fra listen under"
 
@@ -6620,7 +6640,7 @@ msgid "Highlight the whole row"
 msgstr "Framhev hele raden"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:98
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Farger"
 
@@ -6685,20 +6705,20 @@ msgstr "Visualiseringen med den indentifikatoren er allerede registrert: "
 msgid "No visualization for {0}"
 msgstr "Ingen visualisering for {0}"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:75
+#: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
 msgstr "\"{0}\" er et ikke-aggregert felt: Hvis det har mer enn én verdi for et punkt på x-aksen, så vil verdiene bli summert."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:91
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
 msgstr "Denne grafetypen krever minst 2 kolonner."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:96
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
 msgstr "Denne grafetypen støtter ikke mer enn {0} serier med data."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:51
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:297
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
 msgstr "Mål"
 
@@ -6738,25 +6758,25 @@ msgstr "Rediger innstillinger"
 msgid "xValues missing!"
 msgstr "xVerdier mangler!"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:114
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "X-akse"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:140
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
 msgstr "Bryt ut serien..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:153
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Y-akse"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:178
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
 msgstr "Legg til en ny serie..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:195
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
 msgstr "Bobblestørrelse"
 
@@ -6770,7 +6790,7 @@ msgid "Curve"
 msgstr "Kurve"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:69
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
 msgstr "Steg"
 
@@ -6778,27 +6798,27 @@ msgstr "Steg"
 msgid "Show point markers on lines"
 msgstr "Vis punktmarkeringer på linjer"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:235
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
 msgstr "Stabling"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:239
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
 msgstr "Ikke stable"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:240
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
 msgstr "Stable"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:241
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
 msgstr "Stable - 100%"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:300
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
 msgstr "Vis mål"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:306
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
 msgstr "Målverdi"
 
@@ -6818,126 +6838,126 @@ msgstr "Ingenting"
 msgid "Linear Interpolated"
 msgstr "Linjært Interpolert"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:371
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
 msgstr "Skalering av X-akse"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
 msgstr "Tidsserie"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:391
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:409
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:381
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
 msgstr "Lineær"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:410
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:383
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
 msgstr "Kraft"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:384
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
 msgstr "Logg"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:396
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
 msgstr "Histogram"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:398
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
 msgstr "Ordens"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:404
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
 msgstr "Y-akse skala"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:417
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
 msgstr "Vis linje og merker for x-akse"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:423
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
 msgstr "Kompakt"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:424
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
 msgstr "Roter 45°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
 msgstr "Roter 90°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
 msgstr "Vis linje og merker for y-akse"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
 msgstr "Automatisk område for y-aksen"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
 msgstr "Bruk en delt y-akse hvis det er nødvendig"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
 msgstr "Vis etikett på x-akse"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:501
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
 msgstr "X-akse etikett"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:510
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
 msgstr "Vis etikett på y-akse"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:516
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
 msgstr "Y-akse etikett"
 
-#: frontend/src/metabase/visualizations/lib/utils.js:129
+#: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
 msgstr "Standardavvik"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:275
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:17
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:256
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
 msgstr "Område"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
 msgstr "områdediagram"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:276
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:16
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:257
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
 msgstr "Søyle"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
 msgstr "søylediagram"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
 msgstr "Hvilke felter ønsker du å bruke?"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
 msgstr "Trakt"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:76
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:76
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Måle"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
 msgstr "Trakttype"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:88
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
 msgstr "Søylediagram"
 
@@ -6945,144 +6965,144 @@ msgstr "Søylediagram"
 msgid "line chart"
 msgstr "linjediagram"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:224
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Vennligst velg kolonner for lengdegrad og breddegrad i diagraminnstillingene."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
 msgstr "Vennligst velg ett regionalkart."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 #, fuzzy
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Vennligst velg region- og indikator-kolonner i diagraminnstillingene."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:38
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Kart"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:53
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
 msgstr "Kart type"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:57
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:149
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
 msgstr "Regionalkart"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
 msgstr "Kartnål-kart"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
 msgstr "Type kartnål"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
 msgstr "Fliser"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
 msgstr "Markører"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
 msgstr "Felt for breddegrad"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
 msgstr "Felt for lengdegrad"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:142
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:168
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
 msgstr "Indikatorfelt"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
 msgstr "Felt for region"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
 msgstr "Radius"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:198
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
 msgstr "Uskarphet"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
 msgstr "Min gjennomsiktighet"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
 msgstr "Maks zoom"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:175
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
 msgstr "Ingen forhold funnet"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:213
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:290
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
 msgstr "{0} er koblet til:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:47
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
 msgstr "Objekt detaljer"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
 msgstr "objekt"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
 msgstr "Total"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Hvilke kolonner vil du bruke?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:44
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Pai"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Dimensjon"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:81
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 #, fuzzy
 msgid "Show legend"
 msgstr "Vis forklaring"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:86
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 #, fuzzy
 msgid "Show percentages in legend"
 msgstr "Vis prosenter i forklaring"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:92
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Minste oppstykkings-prosent"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:146
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
 msgstr "Mål møtt"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:148
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
 msgstr "Mål overskredet"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
 msgstr "Mål {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
 msgstr "Fremdriftsvisualisering krever et tall."
 
@@ -7090,9 +7110,9 @@ msgstr "Fremdriftsvisualisering krever et tall."
 msgid "Progress"
 msgstr "Fremdrift"
 
-#: frontend/src/metabase/entities/collections.js:108
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:176
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:57
+#: frontend/src/metabase/entities/collections.js:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Farge"
 
@@ -7104,7 +7124,7 @@ msgstr "Raddiagram"
 msgid "row chart"
 msgstr "raddiagram"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:357
+#: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
 msgstr "Separatorstil"
 
@@ -7112,15 +7132,15 @@ msgstr "Separatorstil"
 msgid "Number of decimal places"
 msgstr "Nummer med desimal punkter"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:381
+#: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
 msgstr "Legg til prefiks"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:385
+#: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
 msgstr "Legg til suffiks"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:374
+#: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
 msgstr "Multipliser med ett tall"
 
@@ -7132,7 +7152,7 @@ msgstr "Spredning"
 msgid "scatter plot"
 msgstr "spredningsdiagram"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:78
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
 msgstr "Pivoter tabellen"
 
@@ -7141,7 +7161,8 @@ msgid "Visible fields"
 msgstr "Synlige felter"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-msgid "Write here, and use Markdown if you''d like"
+#, fuzzy
+msgid "Write here, and use Markdown if you'd like"
 msgstr "Skriv her, og bruk gjerne Markdown hvis du vil"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
@@ -7182,13 +7203,13 @@ msgstr "Høyre"
 msgid "Show background"
 msgstr "Vis bakgrunn"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:553
+#: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} samling"
 msgstr[1] "{0} samlinger"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:559
+#: frontend/src/metabase-lib/lib/Dimension.js:731
 msgid "Auto binned"
 msgstr "Auto samling"
 
@@ -7458,26 +7479,26 @@ msgstr "Auto samle"
 msgid "Don''t bin"
 msgstr "Ikke samle"
 
-#: frontend/src/metabase/lib/query_time.js:193 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Dag"
 msgstr[1] "Dager"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
-#: frontend/src/metabase/lib/query_time.js:189 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minutt"
 msgstr[1] "Minutter"
 
-#: frontend/src/metabase/lib/query_time.js:191 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Time"
 msgstr[1] "Timer"
 
-#: frontend/src/metabase/lib/query_time.js:199 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
 msgstr[0] "Kvartal"
@@ -7544,7 +7565,7 @@ msgid "Bin every 20 degrees"
 msgstr "Samle hver 20ende grad"
 
 #. returns `true` if successful -- see JavaDoc
-#: src/metabase/api/tiles.clj src/metabase/pulse/render.clj
+#: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
 msgstr "Ingen passende bildeforfatter funnet!"
 
@@ -7617,10 +7638,12 @@ msgstr "kumulativ sum"
 msgid "{0} and {1}"
 msgstr "{0} og {1}"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} av {1}"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
 msgstr "{0} med {1}"
@@ -7633,9 +7656,12 @@ msgstr "{0} i {1} segmentet"
 msgid "{0} segment"
 msgstr "{0} segment"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
-msgstr "{0} indikator"
+msgid_plural "{0} metrics"
+msgstr[0] "{0} indikator"
+msgstr[1] "{0} indikatorer"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
@@ -8216,6 +8242,7 @@ msgid "Cannot save Question: source query has circular references."
 msgstr "Kan ikke lagre spørsmål: hovedspørring har sirkulære referanser."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
+#: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
 msgstr "Kort {0} fins ikke."
@@ -8618,7 +8645,7 @@ msgstr "Ikke gjenkjent kanal-type {0}"
 msgid "Error sending notification!"
 msgstr "Feil ved sending av varsel!"
 
-#: src/metabase/pulse/color.clj
+#: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
 msgstr "Kan ikke finne JS farge velger her \"{0}\""
 
@@ -8929,43 +8956,43 @@ msgstr "Tilgang til data"
 msgid "Collection permissions"
 msgstr "Tilgang til samlinger"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:56
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
 msgstr "Se alle tilganger til samlinger"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:25
+#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
 msgstr "Endre også undersamlinger"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:282
+#: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
 msgstr "Kan endre denne samlingen og inneholdet"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:289
+#: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
 msgstr "Kan se elementer i denne samlingen"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:749
+#: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
 msgstr "Tilgang til samlinger"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:825
+#: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Denne gruppen har tilgang til å vise minst en undersamling av denne samlingen."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:830
+#: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Denne gruppen har tilganger til å endre minst en av undersamlingene til denne samlingen."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
 msgstr "Vis undersamlingen"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:211
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
 msgstr "Husk meg"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:95
+#: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
 msgstr "Kjør X-ray på dette skjema"
 
@@ -8997,31 +9024,32 @@ msgstr "Lagre infotavle, spørsmål og samlinger i \"{0}\""
 msgid "Access dashboards, questions, and collections in \"{0}\""
 msgstr "Adgang til infotavler, spørsmål og samlinger i \"{0}\""
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:221
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
 msgstr "Sammenlign"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:229
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
 msgstr "Zoom ut"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:233
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
 msgstr "Relatert"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:293
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
 msgstr "Flere X-ray spørringer"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:46
+#: frontend/src/metabase/home/containers/SearchApp.jsx:40
+#: src/metabase/pulse/render/body.clj
 msgid "No results"
 msgstr "Ingen resultater"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:47
+#: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
 msgstr "Metabase kan ikke finne noen resultater for ditt søk."
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:111
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
 msgstr "Ingen indikatorer"
 
@@ -9064,7 +9092,7 @@ msgstr "Klarte ikke å gi tillatelser: {0}"
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
 msgstr "Kan ikke dekryptere kryptert tekststreng. Har du endret eller glemt å sette MB_ENCRYPTION_SECRET_KEY?"
 
-#: frontend/src/metabase/entities/collections.js:164
+#: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
 msgstr "Alle personlige samlinger"
 
@@ -9230,18 +9258,18 @@ msgstr "I/T"
 msgid "Windows domain"
 msgstr "Windows domene"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:509
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:515
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:490
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:499
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
 msgstr "Etiketter"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:329
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
 msgstr "Legg til medlemmer"
 
-#: frontend/src/metabase/entities/collections.js:115
+#: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
 msgstr "Samling den er lagret i"
 
@@ -9262,39 +9290,39 @@ msgid "Sharing"
 msgstr "Deling"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:234
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:270
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:299
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:305
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:313
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:321
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:218
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:251
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:280
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:286
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:294
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:302
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:80
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:85
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:91
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:97
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:50
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:56
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
 msgstr "Visning"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:370
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:416
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:431
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:487
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:358
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:406
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:447
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
 msgstr "Akser"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:222
-#: frontend/src/metabase/admin/settings/selectors.js:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
+#: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
@@ -9328,20 +9356,20 @@ msgstr "X-ray"
 msgid "Compare to the rest"
 msgstr "Sammenlignet med resten"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:244
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Bruk JVM-tidssone"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
 msgstr "Vi anbefaler å la denne være slått av, med mindre du endrer tidssone manuelt i mange eller alle dine spørringer mote disse dataene."
 
-#: frontend/src/metabase/containers/Overworld.jsx:310
+#: frontend/src/metabase/containers/Overworld.jsx:312
 msgid "Your team's most important dashboards go here"
 msgstr "Ditt lags viktigste infoskjermer finnes her"
 
-#: frontend/src/metabase/containers/Overworld.jsx:311
+#: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
 msgstr "Fest infotavler til {0} for at de skal vises på denne plassen for alle sammen"
 
@@ -9357,32 +9385,32 @@ msgstr "Bruk JVM-tidssone"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Vi analyserer nå tabellene og feltene for å hjelpe deg med å utforske dataene dine."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
 msgstr "Tips: "
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:258
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
 msgstr "Velg valutatype"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:318
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
 msgstr "Felt type"
 
 #: frontend/src/metabase/admin/routes.jsx:109
-#: frontend/src/metabase/nav/containers/Navbar.jsx:224
+#: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
 msgstr "Feilsøking"
 
-#: frontend/src/metabase/admin/settings/selectors.js:96
+#: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
 msgstr "Aktiver X-ray-funksjonalitet"
 
-#: frontend/src/metabase/admin/settings/selectors.js:323
+#: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
 msgstr "Formateringsinnstillinger"
 
-#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:19
+#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
 msgstr "Oppgavedetaljer"
 
@@ -9422,7 +9450,7 @@ msgstr "Valuta"
 msgid "Pick a user or channel..."
 msgstr "Velg en bruker eller kanal..."
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
+#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
 msgstr "Ingen formateringsinnstillinger"
 
@@ -9530,31 +9558,31 @@ msgstr "HH:MM:SS.MS"
 msgid "Time style"
 msgstr "Tidsstil"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:299
+#: frontend/src/metabase/visualizations/lib/settings/column.js:300
 msgid "Unit of currency"
 msgstr "Valutaenhet"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:319
+#: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
 msgstr "Valutaetikettstil"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:337
+#: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
 msgstr "Hvor valutaenheten skal vises"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:370
+#: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
 msgstr "Minste antall desimaler"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:271
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
 msgstr "Stablet diagramtype"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:314
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
 msgstr "Måletikett"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:322
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
 msgstr "Vis trendlinje"
 
@@ -9583,7 +9611,7 @@ msgstr "Linje + Stolpe"
 msgid "line and bar chart"
 msgstr "linje- og stolpediagram"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:72
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
 msgstr "Målervisualisering trenger et nummer."
 
@@ -9591,75 +9619,75 @@ msgstr "Målervisualisering trenger et nummer."
 msgid "Gauge"
 msgstr "Måler"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
 msgstr "Målerområde"
 
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
 msgstr "Felt å vise"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
 msgstr "siste {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:185
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
 msgstr "{0} var {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:52
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Grupper etter et tidsfelt for å se hvordan dette har endret seg over tid"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
 msgstr "Bytt positive / negative farger?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
 msgstr "Pivoter kolonnen"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:107
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
 msgstr "Cellekolonne"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:123
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
 msgstr "Synlige kolonner"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:143
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
 msgstr "Betinget Formatering"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
 msgstr "Kolonnetittel"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
 msgstr "Vis et ministolpediagram"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:183
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
 msgstr "Lenke"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:187
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
 msgstr "E-post-lenke"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
 msgstr "Bilde"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:195
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
 msgstr "Automatisk"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:200
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
 msgstr "Vis som lenke eller bilde"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
 msgstr "Lenketekst"
 
@@ -9923,7 +9951,7 @@ msgstr "Feil ved preprosesseringsspørring"
 msgid "No native form returned."
 msgstr "Ingen lokale skjema returnert."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
 msgstr "Ugyldig svar fra databasedriveren. Ingen status oppgitt."
 
@@ -11289,7 +11317,7 @@ msgstr "Klarte ikke å sette `query-caching-max-kb` til {0}"
 msgid "Values greater than {1} are not allowed."
 msgstr "Verdier større enn {1} er ikke tillatt."
 
-#: src/metabase/query_processor/middleware/resolve_database.clj
+#: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
 msgstr "Databasen {0} finnes ikke."
 
@@ -11338,7 +11366,7 @@ msgstr "Triggere"
 msgid "View triggers"
 msgstr "Vis triggere"
 
-#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:82
+#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
 msgstr "Planleggingsinfo"
 
@@ -11370,7 +11398,7 @@ msgstr "Siste kjøringstid"
 msgid "May Fire Again?"
 msgstr "Kan kjøres igjen?"
 
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:75
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
 msgstr "Triggere for {0}"
 
@@ -11382,19 +11410,19 @@ msgstr "Oppgaver"
 msgid "Jobs"
 msgstr "Jobber"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
 msgstr "Duplisert {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:55
+#: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
 msgstr "Dupliser denne"
 
-#: frontend/src/metabase/components/EntityItem.jsx:61
+#: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
 msgstr "Arkiver denne"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:330
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
 msgstr "Dupliser tavle"
 
@@ -11444,63 +11472,64 @@ msgstr "{0} {1} siden"
 msgid "{0} {1} from now"
 msgstr "{0} {1} fra nå"
 
-#: frontend/src/metabase/lib/query_time.js:187
+#: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
 msgstr[0] "Standard periode"
 msgstr[1] "Standard perioder"
 
-#: frontend/src/metabase/lib/query_time.js:203
+#: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
 msgstr[0] "Minutt i time"
 msgstr[1] "Minutter av time"
 
-#: frontend/src/metabase/lib/query_time.js:205
+#: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
 msgstr[0] "Time på dagen"
 msgstr[1] "Timer i dagen"
 
-#: frontend/src/metabase/lib/query_time.js:207
+#: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
 msgstr[0] "Dag i uke"
 msgstr[1] "Dager i uke"
 
-#: frontend/src/metabase/lib/query_time.js:209
+#: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
 msgstr[0] "Dag i måned"
 msgstr[1] "Dager i måned"
 
-#: frontend/src/metabase/lib/query_time.js:211
+#: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
 msgstr[0] "Dag i år"
 msgstr[1] "Dager i år"
 
-#: frontend/src/metabase/lib/query_time.js:213
+#: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
 msgstr[0] "Uke i år"
 msgstr[1] "Uker i år"
 
-#: frontend/src/metabase/lib/query_time.js:215
+#: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
 msgstr[0] "Måned i år"
 msgstr[1] "Måneder i år"
 
-#: frontend/src/metabase/lib/query_time.js:217
+#: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "Kvartal i år"
 msgstr[1] "Kvartaler i år"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:79
+#: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} valgt"
@@ -11514,20 +11543,20 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "Dette"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:64
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
 msgstr "Ukorrekt"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:147
+#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
 msgstr "Legg til tid"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:170
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
 msgstr "Ingenting å sammenligne siden {0}."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:517
+#: frontend/src/metabase-lib/lib/Dimension.js:678
 msgid "by {0}"
 msgstr "etter {0}"
 
@@ -11569,11 +11598,11 @@ msgstr "Hvis du avgjør å bruke H2 for produksjon, vennligst bekreft at backup 
 
 #: src/metabase/db.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres for more information."
-msgstr ""
+msgstr "Se https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres for mer informasjon"
 
 #: src/metabase/db.clj
 msgid "Unable to connect to Metabase {0} DB."
-msgstr ""
+msgstr "Kan ikke koble til Metabase {0} DB."
 
 #: src/metabase/db/migrations.clj
 msgid "Error adding legacy SQL directive to BigQuery saved Question"
@@ -11597,11 +11626,11 @@ msgstr "Driver ikke registrert etter innlasting: {0}"
 
 #: src/metabase/driver.clj
 msgid "Error: attempting to change {0} property `:abstract?` from {1} to {2}."
-msgstr ""
+msgstr "Feil: prøver å endre {0} egenskapen `:abstract?`fra {1} til {2}"
 
 #: src/metabase/driver.clj
 msgid "Registered abstract driver {0}"
-msgstr ""
+msgstr "Registrerte abstrakt driver {0}"
 
 #: src/metabase/driver.clj
 msgid "Registered driver {0}"
@@ -11641,7 +11670,7 @@ msgstr "Starter hendelseslytter"
 
 #: src/metabase/events.clj
 msgid "Unexpected error listening on events"
-msgstr ""
+msgstr "Ukjent feil ved lytting etter hendelser"
 
 #: src/metabase/events/sync_database.clj
 msgid "Error syncing Database {0}"
@@ -11649,7 +11678,7 @@ msgstr "Feil ved synkronisering av database {0}"
 
 #: src/metabase/events/sync_database.clj
 msgid "Failed to process sync-database event."
-msgstr ""
+msgstr "Kunne ikke kjøre sync-database"
 
 #: src/metabase/mbql/util.clj
 msgid "Bad nested-query-level: query does not have a source query"
@@ -11685,35 +11714,35 @@ msgstr ""
 
 #: src/metabase/plugins.clj
 msgid "Metabase does not have permissions to write to plugins directory {0}"
-msgstr ""
+msgstr "Metabase har ikke tilgang til å skrive til mappen med plugins {0}"
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot use the plugins directory {0}"
-msgstr ""
+msgstr "Metabase kan ikke bruke mappen med plugins {0}"
 
 #: src/metabase/plugins.clj
 msgid "Please make sure the directory exists and that Metabase has permission to write to it."
-msgstr ""
+msgstr "Kontroller at mappen eksisterer og at Metabase har tilgang til å skrive"
 
 #: src/metabase/plugins.clj
 msgid "You can change the directory Metabase uses for modules by setting the environment variable MB_PLUGINS_DIR."
-msgstr ""
+msgstr "Du kan endre mappen Metabase bruker for moduler ved å sette miljøvariabelen MB_PLUGINS_DIR."
 
 #: src/metabase/plugins.clj
 msgid "Falling back to a temporary directory for now."
-msgstr ""
+msgstr "Faller tilbake til en midlertidig mappe"
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot write to temporary directory. Please set MB_PLUGINS_DIR to a writable directory and restart Metabase."
-msgstr ""
+msgstr "Metbase kan ikke skrive til den midlertidige mappen. Sett MB-PLUGINS_DIR til en mappe det kan skrives til og start Metabase på nytt"
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory."
-msgstr ""
+msgstr "spark-deps.jar er ikke lenger påkrevd av Metabase 1.0+. Du kan slette den fra plugin-mappen."
 
 #: src/metabase/plugins.clj
 msgid "Failied to initialize plugin {0}"
-msgstr ""
+msgstr "Kunne ikke initialisere plugin {0}"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in {0}..."
@@ -11769,11 +11798,11 @@ msgstr ""
 
 #: src/metabase/plugins/files.clj
 msgid "Extract file {0} -> {1}"
-msgstr ""
+msgstr "Pakk ut filen {0} -> {1}"
 
 #: src/metabase/plugins/files.clj
 msgid "Resource does not exist."
-msgstr ""
+msgstr "Ressursen eksisterer ikke."
 
 #: src/metabase/plugins/init_steps.clj
 msgid "Loading plugin namespace {0}..."
@@ -11781,15 +11810,15 @@ msgstr ""
 
 #: src/metabase/plugins/initialize.clj
 msgid "Dependencies satisfied; these plugins will now be loaded: {0}"
-msgstr ""
+msgstr "Avhengigheter godkjent; disse plugin vil bli lastet inn: {0}"
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Registering JDBC proxy driver for {0}..."
-msgstr ""
+msgstr "Registrerer JDBC proxy driver for {0}..."
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Deregistering original JDBC driver {0}..."
-msgstr ""
+msgstr "Avregistrerer original JDBC driver {0}"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Default connection property {0} does not exist."
@@ -11806,7 +11835,7 @@ msgstr ""
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Cannot initialize plugin: missing required property `driver-name`"
-msgstr ""
+msgstr "Kan ikke initialisere plugin: mangler nødvendig egenskap `driver-name`"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Warning: plugin manifest for {0} does not include connection properties"
@@ -11819,43 +11848,43 @@ msgstr ""
 
 #: src/metabase/pulse.clj
 msgid "Error running query for Card {0}"
-msgstr ""
+msgstr "Feil ved kjøring av spørring for Card {0}"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
-msgstr ""
+msgstr "Forrige uke"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This week"
-msgstr ""
+msgstr "Denne uken"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
-msgstr ""
+msgstr "Forrige måned"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This month"
-msgstr ""
+msgstr "Denne måneden"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
-msgstr ""
+msgstr "Forrige kvartal"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
-msgstr ""
+msgstr "Dette kvartaler"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
-msgstr ""
+msgstr "I fjor"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This year"
-msgstr ""
+msgstr "Dette året"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "*driver* is unbound."
-msgstr ""
+msgstr "*driver* er ikke tilknyttet"
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Error syncing Fields for Table ''{0}''"
@@ -11867,7 +11896,7 @@ msgstr ""
 
 #: src/metabase/sync/sync_metadata/fields/common.clj
 msgid "Field"
-msgstr ""
+msgstr "Felt"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error checking if Fields {0} need to be created or reactivated"
@@ -11925,7 +11954,7 @@ msgstr ""
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Sending anonymous usage stats."
-msgstr ""
+msgstr "Sender anonym brukerstatistikk"
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Error sending anonymous usage stats"
@@ -11933,7 +11962,7 @@ msgstr ""
 
 #: src/metabase/task/send_pulses.clj
 msgid "Error sending Pulse {0}"
-msgstr ""
+msgstr "Feil ved sending av Pulse {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Sending scheduled pulses..."
@@ -11961,15 +11990,15 @@ msgstr ""
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Checking for new Metabase version info."
-msgstr ""
+msgstr "Ser etter ny Metase versjonsinformasjon"
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Error fetching version info"
-msgstr ""
+msgstr "Feil ved henting av versjonsinformasjon"
 
 #: src/metabase/util.clj
 msgid "Maximum memory available to JVM: {0}"
-msgstr ""
+msgstr "Maksimalt minne tilgjengelig for JVM: {0}"
 
 #: src/metabase/util.clj
 msgid "Not something with an ID: {0}"
@@ -11981,7 +12010,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Here's a quick look at your [[this]]"
-msgstr ""
+msgstr "Her er en rask titt på din [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by hour of the day"
@@ -12036,7 +12065,7 @@ msgstr ""
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "Here's a closer look at your [[this]]"
-msgstr ""
+msgstr "Her er en nærmere titt på din [[this]] "
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by day of the week"
@@ -12096,20 +12125,20 @@ msgid "[[CreateDate]] by quarter of the year"
 msgstr ""
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:200
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
-msgstr ""
+msgstr "Rediger bruker"
 
 #: frontend/src/metabase/admin/people/containers/NewUserModal.jsx:13
 msgid "New user"
-msgstr ""
+msgstr "Ny bruker"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
-msgstr ""
+msgstr "Nullstill passord"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:209
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
 msgstr ""
 
@@ -12121,54 +12150,54 @@ msgstr ""
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
 msgstr ""
 
-#: frontend/src/metabase/entities/collections.js:21
+#: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
 msgstr ""
 
-#: frontend/src/metabase/entities/collections.js:22
+#: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
 msgstr ""
 
-#: frontend/src/metabase/entities/dashboards.js:29
+#: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
 msgstr ""
 
-#: frontend/src/metabase/entities/dashboards.js:30
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
 msgstr ""
 
-#: frontend/src/metabase/entities/users.js:125
+#: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
-msgstr ""
+msgstr "Fornavn er påkrevd"
 
-#: frontend/src/metabase/entities/users.js:126
-#: frontend/src/metabase/entities/users.js:133
+#: frontend/src/metabase/entities/users.js:38
+#: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
-msgstr ""
+msgstr "Må være mindre enn 100 tegn"
 
-#: frontend/src/metabase/entities/users.js:132
+#: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
-msgstr ""
+msgstr "Etternavn er påkrevd"
 
-#: frontend/src/metabase/entities/users.js:138
+#: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
-msgstr ""
+msgstr "Epost er påkrevd"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:90
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
-msgstr ""
+msgstr "Ting du arkiverer vil være her"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:16
 msgid "No description"
-msgstr ""
+msgstr "Ingen beskrivelse"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:175
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
-msgstr ""
+msgstr "Sum av alle verdier"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:183
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
-msgstr ""
+msgstr "See alle distinkte verdier"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:12
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started"
@@ -12366,15 +12395,777 @@ msgstr ""
 msgid "Adding User {0} to Admin permissions group..."
 msgstr ""
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
 msgstr ""
 
-#: src/metabase/query_processor/async.clj
+#: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
 msgstr ""
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
+msgstr ""
+
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
+msgid "Misfire Instruction"
+msgstr ""
+
+#: frontend/src/metabase/components/ArchiveModal.jsx:31
+msgid "Archive this?"
+msgstr ""
+
+#: frontend/src/metabase/components/BrowseApp.jsx:244
+msgid "Learn about our data"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
+msgid "Use DNS SRV when connecting"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
+msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
+"an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
+"leave this disabled."
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
+msgid "Automatically run queries when doing simple filtering and summarizing"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr ""
+
+#: frontend/src/metabase/containers/Overworld.jsx:247
+msgid "Learn about this database"
+msgstr ""
+
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+msgid "Archive this dashboard?"
+msgstr ""
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:113
+msgid "All results"
+msgstr ""
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:180
+msgid "Our Analytics"
+msgstr ""
+
+#: frontend/src/metabase/lib/schema_metadata.js:500
+msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
+msgstr ""
+
+#: frontend/src/metabase/lib/schema_metadata.js:508
+msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
+msgstr ""
+
+#: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
+msgid "Filter"
+msgstr ""
+
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+msgid "record"
+msgid_plural "records"
+msgstr[0] ""
+msgstr[1] ""
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:346
+msgid "Browse Data"
+msgstr ""
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:376
+msgid "Write SQL"
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
+msgid "Simple question"
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
+msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
+msgid "Custom question"
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
+msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+msgid "Basic Metrics"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+msgid "Custom…"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
+msgid "Add grouping"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
+msgid "Pick a limit"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
+msgid "Show maximum"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
+msgid "Get Preview"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
+msgid "Back to previous results"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
+msgid "Sample values"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
+msgid "Visualize"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
+msgid "Join data"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
+msgid "Custom column"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
+msgid "Summarize"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
+msgid "Aggregate"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
+msgid "Breakout"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
+msgid "Pick the metric you want to see"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
+#: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
+msgid "Pick a column to group by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
+msgid "Pick your starting data"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select None"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select All"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
+msgid "Pick a table..."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
+msgid "Enter a limit"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
+msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
+msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
+msgid "View the native query"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
+msgid "Native query for this question"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
+msgid "Convert this question to a native query"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
+msgid "SQL for this question"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
+msgid "Convert this question to SQL"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
+msgid "Get alerts"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
+msgid "{0} breakout"
+msgid_plural "{0} breakouts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
+msgid "Hide filters"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
+msgid "Show filters"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
+msgid "Started from"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
+msgid "{0} row"
+msgid_plural "{0} rows"
+msgstr[0] ""
+msgstr[1] ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
+msgid "Show all rows"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
+msgid "Show {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
+msgid "Showing first {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
+msgid "Showing {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
+msgid "Summarized"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Hide editor"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Show editor"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
+msgid "Pick the metric you'd like to see"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
+msgid "{0} options"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
+msgid "Choose a visualization"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
+msgid "Filter by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+msgid "Summarize by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+msgid "Group by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+msgid "Add a metric"
+msgstr ""
+
+#: frontend/src/metabase/user/components/UserSettings.jsx:57
+msgid "Profile"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:548
+msgid "This is usually pretty fast but seems to be taking a while right now."
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
+msgid "Combo"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
+msgid "Row"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
+msgid "Trend"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:129
+msgid "Boolean"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+msgid "Unknown Segment"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+msgid "Unknown Filter"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
+msgid "Left outer join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
+msgid "Right outer join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
+msgid "Inner join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
+msgid "Full outer join"
+msgstr ""
+
+#: src/metabase/api/card.clj
+msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
+msgstr ""
+
+#: src/metabase/api/session.clj
+msgid "Problem connecting to LDAP server, will fall back to local authentication"
+msgstr ""
+
+#: src/metabase/api/setup.clj
+msgid "Cannot create Database: cannot find driver {0}."
+msgstr ""
+
+#: src/metabase/api/tiles.clj
+msgid "Query failed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Warning: {0} returned `nil`"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing result to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing exception to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Request canceled, canceling future."
+msgstr ""
+
+#: src/metabase/cmd/load_from_h2.clj
+msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "Application database setup"
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Could not find {0} driver."
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Abstract drivers cannot derive from concrete parent drivers."
+msgstr ""
+
+#: src/metabase/driver/mysql.clj
+msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifer."
+msgstr ""
+
+#: src/metabase/driver/sql_jdbc/execute.clj
+msgid "Client closed connection, canceling query"
+msgstr ""
+
+#: src/metabase/integrations/ldap.clj
+msgid "{0} is not a valid DN."
+msgstr ""
+
+#: src/metabase/middleware/log.clj
+msgid "Error logging API request"
+msgstr ""
+
+#: src/metabase/middleware/misc.clj
+msgid "Failed to set site-url"
+msgstr ""
+
+#: src/metabase/models/database.clj
+msgid "Error destroying thread pool for DB."
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/models/task_history.clj src/metabase/sync/util.clj
+msgid "Error saving task history"
+msgstr ""
+
+#: src/metabase/plugins.clj
+msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
+msgstr ""
+
+#: src/metabase/plugins/classloader.clj
+msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
+msgstr ""
+
+#: src/metabase/plugins/files.clj
+msgid "Failed to copy file"
+msgstr ""
+
+#: src/metabase/public_settings.clj
+msgid "Invalid site URL: {0}"
+msgstr ""
+
+#: src/metabase/public_settings.clj
+msgid "site-url is invalid; returning nil for now. Will be reset on next request."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "More results have been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "This question has been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "We were unable to display this Pulse."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "Please view this card in Metabase."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "An error occurred while displaying this card."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Can only determine expected columns for MBQL queries."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "No columns returned."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot find Table ID for {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "No matching info found."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Could not resolve {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Invalid fk-> clause: nowhere to add corresponding join."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "{0} driver does not support foreign keys."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Query processor error: number of columns returned by driver does not match results."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Expected {0} columns, but first row of resuls has {1} columns."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "No expression named {0} found. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Distinct values of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Average of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "SD of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Min of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Max of {0}"
+msgstr ""
+
+#. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0} matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Share of rows matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Count of rows matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Request already canceled, will not run synchronous QP code."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unexpectedly got `nil` Query Processor response."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Got InterruptedException. Canceling query."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Query timed out after %s"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Creating new query thread pool for Database {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Destroying query thread pool for Database {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Request canceled, canceling pending query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: query is missing source-metadata"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Using query processor cache backend: {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/expand_macros.clj
+msgid "Invalid metric: {0} reason: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unknown error"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unexpected nil response from query processor."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Query canceled"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: Database {0} does not exist."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_source_table.clj
+msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Cannot store Tables or Fields before Database is stored."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Attempting to fetch second Database. Queries can only reference one Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
+msgstr ""
+
+#: src/metabase/routes/index.clj
+msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Sample dataset DB file ''{0}'' cannot be found."
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Loading sample dataset..."
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Failed to load sample dataset"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Found new tables:"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Marking tables as inactive:"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Updating description for tables:"
+msgstr ""
+
+#: src/metabase/task.clj
+msgid "Rescheduling job {0}"
+msgstr ""
+
+#: src/metabase/task.clj
+msgid "Error rescheduling job"
+msgstr ""
+
+#: src/metabase/task/send_pulses.clj
+msgid "Starting Pulse Execution: {0}"
+msgstr ""
+
+#: src/metabase/task/send_pulses.clj
+msgid "Finished Pulse Execution: {0}"
+msgstr ""
+
+#: src/metabase/task/sync_databases.clj
+msgid "Failed to schedule tasks for Database {0}"
+msgstr ""
+
+#: src/metabase/util/schema.clj
+msgid "All elements must be distinct."
+msgstr ""
+
+#: 
+msgctxt "Modal for selecting columns in source data or when doing a join."
+msgid "Pick the columns you want to include"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
+msgid "Change join type"
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifier."
+msgstr ""
+
+#: src/metabase/integrations/common.clj
+msgid "Error adding User {0} to Group {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Infinite loop detected: recursively preprocessed query {0} times."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Error determining expected columns for query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr ""
 

--- a/locales/nl.po
+++ b/locales/nl.po
@@ -5,31 +5,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 "Project-Id-Version: Metabase\n"
-"Language: fr\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: nl\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:24
 msgid "Your database has been added!"
-msgstr "Votre base de données a été ajoutée !"
+msgstr "Jouw database is toegevoegd!"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:28
-#, fuzzy
 msgid "We took a look at your data, and we have some automated explorations that we can show you!"
-msgstr "Nous avons jeté un coup d'œil à vos données et nous avons des explorations automatiques à vous présenter !"
+msgstr "We hebben naar uw data gekeken en we hebben enkele geautomatiseerde verkenningen die we kunnen tonen!"
 
-#. utilisé pour décliner l'offre d'inspection des données d'une nouvelle base
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:35
 msgid "I'm good thanks"
-msgstr "Non, merci"
+msgstr "Bedankt, ik red me"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:42
 msgid "Explore this data"
-msgstr "Explorer ces données"
+msgstr "Verken deze data"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:42
 msgid "Select a database type"
-msgstr "Sélectionner un type de base de données"
+msgstr "Selecteer een type database"
 
+#. Imperative: Sla op
+#. Verb: Opslaan
 #: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:410
@@ -45,59 +45,59 @@ msgstr "Sélectionner un type de base de données"
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:180
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:164
 msgid "Save"
-msgstr "Sauvegarder"
+msgstr "Opslaan"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:122
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
-msgstr "Metabase doit analyser votre base de données. Nous procéderons à une nouvelle analyse périodique pour maintenir les métadonnées à jour. Vous pouvez contrôler ci-dessous le moment où ces analyses périodiques auront lieu."
+msgstr "Metabase moet je database scannen om zijn magie erop los te kunnen laten. We zullen de database ook periodiek opnieuw scannen om de metadata actueel te houden. Je kunt hieronder instellen wanneer de periodieke scans plaatsvinden."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:127
 msgid "Database syncing"
-msgstr "Synchronisation de la base de données"
+msgstr "Database synchroniseren"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:128
 msgid "This is a lightweight process that checks for\n"
 "updates to this database’s schema. In most cases, you should be fine leaving this\n"
 "set to sync hourly."
-msgstr "Ceci est un processus léger qui vérifie les\n"
-"mises à jour du schéma de données. Dans la plupart des cas, vous pouvez l'effectuer chaque heure."
+msgstr "Dit is een licht proces dat nagaat of het database schema gewijzigd is. Meestal kun je dit zonder problemen elk uur te laten draaien."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
 msgid "Scan"
-msgstr "Analyser"
+msgstr "Scannen"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:152
 msgid "Scanning for Filter Values"
-msgstr "Analyse des valeurs de filtre"
+msgstr "Aan het zoeken naar filterwaarden"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:153
 msgid "Metabase can scan the values present in each\n"
 "field in this database to enable checkbox filters in dashboards and questions. This\n"
 "can be a somewhat resource-intensive process, particularly if you have a very large\n"
 "database."
-msgstr "Metabase peut analyser les champs de cette base de données pour en proposer les valeurs dans les filtres des tableaux de bord et des questions. Cette analyse peut être un processus gourmand en ressources, surtout si vous avez une très grande base de données."
+msgstr "Metabase kan de waardes van elk veld in deze database scannen om de checkbox filters in dashboards en vragen weer te geven. Dit is een resource-intensief proces, voornamelijk indien je een grote database hebt.\n"
+""
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
-msgstr "Quand Metabase doit-il automatiquement analyser et mettre en cache les valeurs des champs ?"
+msgstr "Wanneer moet Metabase de waarden van deze velden automatisch scannen en cachen?"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
-msgstr "Régulièrement, selon un planning"
+msgstr "Regelmatig, volgens een schema"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
-msgstr "Uniquement lors de l'ajout d'un nouveau filtre"
+msgstr "Alleen als je een nieuwe filter widget toevoegd"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
-msgstr "Lorsqu un utilisateur ajoute un nouveau filtre à un tableau de bord ou à une question SQL, Metabase analysera le(s) champ(s) associé(s) à ce filtre pour pouvoir proposer des valeurs."
+msgstr "Op het moment dat een gebruiker een nieuw filter aan een dashboard of SQL vraag toevoegt, zal Metabase de velden die toegewezen zijn aan dat filter scannen om de selecteerbare waardes te tonen"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
 msgid "Never, I'll do this manually if I need to"
-msgstr "Jamais, je le ferai manuellement au besoin"
+msgstr "Nooit, ik doe het handmatig wanneer nodig"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
@@ -106,38 +106,38 @@ msgstr "Jamais, je le ferai manuellement au besoin"
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
 msgid "Saving..."
-msgstr "Sauvegarde..."
+msgstr "Bezig met opslaan..."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
 msgid "Server error encountered"
-msgstr "Erreur serveur"
+msgstr "Serverfout"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
-msgstr "Supprimer la base de données ?"
+msgstr "Verwijder deze database?"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
-msgstr "Toutes les questions, métriques et segments sauvegardés qui dépendent de cette base de données seront perdus."
+msgstr "Alle opgeslagen vragen, metrieken en segmenten die afhankelijk zijn van deze database zullen verloren gaan."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
-msgstr "Cette action ne peut pas être annulée."
+msgstr "Dit kan niet ongedaan gemaakt worden."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
-msgstr "Si vous êtes sûr(e), veuillez saisir"
+msgstr "Als u het zeker weet, typ"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
-msgstr "SUPPRIMER"
+msgstr "VERWIJDER"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
-msgstr "dans cette case :"
+msgstr "in dit kader:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
@@ -174,14 +174,14 @@ msgstr "dans cette case :"
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
-msgstr "Annuler"
+msgstr "Annuleren"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
-msgstr "Supprimer"
+msgstr "Verwijder"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
@@ -193,20 +193,20 @@ msgstr "Supprimer"
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
-msgstr "Bases de données"
+msgstr "Databases"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
-msgstr "Ajouter une base de données"
+msgstr "Voeg database toe"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
-msgstr "Connexion"
+msgstr "Verbinding"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:61
 msgid "Scheduling"
-msgstr "Planification"
+msgstr "Planning"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
@@ -217,17 +217,17 @@ msgstr "Planification"
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
-msgstr "Sauvegarder les modifications"
+msgstr "Sla wijzigingen op"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
-msgstr "Actions"
+msgstr "Acties"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
-msgstr "Synchroniser le schéma de base de données"
+msgstr "Synchroniseer het databaseschema nu"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
@@ -236,50 +236,49 @@ msgstr "Synchroniser le schéma de base de données"
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
-msgstr "Démarrage..."
+msgstr "Bezig met starten..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
-msgstr "Échec de la synchronisation"
+msgstr "Synchronisatie mislukt"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
-msgstr "Synchronisation déclenchée !"
+msgstr "Synchronisatie gestart!"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
-msgstr "Analyser à nouveau les valeurs des filtres maintenant"
+msgstr "Scan veldwaardes opnieuw"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
-msgstr "Impossible de démarrer l analyse"
+msgstr "Scannen mislukt"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
-msgstr "Analyse déclenchée !"
+msgstr "Scan gestart!"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
-msgstr "Zone Dangereuse"
+msgstr "Gevarenzone"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
-msgstr "Supprimer les valeurs mises en cache"
+msgstr "Verwijder bewaarde veldwaardes"
 
-#. Personnellement la première fois que j'ai voulu supprimer une base, j'aurais aimé que soit mentionné le fait que seules les métadonnées sont supprimées, et pas les données.
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
-msgstr "Retirer cette base de données de Metabase"
+msgstr "Verwijder deze database"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
-msgstr "Ajouter une base de données"
+msgstr "Database toevoegen"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
@@ -295,35 +294,35 @@ msgstr "Ajouter une base de données"
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
-msgstr "Nom"
+msgstr "Naam"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
-msgstr "Moteur"
+msgstr "motor"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
-msgstr "Suppression ..."
+msgstr "Bezig met verwijderen..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
-msgstr "Chargement ..."
+msgstr "Bezig met laden..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
-msgstr "Charger de nouveau le jeu de données d'exemple"
+msgstr "Breng de voorbeeld dataset terug"
 
 #: frontend/src/metabase/admin/databases/database.js:175
 msgid "Couldn't connect to the database. Please check the connection details."
-msgstr "Impossible de se connecter à la base de données. Veuillez vérifier les paramètres de connexion."
+msgstr "Kon niet verbinden met de database. Controleer de verbindingdetails"
 
 #: frontend/src/metabase/admin/databases/database.js:383
 msgid "Successfully created!"
-msgstr "Création réussie!"
+msgstr "Succesvol aangemaakt!"
 
 #: frontend/src/metabase/admin/databases/database.js:393
 msgid "Successfully saved!"
-msgstr "Sauvegarde réussie!"
+msgstr "Succesvol opgeslagen!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:281
@@ -331,62 +330,62 @@ msgstr "Sauvegarde réussie!"
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
-msgstr "Modifier"
+msgstr "Bewerken"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:59
 msgid "Revision History"
-msgstr "Historique des modifications"
+msgstr "Revisiegeschiedenis"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
-msgstr "Retirer ce {0}?"
+msgstr "Deze {0} uitfaseren?"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
-msgstr "Les questions sauvegardées et autres éléments dépendants de ce {0} continueront de fonctionner, mais ce {1} ne sera plus sélectionnable dans le créateur de requêtes."
+msgstr "Opgeslagen vragen en andere zaken welke afhankelijk zijn van deze {0} zullen blijven werken, maar {1} zal niet langer te selecteren zijn in de query bouwer"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
-msgstr "Si vous êtes sûr de vouloir retirer ce {0}, veuillez écrire les raisons pour lesquelles il est retiré :"
+msgstr "Als je zeker bent dat je deze {0} wilt uitfaseren schrijf dan een verklaring waarom het uitgefaseerd wordt:"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
-msgstr "Le retrait de ce {0} apparaîtra dans le flux d'activités et dans un courriel envoyé à tous les utilisateurs l'ayant utilisé."
+msgstr "Dit wordt getoond bij jouw aktiviteiten en in een e-mail, die gestuurd wordt naar iedereen in je team, die iets dergelijks als {0} gebruikt."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
-msgstr "Retirer"
+msgstr "Treed af"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
-msgstr "Retrait..."
+msgstr "Aftreden..."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
-msgstr "Échec"
+msgstr "Mislukt"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
-msgstr "Succès"
+msgstr "Succes"
 
 #: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:91
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
-msgstr "Prévisualisation"
+msgstr "Voorbeeld"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
-msgstr "Aucune description pour cette colonne"
+msgstr "Nog geen kolombeschrijving"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
-msgstr "Sélectionner une visibilité de champ"
+msgstr "Selecteer veld zichtbaarheid"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
-msgstr "Aucun type particulier"
+msgstr "Geen speciaal type"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:148
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
@@ -394,15 +393,15 @@ msgstr "Aucun type particulier"
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
-msgstr "Autre"
+msgstr "Anders"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
-msgstr "Sélectionner un type"
+msgstr "Selecteer een speciaal type"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
-msgstr "Sélectionner une cible"
+msgstr "Selecteer een doel"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
@@ -411,18 +410,18 @@ msgstr "Sélectionner une cible"
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
-msgstr "Colonnes"
+msgstr "Kolommen"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
-msgstr "Colonne"
+msgstr "Kolom"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
-msgstr "Visibilité"
+msgstr "Zichtbaarheid"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
 msgid "Type"
@@ -430,77 +429,78 @@ msgstr "Type"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
-msgstr "Base de données actuelle :"
+msgstr "Huidige database:"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
-msgstr "Montrer le schéma original"
+msgstr "Toon origineel schema:"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
-msgstr "Type de donnée"
+msgstr "Data Type"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
-msgstr "Informations additionnelles"
+msgstr "Extra informatie"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
-msgstr "Trouver un schéma"
+msgstr "Zoek een schema"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
-msgstr[0] "{0} schéma"
-msgstr[1] "{0} schémas"
+msgstr[0] "{0} schema"
+msgstr[1] "{0} schema's"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
-msgstr "Pourquoi masquer ?"
+msgstr "Waarom verbergen?"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
-msgstr "Donnée technique"
+msgstr "Technische data"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
-msgstr "Non pertinent"
+msgstr "Onrelevant"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
+#, fuzzy
 msgid "Queryable"
-msgstr "Interrogeable"
+msgstr "Bevraagbaar"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
-msgstr "Masqué"
+msgstr "Verborgen"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
-msgstr "Aucune description pour cette table"
+msgstr "Nog geen tabelbeschrijving"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:124
 msgid "Metadata Strength"
-msgstr "Force des métadonnées"
+msgstr "Metadata kwaliteit"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
-msgstr[0] "{0} Table interrogeable"
-msgstr[1] "{0} Tables interrogeables"
+msgstr[0] "{0} bevraagbare tabel"
+msgstr[1] "{0} bevraagbaren tabellen"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
-msgstr[0] "{0} Table cachée"
-msgstr[1] "{0} Tables cachées"
+msgstr[0] "{0} verborgen tabel"
+msgstr[1] "{0} verborgen tabellen"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
-msgstr "Trouver une table"
+msgstr "Zoek een tabel"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
-msgstr "Schémas"
+msgstr "Schema's"
 
 #: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
@@ -512,22 +512,21 @@ msgstr "Schémas"
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
-msgstr "Métriques"
+msgstr "Metrieken"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
-msgstr "Ajouter une métrique"
+msgstr "Voeg een metriek toe"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
-msgstr "Définition"
+msgstr "Definitie"
 
-#. Bonjour François, ici il semble s'agir de la liste déroulante 'View' du générateur de requête
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
-msgstr "Créer des métriques pour les ajouter au menu déroulant 'Vue' du générateur de requêtes"
+msgstr "Maak metrieken aan om deze to te voegen aan de View dropdown in de vraagbouwer"
 
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
 #: frontend/src/metabase/home/containers/SearchApp.jsx:73
@@ -537,293 +536,298 @@ msgstr "Créer des métriques pour les ajouter au menu déroulant 'Vue' du gén�
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
-msgstr "Segments"
+msgstr "Segmenten"
 
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
-msgstr "Ajouter un segment"
+msgstr "Voeg een segment toe"
 
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
-msgstr "Créer des segments pour les ajouter à la liste déroulante Filtre dans le générateur de requêtes"
+msgstr "Maak segmenten om ze toe te voegen aan het de filter selectie in de query bouwer"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "created"
-msgstr "créé"
+msgstr "aangemaakt"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
 msgid "reverted to a previous version"
-msgstr "retour à une version précédente"
+msgstr "teruggedraaid naar een vorige versie"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
 msgid "edited the title"
-msgstr "modifier le titre"
+msgstr "heeft de titel bewerkt"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
 msgid "edited the description"
-msgstr "modifier la description"
+msgstr "heeft de omschrijving bewerkt"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "edited the "
-msgstr "modifier le "
+msgstr "bewerkte de "
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
 msgid "made some changes"
-msgstr "a fait des modifications"
+msgstr "heeft wat wijzigingen gemaakt"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
 #: frontend/src/metabase/home/components/Activity.jsx:82
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
-msgstr "Vous"
+msgstr "U"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
-msgstr "Modèle de données"
+msgstr "Datamodel"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
-msgstr " Historique"
+msgstr " geschiedenis"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
-msgstr "Historique de modification pour"
+msgstr "Revisiegeschiedenis voor"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
-msgstr "{0} – Réglages du champ"
+msgstr "{0} - Veldinstellingen"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
-msgstr "Où ce champ apparaîtra dans Metabase"
+msgstr "Waar dit veld zichtbaar wordt via Metabase"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
-msgstr "Filtrer sur ce champ"
+msgstr "Filteren op dit veld"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
-msgstr "Lorsque ce champ est utilisé dans un filtre, que doivent faire les utilisateurs pour saisir la valeur à filtrer?"
+msgstr "Als dit veld wordt gebruikt in een filter, wat moet men gebruiken om te filteren op de waarde die ze hebben ingevoerd?"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
-msgstr "Aucune description pour ce champ"
+msgstr "Nog geen beschrijving voor dit veld"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
-msgstr "Valeur d'origine"
+msgstr "Originele waarde"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
+#, fuzzy
 msgid "Mapped value"
-msgstr "Valeur correspondante"
+msgstr "Gekoppelde waarde"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
-msgstr "Saisir une valeur"
+msgstr "Voer een waarde in"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
 msgid "Use original value"
-msgstr "Utiliser la valeur d'origine"
+msgstr "Gebruik originele waarde"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use foreign key"
-msgstr "Utiliser la clé étrangère"
+msgstr "Gebruik verwijzende sleutel"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
+#, fuzzy
 msgid "Custom mapping"
-msgstr "Correspondance personnalisée"
+msgstr "Eigen koppeling"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
+#, fuzzy
 msgid "Unrecognized mapping type"
-msgstr "Type de correspondance non reconnu"
+msgstr "Type voor koppeling niet herkend"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
-msgstr "Le champ actuel n'est pas une clé étrangère ou les métadonnées de la table cible de la clé étrangère sont manquantes"
+msgstr "Het huidige veld is geen verwijzende sleutel of of de metadata van de doeltabel mist"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
-msgstr "Le champ sélectionné n'est pas une clé étrangère"
+msgstr "Het geselecteerde veld is geen verwijzende sleutel"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
-msgstr "Afficher les valeurs"
+msgstr "Toon waarden"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
-msgstr "Choisir d'afficher la valeur originale dans la base de données, ou une information associée ou personnalisée."
+msgstr "Kies om de originele waarde vanuit de database te zien of toon het veld met verwante of custom informatie."
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
-msgstr "Choisissez un champ"
+msgstr "Kies een veld"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
-msgstr "S'il vous plaît, sélectionnez une colonne à utiliser pour l'affichage"
+msgstr "Selecteer een kolom om te gebruiken voor weergave"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:771
 msgid "Tip:"
-msgstr "Astuce:"
+msgstr "Tip:"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
-msgstr "Il se peut que vous vouliez mettre à jour le nom du champ pour s'assurer qu'il est toujours pertinent selon vos choix de mise en corespondance."
+msgstr "Je kunt ervoor kiezen om de veldnaam aan te passen, om er zeker van te zijn dat deze nog duidelijk is, baserend op je hermapping keuzes."
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
-msgstr "Valeurs des filtres mises en cache"
+msgstr "Opgeslagen veldwaarden"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
-msgstr "Metabase peut analyser les valeurs de ce champ pour proposer des filtres dans les tableaux de bord et les questions."
+msgstr "Metabase kan de waarden voor dit veld scannen om checkbox filters in dashboards en vragen in te schakelen."
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:14
 msgid "Re-scan this field"
-msgstr "Analyser à nouveau ce champ"
+msgstr "Herscan dit veld"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
-msgstr "Supprimer les valeurs des filtres du cache"
+msgstr "Verwijder opgeslagen veldwaarden"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
-msgstr "Impossible de supprimer les valeurs"
+msgstr "Verwijderen van opgeslagen veldwaarden is mislukt"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
+#, fuzzy
 msgid "Discard triggered!"
-msgstr "Suppression lancée"
+msgstr "Weggooien geactiveerd!"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
-msgstr "Sélectionner une table pour voir son schéma et enrichir ses métadonnées"
+msgstr "Selecteer een tabel om het schema te zien en om metadata toe te voegen of te wijzigen."
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
-msgstr "Le nom est requis"
+msgstr "Naam is verplicht"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
-msgstr "La description est requise"
+msgstr "Omschrijving is verplicht"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
-msgstr "Un message d'historique est requis"
+msgstr "Herzieningsbericht is verplicht"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
-msgstr "Une agrégation est requise."
+msgstr "Aggregatie is benodigd"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
-msgstr "Éditer votre métrique"
+msgstr "Bewerk uw metriek"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
-msgstr "Créer votre métrique"
+msgstr "Maak uw metriek"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
-msgstr "Modifier votre métrique et laisser un commentaire pour ces changements."
+msgstr "Pas de meetwaarde aan en laat een verklaring achter"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
-msgstr "Sauvegardez des métriques pour les rendre disponibles dans l'option de Vue de cette table. Les métriques se définissent par un type d'agrégation, un champ aggrégé, et optionnellement tous filtres que vous y ajouterez. Par exemple, vous pourriez vouloir créer une métrique pour définir la façon officielle de calculer le \"Prix moyen\" d'une table qui contient des Commandes."
+msgstr "Je kunt opgeslagen metrieken aanmaken om een metriek optie toe tevoegen aan deze tabel. Opgeslagen metrieken omvatten het aggregatietype, het geaggregeerde veld en elk filter dat u toevoegt. Bijvoorbeeld: je kunt deze optie gebruiken voor een standaard manier voor het berekenen van een \"gemiddelde prijs\" for een bestellingen tabel."
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
-msgstr "Résultat : "
+msgstr "Resultaat: "
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
-msgstr "Nommez votre métrique"
+msgstr "Geef uw metriek een naam"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
-msgstr "Donnez un nom à votre métrique pour aider les autres à la retrouver."
+msgstr "Geef uw metriek een naam om het vindbaar te maken voor anderen."
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
-msgstr "Description syntétique"
+msgstr "Iets verduidelijkends maar niet te lang"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
-msgstr "Décrivez votre métrique"
+msgstr "Beschrijf uw metriek"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
-msgstr "Donnez une description à votre métrique pour aider les autres à mieux l'utiliser."
+msgstr "Beschrijf uw metriek om het uit te leggen aan anderen."
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
-msgstr "C'est le bon endroit pour expliquer plus précisement à quoi sert votre métrique et comment vous l'avez construite."
+msgstr "Hier kun je preciezer zijn over metriken die minder duidelijk zijn"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
-msgstr "Raison des modifications"
+msgstr "Reden voor wijzigingen"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
-msgstr "Laisser un mot d'explication sur les changements que vous avez fait et pourquoi ils étaient nécessaires."
+msgstr "Laat een notitie achter, om de veranderingen uit te leggen en waarom ze nodig waren."
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
-msgstr "Sera affiché dans l'historique des révisions de cette métrique afin d'aider tout le monde à se souvenir des changements effectués."
+msgstr "Dit wordt weergegeven in de revisiegeschiedenis voor deze metriek zodat de reden voor iedereen duidelijk is"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
-msgstr "Au moins un filtre est requis"
+msgstr "Er is ten minste één filter benodigd"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
-msgstr "Modifier votre segment"
+msgstr "Bewerk uw segment"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
-msgstr "Créez votre segment"
+msgstr "Maak uw segment"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
-msgstr "Faites des changement à votre segment et laissez une note explicative"
+msgstr "Verander je segment en laat een uitleg achter."
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
-msgstr "Sélectionnez et ajoutez des filtres pour créer un nouveau segement pour la table {0}"
+msgstr "Selecteer en voeg filters toe om een nieuw segment voor de {0} tabel te maken."
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
-msgstr "Nommez votre segment"
+msgstr "Benoem uw segment"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
-msgstr "Donnez un nom à votre segment pour aider les utilisateurs à le retrouver."
+msgstr "Geef uw segment een naam om het vindbaar te maken voor anderen."
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
-msgstr "Décrivez votre segment"
+msgstr "Beschrijf uw segment"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
+#, fuzzy
 msgid "Give your segment a description to help others understand what it's about."
-msgstr "Donnez une description à votre segment pour aider les autres à mieux l'utiliser."
+msgstr "Benoem je segment, zodat anderen begrijpen wat het doet."
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
-msgstr "C'est le bon endroit pour être plus spécifique sur les règles de segment moins évidentes"
+msgstr "Dit is een goede plek om specifieker te zijn over minder voor de hand liggende segment regels."
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
-msgstr "Ce sera affiché dans l'historique des révisions pour ce segement, afin d'aider tout le monde à se souvenir pour ça a été changé"
+msgstr "Dit wordt getoond in de revisiegeschiedenis, zodat iedereen weet waarom dit segment werd aangepast."
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
@@ -833,38 +837,38 @@ msgstr "Ce sera affiché dans l'historique des révisions pour ce segement, afin
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
-msgstr "Paramètres"
+msgstr "Instellingen"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
-msgstr "Metabase peut analyser les valeurs des champs de cette table pour activer les filtres de case à cocher dans les tableaux de bord et les questions."
+msgstr "Metabase kan de waardes van deze tabel scannen om checkbox filters in dashboards en vragen aan te zetten."
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
-msgstr "Analyser à nouveau cette table"
+msgstr "Herscan deze tabel"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
-msgstr "Ajouter"
+msgstr "Toevoegen"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:103
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:67
 msgid "Not a valid formatted email address"
-msgstr "Format de l'adresse électronique invalide"
+msgstr "Geen valide e-mailadres"
 
 #: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:100
 msgid "First name"
-msgstr "Prénom"
+msgstr "Voornaam"
 
 #: frontend/src/metabase/entities/users.js:42
 #: frontend/src/metabase/setup/components/UserStep.jsx:203
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:117
 msgid "Last name"
-msgstr "Nom"
+msgstr "Achternaam"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:77
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:161
@@ -873,34 +877,34 @@ msgstr "Nom"
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
-msgstr "Adresse électronique"
+msgstr "E-mailadres"
 
 #: frontend/src/metabase/admin/people/components/EditUserForm.jsx:202
 msgid "Permission Groups"
-msgstr "Groupes de permissions"
+msgstr "Rechtengroepen"
 
 #: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
 msgid "Make this user an admin"
-msgstr "Faire de cet utilisateur un administrateur"
+msgstr "Maak deze gebruiker een beheerder"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
-msgstr "Tous les utilisateurs appartiennent au groupe {0} et ne peuvent pas en être supprimé. Les réglages de permission pour ce groupe sont un bon moyen de s'assurer de ce que les nouveaux utilisateurs de Metabase verront."
+msgstr "Alle gebruikers behoren tot de groep {0} en kunnen niet verwijderd worden uit deze groep. Restricties toekennen voor deze groep is een goede manier om er zeker van te zijn wat nieuwe Metabase gebruikers kunnen zien."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
-msgstr "Il s’agit d’un groupe spécial dont les membres peuvent tout voir dans l’instance Metabase et qui peut accéder et apporter des modifications aux paramètres du panneau d'administration, y compris la modification des autorisations ! Donc, ajoutez des personnes à ce groupe avec précaution."
+msgstr "Dit is een speciale groep waarvan leden alles kunnen zien in deze Metabase omgeving, wie toegang heeft en wijzigingen kunnen maken binnen het Admin paneel, inclusief het wijzigen van restricties! Wees voorzichtig met het toevoegen van gebruikers aan deze groep."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
-msgstr "Pour s'assurer de ne pas être exclu de Metabase, il doit toujours y avoir au moins un utilisateur dans ce groupe."
+msgstr "Om te verzekeren dat je niet buitengesloten wordt van Metabase moet er altijd minimaal één gebruiker in deze groep zijn"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
-msgstr "Membres"
+msgstr "Gebruikers"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
@@ -909,68 +913,67 @@ msgstr "Membres"
 #: frontend/src/metabase/lib/core.js:55
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
-msgstr "Adresse électronique"
+msgstr "E-mail"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
-msgstr "Un groupe n'a de valeur que lorsqu'il contient des utilisateurs."
+msgstr "Een groep is slechts zo goed als zijn leden."
 
-#. tous les items du menu paramètres sont des noms...
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
 #: frontend/src/metabase/admin/routes.jsx:48
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:49
 msgid "Admin"
-msgstr "Administration"
+msgstr "Beheerder"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
-msgstr "et"
+msgstr "en"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:19
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:31
 msgid "{0} other group"
 msgid_plural "{0} other groups"
-msgstr[0] "{0} autre groupe"
-msgstr[1] "{0} autres groupes"
+msgstr[0] "{0} andere groep"
+msgstr[1] "{0} andere groepen"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:37
 msgid "Default"
-msgstr "Défaut"
+msgstr "Standaard"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:39
 msgid "Something like \"Marketing\""
-msgstr "Quelque chose comme \"Marketing\""
+msgstr "Bijvoorbeeld \"Marketing\""
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:58
 msgid "Remove this group?"
-msgstr "Supprimer ce groupe ?"
+msgstr "Verwijder deze groep?"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:60
 msgid "Are you sure? All members of this group will lose any permissions settings they have based on this group.\n"
 "This can't be undone."
-msgstr "Êtes-vous sûr ? Tous les membres de ce groupe perdront toutes leurs  autorisations basées sur ce groupe.\n"
-"Cette action ne peut pas être annulée."
+msgstr "Weet je het zeker? Alle leden in deze groep zullen de rechten verliezen die ze hebben verkregen binnen deze groep. \n"
+"Dit kan niet ongedaan worden gemaakt."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
-msgstr "Oui"
+msgstr "Ja"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
-msgstr "Non"
+msgstr "Nee"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:92
 msgid "Edit Name"
-msgstr "Modifier le Nom"
+msgstr "Bewerk naam"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:95
 msgid "Remove Group"
-msgstr "Supprimer le groupe"
+msgstr "Verwijder groep"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:46
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:138
@@ -985,11 +988,11 @@ msgstr "Supprimer le groupe"
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
-msgstr "Fait"
+msgstr "Klaar"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Group name"
-msgstr "Nom du groupe"
+msgstr "Groepsnaam"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
@@ -997,383 +1000,383 @@ msgstr "Nom du groupe"
 #: frontend/src/metabase/admin/routes.jsx:88
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
-msgstr "Groupes"
+msgstr "Groeperen"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:364
 msgid "Create a group"
-msgstr "Créer un groupe"
+msgstr "Maak een groep"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:370
 msgid "You can use groups to control your users' access to your data. Put users in groups and then go to the Permissions section to control each group's access. The Administrators and All Users groups are special default groups that can't be removed."
-msgstr "Vous pouvez utiliser des groupes pour contrôler l'accès de vos utilisateurs à vos données. Placez les utilisateurs dans des groupes, puis accédez à la section Autorisations pour contrôler l'accès de chaque groupe. Les groupes Administrateurs et \"Tous les utilisateurs\" sont des groupes par défaut spéciaux qui ne peuvent être supprimés."
+msgstr "Je kunt groepen gebruiken om de toegang tot bepaalde gegevens te bepalen. Voeg gebruikers toe aan groepen en beheer daarna de rechten voor elke groep. De \"Beheerders\" en \"Alle gebruikers\" zijn speciale standaard groepen en kunnen niet verwijderd worden."
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:79
 msgid "Edit Details"
-msgstr "Modifier les Détails"
+msgstr "Bewerk gegevens"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:85
 msgid "Re-send Invite"
-msgstr "Renvoyer l'invitation"
+msgstr "Herstuur uitnodiging"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:90
 msgid "Reset Password"
-msgstr "Réinitialiser le mot de passe"
+msgstr "Stel wachtwoord opnieuw in"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:40
 msgid "Deactivate"
-msgstr "Désactiver"
+msgstr "Deactiveer"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
 #: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
-msgstr "Utilisateurs"
+msgstr "Mensen"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:192
 msgid "Who do you want to add?"
-msgstr "Que voulez-vous ajouter?"
+msgstr "Wie wilt u toevoegen?"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:207
 msgid "Edit {0}'s details"
-msgstr "Modifier les détails de {0}"
+msgstr "Bewerk {0}'s gegevens"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:40
 msgid "{0} has been added"
-msgstr "{0} a été ajouté"
+msgstr "{0} is toegevoegd"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:224
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:262
 msgid "Add another person"
-msgstr "Ajouter une autre personne"
+msgstr "Voeg nog een persoon toe"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:231
 msgid "We couldn’t send them an email invitation,\n"
 "so make sure to tell them to log in using {0}\n"
 "and this password we’ve generated for them:"
-msgstr "Nous n'avons pas pu lui envoyer un courriel d'invitation, assurez-vous donc qu'il se connecte en utilisant {0} et le mot de passe que nous avons généré :"
+msgstr "We konden geen email uitnodiging versturen. Vertel daarom om in te loggen met {0} en het wachtwoord wat we gegenereerd hebben:"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:73
 msgid "If you want to be able to send email invites, just go to the {0} page."
-msgstr "Si vous souhaitez pouvoir envoyer des courriels d'invitation, accédez à la page {0}."
+msgstr "Als u e-mailuitnodigingen wilt kunnen versturen, ga dan naar de {0} pagina."
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:55
 msgid "We’ve sent an invite to {0} with instructions to set their password."
-msgstr "Nous avons envoyé une invitation à {0} avec les instructions pour modifier le mot de passe"
+msgstr "Wij hebben {0} een uitnodiging verstuurd om hun wachtwoord te wijzigen."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:283
 msgid "We've re-sent {0}'s invite"
-msgstr "Nous avons renvoyé l'invitation de {0}"
+msgstr "Wij hebben {0}'s uitnodiging opnieuw verzonden"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
 msgid "Okay"
-msgstr "OK"
+msgstr "Ok"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:289
 msgid "Any previous email invites they have will no longer work."
-msgstr "Les invitations précédentes, envoyées par courriel, ne fonctionneront plus."
+msgstr "Eerder verstuurde e-mailuitnodigingen zullen niet meer werken"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:31
 msgid "Deactivate {0}?"
-msgstr "Désactiver {0}?"
+msgstr "Deactiveer {0}?"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:34
 msgid "{0} won't be able to log in anymore."
-msgstr "{0} ne pourra plus se connecter."
+msgstr "{0} zal niet meer kunnen inloggen."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:320
 msgid "Reactivate {0}'s account?"
-msgstr "Réactiver le compte de {0}?"
+msgstr "Heractiveer {0}'s account?"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:58
 msgid "Reactivate"
-msgstr "Réactiver"
+msgstr "Heractiveer"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:51
 msgid "They'll be able to log in again, and they'll be placed back into the groups they were in before their account was deactivated."
-msgstr "Ces utilisateurs pourront se connecter à nouveau et ils seront replacés dans les groupes où ils se trouvaient avant que leur compte ne soit désactivé."
+msgstr "Ze kunnen weer inloggen en worden teruggeplaatst in de groepen waar ze zich in bevonden voordat hun account werd gedeactiveerd."
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:51
 msgid "Reset {0}'s password?"
-msgstr "Réinitialiser le mot de passe de {0}"
+msgstr "Stel {0}'s wachtwoord opnieuw in?"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
-msgstr "Réinitialiser"
+msgstr "Reset"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
-msgstr "Êtes-vous sûr de vouloir faire cela ?"
+msgstr "Weet u zeker dat u dit wilt doen?"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:41
 msgid "{0}'s password has been reset"
-msgstr "Le mot de passe de {0} a été réinitialisé"
+msgstr "{0}'s wachtwoord is opnieuw ingesteld"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:45
 msgid "Here’s a temporary password they can use to log in and then change their password."
-msgstr "Voici un mot de passe temporaire que les utilisateurs peuvent utiliser pour se connecter, puis modifier leur mot de passe."
+msgstr "Hier is een tijdelijk wachtwoord wat ze kunnen gebruiken om in te loggen en het wachtwoord te wijzigen."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:388
 msgid "We've sent them an email with instructions for creating a new password."
-msgstr "Nous avons envoyé un courriel à cet utilisateur avec les instructions pour créer un nouveau mot de passe."
+msgstr "We hebben een mail verstuurd met instructies voor het maken van een nieuw wachtwoord."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
-msgstr "Actif"
+msgstr "Activeer"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
-msgstr "Désactivé"
+msgstr "Deactiveer"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
-msgstr "Ajouter quelqu'un"
+msgstr "Voeg iemand toe"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
-msgstr "Dernier login"
+msgstr "Laatste inlog"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
-msgstr "Inscription via Google"
+msgstr "Aangemeld via Google"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
-msgstr "Inscription via LDAP"
+msgstr "Aangemeld via LDAP"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
-msgstr "Ré-activer ce compte"
+msgstr "Heractiveer dit account"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
-msgstr "Jamais"
+msgstr "Nooit"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
-msgstr[0] "{0} table"
-msgstr[1] "{0} tables"
+msgstr[0] "{0} tabel"
+msgstr[1] "{0} tabellen"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
-msgstr " sera "
+msgstr " zullen "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
-msgstr "accès donné à"
+msgstr "heeft toegang gegeven tot"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
-msgstr " et "
+msgstr " en "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
-msgstr "accès accordé à"
+msgstr "heeft toegang geweigerd tot"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
-msgstr " ne sera plus autorisé(s) à "
+msgstr " kunnen niet langer "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
-msgstr " sera désormais autorisé à "
+msgstr "kunnen vanaf nu"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
-msgstr " questions brutes pour "
+msgstr " standaard queries voor "
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
 #: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
-msgstr "Permissions"
+msgstr "Rechten"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:32
 msgid "Save permissions?"
-msgstr "Sauvegarder les permissions ?"
+msgstr "Rechten opslaan?"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:38
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:161
 msgid "Save Changes"
-msgstr "Sauvegarder les modifications"
+msgstr "Sla wijzigingen op"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:44
 msgid "Discard changes?"
-msgstr "Annuler les modifications ?"
+msgstr "Veranderingen ongedaan maken?"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:46
 msgid "No changes to permissions will be made."
-msgstr "Aucune modification ne sera faite aux permissions."
+msgstr "Er zullen geen wijzigingen in de rechten gemaakt worden."
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:65
 msgid "You've made changes to permissions."
-msgstr "Vous avez fait des modifications aux permissions."
+msgstr "U hebt aanpassingen gedaan aan rechten."
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
-msgstr "Permissions pour cette collection"
+msgstr "Rechten voor deze collectie"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
-msgstr "Vous avez des modifications non sauvegardées"
+msgstr "U hebt niet opgeslagen wijzigingen"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
-msgstr "Voulez-vous quitter cette page et ignorer vos modifications ?"
+msgstr "Wil je deze pagina verlaten zonder de wijzigingen op te slaan?"
 
 #: frontend/src/metabase/admin/permissions/permissions.js:126
 msgid "Sorry, an error occurred."
-msgstr "Désolé, une erreur est survenue."
+msgstr "Sorry, er is een fout opgetreden."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:65
 msgid "Administrators always have the highest level of access to everything in Metabase."
-msgstr "Les administrateurs ont toujours le plus haut niveau d'accès à tout dans Metabase."
+msgstr "Beheerders hebben altijd het hoogste nivo van toegang tot alles binnen Metabase."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:67
 msgid "Every Metabase user belongs to the All Users group. If you want to limit or restrict a group's access to something, make sure the All Users group has an equal or lower level of access."
-msgstr "Tous les utilisateurs de Metabase appartiennent au groupe \"Tous les utilisateurs\". Si vous voulez limiter ou restreindre l'accès d'un groupe à un élément, assurez-vous que le groupe \"Tous les utilisateurs\" a un niveau d'accès égal ou inférieur."
+msgstr "Elke Metabase gebruiker behoord tot de \"Alle gebruikers\" groep. Zorg ervoor dat de \"Alle gebruikers\" groep gelijke of minder rechten hebben wanneer je de toegang van een groep wilt beperken."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:69
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
-msgstr "MetaBot est le bot Slack de Metabase. Vous pouvez choisir à quoi il a accès ici."
+msgstr "MetaBot is de Slack bot van Metabase. Je kan kiezen waar het hier recht toe heeft."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
-msgstr "Le groupe \"{0}\" peut avoir accès à un ensemble différent de {1} que ce groupe, ce qui peut donner à ce groupe un accès supplémentaire à certains {2}."
+msgstr "De \"{0}\" groep heeft mogelijk toegang tot een andere set van {1} dan deze groep, waardoor deze groep mogelijk extra toegang heeft tot een aantal {2}."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
-msgstr "Le groupe \"{0}\" a un niveau d'accès plus élevé que celui-ci, qui remplacera ce paramètre. Vous devez limiter ou révoquer l'accès du groupe \"{1}\" à cet élément."
+msgstr "De groep \"{0}\" heeft een hoger toegangsniveau dan deze, waardoor deze instelling wordt opgeheven. Je moet de toegang van de groep \"{1}\" tot dit item beperken of intrekken."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
-msgstr "Limite"
+msgstr "Limiet"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
-msgstr "Révoquer"
+msgstr "Intrekken"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
-msgstr "accéder même si \"{0}\" a accès supérieur?"
+msgstr "Betreden terwijl \"{0}\" meer rechten heeft?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
-msgstr "Limiter l'accès"
+msgstr "Limiteer toegang"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
-msgstr "Révoquer l'accès"
+msgstr "Trek toegang in"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
-msgstr "Changer l'accès de cette base de données à limité ?"
+msgstr "Wijzig de toegang tot deze database in gelimiteerd?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
-msgstr "Changer"
+msgstr "Wijziging"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
-msgstr "Autoriser l'écriture de requête brute ?"
+msgstr "Toestaan om \"Raw queries\" te schrijven?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
-msgstr "Cela aura aussi pour effet de donner à ce groupe un accès non restreint aux données de cette base."
+msgstr "Hiermee wordt ook de gegevenstoegang van deze groep gewijzigd in Onbeperkt voor deze database."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
-msgstr "Autoriser"
+msgstr "Toestaan"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
-msgstr "Révoquer l'accès à toutes les tables ?"
+msgstr "Rechten intrekken voor alle tabellen?"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
-msgstr "Cela aura aussi pour effet de révoquer à ce groupe l'usage des questions brutes vers cette base de données."
+msgstr "Hiermee wordt ook de toegang van deze groep tot \"raw queries\" voor deze database ingetrokken."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
-msgstr "Accorder un accès non restreint"
+msgstr "Ken onbeperkte toegang toe"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
-msgstr "Accès non restreint"
+msgstr "Onbeperkte toegang"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
-msgstr "Accès limité"
+msgstr "Gelimiteerde toegang"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
-msgstr "Aucun accès"
+msgstr "Geen toegang"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
-msgstr "Ecrire des questions brutes"
+msgstr "Schrijf \"raw queries\""
 
 #: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
-msgstr "Peut/peuvent écrire des questions brutes"
+msgstr "Kan \"raw queries\" schrijven"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
-msgstr "Organiser une collection"
+msgstr "Beheer collectie"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
-msgstr "Voir le contenu d'une collection"
+msgstr "Toon verzamelingen"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:430
 #: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
-msgstr "Accès aux données"
+msgstr "Datatoegang"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:495
 #: frontend/src/metabase/admin/permissions/selectors.js:652
 #: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
-msgstr "Voir les tables"
+msgstr "Toon tabellen"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
-msgstr "Requêtes SQL"
+msgstr "SQL Queries"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
-msgstr "Voir les schémas"
+msgstr "Toon schema's"
 
 #: frontend/src/metabase/admin/routes.jsx:59
 #: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
-msgstr "Modèles de données"
+msgstr "Datamodel"
 
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:11
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:118
 msgid "Sign in with Google"
-msgstr "S'authentifier avec Google"
+msgstr "Inloggen met Google"
 
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
-msgstr "Permet aux utilisateurs ayant un compte Metabase de se connecter avec un compte Google ayant la même adresse électronique en plus de leur identifiant et mot de passe Metabase."
+msgstr "Hiermee kunnen gebruikers met bestaande Metabase-accounts inloggen met een Google-account dat overeenkomt met hun e-mailadres naast hun Metabase-gebruikersnaam en -wachtwoord."
 
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
-msgstr "Configurer"
+msgstr "Configureer"
 
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
@@ -1383,133 +1386,133 @@ msgstr "LDAP"
 
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
-msgstr "Permet aux utilisateurs de votre annuaire LDAP de se connecter à Metabase avec leur compte LDAP, et offre la possibilité de réaliser une correspondance automatique des groupes LDAP et Metabase."
+msgstr "Hiermee kunnen gebruikers in uw LDAP-directory zich aanmelden bij Metabase met hun LDAP-inloggegevens en kunnen LDAP-groepen automatisch worden toegewezen aan Metabase-groepen."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
 #: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
-msgstr "Ce n'est pas une adresse électronique valide"
+msgstr "Dat is geen valide e-mailadres"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:21
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:73
 msgid "That's not a valid integer"
-msgstr "Ce n'est pas un entier valide"
+msgstr "Dat is geen geldig getal"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:161
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:223
 msgid "Changes saved!"
-msgstr "Modifications sauvegardées!"
+msgstr "Wijzigingen opgeslagen!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:157
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:132
 msgid "Looks like we ran into some problems"
-msgstr "Il semble que nous avons rencontré des problèmes"
+msgstr "Het lijkt er op dat we tegen een probleem zijn aangelopen"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:12
 msgid "Send test email"
-msgstr "Envoyer un courriel de test"
+msgstr "Verstuur teste-mail"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:13
 msgid "Sending..."
-msgstr "Envoi en cours..."
+msgstr "Bezig met versturen..."
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:14
 msgid "Sent!"
-msgstr "Envoyé !"
+msgstr "Verzonden!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:82
 msgid "Clear"
-msgstr "Effacer"
+msgstr "Leeg"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
-msgstr "Authentification"
+msgstr "Authenticatie"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:18
 msgid "Server Settings"
-msgstr "Paramètres serveur"
+msgstr "Serverinstellingen"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:29
 msgid "User Schema"
-msgstr "Schéma utilisateur"
+msgstr "Gebruikersschema"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:33
 msgid "Attributes"
-msgstr "Attributs"
+msgstr "Attributen"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:42
 msgid "Group Schema"
-msgstr "Schéma de groupe"
+msgstr "Groepschema"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetting.jsx:28
 msgid "Using "
-msgstr "Utilise "
+msgstr "Gebruik makend van "
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:105
 msgid "Getting set up"
-msgstr "Configuration en cours"
+msgstr "Aan de slag"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:106
 msgid "A few things you can do to get the most out of Metabase."
-msgstr "Quelques astuces à suivre pour tirer le meilleur parti de Metabase."
+msgstr "Een paar dingen die je kunt doen om het meeste uit Metabase te halen."
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:115
 msgid "Recommended next step"
-msgstr "Prochaine étape recommandée"
+msgstr "Aanbevolen volgende stap"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:114
 msgid "Google Sign-In"
-msgstr "S'authentifier avec Google"
+msgstr "Google Log-in"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:123
 msgid "To allow users to sign in with Google you'll need to give Metabase a Google Developers console application client ID. It only takes a few steps and instructions on how to create a key can be found {0}"
-msgstr "Pour permettre aux utilisateurs de se connecter avec leur compte Google, vous devez fournir à Metabase le \"Client ID\" créé depuis la console Google API. Cela ne prend que quelques instants et la procédure à suivre se trouve ici : {0}"
+msgstr "Er is een Client ID via het Google Developers console application client ID nodig om gebruikers de mogelijkheid te geven om in te loggen met Google. Het duurt niet lang om de volgende stappen en instructies te volgen {0}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:137
 msgid "Your Google client ID"
-msgstr "Votre Google client ID"
+msgstr "Je Google client ID"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:142
 msgid "Allow users to sign up on their own if their Google account email address is from:"
-msgstr "Autoriser les utilisateurs à se connecter uniquement si leur compte Google se termine par :"
+msgstr "Sta gebruikers toe om te registeren via een Google account e-mailadres van:"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
 msgid "Answers sent right to your Slack #channels"
-msgstr "Réponses envoyées directement vers vos #canaux Slack"
+msgstr "Stuur antwoorden direct naar Slack #channels"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
 msgid "Create a Slack Bot User for MetaBot"
-msgstr "Créer un Slack Bot User pour MetaBot"
+msgstr "Maak een Slack Bot account aan voor MetaBot"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
-msgstr "Cela fait, donnez lui/elle un nom et cliquer {0}. Copier et coller ensuite le Bot API Token dans le champ ci-dessous. Enfin, créez un canal Slack \"metabase_files\" . Metabase en a besoin pour télécharger les graphiques."
+msgstr "Volg de stappen, geef het een naam en klik op {0}. Kopieer en plak de Bot API token in het onderstaande veld. Wanneer dit voltooid is kun je een \"metabase_files\" channel aanmaken in Slack. Metabase heeft dit nodig om afbeeldingen te uploaden."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
-msgstr "Vous faites tourner Metabase {0} qui est la dernière et meilleure version !"
+msgstr "U draait Metabase {0}, de nieuwste versie."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
-msgstr "Metabase {0} est disponible. Vous faites actuellement tourner {1}"
+msgstr "Metabase {0} is beschikbaar. U draait nu {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
-msgstr "Mettre à jour"
+msgstr "Update"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
-msgstr "Ce qui a changé :"
+msgstr "Wat is er veranderd:"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:131
 msgid "Add a map"
-msgstr "Ajouter une carte"
+msgstr "Voeg een kaart toe"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
 #: frontend/src/metabase/lib/core.js:105
@@ -1518,7 +1521,7 @@ msgstr "URL"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
-msgstr "Supprimer une carte personnalisée"
+msgstr "Verwijder aangepaste kaart"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
@@ -1527,7 +1530,7 @@ msgstr "Supprimer une carte personnalisée"
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
-msgstr "Supprimer"
+msgstr "Verwijderen"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
@@ -1535,582 +1538,580 @@ msgstr "Supprimer"
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
-msgstr "Sélectionner..."
+msgstr "Selecteer..."
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
-msgstr "Valeurs d'exemple:"
+msgstr "Voorbeeldwaarden:"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
-msgstr "Ajouter une nouvelle carte"
+msgstr "Voeg kaart toe"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
-msgstr "Modifier la carte"
+msgstr "Bewerk kaart"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
-msgstr "Comment voulez-vous appeler cette carte ?"
+msgstr "Welke naam wilt u aan deze kaart geven?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
-msgstr "Exemple : Royaume-Uni, Brésil, Mars"
+msgstr "bijv. Engeland, Brazilië, Mars"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
-msgstr "URL du fichier GeoJSON que vous voulez utiliser"
+msgstr "URL voor het GeoJSON bestand dat u wilt gebruiken"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
-msgstr "Exemple : https://my-mb-server.com/maps/my-map.json"
+msgstr "Bijvoorbeeld https://my-mb-server.com/maps/my-map.json"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
-msgstr "Rafraîchir"
+msgstr "Vernieuwen"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
-msgstr "Charger"
+msgstr "Laden"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
-msgstr "Quelle propriété spécifie l'identifiant de région ?"
+msgstr "Welke eigenschap specificeert de regio?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
-msgstr "Quelle propriété spécifie le libellé de la région ?"
+msgstr "Welke eigenschap specificeert de weergave naam voor de regio?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
-msgstr "Charger un fichier GeoJSON pour voir un aperçu"
+msgstr "Laad een GeoJSON bestand om een voorbeeld te zien"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
-msgstr "Sauvegarder la carte"
+msgstr "Sla kaart op"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
-msgstr "Ajouter une carte"
+msgstr "Voeg kaart toe"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:7
 msgid "Using embedding"
-msgstr "Utiliser l'intégration"
+msgstr "Gebruik maken van embedding"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:9
 msgid "By enabling embedding you're agreeing to the embedding license located at"
-msgstr "En activant l'intégration vous donner votre accord à la licence d'intégration située à"
+msgstr "Bij het inschakelen van embedding ga je akkoord met de embedding licentie die gevonden kan worden op"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
-msgstr "Précisément, quand vous intégrez des questions ou des tableaux de bord depuis Metabase dans votre propre application, cette application n'est pas l'objet de l'Affero General Public License qui couvre le reste de Metabase, du moment que vous conservez le logo Metabase et \"Powered by Metabase\" visibles dans ces intégrations. Vous devriez, cependant, lire le texte de la licence référencée ci-dessus, car c'est la licence à laquelle vous donnez dans les faits votre accord en activant cette fonctionnalité."
+msgstr "Kort samengevat, wanneer je grafieken of dashboards embed binnen je eigen applicatie is de applicatie niet gebonden aan de Affero General Public License, zolang je de Metabase logo en de \"Mogelijk gemaakt door Metabase\" zichtbaar toont binnen deze embeds. Je moet de licentie nog wel lezen, aangezien dat de licentie is waarmee je akkoord gaat bij het inschakelen van deze functionaliteit."
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
-msgstr "Activer"
+msgstr "Zet aan"
 
-#. Que pensez-vous de "intégrer" / "intégration" / etc ?
-#. (pour "embed", "embedding", etc)
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:24
 msgid "Premium embedding enabled"
-msgstr "Intégration Premium activée"
+msgstr "Premium embedding ingeschakeld"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:26
 msgid "Enter the token you bought from the Metabase Store"
-msgstr "Saisissez le jeton que vous avez acheté dans la boutique Metabase"
+msgstr "Voer de token in van de aankoop uit de Metabase Store"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:53
 msgid "Premium embedding lets you disable \"Powered by Metabase\" on your embedded dashboards and questions."
-msgstr "L'Intégration Premium vous permet de désactiver \"Powered by Metabase\" dans vos tableaux de bord et questions intégrés."
+msgstr "Met premium embedding kan de melding \"Mogelijk gemaakt door Metabase\" worden uitgeschakeld binnen de embedded dashboards en vragen."
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:60
 msgid "Buy a token"
-msgstr "Acheter un jeton"
+msgstr "Koop een token"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:63
 msgid "Enter a token"
-msgstr "Saisir un jeton"
+msgstr "Voer een token in"
 
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
-msgstr "Modifier les correspondances"
+msgstr "Pas mappings aan"
 
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
-msgstr "Correspondances de groupe"
+msgstr "Groep mappings"
 
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
-msgstr "Créer une correspondance"
+msgstr "Maak een mapping"
 
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
-msgstr "Les correspondances permettent à Metabase d'ajouter ou retirer automatiquement un utilisateur aux groupes selon les informations fournies par l'annuaire. L'appartenance au groupe 'Admin' peut être accordée par ce mécanisme, mais ne sera pas automatiquement retirée par mesure de sécurité."
+msgstr "Met toewijzingen kan Metabase automatisch gebruikers toevoegen aan en verwijderen uit groepen op basis van de lidmaatschapsinformatie van de\n"
+"directoryserver. Lidmaatschap van de beheerdersgroep kan worden verleend via toewijzingen, maar wordt niet automatisch verwijderd voor de veiligheid."
 
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
-msgstr "Distinguished Name"
+msgstr "Onderscheidende naam"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:92
 msgid "Public Link"
-msgstr "Lien public"
+msgstr "Publieke link"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:93
 msgid "Revoke Link"
-msgstr "Retirer le lien"
+msgstr "Trek link in"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
-msgstr "Désactiver ce lien ?"
+msgstr "Maak de link onbruikbaar?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
-msgstr "Ils ne fonctionneront plus, et ne seront pas restaurés, mais vous pouvez créer de nouveaux liens."
+msgstr "Ze werken niet meer en kunnen niet worden hersteld, maar je kunt wel nieuwe links maken."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
-msgstr "Liste des tableaux de bord publics"
+msgstr "Lijst van openbare dashboards"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
-msgstr "Aucun tableau de bord n'a encore été publiquement partagé."
+msgstr "Er is nog geen dashboard publiekelijk gedeeld"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
-msgstr "Liste des questions publiques"
+msgstr "Lijst van openbare kaarten"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
-msgstr "Aucune question n'a encore été publiquement partagée."
+msgstr "Geen enkele vraag is openbaar gedeeld."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
-msgstr "Liste des tableaux de bord intégrés"
+msgstr "Lijst van embedded dashboards"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
-msgstr "Aucun tableau de bord n'a encore été intégré."
+msgstr "Geen enkele dashboard is embeded."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
-msgstr "Liste des questions intégrées"
+msgstr "Lijst van embedded kaarten"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
-msgstr "Aucune question n'a encore été intégrée."
+msgstr "Geen enkele vraag is publiek embedded."
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:35
 msgid "Regenerate embedding key?"
-msgstr "Regenérer la clé d'intégration ?"
+msgstr "Embedding sleutel opnieuw genereren?"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:36
 msgid "This will cause existing embeds to stop working until they are updated with the new key."
-msgstr "Cela provoquera le dysfonctionnement des intégrations existantes jusqu'à leur mise à jour avec la nouvelle clé."
+msgstr "Dit zorgt ervoor dat bestaande embeds niet meer werken totdat deze zijn bijgewerkt met de nieuwe sleutel."
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:39
 msgid "Regenerate key"
-msgstr "Re-générer une clé"
+msgstr "Hergenereer sleutel"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:47
 msgid "Generate Key"
-msgstr "Générer une clé"
+msgstr "Genereer sleutel"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
 #: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
-msgstr "Activé"
+msgstr "Aangezet"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
 #: frontend/src/metabase/admin/settings/selectors.js:82
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
-msgstr "Désactivé"
+msgstr "Uitgezet"
 
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
-msgstr "Réglage inconnu {0}"
+msgstr "Onbekende instelling {0}"
 
 #: frontend/src/metabase/admin/settings/selectors.js:23
 msgid "Setup"
-msgstr "Réglages"
+msgstr "Setup"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
-msgstr "Général"
+msgstr "Algemeen"
 
 #: frontend/src/metabase/admin/settings/selectors.js:33
 msgid "Site Name"
-msgstr "Nom du site"
+msgstr "Site naam"
 
 #: frontend/src/metabase/admin/settings/selectors.js:38
 msgid "Site URL"
-msgstr "URL du site"
+msgstr "Site URL"
 
 #: frontend/src/metabase/admin/settings/selectors.js:43
 msgid "Email Address for Help Requests"
-msgstr "Adresse électronique pour les demandes d'aide"
+msgstr "E-mailadres voor hulpverzoeken"
 
 #: frontend/src/metabase/admin/settings/selectors.js:48
 msgid "Report Timezone"
-msgstr "Fuseau horaire des rapports"
+msgstr "Rapport tijdzone"
 
 #: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Database Default"
-msgstr "Valeur par défaut de la base de données"
+msgstr "Standaard database"
 
 #: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Select a timezone"
-msgstr "Choisir un fuseau horaire"
+msgstr "Selecteer een tijdzone"
 
 #: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
-msgstr "Toutes les bases de données ne gèrent pas les fuseaux horaires, le cas échéant ce réglage sera sans effet."
+msgstr "Niet alle database ondersteunen tijdzones, in die gevallen heeft deze instelling geen effect."
 
 #: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
-msgstr "Langage"
+msgstr "Taal"
 
 #: frontend/src/metabase/admin/settings/selectors.js:65
 msgid "Select a language"
-msgstr "Choisir une langue"
+msgstr "Selecteer een taal"
 
 #: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
-msgstr "Tracking anonyme"
+msgstr "Anoniem volgen"
 
 #: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
-msgstr "Adaptation des noms de table et de champ"
+msgstr "Vriendelijke tabel- en veldnamen"
 
 #: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
-msgstr "Remplacer seulement les soulignés et tirés par un espace"
+msgstr "Alleen liggende streepjes en strepen vervangen door spaties"
 
 #: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
-msgstr "Autoriser les requêtes imbriquées"
+msgstr "Geneste vragen inschakelen"
 
 #: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
-msgstr "Mises à jour"
+msgstr "Updates"
 
 #: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
-msgstr "Rechercher des mises à jour"
+msgstr "Controleer op updates"
 
 #: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
-msgstr "Hôte SMTP"
+msgstr "SMTP host"
 
 #: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
-msgstr "Port SMTP"
+msgstr "SMTP poort"
 
 #: frontend/src/metabase/admin/settings/selectors.js:127
 #: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
-msgstr "Ce n'est pas un numéro de port valide"
+msgstr "Dat is geen valide poortnummer"
 
 #: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
-msgstr "Sécurité SMTP"
+msgstr "SMTP beveiliging"
 
 #: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
-msgstr "Utilisateur SMTP"
+msgstr "SMTP gebruikersnaam"
 
 #: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
-msgstr "Mot de passe SMTP"
+msgstr "SMTP wachtwoord"
 
 #: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
-msgstr "Depuis l'adresse"
+msgstr "Van adres"
 
 #: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
-msgstr "Jeton d'API Slack"
+msgstr "Slack API token"
 
 #: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
-msgstr "Saisissez le jeton que vous avez reçu de Slack"
+msgstr "Voer de token in die je hebt gekregen van Slack"
 
 #: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
-msgstr "Authentification unique"
+msgstr "Single Sign-On"
 
 #: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
-msgstr "Authentification LDAP"
+msgstr "LDAP authenticatie"
 
 #: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
-msgstr "Hôte LDAP"
+msgstr "LDAP host"
 
 #: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
-msgstr "Port LDAP"
+msgstr "LDAP poort"
 
 #: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
-msgstr "Sécurité LDAP"
+msgstr "LDAP beveiliging"
 
 #: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
-msgstr "Utilisateur"
+msgstr "Gebruikersnaam of DN"
 
 #: frontend/src/metabase/admin/settings/selectors.js:244
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:191
 #: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
-msgstr "Mot de passe"
+msgstr "Wachtwoord"
 
 #: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "User search base"
-msgstr "Base de recherche des utilisateurs"
+msgstr "Gebruiker zoekbasis"
 
 #: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
-msgstr "Filtre utilisateur"
+msgstr "Gebruikersfilter"
 
 #: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
-msgstr "Vérifier vos parenthèses"
+msgstr "Controleer je haakjes"
 
 #: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
-msgstr "Attribut adresse électronique"
+msgstr "Email attribuut"
 
 #: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
-msgstr "Attribut prénom"
+msgstr "Voornaamattribuut"
 
 #: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
-msgstr "Attribut Nom"
+msgstr "Achternaamattribuut"
 
 #: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
-msgstr "Synchroniser les appartenances de groupe"
+msgstr "Groepslidmaatschappen synchroniseren"
 
 #: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
-msgstr "Base de recherche des groupes"
+msgstr "Groep zoekbasis"
 
 #: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
-msgstr "Cartes"
+msgstr "Kaarten"
 
 #: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
-msgstr "URL du serveur de cartes"
+msgstr "URL van kaarttegelserver (Maps)"
 
 #: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
-msgstr "Metabase utilise OpenStreetMaps par défaut."
+msgstr "Metabase gebruikt standaard OpenStreetMaps."
 
 #: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
-msgstr "Cartes personnalisées"
+msgstr "Aangepaste kaarten"
 
 #: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
-msgstr "Ajouter vos propres fichiers GeoJSON pour permettre la visualisation sur d'autres régions"
+msgstr "Voeg je eigen GeoJSON bestanden toe om andere regio visualisaties in te schakelen"
 
 #: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
-msgstr "Partage public"
+msgstr "Publiek delen"
 
 #: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
-msgstr "Activer le partage public"
+msgstr "Schakel publiek delen in"
 
 #: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
-msgstr "Tableaux de bord partagés"
+msgstr "Gedeelde dashboards"
 
 #: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
-msgstr "Questions partagées"
+msgstr "Gedeelde vragen"
 
 #: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
-msgstr "Intégration dans d'autres applications"
+msgstr "Embedden in andere applicaties"
 
 #: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
-msgstr "Autoriser l'intégration de Metabase dans d'autres applications"
+msgstr "Embedden van Metabase in andere applicaties inschakelen"
 
 #: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
-msgstr "Clé secrète d'intégration"
+msgstr "Embedding secret key"
 
 #: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
-msgstr "Tableaux de bord intégrés"
+msgstr "Embedded Dashboards"
 
 #: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
-msgstr "Questions intégrées"
+msgstr "Embedded Vragen"
 
 #: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
-msgstr "Mise en cache"
+msgstr "Caching"
 
 #: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
-msgstr "Autoriser la mise en cache"
+msgstr "Schakel caching in"
 
 #: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
-msgstr "Durée d'exécution minimum d'une requête"
+msgstr "minimale query duur"
 
 #: frontend/src/metabase/admin/settings/selectors.js:424
 msgid "Cache Time-To-Live (TTL) multiplier"
-msgstr "Multiplicateur TTL du cache"
+msgstr "cache levensduur (TTL) vermenigvuldiging"
 
-#. Erreur de compréhension dans ma première traduction
 #: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
-msgstr "Taille maximum d'une entrée du cache"
+msgstr "Maximale cachegrootte"
 
 #: frontend/src/metabase/alert/alert.js:60
 msgid "Your alert is all set up."
-msgstr "Votre alerte est configurée."
+msgstr "Je alert is ingesteld"
 
 #: frontend/src/metabase/alert/alert.js:101
 msgid "Your alert was updated."
-msgstr "Votre alerte a été mise à jour"
+msgstr "Je alert is geüpdatet"
 
 #: frontend/src/metabase/alert/alert.js:149
 msgid "The alert was successfully deleted."
-msgstr "L'alerte a été supprimer avec succès."
+msgstr "De alert is succesvol verwijderd"
 
 #: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
-msgstr "Veuillez saisir un adresse électronique valide."
+msgstr "Voer een valide email adres in"
 
 #: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
-msgstr "Les mots de passe ne correspondent pas"
+msgstr "Wachtwoorden komen niet overeen"
 
 #: frontend/src/metabase/auth/components/BackToLogin.jsx:6
 msgid "Back to login"
-msgstr "Retour à la page de connexion"
+msgstr "Terug naar inloggen"
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:15
 msgid "No Metabase account exists for this Google account."
-msgstr "Aucun compte Metabase n'existe pour ce compte Google"
+msgstr "Er bestaat geen Metabase account voor dit Google account."
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:17
 msgid "You'll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Vous aurez besoin qu'un administrateur Metabase crée un compte avant de pouvoir utiliser Google pour vous connecter."
+msgstr "Je hebt een beheerder nodig om een Metabase account aan te maken voordat je met Google kan inloggen."
 
 #: frontend/src/metabase/auth/components/SSOLoginButton.jsx:18
 msgid "Sign in with {0}"
-msgstr "Se connecter avec {0}"
+msgstr "Log in met {0}"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:56
 msgid "Please contact an administrator to have them reset your password"
-msgstr "S'il vous plaît, demandez à un administrateur Metabase de réinitialiser votre mot de passe"
+msgstr "Neem contact op met een beheerder om het wachtwoord te hertellen"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:69
 msgid "Forgot password"
-msgstr "Mot de passe oublié"
+msgstr "Wachtwoord vergeten"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:84
 msgid "The email you use for your Metabase account"
-msgstr "L'adresse électronique que vous utilisez pour votre compte Metabase"
+msgstr "Het e-mailadres welke je gebruikt voor je Metabase account"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:99
 msgid "Send password reset email"
-msgstr "Envoyer un courriel de réinitialisation de mot de passe"
+msgstr "Verstuur e-mail voor wachtwoord reset"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:110
 msgid "Check your email for instructions on how to reset your password."
-msgstr "Vérifiez vos courriels pour obtenir les instructions de réinitialisation de votre mot de passe."
+msgstr "Controleer de instructies in e-mail inbox om je wachtwoord te wijzigen."
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
-msgstr "Se connecter à Metabase"
+msgstr "Log in in Metabase"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
-msgstr "OU"
+msgstr "OF"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
-msgstr "Identifiant ou adresse électronique"
+msgstr "Gebruikersnaam of e-mailadres"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
-msgstr "Se connecter"
+msgstr "Inloggen"
 
-#. faute d'accord
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
-msgstr "Je semble avoir oublié mon mot de passe"
+msgstr "Het lijkt er op dat ik mijn wachtwoord vergeten ben"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
-msgstr "demander un nouveau courriel de réinitialisation"
+msgstr "verzoek een nieuwe reset email"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
-msgstr "Oups, ce lien a expiré"
+msgstr "Oeps... dat is een verlopen link"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
-msgstr "Pour des raisons de sécurité, les liens de réinitialisation de mot de passe expirent après un petit moment. Si vous avez toujours besoin de réinitialiser votre mot de passe, vous pouvez {0}."
+msgstr "Vanwege veiligheidsredenen verlopen de links voor het herstellen van een wachtwoord na een tijdje. \n"
+"Wanneer je nog steeds je wachtwoord wilt wijzigen kun je {0}."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
-msgstr "Nouveau mot de passe"
+msgstr "Nieuw wachtwoord"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
-msgstr "Pour conserver vos données en sécurité, les mots de passe {0}"
+msgstr "Om je data veilig te houden, wachtwoorden {0}"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
-msgstr "Créer un nouveau mot de passe"
+msgstr "Maak een nieuw wachtwoord"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
-msgstr "Assurez-vous que c'est sécurisé conformément aux instruction ci-dessus"
+msgstr "Zorg ervoor dat het net zo veilig is als de bovenstaande instructies"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
-msgstr "Confirmer le nouveau mot de passe"
+msgstr "Bevestiging nieuw wachtwoord"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
-msgstr "Assurez-vous qu'il correspond à celui que vous venez de saisir"
+msgstr "Zorg ervoor dat het overeenkomt met degene die je net hebt ingevuld"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
-msgstr "Votre mot de passe a été réinitialisé."
+msgstr "Uw wachtwoord is opnieuw ingesteld."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
-msgstr "Vous connecter avec votre nouveau mot de passe"
+msgstr "Log in met uw nieuwe wachtwoord"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
-msgstr "La sauvegarde a échouée"
+msgstr "Opslaan mislukt"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
@@ -2118,19 +2119,19 @@ msgstr "La sauvegarde a échouée"
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
-msgstr "Sauvegardé"
+msgstr "Opgeslagen"
 
 #: frontend/src/metabase/components/Alert.jsx:12
 msgid "Ok"
-msgstr "C'est tout bon"
+msgstr "Ok"
 
 #: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
-msgstr "Archiver cette collection ?"
+msgstr "Verplaats deze verzameling naar het archief?"
 
 #: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
-msgstr "Les tableaux de bord, collections et pulses de cette collection seront aussi archivés."
+msgstr "De dashboards, collecties en pulsen in deze collectie zullen ook gearchiveerd worden."
 
 #: frontend/src/metabase/components/ArchiveModal.jsx:38
 #: frontend/src/metabase/components/CollectionLanding.jsx:620
@@ -2142,151 +2143,151 @@ msgstr "Les tableaux de bord, collections et pulses de cette collection seront a
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
-msgstr "Archiver"
+msgstr "Archief"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:63
 msgid "This {0} has been archived"
-msgstr "Ce/cette {0} a été archivé(e)"
+msgstr "{0} is gearchiveerd"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
-msgstr "Voir l'archive"
+msgstr "Toon het archief"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
-msgstr "Annuler l'archivage de ce/cette {0}"
+msgstr "Dearchiveer dit {0}"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:39
 #: frontend/src/metabase/components/BrowseApp.jsx:102
 #: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
-msgstr "Nos données"
+msgstr "Onze data"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
-msgstr "Radiographier cette table"
+msgstr "X-ray deze tabel"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
-msgstr "Apprendre au sujet de cette table"
+msgstr "Leer over deze tabel"
 
 #: frontend/src/metabase/components/Button.info.js:11
 #: frontend/src/metabase/components/Button.info.js:12
 #: frontend/src/metabase/components/Button.info.js:13
 msgid "Clickity click"
-msgstr "Clickity click"
+msgstr "Klik klik"
 
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:9
 msgid "Saved!"
-msgstr "Sauvegardé !"
+msgstr "Opgeslagen!"
 
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:10
 msgid "Saving failed."
-msgstr "La sauvegarde a échoué."
+msgstr "Opslaan mislukt."
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
-msgstr "dim."
+msgstr "Zo"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
-msgstr "lun."
+msgstr "Ma"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
-msgstr "mar."
+msgstr "Di"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
-msgstr "mer."
+msgstr "Wo"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
-msgstr "jeu."
+msgstr "Do"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
-msgstr "ven."
+msgstr "Vr"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
-msgstr "sam."
+msgstr "Za"
 
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:41
 msgid "Your admin's email address"
-msgstr "L'adresse électronique de votre administrateur"
+msgstr "Uw beheerder's e-mailadres"
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:37
 msgid "To send {0}, you'll need to set up {1} integration."
-msgstr "Pour envoyer un/des {0}, vous devez configurer l'intégration du/des {1}"
+msgstr "Om {0} te versturen moet je de {1} integratie instellen."
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:38
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:41
 msgid " or "
-msgstr " ou "
+msgstr " of "
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:40
 msgid "To send {0}, an admin needs to set up {1} integration."
-msgstr "Pour envoyer un/des {0}, un administrateur Metabase doit configurer l'intégration du/des {1}"
+msgstr "Om {0} te versturen moet een beheerder de {1} integratie instellen."
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:15
 msgid "This collection is empty, like a blank canvas"
-msgstr "Cette collection est vide, comme une toile blanche"
+msgstr "Deze collectie is leeg, net als een wit canvas."
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:16
 msgid "You can use collections to organize and group dashboards, questions and pulses for your team or yourself"
-msgstr "Vous pouvez utiliser les collections pour organiser et grouper vos tableaux de bord, questions et pulses pour votre équipe ou vous même"
+msgstr "Je kunt collecties gebruiken om dashboards, vragen en pulsen te organiseren voor je team en jezelf"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:28
 msgid "Create another collection"
-msgstr "Créer une autre collection"
+msgstr "Maak nog een collectie"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:68
 msgid "Dashboards let you collect and share data in one place."
-msgstr "Les tableaux de bord vous permettent de rassembler et partager la donnée à un seul endroit."
+msgstr "Via dashboards kun op één plek gegevens verzamelen en delen."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:77
 msgid "Pulses let you send out the latest data to your team on a schedule via email or slack."
-msgstr "Les Pulses vous permettent d'envoyer les plus récentes données à votre équipe de façon planifiée, par courriel ou via slack."
+msgstr "Met pulsen kun je de nieuwste gegevens volgens een schema via e-mail of Slack naar je team sturen."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:86
 msgid "Questions are a saved look at your data."
-msgstr "Une question est une vue sauvegardée de vos données."
+msgstr "Vragen zijn opgeslagen en bekijken de data."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
-msgstr "Epingles"
+msgstr "Pins"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
-msgstr "Déposer quelque chose ici pour l'épingler en haut"
+msgstr "Sleep iets hier om het bovenaan vast te zetten"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:740
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
-msgstr "Collections"
+msgstr "Verzamelingen"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:431
 #: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
-msgstr "Déposer ici pour ôter une épingle"
+msgstr "Verplaats hier om los te maken"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
-msgstr[0] "{0} élément sélectionné"
-msgstr[1] "{0} éléments sélectionnés"
+msgstr[0] "{0} item geselecteerd"
+msgstr[1] "{0} items geselecteerd"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
-msgstr "Déplacer {0} éléments"
+msgstr "Verplaats {0} items?"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
-msgstr "Déplacer \"{0}\" ?"
+msgstr "Verplaats \"{0}\"?"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
@@ -2294,82 +2295,81 @@ msgstr "Déplacer \"{0}\" ?"
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
-msgstr "Déplacer"
+msgstr "Verplaats"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
-msgstr "Modifier cette collection"
+msgstr "Bewerk deze verzameling"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
-msgstr "Archiver cette collection"
+msgstr "Archiveer deze verzameling"
 
 #: frontend/src/metabase/components/CollectionList.jsx:67
 #: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
-msgstr "Ma collection personnelle"
+msgstr "Mijn persoonlijke verzameling"
 
 #: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
-msgstr "Nouvelle collection"
+msgstr "Nieuwe verzameling"
 
 #: frontend/src/metabase/components/CopyButton.jsx:35
 msgid "Copied!"
-msgstr "Copié(e)(s) !"
+msgstr "Gekopiëerd!"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
-msgstr "Utiliser un tunnel SSH pour les connexions à la base de données"
+msgstr "Gebruik een SSH-tunnel voor databaseverbindingen"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
-msgstr "Certaines bases de données ne sont accessibles qu'en SSH au travers d'un serveur bastion. Cette option ajoute aussi une couche de sécurité lors d'une connexion hors VPN. L'activer est plus lent qu'une connexion directe."
+msgstr "Sommige database-installaties kunnen alleen benaderd worden met een SSH verbinding. Deze optie zorgt ook voor een extra beveiliging wanneer een VPN niet beschikbaar is. Het inschakelen van deze optie is vaak langzamer dan een directe verbinding."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
-msgstr "C'est une grande base de données, laissez-moi donc choisir quand Metabase lance les synchronisations et les analyses"
+msgstr "Dit is een grote database, laat mij kiezen wat Metabase moet synchroniseren en scannen."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
-msgstr "Par défaut, Metabase effectue une synchronisation horaire légère et un analyse journalière intensive des valeurs de filtre.\n"
-"Si vous avez une grande base de données, nous vous recommandons d'activer cette option et de définir quand et à quelle fréquence l'analyse des valeurs de filtre s'effectue."
+msgstr "Metabase voert standaard een lichte synchronisatie uit en dagelijks een volledige scan van de velden. Wanneer je een grote database hebt adviseren we deze optie aan te zetten zodat je zelf kan bepalen wat en hoe de velden gescand moeten worden."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
-msgstr "{0} pour générer un ID et un secret client pour votre projet."
+msgstr "{0} om een Client ID en Client Secret te genereren voor je project."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
-msgstr "Cliquer ici"
+msgstr "Klik hier"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
-msgstr "Choisir \"Autre\" comme type d'application. La nommer comme bon vous semble."
+msgstr "Kies \"Anders\" als applicatie type. Noem het zoals je wilt."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
-msgstr "{0} pour obtenir un code d'authentification"
+msgstr "{0} om een auth code te verkrijgen"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
-msgstr "avec les permissions de Google Drive"
+msgstr "met Google Drive rechten"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
-msgstr "Pour pouvoir utiliser Metabase avec cette donnée, vous devez activer l'accès à l'API dans la Google Developers Console."
+msgstr "Om Metabase te gebruiken met deze data moet je de API toegang inschakelen in de Google Developers Console."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
-msgstr "{0} pour se rendre dans la console si ce n'est déjà fait."
+msgstr "{0} om naar het console te gaan, wanneer je dit nog niet gedaan hebt."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
-msgstr "Sous quel nom souhaitez-vous référencer cette base de données ?"
+msgstr "Hoe wil je naar deze database verwijzen?"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
@@ -2379,148 +2379,148 @@ msgstr "Sous quel nom souhaitez-vous référencer cette base de données ?"
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
-msgstr "Suivant"
+msgstr "Volgende"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
-msgstr "Supprimer ce/cette {0}"
+msgstr "Verwijder dit {0}"
 
 #: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
-msgstr "Epingler cet élément"
+msgstr "Pin dit item"
 
 #: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
-msgstr "Déplacer cet élément"
+msgstr "Verplaats dit item"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
-msgstr "Modifier cette question"
+msgstr "Pas deze vraag aan"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:26
 #: frontend/src/metabase/components/EntityMenu.info.js:47
 #: frontend/src/metabase/components/EntityMenu.info.js:82
 #: frontend/src/metabase/components/EntityMenu.info.js:99
 msgid "Action type"
-msgstr "Type d'action"
+msgstr "Actie type"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
-msgstr "Voir l'historique des modifications"
+msgstr "Bekijk revisie historie"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 msgid "Move action"
-msgstr "Déplacement"
+msgstr "Verplaats actie"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:33
 #: frontend/src/metabase/components/EntityMenu.info.js:89
 msgid "Archive action"
-msgstr "Archivage"
+msgstr "Archiveer actie"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
-msgstr "Ajouter à un tableau de bord"
+msgstr "Voeg toe aan dashboard"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:49
 #: frontend/src/metabase/components/EntityMenu.info.js:101
 msgid "Download results"
-msgstr "Télécharger les résultats"
+msgstr "Download resultaten"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:51
 #: frontend/src/metabase/components/EntityMenu.info.js:103
 #: frontend/src/metabase/public/components/widgets/EmbedWidget.jsx:52
 msgid "Sharing and embedding"
-msgstr "Partager et intégrer"
+msgstr "Delen en embedden"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:53
 #: frontend/src/metabase/components/EntityMenu.info.js:105
 msgid "Another action type"
-msgstr "Un autre type d'action"
+msgstr "Ander actietype"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:65
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
 msgid "Get alerts about this"
-msgstr "Obtenir des alertes sur ce sujet"
+msgstr "Ontvang meldingen hierover"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
-msgstr "Visualiser le SQL"
+msgstr "Bekijk de SQL"
 
 #: frontend/src/metabase/components/EntitySegments.jsx:18
 msgid "Segments for this"
-msgstr "Segments associés"
+msgstr "Segmenten hiervoor"
 
 #: frontend/src/metabase/components/ErrorDetails.jsx:20
 msgid "Show error details"
-msgstr "Montrer l'erreur en détail"
+msgstr "Toon foutdetails"
 
 #: frontend/src/metabase/components/ErrorDetails.jsx:26
 msgid "Here's the full error message"
-msgstr "Voici le message d'erreur complet"
+msgstr "Hier is de volledige fout"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:19
 msgid "Hi, Metabot here."
-msgstr "Salut, ici MetaBot."
+msgstr "Hi, Metabot hier."
 
 #: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
-msgstr "Selon le schéma"
+msgstr "Gebaseerd op het schema"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
-msgstr "Jeter un œil à votre"
+msgstr "Bekijk uw"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
-msgstr "Recherche dans la liste"
+msgstr "Doorzoek te lijst"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
-msgstr "Recherche par {0}"
+msgstr "Zoeken op {0}"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
-msgstr " ou saisir un ID"
+msgstr " of voer een ID in"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
-msgstr "Saisir un ID"
+msgstr "Voer een ID in"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
-msgstr "Saisir un nombre"
+msgstr "Voer een nummer in"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
-msgstr "Saisir du texte"
+msgstr "Voer tekst in"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
-msgstr "Aucun(e) {0} correspondant trouvé(e)."
+msgstr "Geen overeenkomende {0} gevonden."
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
-msgstr "Inclure chaque option dans votre filtre n'apportera probablement pas grand chose..."
+msgstr "Het opnemen van elke optie in deze filter zal waarschijnlijk niet veel doen ..."
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:24
 msgid "Something's gone wrong"
-msgstr "Quelque chose s'est mal passé"
+msgstr "Er is iets misgegaan"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:25
 msgid "We've run into an error. You can try refreshing the page, or just go back."
-msgstr "Une erreur est survenue. Vous pouvez essayer de rafraîchir la page, ou juste revenir en arrière."
+msgstr "Er is een fout opgetreden. Je kunt proberen de pagina te vernieuwen of gewoon teruggaan."
 
 #: frontend/src/metabase/components/Header.jsx:97
 #: frontend/src/metabase/components/HeaderBar.jsx:45
@@ -2533,329 +2533,329 @@ msgstr "Une erreur est survenue. Vous pouvez essayer de rafraîchir la page, ou 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
-msgstr "Aucune description"
+msgstr "Nog geen omschrijving"
 
 #: frontend/src/metabase/components/Header.jsx:112
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
-msgstr "Nouveau/nouvelle {0}"
+msgstr "Nieuwe {0}"
 
 #: frontend/src/metabase/components/Header.jsx:123
 msgid "Asked by {0}"
-msgstr "Demandé par {0}"
+msgstr "Gevraagd door {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
-msgstr "Aujourd'hui, "
+msgstr "Vandaag, "
 
 #: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
-msgstr "Hier, "
+msgstr "Gisteren, "
 
 #: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
-msgstr "Première version."
+msgstr "Eerste revisie"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
-msgstr "Ramené(e) à une précédente version et {0}"
+msgstr "Teruggezet naar een eerdere revisie en {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
-msgstr "Historique des modifications"
+msgstr "Revisiegeschiedenis"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
-msgstr "Quand"
+msgstr "Wanneer"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
-msgstr "Qui"
+msgstr "Wie"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
-msgstr "Quoi"
+msgstr "Wat"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
-msgstr "Revenir à la version précédente"
+msgstr "Terugdraaien"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
-msgstr "Retour à la version précédente..."
+msgstr "Aan het terugdraaien..."
 
 #: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
-msgstr "Le retour à la version précédente a échoué"
+msgstr "Terugdraaien mislukt"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
-msgstr "Revenu à la version précédente"
+msgstr "Teruggedraaid"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:13
 msgid "Everything"
-msgstr "Tout"
+msgstr "Alles"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
 msgid "Dashboards"
-msgstr "Tableaux de bord"
+msgstr "Dashboards"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
 msgid "Questions"
-msgstr "Questions"
+msgstr "Vragen"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
 #: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
-msgstr "Pulses"
+msgstr "Pulsen"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
 #: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
-msgstr "Retour"
+msgstr "Terug"
 
 #: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
-msgstr "Chercher..."
+msgstr "Zoeken..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 msgid "An error occured"
-msgstr "Une erreur est survenue"
+msgstr "Er is een fout opgetreden"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:35
 msgid "Loading..."
-msgstr "Chargement..."
+msgstr "Aan het laden..."
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:71
 msgid "Metabase Newsletter"
-msgstr "Bulletin d'information de Metabase"
+msgstr "Metabase nieuwsbrief"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:81
 msgid "Get infrequent emails about new releases and feature updates."
-msgstr "Obtenir des courriel ponctuels au sujet des nouvelles versions et des mises à jour de fonctionnalités."
+msgstr "Ontvang af en toe e-mails over nieuwe versies en functionaliteiten."
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:99
 msgid "Subscribe"
-msgstr "S'inscrire"
+msgstr "Aanmelden"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:106
 msgid "You're subscribed. Thanks for using Metabase!"
-msgstr "Vous êtes inscrit. Merci d'utiliser Metabase !"
+msgstr "U hebt zich aangemeld. Bedankt voor het gebruik van Metabase!"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:44
 msgid "We're a little lost..."
-msgstr "Nous sommes un peu perdus..."
+msgstr "Wij zijn een beetje verdwaald..."
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:27
 msgid "Temporary Password"
-msgstr "Mot de passe temporaire"
+msgstr "Tijdelijk wachtwoord"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:411
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
-msgstr "Masquer"
+msgstr "Verbergen"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:412
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
-msgstr "Montrer"
+msgstr "Toon"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:17
 msgid "Saved! Add this to a dashboard?"
-msgstr "Sauvegardé ! Ajouter cela à un tableau de bord ?"
+msgstr "Opgeslagen! Voeg dit toe aan een dashboard?"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:25
 msgid "Yes please!"
-msgstr "Oui s'il vous plaît !"
+msgstr "Ja, graag!"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:29
 msgid "Not now"
-msgstr "Pas maintenant"
+msgstr "Niet nu"
 
 #: frontend/src/metabase/components/SaveStatus.jsx:53
 msgid "Error:"
-msgstr "Erreur:"
+msgstr "Fout:"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:23
 msgid "Sunday"
-msgstr "Dimanche"
+msgstr "Zondag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:24
 msgid "Monday"
-msgstr "Lundi"
+msgstr "Maandag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:25
 msgid "Tuesday"
-msgstr "Mardi"
+msgstr "Dinsdag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:26
 msgid "Wednesday"
-msgstr "Mercredi"
+msgstr "Woensdag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:27
 msgid "Thursday"
-msgstr "Jeudi"
+msgstr "Donderdag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:28
 msgid "Friday"
-msgstr "Vendredi"
+msgstr "Vrijdag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:29
 msgid "Saturday"
-msgstr "Samedi"
+msgstr "Zaterdag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:33
 msgid "First"
-msgstr "Premier"
+msgstr "Eerstw"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:34
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
 msgid "Last"
-msgstr "Dernier"
+msgstr "Laatste"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:35
 msgid "15th (Midpoint)"
-msgstr "Le quinze du mois"
+msgstr "15e (middenpunt)"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:125
 msgid "Calendar Day"
-msgstr "Jour calendaire"
+msgstr "Kalenderdag"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
-msgstr "Fuseau horaire de Metabase"
+msgstr "uw Metabase tijdzone"
 
 #: frontend/src/metabase/components/SearchHeader.jsx:21
 msgid "Filter this list..."
-msgstr "Filtrer cette liste..."
+msgstr "Filter in deze lijst..."
 
 #: frontend/src/metabase/components/Select.info.js:8
 msgid "Blue"
-msgstr "Bleu"
+msgstr "Blauw"
 
 #: frontend/src/metabase/components/Select.info.js:9
 msgid "Green"
-msgstr "Vert"
+msgstr "Groen"
 
 #: frontend/src/metabase/components/Select.info.js:10
 msgid "Red"
-msgstr "Rouge"
+msgstr "Rood"
 
 #: frontend/src/metabase/components/Select.info.js:11
 msgid "Yellow"
-msgstr "Jaune"
+msgstr "Geel"
 
 #: frontend/src/metabase/components/Select.info.js:14
 msgid "A component used to make a selection"
-msgstr "Un composant utilisé pour effectuer un choix"
+msgstr "Een component die wordt gebruikt om een selectie te maken"
 
 #: frontend/src/metabase/components/Select.info.js:20
 #: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
-msgstr "Sélectionné(e)(s)"
+msgstr "Geselecteerd"
 
 #: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
-msgstr "Rien à sélectionner"
+msgstr "Niks te selecteren"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:54
 msgid "Sorry, you don’t have permission to see that."
-msgstr "Désolé, vous n'avez pas la permission de voir cela."
+msgstr "Sorry, u hebt geen rechten om dat te zien."
 
 #: frontend/src/metabase/components/form/FormMessage.jsx:5
 msgid "Unknown error encountered"
-msgstr "Un erreur inconnue a été rencontrée"
+msgstr "Onbekende fout"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
 #: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
-msgstr "Créer"
+msgstr "Aanmaken"
 
 #: frontend/src/metabase/containers/DashboardForm.jsx:9
 msgid "Create dashboard"
-msgstr "Créer un tableau de bord"
+msgstr "Maak dashboard aan"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
-msgstr "Table"
+msgstr "Tabel"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
 msgid "Database"
-msgstr "Base de données"
+msgstr "Database"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:49
 msgid "Creator"
-msgstr "Créateur"
+msgstr "Maker"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
-msgstr "Aucun résultat trouvé"
+msgstr "Geen resultaten gevonden"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
-msgstr "Essayez d'ajuster votre filtre pour trouver ce que vous recherchez"
+msgstr "Pas het filter aan om te vinden waar je naar zoekt."
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
-msgstr "Voir par"
+msgstr "Bekijk als"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:495
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
-msgstr "de"
+msgstr "van"
 
 #: frontend/src/metabase/containers/Overworld.jsx:75
 msgid "Don't tell anyone, but you're my favorite."
-msgstr "Ne le dites à personne, mais vous êtes mon favori."
+msgstr "Niet verder vertellen, maar u bent mijn favoriet."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:85
 msgid "Once you connect your own data, I can show you some automatic explorations called x-rays. Here are some examples with sample data."
-msgstr "Une fois connecté à vos propres données, je peux vous montrer quelques explorations automatiquement générées, appelées radiographies. En voici quelques exemples basés sur des données de démonstration."
+msgstr "Nadat u uw eigen gegevens hebt verbonden, kan ik enkele automatische verkenningen laten zien die z-rays worden genoemd. Hier zijn enkele voorbeelden met voorbeeldgegevens."
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
 #: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
-msgstr "Commencez ici"
+msgstr "Begin hier"
 
 #: frontend/src/metabase/containers/Overworld.jsx:296
 #: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
-msgstr "Notre décisionnel"
+msgstr "Onze analyse"
 
 #: frontend/src/metabase/containers/Overworld.jsx:203
 msgid "Browse all items"
-msgstr "Parcourir tous les éléments"
+msgstr "Bekijk alle items"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
-msgstr "Remplacer ou sauvegarder en tant que nouvel élément ?"
+msgstr "Vervang of opslaan als nieuwe vraag?"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
-msgstr "Remplacer la question originale. \"{0}\""
+msgstr "Vervang de originele vraag, \"{0}\""
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
-msgstr "Sauvegarder en tant que nouvelle question"
+msgstr "Sla op als nieuwe vraag"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
-msgstr "Avant toute chose, sauvegardez votre question"
+msgstr "Sla eerst uw vraag op"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
-msgstr "Sauvegarder la question"
+msgstr "Sla vraag op"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
-msgstr "Quel est le nom de votre carte ?"
+msgstr "Wat is de naam van uw kaart"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
@@ -2871,455 +2871,453 @@ msgstr "Quel est le nom de votre carte ?"
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
-msgstr "Description"
+msgstr "Omschrijving"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
 #: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
-msgstr "C'est facultatif, mais ô combien utile"
+msgstr "Het optioneel, maar oh zo handig"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
-msgstr "Dans quelle collection cela devrait-il aller ?"
+msgstr "In welke collectie moet dit komen?"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:34
 msgid "modified"
-msgstr "modifié"
+msgstr "aangepast"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:34
 msgid "item"
-msgstr "élément"
+msgstr "item"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
-msgstr "Annuler la modification"
+msgstr "Ongedaan maken"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "Applying Question"
-msgstr "Poser la question"
+msgstr "Vraag toepassen"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:274
 msgid "That question isn't compatible"
-msgstr "Cette question n'est pas compatible"
+msgstr "Die vraag is niet compatibel"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:310
 msgid "Search for a question"
-msgstr "Rechercher une question"
+msgstr "Een vraag opzoeken"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:339
 msgid "We're not sure if this question is compatible"
-msgstr "Nous ne sommes pas sûr que cette question soit compatible"
+msgstr "We weten niet zeker of deze vraag compatibel is"
 
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:43
 msgid "Archive Dashboard"
-msgstr "Archiver le tableau de bord"
+msgstr "Archiveer dashboard"
 
 #: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
-msgstr "Assurez-vous de faire un choix pour chaque série de données, ou le filtre ne fonctionnera pas avec cette carte."
+msgstr "Zorg ervoor dat je voor elke serie een selectie maakt, anders werkt het filter niet op deze kaart."
 
 #: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
-msgstr "Ce tableau de bord semble vide."
+msgstr "Het dashboard ziet er leeg uit."
 
 #: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
-msgstr "Ajoutez une question pour commencer à le rendre utile !"
+msgstr "Voeg een vraag toe om het nuttig te maken!"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:38
 msgid "Daytime mode"
-msgstr "Mode jour"
+msgstr "Dagmodus"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:38
 msgid "Nighttime mode"
-msgstr "Mode nuit"
+msgstr "Nachtmodus"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:56
 msgid "Exit fullscreen"
-msgstr "Sortir du mode plein écran"
+msgstr "Sluit volledig scherm"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:56
 msgid "Enter fullscreen"
-msgstr "Passer en mode plein écran"
+msgstr "Open volledig scherm"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
-msgstr "Sauvegarde en cours..."
+msgstr "Aan het opslaan..."
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
-msgstr "Ajouter une question"
+msgstr "Voeg een vraag toe"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
-msgstr "Ajouter une question à ce tableau de bord"
+msgstr "Voeg een vraag toe aan dit dashboard"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
-msgstr "Ajouter un filtre"
+msgstr "Voeg een filter toe"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
-msgstr "Paramètres"
+msgstr "Parameters"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
-msgstr "Ajouter une zone de texte"
+msgstr "Voeg een tekstveld toe"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
-msgstr "Déplacer le tableau de bord"
+msgstr "Verplaats dashboard"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
-msgstr "Modifier le tableau de bord"
+msgstr "Bewerk dashboard"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
-msgstr "Modifier l'agencement du tableau de bord"
+msgstr "Pas dashboard layout aan"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
-msgstr "Vous modifiez un tableau de bord"
+msgstr "U bent een dashboard aan het bewerken"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
-msgstr "Sélectionner le champ qui devrait être filtré pour chaque carte"
+msgstr "Selecteer het veld dat voor elke kaart moet worden gefilterd"
 
 #: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
-msgstr "Déplacer le tableau de bord vers..."
+msgstr "Verplaats dashboard naar..."
 
 #: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
-msgstr "Tableau de bord déplacé vers {0}"
+msgstr "Dashboard verplaatst naar {0}"
 
 #: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
 msgid "What do you want to filter?"
-msgstr "Que voulez-vous filtrer ?"
+msgstr "Wat wil je filteren?"
 
 #: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
 msgid "What kind of filter?"
-msgstr "Quel type de filtre ?"
+msgstr "Welke type filter?"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
-msgstr "Inactif"
+msgstr "Uit"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:14
 msgid "1 minute"
-msgstr "1 minute"
+msgstr "1 minuut"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:15
 msgid "5 minutes"
-msgstr "5 minutes"
+msgstr "5 minuten"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:16
 msgid "10 minutes"
-msgstr "10 minutes"
+msgstr "10 minuten"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:17
 msgid "15 minutes"
-msgstr "15 minutes"
+msgstr "15 minuten"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:18
 msgid "30 minutes"
-msgstr "30 minutes"
+msgstr "30 minuten"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:19
 msgid "60 minutes"
-msgstr "60 minutes"
+msgstr "60 minuten"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:31
 msgid "Auto-refresh"
-msgstr "Rafraîchissement automatique"
+msgstr "Auto-verversen"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:37
 msgid "Refreshing in"
-msgstr "Rafraîchissement dans"
+msgstr "Verversen in"
 
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:36
 msgid "Remove this question?"
-msgstr "Enlever cette question ?"
+msgstr "Verwijder deze vraag?"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
-msgstr "Votre tableau de bord a été sauvegardé"
+msgstr "Je dashboard is opgeslagen"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:744
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
-msgstr "Voir le résultat"
+msgstr "Bekijk het"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
-msgstr "Sauvegarder tout cela"
+msgstr "Sla dit op"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
-msgstr "Afficher plus d'information à ce propos"
+msgstr "Toon meer hierover"
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
-msgstr "Cette carte n'a aucun champ ou paramètre qui pourrait être mis en correspondance avec ce type de paramètre."
+msgstr "Deze kaart heeft geen velden of parameters die kunnen worden toegewezen aan dit parametertype."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
-msgstr "Les valeurs de ce champ ne chevauchent les valeurs d'aucun autre champ sélectionné."
+msgstr "De waarden in dit veld overlappen niet met de waarden van andere velden die je hebt gekozen."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
-msgstr "Aucun champ valide"
+msgstr "Geen valide velden"
 
 #: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
-msgstr "Le nom ne pas contenir plus de 100 caractères"
+msgstr "Naam moet 100 tekens of minder zijn"
 
 #: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
-msgstr "Une couleur est exigée"
+msgstr "Kleur is verplicht"
 
 #: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
-msgstr "Quel est le nom de votre tableau de bord"
+msgstr "Wat is de naam van je dashboard?"
 
 #: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
-msgstr "a fait des merveilles difficiles à expliquer"
+msgstr "Ik heb een aantal geweldige dingen gedaan die te moeilijk zijn om te beschrijven"
 
 #: frontend/src/metabase/home/components/Activity.jsx:103
 #: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
-msgstr "a créé une alerte concernant - "
+msgstr "maak een alert over - "
 
 #: frontend/src/metabase/home/components/Activity.jsx:128
 #: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
-msgstr "a supprimé une alerte concernant - "
+msgstr "verwijder een alert over - "
 
 #: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
-msgstr "a sauvegardé une question concernant "
+msgstr "heeft een vraag opgeslagen over "
 
 #: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
-msgstr "a sauvegardé une question"
+msgstr "heeft een vraag opgeslagen"
 
 #: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
-msgstr "a supprimé une question"
+msgstr "heeft een vraag verwijderd"
 
-#. correction de l'impératif au passé composé (historique des modifications)
 #: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
-msgstr "a créé un tableau de bord"
+msgstr "heeft een dashboard aangemaakt"
 
 #: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
-msgstr "supprimer un tableau de bord"
+msgstr "heeft een dashboard verwijderd"
 
 #: frontend/src/metabase/home/components/Activity.jsx:183
 #: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
-msgstr "a ajouté une question au tableau de bord "
+msgstr "heeft een vraag toegevoegd aan het dashboard - "
 
 #: frontend/src/metabase/home/components/Activity.jsx:208
 #: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
-msgstr "a enlevé une question du tableau de bord - "
+msgstr "heeft een vraag verwijderd uit het dashboard - "
 
 #: frontend/src/metabase/home/components/Activity.jsx:233
 #: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
-msgstr "a reçu les dernières données de"
+msgstr "heeft de laatste data ontvangen van"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:814
 #: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
-msgstr "Inconnu"
+msgstr "Onbekend"
 
 #: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
-msgstr "Salut la compagnie !"
+msgstr "Hallo Wereld!"
 
 #: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
-msgstr "Metabase est démarré"
+msgstr "Metabase is klaar voor gebruik"
 
 #: frontend/src/metabase/home/components/Activity.jsx:260
 #: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
-msgstr "a ajouté la métrique "
+msgstr "metriek toegevoegd "
 
 #: frontend/src/metabase/home/components/Activity.jsx:274
 #: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
-msgstr " au "
+msgstr " tot het "
 
 #: frontend/src/metabase/home/components/Activity.jsx:284
 #: frontend/src/metabase/home/components/Activity.jsx:324
 #: frontend/src/metabase/home/components/Activity.jsx:374
 #: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
-msgstr " table"
+msgstr " tabel"
 
 #: frontend/src/metabase/home/components/Activity.jsx:300
 #: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
-msgstr "a fait des changements sur la métrique "
+msgstr "wijzigingen aangebracht in de metrieken "
 
 #: frontend/src/metabase/home/components/Activity.jsx:314
 #: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
-msgstr " dans le/la "
+msgstr " in de "
 
 #: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
-msgstr "a supprimé la métrique "
+msgstr "de metriek verwijderd "
 
 #: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
-msgstr "a créé un pulse"
+msgstr "een pulse toegevoegd"
 
 #: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
-msgstr "a supprimé un pulse"
+msgstr "een pulse verwijderd"
 
 #: frontend/src/metabase/home/components/Activity.jsx:349
 #: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
-msgstr "a a jouté le filtre"
+msgstr "het filter toegevoegd"
 
 #: frontend/src/metabase/home/components/Activity.jsx:390
 #: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
-msgstr "a fait des modifications au filtre"
+msgstr "heeft wijzigingen aangebracht aan het filter"
 
 #: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
-msgstr "a supprimé le filtre {0}"
+msgstr "het filter {0} verwijderd"
 
 #: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
-msgstr "nous a rejoint !"
+msgstr "is lid geworden!"
 
 #: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
-msgstr "Humm, il semble que rien ne se soit encore passé"
+msgstr "Hmmm, het lijkt erop dat er nog niets is gebeurd."
 
 #: frontend/src/metabase/home/components/Activity.jsx:534
 msgid "Save a question and get this baby going!"
-msgstr "Sauvegardez une question et en avant !"
+msgstr "Sla een vraag op en ga direct van start!"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:19
 msgid "Ask questions and explore"
-msgstr "Poser des questions et explorer"
+msgstr "Vraag iets en verken"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:20
 msgid "Click on charts or tables to explore, or ask a new question using the easy interface or the powerful SQL editor."
-msgstr "Cliquer sur les graphiques ou les tables pour les explorer, ou poser une nouvelle question en utilisant le générateur intuitif ou le puissant éditeur SQL."
+msgstr "Klik op grafieken of tabellen om te verkennen, stel een nieuwe vraag met behulp van de eenvoudige interface of maak gebruik van de krachtige SQL-editor."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:30
 msgid "Make your own charts"
-msgstr "Construire vos propres graphiques"
+msgstr "Maak je eigen grafieken"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:31
 msgid "Create line charts, scatter plots, maps, and more."
-msgstr "Créer des graphiques, nuages de points, cartes, et bien plus."
+msgstr "Maak lijndiagrammen, spreidingsplots, kaarten en meer."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:41
 msgid "Share what you find"
-msgstr "Partagez vos découvertes"
+msgstr "Deel wat je vind"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:42
 msgid "Create powerful and flexible dashboards, and send regular updates via email or Slack."
-msgstr "Créer des tableaux de bord puissants et flexibles, et envoyer des mises à jour régulières par courriel ou via Slack."
+msgstr "Maak krachtige en flexibele dashboards en stuur regelmatig updates via e-mail of Slack."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
 msgid "Let's go"
-msgstr "Allons-y"
+msgstr "Laten we gaan!"
 
 #: frontend/src/metabase/home/components/NextStep.jsx:34
 msgid "Setup Tip"
-msgstr "Astuce de réglage"
+msgstr "Installatie Tip"
 
 #: frontend/src/metabase/home/components/NextStep.jsx:40
 msgid "View all"
-msgstr "Tout voir"
+msgstr "Toon alle"
 
 #: frontend/src/metabase/home/components/RecentViews.jsx:40
 msgid "Recently Viewed"
-msgstr "Consulté récemment"
+msgstr "Recent getoond"
 
 #: frontend/src/metabase/home/components/RecentViews.jsx:75
 msgid "You haven't looked at any dashboards or questions recently"
-msgstr "Vous n'avez consulté aucun tableau de bord ou question récemment"
+msgstr "Je hebt recent geen dashboards of vragen bekeken"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
-msgstr "{0} élément(s) sélectionné(s)"
+msgstr "{0} items geselecteerd"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
-msgstr "Désarchiver"
+msgstr "Dearchiveer"
 
 #: frontend/src/metabase/home/containers/HomepageApp.jsx:77
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
-msgstr "Activité"
+msgstr "Activiteit"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
-msgstr "Résultats pour \"{0}\""
+msgstr "Resultaten voor \"{0}\""
 
-#. Le terme "Pulse" désigne une fonctionnalité bien spécifique de Metabase, je pense qu'on ne devrait pas le traduire. Surtout qu'en Français "Pulse" est très compréhensible.
 #: frontend/src/metabase/home/containers/SearchApp.jsx:138
 msgid "Pulse"
 msgstr "Pulse"
 
 #: frontend/src/metabase/lib/core.js:7
 msgid "Entity Key"
-msgstr "Clé d'entité (PK)"
+msgstr "Entiteitssleutel"
 
 #: frontend/src/metabase/lib/core.js:8 frontend/src/metabase/lib/core.js:14
 #: frontend/src/metabase/lib/core.js:20
 msgid "Overall Row"
-msgstr "Toutes les lignes"
+msgstr "Algemene rij"
 
 #: frontend/src/metabase/lib/core.js:9
 msgid "The primary key for this table."
-msgstr "La clé primaire de cette table"
+msgstr "De primaire sleutel voor deze tabel."
 
 #: frontend/src/metabase/lib/core.js:13
 msgid "Entity Name"
-msgstr "Nom de l'entité"
+msgstr "Entiteit naam"
 
 #: frontend/src/metabase/lib/core.js:15
 msgid "The \"name\" of each record. Usually a column called \"name\", \"title\", etc."
-msgstr "Nom, libellé, clé candidate de chaque enregistrement. Habituellement une colonne nommée \"nom\", \"titre\", \"libellé\", etc. (UK)"
+msgstr "De \"naam\" van elk record. Meestal een kolom met de naam \"naam\", \"titel\", enz."
 
 #: frontend/src/metabase/lib/core.js:19
 msgid "Foreign Key"
-msgstr "Clé étrangère (FK)"
+msgstr "Foreign Key"
 
 #: frontend/src/metabase/lib/core.js:21
 msgid "Points to another table to make a connection."
-msgstr "Référence la clé primaire d'une autre table et établit une connexion."
+msgstr "Wijs naar een andere tabel om verbinding te maken."
 
 #: frontend/src/metabase/lib/core.js:25
 msgid "Avatar Image URL"
-msgstr "URL de l'image d'avatar"
+msgstr "Avatar afbeeldings-URL"
 
 #: frontend/src/metabase/lib/core.js:26 frontend/src/metabase/lib/core.js:31
 #: frontend/src/metabase/lib/core.js:36 frontend/src/metabase/lib/core.js:41
@@ -3343,138 +3341,137 @@ msgstr "URL de l'image d'avatar"
 #: frontend/src/metabase/lib/core.js:216 frontend/src/metabase/lib/core.js:221
 #: frontend/src/metabase/lib/core.js:226 frontend/src/metabase/lib/core.js:231
 msgid "Common"
-msgstr "Commun"
+msgstr "Algemeen"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
 msgid "Category"
-msgstr "Catégorie"
+msgstr "Categorie"
 
 #: frontend/src/metabase/lib/core.js:35
 #: frontend/src/metabase/meta/Dashboard.js:61
 msgid "City"
-msgstr "Ville/Commune"
+msgstr "Stad"
 
 #: frontend/src/metabase/lib/core.js:40
 #: frontend/src/metabase/meta/Dashboard.js:73
 msgid "Country"
-msgstr "Pays"
+msgstr "Land"
 
 #: frontend/src/metabase/lib/core.js:60
 msgid "Enum"
-msgstr "Enumération"
+msgstr "Enumerator"
 
 #: frontend/src/metabase/lib/core.js:65
 msgid "Image URL"
-msgstr "URL d'une image"
+msgstr "Afbeelding URL"
 
 #: frontend/src/metabase/lib/core.js:70
 msgid "Field containing JSON"
-msgstr "Champ JSON"
+msgstr "Veld bevat JSON"
 
 #: frontend/src/metabase/lib/core.js:75
 msgid "Latitude"
-msgstr "Latitude"
+msgstr "Breedtegraad"
 
 #: frontend/src/metabase/lib/core.js:80
 msgid "Longitude"
-msgstr "Longitude"
+msgstr "Lengtegraad"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
-msgstr "Numérique"
+msgstr "Nummer"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:19
 #: frontend/src/metabase/lib/core.js:90
 #: frontend/src/metabase/meta/Dashboard.js:65
 msgid "State"
-msgstr "Etat d'un pays"
+msgstr "Staat"
 
 #: frontend/src/metabase/lib/core.js:95
 msgid "UNIX Timestamp (Seconds)"
-msgstr "Horodatage UNIX (Secondes)"
+msgstr "UNIX Timestamp (Seconden)"
 
 #: frontend/src/metabase/lib/core.js:100
 msgid "UNIX Timestamp (Milliseconds)"
-msgstr "Horodatage UNIX (Millisecondes)"
+msgstr "UNIX Timestamp (Miliseconden)"
 
 #: frontend/src/metabase/lib/core.js:110
 msgid "Zip Code"
-msgstr "Code postal"
+msgstr "Postcode"
 
 #: frontend/src/metabase/lib/core.js:115
 msgid "Quantity"
-msgstr "Quantité"
+msgstr "Aantal"
 
 #: frontend/src/metabase/lib/core.js:120
 msgid "Income"
-msgstr "Revenu"
+msgstr "Inkomen"
 
 #: frontend/src/metabase/lib/core.js:125
 msgid "Discount"
-msgstr "Remise"
+msgstr "Korting"
 
 #: frontend/src/metabase/lib/core.js:130
 msgid "Creation timestamp"
-msgstr "Horodatage de création"
+msgstr "Creatie"
 
 #: frontend/src/metabase/lib/core.js:135
 msgid "Creation time"
-msgstr "Heure de création"
+msgstr "Creatietijd"
 
 #: frontend/src/metabase/lib/core.js:140
 msgid "Creation date"
-msgstr "Date de création"
+msgstr "Creatiedatum"
 
 #: frontend/src/metabase/lib/core.js:145
 msgid "Product"
-msgstr "Produit"
+msgstr "Product"
 
 #: frontend/src/metabase/lib/core.js:150
 msgid "User"
-msgstr "Utilisateur"
+msgstr "Gebruiker"
 
 #: frontend/src/metabase/lib/core.js:155
 msgid "Source"
-msgstr "Origine"
+msgstr "Bron"
 
 #: frontend/src/metabase/lib/core.js:160
 msgid "Price"
-msgstr "Prix"
+msgstr "Prijs"
 
 #: frontend/src/metabase/lib/core.js:165
 msgid "Join timestamp"
-msgstr "Joindre l'horodatage"
+msgstr "Lid sinds"
 
 #: frontend/src/metabase/lib/core.js:170
 msgid "Join time"
-msgstr "Joindre l'heure"
+msgstr "Lid sinds (tijd)"
 
 #: frontend/src/metabase/lib/core.js:175
 msgid "Join date"
-msgstr "Joindre la date"
+msgstr "Lid sinds (datum)"
 
-#. Il semble que ce soit plus dans un context économique ou financier
 #: frontend/src/metabase/lib/core.js:180
 msgid "Share"
-msgstr "Action/Part"
+msgstr "Delen"
 
 #: frontend/src/metabase/lib/core.js:185
 msgid "Owner"
-msgstr "Propriétaire"
+msgstr "Eigenaar"
 
 #: frontend/src/metabase/lib/core.js:190
 msgid "Company"
-msgstr "Entreprise"
+msgstr "Bedrijf"
 
 #: frontend/src/metabase/lib/core.js:195
 msgid "Subscription"
-msgstr "Inscription"
+msgstr "Abonnement"
 
 #: frontend/src/metabase/lib/core.js:200
 msgid "Score"
@@ -3484,59 +3481,59 @@ msgstr "Score"
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
-msgstr "Titre"
+msgstr "Titel"
 
 #: frontend/src/metabase/lib/core.js:215
 msgid "Comment"
-msgstr "Commentaire"
+msgstr "Commentaar"
 
 #: frontend/src/metabase/lib/core.js:220
 msgid "Cost"
-msgstr "Coût"
+msgstr "Kosten"
 
 #: frontend/src/metabase/lib/core.js:225
 msgid "Gross margin"
-msgstr "Marge brute"
+msgstr "Brutomarge"
 
 #: frontend/src/metabase/lib/core.js:230
 msgid "Birthday"
-msgstr "Date de naissance"
+msgstr "Geboortedatum"
 
 #: frontend/src/metabase/lib/core.js:241
 msgid "Search box"
-msgstr "Zone de recherche avec autocomplétion"
+msgstr "Zoekveld"
 
 #: frontend/src/metabase/lib/core.js:242
 msgid "A list of all values"
-msgstr "Liste de toutes les valeurs"
+msgstr "Een lijst van alle waarden"
 
 #: frontend/src/metabase/lib/core.js:243
 msgid "Plain input box"
-msgstr "Zone de texte"
+msgstr "Gewoon invoervak"
 
 #: frontend/src/metabase/lib/core.js:249
 msgid "Everywhere"
-msgstr "Partout"
+msgstr "Overal"
 
 #: frontend/src/metabase/lib/core.js:250
 msgid "The default setting. This field will be displayed normally in tables and charts."
-msgstr "Réglage par défaut. Ce champ sera affiché normalement dans les tables et graphiques."
+msgstr "De standaard instelling. Dit veld wordt weergegeven in tabellen en grafieken."
 
 #: frontend/src/metabase/lib/core.js:254
 msgid "Only in Detail Views"
-msgstr "Seulement dans les vues détaillées"
+msgstr "Alleen in detailweergaven"
 
 #: frontend/src/metabase/lib/core.js:255
 msgid "This field will only be displayed when viewing the details of a single record. Use this for information that's lengthy or that isn't useful in a table or chart."
-msgstr "Ce champ sera affiché seulement dans la vue détaillée d'un enregistrement. Utilisez ce réglage pour les informations verbeuses ou non pertinentes dans une table ou un graphique."
+msgstr "Dit veld wordt alleen weergegeven als je de details van één record bekijkt. Gebruik dit voor informatie die lang is of die niet nuttig is in een tabel of grafiek."
 
 #: frontend/src/metabase/lib/core.js:259
 msgid "Do Not Include"
-msgstr "Nulle part"
+msgstr "Voeg niet toe"
 
 #: frontend/src/metabase/lib/core.js:260
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
-msgstr "Metabase ne récupèrera jamais ce champ. Utilisez ce réglage pour les informations sensibles ou non pertinentes."
+msgstr "Metabase haalt dit veld nooit op. Gebruik dit voor gevoelige of irrelevante informatie."
 
 #: frontend/src/metabase/lib/expressions/config.js:7
 #: frontend/src/metabase/lib/query.js:300
@@ -3548,176 +3545,176 @@ msgstr "Metabase ne récupèrera jamais ce champ. Utilisez ce réglage pour les 
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Count"
-msgstr "Nombre de lignes"
+msgstr "Aantal"
 
 #: frontend/src/metabase/lib/expressions/config.js:8
 msgid "CumulativeCount"
-msgstr "Nombre cumulé de lignes"
+msgstr "CumulatiefAantal"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
-msgstr "Somme"
+msgstr "Som"
 
 #: frontend/src/metabase/lib/expressions/config.js:10
 msgid "CumulativeSum"
-msgstr "Somme cumulée"
+msgstr "CumulatiefSom"
 
 #: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
-msgstr "Nombre de valeurs distinctes"
+msgstr "Uniek"
 
 #: frontend/src/metabase/lib/expressions/config.js:12
 msgid "StandardDeviation"
-msgstr "Ecart-type"
+msgstr "StandaardDeviatie"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 msgid "Average"
-msgstr "Moyenne"
+msgstr "Gemiddelde"
 
 #: frontend/src/metabase/lib/expressions/config.js:14
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:25
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
-msgstr "Minimum"
+msgstr "Min"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
-msgstr "Maximum"
+msgstr "Max"
 
 #: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
-msgstr "Des ereurs syntaxiques ou lexicales ont été détectées"
+msgstr "Triest! lexing fout ontdekt."
 
 #: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} seconde"
-msgstr[1] "{0} secondes"
+msgstr[1] "{0} seconden"
 
 #: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
-msgstr[0] "{0} minute"
-msgstr[1] "{0} minutes"
+msgstr[0] "{0} minuut"
+msgstr[1] "{0} minuten"
 
 #: frontend/src/metabase/lib/greeting.js:4
 msgid "Hey there"
-msgstr "Héy"
+msgstr "Hallo daar"
 
 #: frontend/src/metabase/lib/greeting.js:5
 #: frontend/src/metabase/lib/greeting.js:29
 msgid "How's it going"
-msgstr "Comment ça va"
+msgstr "Hoe gaat het"
 
 #: frontend/src/metabase/lib/greeting.js:6
 msgid "Howdy"
-msgstr "Salut"
+msgstr "Howdy"
 
 #: frontend/src/metabase/lib/greeting.js:7
 msgid "Greetings"
-msgstr "Bienvenue"
+msgstr "Gegroet"
 
 #: frontend/src/metabase/lib/greeting.js:8
 msgid "Good to see you"
-msgstr "Un plaisir de vous revoir"
+msgstr "Goed om je te zien"
 
 #: frontend/src/metabase/lib/greeting.js:12
 msgid "What do you want to know?"
-msgstr "Que voulez-vous savoir ?"
+msgstr "Wat wil je te weten komen?"
 
 #: frontend/src/metabase/lib/greeting.js:13
 msgid "What's on your mind?"
-msgstr "Qu'avez-vous en tête ?"
+msgstr "Waar denk je aan?"
 
 #: frontend/src/metabase/lib/greeting.js:14
 msgid "What do you want to find out?"
-msgstr "Que voulez-vous déterminer ?"
+msgstr "Waar ben je naar op zoek?"
 
 #: frontend/src/metabase/lib/query.js:298
 #: frontend/src/metabase/lib/schema_metadata.js:458
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
-msgstr "Données brutes"
+msgstr "Rauwe data"
 
 #: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
-msgstr "Nombre cumulé"
+msgstr "Cumulatief aantal"
 
 #: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
-msgstr "Moyenne du/de la "
+msgstr "Gemiddelde van "
 
 #: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
-msgstr "Valeurs distinctes du/de la "
+msgstr "Verschillende waarden van "
 
 #: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
-msgstr "Ecart-type du/de la "
+msgstr "Standaardafwijking van "
 
 #: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
-msgstr "Somme du/de la "
+msgstr "Som van "
 
 #: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
-msgstr "Somme cumulée du/de la "
+msgstr "Cumulatieve som van "
 
 #: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
-msgstr "Maximum du/de la "
+msgstr "Maximum van"
 
 #: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
-msgstr "Minimum du/de la "
+msgstr "Minimum van"
 
 #: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
-msgstr "Aggrégé par "
+msgstr "Groeperen bij "
 
 #: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
-msgstr "Filtré(e) par "
+msgstr "Filteren bij "
 
 #: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
-msgstr "Trié par "
+msgstr "Sorteren bij "
 
 #: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
-msgstr "Vrai"
+msgstr "Waar"
 
 #: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
-msgstr "Faux"
+msgstr "Niet waar"
 
 #: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
-msgstr "Sélectionner le champ longitude"
+msgstr "Selecteer longitude"
 
 #: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
-msgstr "Saisir la latitude supérieure"
+msgstr "Vul hoogste latitude in"
 
 #: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
-msgstr "Saisir la longitude inférieure"
+msgstr "Vul longitude (links) in"
 
 #: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
-msgstr "Saisir la latitude inférieure"
+msgstr "Vul laagste latitude in"
 
 #: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
-msgstr "Saisir la longitude supérieure"
+msgstr "Vul longitude (rechts) in"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:505
 #: frontend/src/metabase-lib/lib/Dimension.js:507
@@ -3729,7 +3726,7 @@ msgstr "Saisir la longitude supérieure"
 #: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
-msgstr "Est"
+msgstr "Is"
 
 #: frontend/src/metabase/lib/schema_metadata.js:352
 #: frontend/src/metabase/lib/schema_metadata.js:372
@@ -3737,7 +3734,7 @@ msgstr "Est"
 #: frontend/src/metabase/lib/schema_metadata.js:396
 #: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
-msgstr "N'est pas"
+msgstr "Is niet"
 
 #: frontend/src/metabase/lib/schema_metadata.js:353
 #: frontend/src/metabase/lib/schema_metadata.js:367
@@ -3747,7 +3744,7 @@ msgstr "N'est pas"
 #: frontend/src/metabase/lib/schema_metadata.js:397
 #: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
-msgstr "Est vide"
+msgstr "Is leeg"
 
 #: frontend/src/metabase/lib/schema_metadata.js:354
 #: frontend/src/metabase/lib/schema_metadata.js:368
@@ -3757,280 +3754,280 @@ msgstr "Est vide"
 #: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
-msgstr "Non vide"
+msgstr "Is niet leeg"
 
 #: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
-msgstr "Egal(e) à"
+msgstr "Gelijk aan"
 
 #: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
-msgstr "Différent(e) de"
+msgstr "Niet gelijk aan"
 
 #: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
-msgstr "Supérieur à"
+msgstr "Groter dan"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
-msgstr "Inférieur à"
+msgstr "Kleiner dan"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:390
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
-msgstr "Entre"
+msgstr "Tussen"
 
 #: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
-msgstr "Supérieur ou égal à"
+msgstr "Groter dan of gelijk aan"
 
 #: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
-msgstr "Inférieur ou égal à"
+msgstr "Kleiner dan of gelijk aan"
 
 #: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
-msgstr "Contient"
+msgstr "Bevat"
 
 #: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
-msgstr "Ne contient pas"
+msgstr "Bevat geen"
 
 #: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
-msgstr "Commence par"
+msgstr "Begint met"
 
 #: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
-msgstr "Finit par"
+msgstr "Eindigt met"
 
 #: frontend/src/metabase/lib/schema_metadata.js:388
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
-msgstr "Avant"
+msgstr "Voor"
 
 #: frontend/src/metabase/lib/schema_metadata.js:389
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
-msgstr "Après"
+msgstr "Na"
 
 #: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
-msgstr "Dans"
+msgstr "Binnen"
 
 #: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
-msgstr "Juste une table avec ces lignes dans la réponse, aucune opération additionnelle."
+msgstr "Gewoon een tabel met de rijen in het antwoord, geen extra bewerkingen."
 
 #: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
-msgstr "Nombre de lignes"
+msgstr "Aantal rijen"
 
 #: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
-msgstr "Nombre total de lignes dans la réponse."
+msgstr "Totaal aantal rijen in het antwoord."
 
 #: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
-msgstr "Somme de ..."
+msgstr "Som van ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
-msgstr "Somme de toutes les valeurs d'une colonne."
+msgstr "Som van alle waarden van een kolom."
 
 #: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
-msgstr "Moyenne de ..."
+msgstr "Gemiddelde van ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
-msgstr "Moyenne de toutes les valeurs d'une colonne"
+msgstr "Gemiddelde van alle waarden van een kolom"
 
 #: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
-msgstr "Nombre de valeurs distinctes de ..."
+msgstr "Aantal verschillende waarden van ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
-msgstr "Nombre de valeurs uniques d'une colonne parmi toutes les lignes dans la réponse."
+msgstr "Aantal unieke waarden van een kolom tussen alle rijen in het antwoord."
 
 #: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
-msgstr "Somme cumulée de ..."
+msgstr "Cumulatieve som van ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
-msgstr "Somme cumulée de toutes les valeurs d'une colonne. Ex : Gain total au cours du temps."
+msgstr "Additieve som van alle waarden van een kolom. \\\\ Voorbeeld: totale omzet in de loop van de tijd."
 
 #: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
-msgstr "Nombre cumulé de lignes"
+msgstr "Cumulatief aantal rijen"
 
 #: frontend/src/metabase/lib/schema_metadata.js:501
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
-msgstr "Nombre cumulé de lignes. Ex : Nombre total de ventes au cours du temps."
+msgstr "Optelling van het aantal rijen. \\\\ Voorbeeld: totaal aantal verkopen in de loop van de tijd."
 
 #: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
-msgstr "Ecart-type de ..."
+msgstr "Standaardafwijking van ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
-msgstr "Nombre qui exprime la dispersion des valeurs d'une colonne parmi toutes les lignes dans la réponse."
+msgstr "Getal dat aangeeft hoeveel de waarden van een kolom variëren tussen alle rijen in het antwoord."
 
 #: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
-msgstr "Minimum de ..."
+msgstr "Minimum van ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
-msgstr "Valeur minimum d'une colonne"
+msgstr "Minimale waarde van een kolom"
 
 #: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
-msgstr "Maximum de ..."
+msgstr "Maximum van ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
-msgstr "Valeur maximum d'une colonne"
+msgstr "Maximale waarde van een kolom"
 
 #: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
-msgstr "Eclater par dimension"
+msgstr "Breek uit door dimensie"
 
 #: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
-msgstr "minuscule"
+msgstr "kleine letter"
 
 #: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
-msgstr "majuscule"
+msgstr "hoofdletter"
 
 #: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
-msgstr "nombre"
+msgstr "nummer"
 
 #: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
-msgstr "caractère spécial"
+msgstr "speciaal karakter"
 
 #: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
-msgstr "doit avoir une taille de"
+msgstr "moet"
 
 #: frontend/src/metabase/lib/settings.js:120
 #: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
-msgstr "caractères de longueur"
+msgstr "karakters lang"
 
 #: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
-msgstr "Doit être"
+msgstr "Moet"
 
 #: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
-msgstr "et inclure"
+msgstr "en tel mee"
 
 #: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
-msgstr "zéro"
+msgstr "nul"
 
 #: frontend/src/metabase/lib/utils.js:86
 msgid "one"
-msgstr "un"
+msgstr "een"
 
 #: frontend/src/metabase/lib/utils.js:87
 msgid "two"
-msgstr "deux"
+msgstr "twee"
 
 #: frontend/src/metabase/lib/utils.js:88
 msgid "three"
-msgstr "trois"
+msgstr "drie"
 
 #: frontend/src/metabase/lib/utils.js:89
 msgid "four"
-msgstr "quatre"
+msgstr "vier"
 
 #: frontend/src/metabase/lib/utils.js:90
 msgid "five"
-msgstr "cinq"
+msgstr "vijf"
 
 #: frontend/src/metabase/lib/utils.js:91
 msgid "six"
-msgstr "six"
+msgstr "zes"
 
 #: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
-msgstr "sept"
+msgstr "zeven"
 
 #: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
-msgstr "huit"
+msgstr "acht"
 
 #: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
-msgstr "neuf"
+msgstr "negen"
 
 #: frontend/src/metabase/meta/Dashboard.js:30
 msgid "Month and Year"
-msgstr "Mois et Année"
+msgstr "Maand en jaar"
 
 #: frontend/src/metabase/meta/Dashboard.js:31
 msgid "Like January, 2016"
-msgstr "Par exemple Janvier 2016"
+msgstr "Zoals januari 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:35
 msgid "Quarter and Year"
-msgstr "Semestre et Année"
+msgstr "Kwartaal en jaar"
 
 #: frontend/src/metabase/meta/Dashboard.js:36
 msgid "Like Q1, 2016"
-msgstr "Par exemple Q1, 2016"
+msgstr "Bijvoorbeeld Q1, 2019"
 
 #: frontend/src/metabase/meta/Dashboard.js:40
 msgid "Single Date"
-msgstr "Date simple"
+msgstr "Enkele datum"
 
 #: frontend/src/metabase/meta/Dashboard.js:41
 msgid "Like January 31, 2016"
-msgstr "Par exemple 31 Janvier 2016"
+msgstr "Zoals 31 januari 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:45
 msgid "Date Range"
-msgstr "Intervalle de dates"
+msgstr "Datum reeks"
 
 #: frontend/src/metabase/meta/Dashboard.js:46
 msgid "Like December 25, 2015 - February 14, 2016"
-msgstr "Par exemple 25 Décembre 2015 - 14 Février 2016"
+msgstr "Bijvoorbeeld 25 december 2019 - 14 februari 2020"
 
 #: frontend/src/metabase/meta/Dashboard.js:50
 msgid "Relative Date"
-msgstr "Date relative"
+msgstr "Relatieve datum"
 
 #: frontend/src/metabase/meta/Dashboard.js:51
 msgid "Like \"the last 7 days\" or \"this month\""
-msgstr "Par exemple \"les 7 derniers jours\" ou \"ce mois-ci\""
+msgstr "Bijvoorbeeld \"De laatste 7 dagen\" of \"Deze maand\""
 
 #: frontend/src/metabase/meta/Dashboard.js:55
 msgid "Date Filter"
-msgstr "Filtre de date"
+msgstr "Datum filter"
 
 #: frontend/src/metabase/meta/Dashboard.js:56
 msgid "All Options"
-msgstr "Toutes les options"
+msgstr "Alle opties"
 
 #: frontend/src/metabase/meta/Dashboard.js:57
 msgid "Contains all of the above"
-msgstr "Contient tout ce qui précède"
+msgstr "Bevat al het bovenstaande"
 
 #: frontend/src/metabase/meta/Dashboard.js:69
 msgid "ZIP or Postal Code"
-msgstr "Code postal"
+msgstr "ZIP- of postcode"
 
 #: frontend/src/metabase/meta/Dashboard.js:77
 #: frontend/src/metabase/meta/Dashboard.js:107
@@ -4040,155 +4037,152 @@ msgstr "ID"
 #: frontend/src/metabase/meta/Dashboard.js:95
 #: frontend/src/metabase/modes/components/actions/PivotByTimeAction.jsx:8
 msgid "Time"
-msgstr "Heure"
+msgstr "Tijd"
 
 #: frontend/src/metabase/meta/Dashboard.js:96
 msgid "Date range, relative date, time of day, etc."
-msgstr "Intervalle de date, date relative, heure du jour, etc."
+msgstr "Datumbereik, relatieve datum, tijd van de dag, etc."
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
-msgstr "Lieu"
+msgstr "Locatie"
 
 #: frontend/src/metabase/meta/Dashboard.js:102
 msgid "City, State, Country, ZIP code."
-msgstr "Ville, Région, Pays, Code postal."
+msgstr "Stad, Provincie, Land, Postcode"
 
 #: frontend/src/metabase/meta/Dashboard.js:108
 msgid "User ID, product ID, event ID, etc."
-msgstr "ID Utilisateur, produit, évènement, etc."
+msgstr "User ID, product ID, event ID, etc."
 
 #: frontend/src/metabase/meta/Dashboard.js:113
 msgid "Other Categories"
-msgstr "Autres catégories"
+msgstr "Andere categorieën"
 
 #: frontend/src/metabase/meta/Dashboard.js:114
 msgid "Category, Type, Model, Rating, etc."
-msgstr "Catégorie, Type, Modèle, Classement"
+msgstr "Categorie, Type, Model, Beoordeling, etc."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
 #: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
-msgstr "Réglages du compte utilisateur"
+msgstr "Account instellingen"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:49
 msgid "Exit admin"
-msgstr "Quitter le panneau d'administration"
+msgstr "Admin afsluiten"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:34
 msgid "Logs"
-msgstr "Journaux"
+msgstr "Logs"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:64
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
-msgstr "Aide"
+msgstr "Help"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
-msgstr "A propos de Metabase"
+msgstr "Over Metabase"
 
-#. Les items du menu sont tous des noms...
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
-msgstr "Déconnexion"
+msgstr "Uitloggen"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
-msgstr "Merci d'utiliser"
+msgstr "Bedankt voor het gebruik"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
-msgstr "Vous êtes en version"
+msgstr "Je gebruikt versie"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
-msgstr "Sortie le"
+msgstr "Gebouwd op"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
-msgstr "est une marque de"
+msgstr "is een handelsmerk van"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
-msgstr "et est fabriqué avec soin à San Francisco, CA"
+msgstr "en is met zorg gebouwd in San Francisco, CA"
 
-#. C'est le texte dans le coin haut gauche du panneau d'administration
 #: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
-msgstr "Admin Metabase"
+msgstr "Metabase administrator"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
-msgstr "Poser une question"
+msgstr "Een vraag stellen"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
-msgstr "Nouveau tableau de bord"
+msgstr "Nieuw dashboard"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:361
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
-msgstr "Nouveau pulse"
+msgstr "Nieuwe puls"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:323
 msgid "Reference"
-msgstr "Référentiel"
+msgstr "Referentie"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
-msgstr "Quelle métrique ?"
+msgstr "Welke metriek?"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
-msgstr "Définissez des métriques pour aider votre équipe à poser des questions plus simplement"
+msgstr "Door gemeenschappelijke statistieken voor je team te definiëren, kun je nog eenvoudiger vragen stellen"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
-msgstr "Comment créer des métriques"
+msgstr "Hoe maak je metrieken"
 
-#. correction d'accord
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:138
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
-msgstr "Voir la donnée comme série chronologique, carte, ou tableau croisé pour vous aider à comprendre les tendances ou les changements."
+msgstr "Bekijk gegevens in de loop van de tijd of als een kaart om trends of veranderingen beter te kunnen begrijpen."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
 msgid "Custom"
-msgstr "Personnalisée"
+msgstr "Aangepast"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
-msgstr "Nouvelle question"
+msgstr "Nieuwe vraag"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:152
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
-msgstr "Utilisez le générateur de questions pour voir des tendances, afficher des listes ou créer vos propres métriques."
+msgstr "Gebruik de eenvoudige vragenmaker om trends, lijsten met dingen te bekijken of om je eigen statistieken te maken."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
-msgstr "Requête native"
+msgstr "Native query"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
-msgstr "Pour des questions plus complexes, vous pouvez écrire votre propre requête SQL"
+msgstr "Voor meer gecompliceerde vragen kunt u uw eigen SQL- of native query schrijven."
 
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
-msgstr "Choisir une valeur par défaut"
+msgstr "Selecteer een standaardwaarde..."
 
 #: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
 #: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
-msgstr "Mettre à jour le filtre"
+msgstr "Update filter"
 
 #: frontend/src/metabase/lib/query_time.js:112
 #: frontend/src/metabase/lib/query_time.js:123
@@ -4196,22 +4190,22 @@ msgstr "Mettre à jour le filtre"
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
 #: src/metabase/pulse/render/datetime.clj
 msgid "Today"
-msgstr "Aujourd'hui"
+msgstr "Vandaag"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
 #: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
-msgstr "Hier"
+msgstr "Gisteren"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:18
 msgid "Past 7 days"
-msgstr "Les 7 derniers jours"
+msgstr "Afgelopen 7 dagen"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:19
 msgid "Past 30 days"
-msgstr "Les 30 derniers jours"
+msgstr "Afgelopen 30 dagen"
 
 #: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
@@ -4219,8 +4213,8 @@ msgstr "Les 30 derniers jours"
 #: src/metabase/api/table.clj
 msgid "Week"
 msgid_plural "Weeks"
-msgstr[0] "Semaine"
-msgstr[1] "Semaines"
+msgstr[0] "Week"
+msgstr[1] "Weken"
 
 #: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
@@ -4228,8 +4222,8 @@ msgstr[1] "Semaines"
 #: src/metabase/api/table.clj
 msgid "Month"
 msgid_plural "Months"
-msgstr[0] "Mois"
-msgstr[1] "Mois"
+msgstr[0] "Maand"
+msgstr[1] "Maanden"
 
 #: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
@@ -4237,86 +4231,86 @@ msgstr[1] "Mois"
 #: src/metabase/api/table.clj
 msgid "Year"
 msgid_plural "Years"
-msgstr[0] "Année"
-msgstr[1] "Années"
+msgstr[0] "Jaar"
+msgstr[1] "Jaren"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:152
 msgid "Past 7 Days"
-msgstr "Les 7 derniers jours"
+msgstr "Laatste 7 dagen"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:156
 msgid "Past 30 Days"
-msgstr "Les 30 derniers jours"
+msgstr "Laatste 30 dagen"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:160
 msgid "Last Week"
-msgstr "La semaine dernière"
+msgstr "Vorige week"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:164
 msgid "Last Month"
-msgstr "Le mois dernier"
+msgstr "Vorige maand"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:168
 msgid "Last Year"
-msgstr "L'année dernière"
+msgstr "Vorig jaar"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:172
 msgid "This Week"
-msgstr "Cette semaine"
+msgstr "Deze week"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:176
 msgid "This Month"
-msgstr "Ce mois-ci"
+msgstr "Deze maand"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:180
 msgid "This Year"
-msgstr "Cette année"
+msgstr "Dit jaar"
 
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:89
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
-msgstr "Saisir une valeur..."
+msgstr "Voer een waarde in..."
 
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:90
 msgid "Enter a default value..."
-msgstr "Saisir une valeur par défaut..."
+msgstr "Voer een standaard waarde in..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
-msgstr "Une erreur est survenue"
+msgstr "Een error is opgetreden"
 
 #: frontend/src/metabase/public/components/PublicNotFound.jsx:11
 msgid "Not found"
-msgstr "Non trouvé"
+msgstr "Niet gevonden"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:82
 msgid "You’ve made changes that need to be published before they will be reflected in your application embed."
-msgstr "Vous avez fait des modifications qui doivent être publiées avant d'être visibles dans l'intégration de votre application."
+msgstr "Je hebt wijzigingen aangebracht die gepubliceerd moeten worden voordat deze worden toegepast in uw embeded applicatie."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:83
 msgid "You will need to publish this {0} before you can embed it in another application."
-msgstr "Vous devrez publier ce/cette {0} avant de pouvoir l'intégrer dans une autre application."
+msgstr "Je moet deze {0} publiceren voordat je deze in een andere toepassing kunt insluiten"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:92
 msgid "Discard Changes"
-msgstr "Annuler les modifications"
+msgstr "Veranderingen ongedaan maken"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:99
 msgid "Updating..."
-msgstr "Mise à jour..."
+msgstr "Aanpassen..."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:100
 msgid "Updated"
-msgstr "Mis à jour"
+msgstr "Aangepast"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:101
 msgid "Failed!"
-msgstr "Echec !"
+msgstr "Mislukt!"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:102
 msgid "Publish"
-msgstr "Publier"
+msgstr "Publiceren"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:111
 msgid "Code"
@@ -4325,268 +4319,265 @@ msgstr "Code"
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
-msgstr "Style"
+msgstr "Stijl"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
-msgstr "Quels paramètres les utilisateurs de cette intégration peuvent-ils utiliser ?"
+msgstr "Welke parameters kunnen gebruikers van deze embed gebruiken?"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
-msgstr "Le/la {0} n'a encore aucun paramètre à configurer."
+msgstr "Er zijn nog geen parameters om te configureren voor deze {0}."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
-msgstr "Modifiable"
+msgstr "Aanpasbaar"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
-msgstr "Vérouillé"
+msgstr "Vergrendeld"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:113
 msgid "Preview Locked Parameters"
-msgstr "Aperçu des paramètres verrouillés"
+msgstr "Voorbeeld van vergrendelde parameters"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
-msgstr "Essayez de passer quelques valeurs à vos paramètres verrouillés ici. Votre serveur devra fournir les valeurs réelles dans le jeton signé en situation réelle."
+msgstr "Probeer hier enkele waarden door te geven aan de vergrendelde parameters. De server moet de werkelijke waarden in het ondertekende token opgeven wanneer dit echt gebruikt wordt."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
-msgstr "Zone dangereuse"
+msgstr "Gevarenzone"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
-msgstr "Cela désactivera l'intégration pour ce/cette {0}."
+msgstr "Hiermee wordt insluiten voor deze {0} uitgeschakeld."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
-msgstr "Retirer la publication"
+msgstr "Depubliceren"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:17
 msgid "Light"
-msgstr "Clair"
+msgstr "Licht"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:18
 msgid "Dark"
-msgstr "Sombre"
+msgstr "Donker"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:37
 msgid "Border"
-msgstr "Bordure"
+msgstr "Rand"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:62
 msgid "To embed this {0} in your application:"
-msgstr "Pour intégrer ce/cette {0} dans votre application:"
+msgstr "Om deze {0} in te sluiten in je applicatie:"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:64
 msgid "Insert this code snippet in your server code to generate the signed embedding URL "
-msgstr "Insérez cet extrait  dans le code de votre serveur pour générer l'URL d'intégration signée ␣"
+msgstr "Gebruik de volgende code snippet op je server om gesigneerde URL voor het insluiten te genereren "
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:87
 msgid "Then insert this code snippet in your HTML template or single page app."
-msgstr "Ensuite, insérez cet extrait de code dans votre modèle HTML ou votre application à page unique."
+msgstr "En gebruik deze code in je HTML template of Single Page App."
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:94
 msgid "Embed code snippet for your HTML or Frontend Application"
-msgstr "Extrait de code pour intégration dans votre HTML ou votre application d'IHM"
+msgstr "Embed code voor je HTML of frontend applicatie"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:101
 msgid "More {0}"
-msgstr "Plus de {0}"
+msgstr "Meer {0}"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:103
 msgid "examples on GitHub"
-msgstr "exemples sur GitHub"
+msgstr "Voorbeelden op Github"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
-msgstr "Autoriser le partage"
+msgstr "Delen inschakelen"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
-msgstr "Désactiver ce lien public ?"
+msgstr "Deze openbare link uitschakelen?"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
-msgstr "Cela empêchera le lien existant de fonctionner. Vous pouvez le réactiver, mais si vous le faites, le lien sera différent."
+msgstr "Hierdoor stopt de bestaande link met werken. Je kunt het opnieuw inschakelen, maar als je dat doet, zal het een andere link zijn."
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
-msgstr "Lien public"
+msgstr "Publieke link"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
-msgstr "Partagez ce/cette {0} avec des personnes qui ne possèdent pas de compte Metabase en utilisant l'URL ci-dessous:"
+msgstr "Deel dit {0} met mensen die geen Metabase-account hebben met behulp van de onderstaande URL:"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
-msgstr "Intégration publique"
+msgstr "Openbaar insluiten"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
-msgstr "Intégrez ce/cette {0} dans les posts de blog ou les pages web en copiant/collant ce bout de code."
+msgstr "Sluit dit {0} in in blogberichten of webpagina's door dit fragment te kopiëren en te plakken:"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
-msgstr "Intégrer ce/cette {0} dans une application"
+msgstr "Embed dit {0} in een applicatie"
 
-#. incompréhension dans ma première traduction
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
-msgstr "En vous intégrant dans le code de votre serveur d'application, vous pouvez fournir un(e) {0} sécurisé(e) limité(e) à un utilisateur, client, organisation, etc. spécifique."
+msgstr "Door te integreren met servercode, kun je beveiligde statistieken {0} bieden die beperkt zijn tot een specifieke gebruiker, klant, organisatie, etc."
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
-msgstr "Supprimer la pièce jointe"
+msgstr "Verwijder bijlage"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
-msgstr "Joindre le fichier des résultats"
+msgstr "Bestand bijvoegen met resultaten"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
-msgstr "Cette question sera ajoutée en pièce jointe"
+msgstr "Deze vraag wordt toegevoegd als een bestandsbijlage"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
-msgstr "Cette question ne sera pas incluse dans votre pulse"
+msgstr "Deze vraag zal niet worden opgenomen in uw Puls"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
-msgstr "Ce pulse ne sera plus envoyée par courriel à {0} {1}"
+msgstr "Deze puls zal niet langer worden gemaild naar {0} {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
-msgstr[0] "{0} adresse"
-msgstr[1] "{0} adresses"
+msgstr[0] "{0} adres"
+msgstr[1] "{0} adressen"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:102
 msgid "Slack channel {0} will no longer get this pulse {1}"
-msgstr "Le canal Slack {0} ne recevra plus ce pulse {1}"
+msgstr "Deze puls {1} zal niet langer worden verzonden naar Slack channel {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
-msgstr "Le canal {0} ne recevra plus ce pulse {1}"
+msgstr "Channel {0} ontvangt deze puls niet meer {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
-msgstr "Modifier le pulse"
+msgstr "Pulse aanpassen"
 
-#. Qu'est ce --> Qu'est-ce ?
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
-msgstr "Qu'est-ce qu'un Pulse ?"
+msgstr "Wat is een Pulse?"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
-msgstr "J'ai compris"
+msgstr "Ik begrijp het"
 
-#. pour accord avec 'Sélectionner vos données'
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
-msgstr "Où devraient aller ces données ?"
+msgstr "Waar moeten deze gegevens naartoe?"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
-msgstr "Désarchivage en cours..."
+msgstr "Archivering ongedaan maken..."
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
-msgstr "Le désarchivage à échoué"
+msgstr "Fout bij het ongedaan maken van archivering"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
-msgstr "Désarchivé"
+msgstr "Archivering ongedaan gemaakt"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
-msgstr "Créer un pulse"
+msgstr "Puls aanmaken"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:90
 msgid "Attachment"
-msgstr "Pièce jointe"
+msgstr "Bijlage"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
-msgstr "Avertissement"
+msgstr "Let op"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:105
 msgid "We'll show the first 10 columns and 20 rows of this table in your Pulse. If you email this, we'll add a file attachment with all columns and up to 2,000 rows."
-msgstr "Nous afficherons les 10 premières colonnes et 20 premières lignes de cette table dans votre Pulse. Si vous envoyez un courriel, nous ajouterons un fichier contenant toutes les colonnes et jusqu'à 2 000 lignes."
+msgstr "We tonen de eerste 10 kolommen en 20 rijen van deze tabel in de Puls. Bij e-mails voegen we een bestandsbijlage toe met alle kolommen en maximaal 2.000 rijen."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:112
 msgid "Raw data questions can only be included as email attachments"
-msgstr "Les questions de données brutes ne peuvent être incluses que sous forme de pièces jointes."
+msgstr "Vragen met onbewerkte gegevens kunnen alleen als e-mailbijlagen worden opgenomen."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:119
 msgid "Looks like this pulse is getting big"
-msgstr "Il semble que ce pulse devienne trop grand"
+msgstr "Het lijkt er op dat deze puls groot aan het worden is"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:120
 msgid "We recommend keeping pulses small and focused to help keep them digestible and useful to the whole team."
-msgstr "Nous recommandons de garder les pulses petits et ciblés pour aider à les conserver compréhensibles et utiles pour l'ensemble de l'équipe"
+msgstr "We raden aan om pulsen klein en geconcentreerd te houden om ze relevant en nuttig te houden voor het hele team."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
 #: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
-msgstr "Sélectionner vos données"
+msgstr "Kies je gegevens"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:162
 msgid "Choose questions you'd like to send in this pulse"
-msgstr "Choisissez les questions que vous voudriez envoyer dans ce pulse"
+msgstr "Kies de vragen welke je graag wilt versturen met deze puls"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
 msgid "Emails"
-msgstr "Courriels"
+msgstr "E-mails"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
 msgid "Slack messages"
-msgstr "Messages Slack"
+msgstr "Slack berichten"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
-msgstr "Envoyé"
+msgstr "Verstuurd"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
-msgstr "{0} sera envoyé à"
+msgstr "{0} wordt verzonden om"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
-msgstr "Messages"
+msgstr "Berichten"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
-msgstr "Envoyer par courriel maintenant"
+msgstr "Verstuur e-mail nu"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
-msgstr "Envoyer à {0} maintenant"
+msgstr "Verstuur nu naar {0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
-msgstr "Envoi en cours..."
+msgstr "Versturen..."
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
-msgstr "L'envoi a échoué"
+msgstr "Versturen mislukt"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
-msgstr "L'envoi n'a pas été fait car le pulse n'a aucun résultat."
+msgstr "Niet verzonden omdat de puls geen resultaten heeft."
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
-msgstr "Pulse envoyé"
+msgstr "Pulse verstuurd"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
-msgstr "{0} a besoin d'être configuré(e) par un administrateur."
+msgstr "{0} moet worden ingesteld door een beheerder."
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
@@ -4594,448 +4585,447 @@ msgstr "Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditCollection.jsx:12
 msgid "Which collection should this pulse live in?"
-msgstr "Dans quelle collection ce pulse devrait-il être ?"
+msgstr "In welke collectie moet deze puls leven?"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:35
 msgid "Name your pulse"
-msgstr "Nommer votre pulse"
+msgstr "Naam van je puls"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:37
 msgid "Give your pulse a name to help others understand what it's about"
-msgstr "Donnez un nom à votre pulse pour aider les autres utilisateurs à comprendre son intérêt"
+msgstr "Geef je puls een naam zodat anderen begrijpen waar het over gaat"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:49
 msgid "Important metrics"
-msgstr "Métriques importantes"
+msgstr "Belangrijke metrieken"
 
 #: frontend/src/metabase/pulse/components/PulseEditSkip.jsx:22
 msgid "Skip if no results"
-msgstr "Ignorer si aucun résultat"
+msgstr "Sla over bij geen resultaten"
 
 #: frontend/src/metabase/pulse/components/PulseEditSkip.jsx:24
 msgid "Skip a scheduled Pulse if none of its questions have any results"
-msgstr "Ignorer un Pulse planifié si aucune de ses questions n'a de résultat"
+msgstr "Sla een ingeplande puls over wanneer geen enkele vragen resultaten op levert"
 
 #: frontend/src/metabase/pulse/components/RecipientPicker.jsx:65
 msgid "Enter email addresses you'd like this data to go to"
-msgstr "Saisissez les adresses électroniques des destinataires des données"
+msgstr "Vul een e-mailadres in waar je de data naar toe wilt sturen"
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:16
 msgid "Help everyone on your team stay in sync with your data."
-msgstr "Aidez chacun de vos utilisateurs à rester en phase avec vos données."
+msgstr "Help iedereen in je team en blijf op de hoogte van je data"
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:30
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
-msgstr "Les Pulses vous permettent d'envoyer vos données de façon planifiée, par e-mail ou via slack."
+msgstr "Pulsen kunnen vanuit Metabase verzonden worden via e-mail of Slack op een ingeplande datum naar keuze."
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "After {0}"
-msgstr "Après {0}"
+msgstr "Na {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 msgid "Before {0}"
-msgstr "Avant {0}"
+msgstr "Voor {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
-msgstr "Est vide"
+msgstr "Is leeg"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
-msgstr "N'est pas vide"
+msgstr "Niet leeg"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
-msgstr "Tout le temps"
+msgstr "Altijd"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
-msgstr "Appliquer les modifications"
+msgstr "Pas toe"
 
 #: frontend/src/metabase/modes/components/actions/CommonMetricsAction.jsx:21
 msgid "View {0}"
-msgstr "Vue {0}"
+msgstr "Bekijk {0}"
 
 #: frontend/src/metabase/modes/components/actions/CompareWithTable.jsx:29
 msgid "Compare this with all rows in the table"
-msgstr "Comparer cela avec toutes les lignes de la table"
+msgstr "Vergelijk dit met alle rijen in de tabel"
 
 #: frontend/src/metabase/modes/components/actions/CompoundQueryAction.jsx:14
 msgid "Analyze the results of this Query"
-msgstr "Analyser les résultats de cette requête"
+msgstr "Analyseer de resultaten van deze query"
 
 #: frontend/src/metabase/modes/components/actions/CountByTimeAction.jsx:29
 msgid "Count of rows by time"
-msgstr "Nombre de lignes au fil du temps"
+msgstr "Aantal rijen over de tijd"
 
 #: frontend/src/metabase/modes/components/actions/PivotByAction.jsx:52
 msgid "Break out by {0}"
-msgstr "Eclater par {0}"
+msgstr "Uitbreken met {0}"
 
 #: frontend/src/metabase/modes/components/actions/SummarizeBySegmentMetricAction.jsx:31
 msgid "Summarize this segment"
-msgstr "Résumez ce segment"
+msgstr "Vat dit segment samen"
 
 #: frontend/src/metabase/modes/components/actions/UnderlyingDataAction.jsx:14
 msgid "View this as a table"
-msgstr "Voir ceci comme un tableau"
+msgstr "Bekijk dit als tabel"
 
 #: frontend/src/metabase/modes/components/actions/UnderlyingRecordsAction.jsx:22
 msgid "View the underlying {0} records"
-msgstr "Afficher les enregistrements sous-jacents {0}"
+msgstr "Bekijk de onderliggende {0} records"
 
 #: frontend/src/metabase/modes/components/actions/XRayCard.jsx:20
 msgid "X-Ray this question"
-msgstr "Radiographier cette question"
+msgstr "Gebruik X-Ray voor deze vraag"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 msgid "X-ray {0} {1}"
-msgstr "Radiographier {0} {1}"
+msgstr "X-ray {0} {1}"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "these"
-msgstr "ce/cette/ces"
+msgstr "deze"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "this"
-msgstr "ce/cette"
+msgstr "dit"
 
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "Compare {0} {1} to the rest"
-msgstr "Comparer {0} {1} au reste"
+msgstr "Vergelijk {0} {1} met de rest"
 
 #: frontend/src/metabase/modes/components/drill/DistributionDrill.jsx:35
 msgid "Distribution"
-msgstr "Distribution"
+msgstr "Distributie"
 
 #: frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx:38
 msgid "View details"
-msgstr "Voir les détails"
+msgstr "Bekijk details"
 
 #: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
-msgstr "Voir les {1} de ce/cette {0}"
+msgstr "Bekijk deze {0}s {1}"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:42
 msgid "Ascending"
-msgstr "Croissant"
+msgstr "Oplopend"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:50
 msgid "Descending"
-msgstr "Décroissant"
+msgstr "Aflopend"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js:47
 msgid "over time"
-msgstr "au cours du temps"
+msgstr "Over een periode"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:21
 msgid "Avg"
-msgstr "Moyenne"
+msgstr "Gemiddeld"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:33
 msgid "Distincts"
-msgstr "Valeurs distinctes"
+msgstr "Uniek"
 
 #: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
-msgstr[0] "Visualiser ce/cette {0}"
-msgstr[1] "Visualiser ces {0}"
+msgstr[0] "Bekijk deze {0}"
+msgstr[1] "Bekijk deze {0}"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
-msgstr "Agrandir"
+msgstr "Inzoomen"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
-msgstr "Expression personnalisée"
+msgstr "Aangepaste expressie"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
-msgstr "Métriques communes"
+msgstr "Populaire statistieken"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:209
 msgid "Metabasics"
-msgstr "Metabasiques"
+msgstr "Metabasics"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
-msgstr "Nom (optionnel)"
+msgstr "Naam (optioneel)"
 
 #: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:156
 msgid "Choose an aggregation"
-msgstr "Choisir un agrégat"
+msgstr "Kies een aggregatie"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:100
 msgid "Set up your own alert"
-msgstr "Configurez votre propre alerte"
+msgstr "Stel je eigen alert in"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
-msgstr "En cours de désinscription..."
+msgstr "Uitschrijven..."
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
-msgstr "Echec de la désinscription"
+msgstr "Uitschrijven mislukt"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
-msgstr "Se désinscrire"
+msgstr "Uitschrijven"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
-msgstr "Aucun canal"
+msgstr "Geen kanaal"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
-msgstr "Voilà, vous êtes désinscrit"
+msgstr "Oke, je bent uitgeschreven"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
-msgstr "Vous recevez les alertes de {0}"
+msgstr "U ontvangt {0} meldingen"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
-msgstr "{0} a configuré une alerte"
+msgstr "{0} stel een waarschuwing in"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:160
 msgid "alerts"
-msgstr "alertes"
+msgstr "meldingen"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:183
 msgid "Let's set up your alert"
-msgstr "Configurons votre alerte"
+msgstr "Laten we een melding instellen"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:214
 msgid "The wide world of alerts"
-msgstr "Le vaste monde des alertes"
+msgstr "De wijde wereld van meldingen"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:215
 msgid "There are a few different kinds of alerts you can get"
-msgstr "Il y a une poignée de types d'alerte que vous pouvez recevoir"
+msgstr "Er zijn een paar verschillende soorten meldingen die je kunt krijgen"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:229
 msgid "When a raw data question {0}"
-msgstr "Quand une question de données brutes {0}"
+msgstr "Wanneer een onbewerkte gegevens vraag {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:230
 msgid "returns any results"
-msgstr "ramène un résultat"
+msgstr "resultaten terug geeft"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:241
 msgid "When a line or bar {0}"
-msgstr "Quand une ligne de graphique ou une barre d'histogramme {0}"
+msgstr "Wanneer een regel of balk {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:242
 msgid "crosses a goal line"
-msgstr "traverse une ligne d'objectif"
+msgstr "een doellijn overschrijdt"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:253
 msgid "When a progress bar {0}"
-msgstr "Quand une barre de progression {0}"
+msgstr "Wanneer een voortgangsbalk {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:254
 msgid "reaches its goal"
-msgstr "objectif atteint"
+msgstr "zijn doel bereikt"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:262
 msgid "Set up an alert"
-msgstr "Configurer une alerte"
+msgstr "Stel een waarschuwing in"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:331
 msgid "Edit your alert"
-msgstr "Modifier votre alerte"
+msgstr "Bewerk uw melding"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:331
 msgid "Edit alert"
-msgstr "Modifier l'alerte"
+msgstr "Melding bewerken"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
-msgstr "Cette alerte ne sera plus envoyée par e-mail à {0}."
+msgstr "Deze melding wordt niet langer per e-mail verzonden naar {0}."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
-msgstr "Le channel Slack {0} ne recevra plus cette alerte."
+msgstr "Slack channel {0} ontvangt deze waarschuwing niet meer."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
-msgstr "Le canal {0} ne recevra plus cette alerte."
+msgstr "Channel {0} ontvangt deze melding niet meer."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
-msgstr "Supprimer cette alerte"
+msgstr "Verwijder deze melding"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
-msgstr "Arrêter la génération et supprimer cette alerte. Il n'y a aucun retour arrière, soyez donc prudent."
+msgstr "Beëindig de levering en verwijder deze melding. Dit kan niet ongedaan worden gemaakt, dus wees voorzichtig."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
-msgstr "Supprimer cette alerte ?"
+msgstr "Deze melding verwijderen?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
-msgstr "Prévenez moi quand la ligne ..."
+msgstr "Waarschuw me wanneer de lijn ..."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
-msgstr "Me prévenir quand la barre de progression"
+msgstr "Waarschuw me wanneer de voortgangsbalk ..."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
-msgstr "Passe au dessus de la ligne d'objectif"
+msgstr "Boven de doellijn gaat"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
-msgstr "Objectif atteint"
+msgstr "Het doel bereikt"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
-msgstr "Passe en dessous de la ligne d'objectif"
+msgstr "Onder de doellijn gaat"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
-msgstr "Passe sous l'objectif"
+msgstr "Onder het doel gaat"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
-msgstr "Au premier croisement, ou à chaque fois ?"
+msgstr "De eerste keer dat het kruist, of elke keer?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
-msgstr "La première fois que l'objectif est atteint, ou à chaque fois ?"
+msgstr "De eerste keer dat het het doel bereikt, of elke keer?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
-msgstr "La première fois"
+msgstr "De eerste keer"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
-msgstr "Chaque fois"
+msgstr "Elke keer"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
-msgstr "Où voulez-vous envoyer ces alertes ?"
+msgstr "Waar wil je deze meldingen naartoe sturen?"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
-msgstr "Envoyer par courriel à :"
+msgstr "E-mailmeldingen naar:"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
-msgstr "{0} Les alertes basées sur l'objectif ne prennent pas encore en charge les graphiques multi-lignes, cette alerte sera donc envoyée chaque fois que le graphique a {1}."
+msgstr "{0} Op doel gebaseerde waarschuwingen worden nog niet ondersteund voor grafieken met meer dan één regel, dus deze waarschuwing wordt verzonden wanneer de grafiek {1} heeft."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
-msgstr "résultats"
+msgstr "resultaten"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
-msgstr "{0} ce type d'alerte est surtout utile quand votre question sauvegardée ne retourne {1} pas de résutat, mais que vous voulez savoir quand elle en retourne un."
+msgstr "{0} Dit soort waarschuwingen zijn het handigst wanneer de opgeslagen vraag {1} geen resultaten oplevert, maar je wilt weten wanneer dat wel het geval is."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
-msgstr "Astuce"
+msgstr "Tip"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
-msgstr "habituellement"
+msgstr "doorgaans"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
-msgstr "Choisir un segment ou une table"
+msgstr "Kies een segment of tabel"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
-msgstr "Sélectionner une base de données"
+msgstr "Selecteer een database"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
-msgstr "Sélectionner..."
+msgstr "Selecteer..."
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
-msgstr "Sélectionner une table"
+msgstr "Selecteer een tabel"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
-msgstr "Aucune table trouvé dans cette base de données"
+msgstr "Geen tabellen gevonden in deze database"
 
-#. Manque-t-il ? https://www.lalanguefrancaise.com/orthographe/y-a-t-il-orthographe/
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
-msgstr "Manque-t-il une question ?"
+msgstr "Mist er een vraag?"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
-msgstr "En savoir plus sur les questions imbriquées"
+msgstr "Meer informatie over geneste zoekopdrachten"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
-msgstr "Champs"
+msgstr "Velden"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
-msgstr "Aucun segment trouvé."
+msgstr "Er zijn geen segmenten gevonden."
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
-msgstr "Trouver un segment"
+msgstr "Zoek een segment"
 
 #: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
-msgstr "Voir l'essentiel"
+msgstr "Bekijk minder"
 
 #: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
-msgstr "Voir en détails"
+msgstr "Bekijk meer"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:112
 msgid "Pick a field to sort by"
-msgstr "Choisir un champ selon lequel trier"
+msgstr "Kies een veld om op te sorteren"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
-msgstr "Trier"
+msgstr "Sorteer"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
-msgstr "Nombre de lignes maximum"
+msgstr "Rij limiet"
 
 #: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
-msgstr "Champ inconnu"
+msgstr "Onbekend veld"
 
 #: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
-msgstr "champ"
+msgstr "veld"
 
 #: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
-msgstr "Correspondances"
+msgstr "Matcht"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
-msgstr "Ajouter des filtres pour préciser votre réponse"
+msgstr "Voeg filters toe om je antwoord te verfijnen"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
-msgstr "Ajouter une agrégation"
+msgstr "Groepering toevoegen"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
@@ -5053,110 +5043,107 @@ msgstr "Ajouter une agrégation"
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
-msgstr "Données"
+msgstr "Data"
 
-#. Si l'on tient à l'enchaînement Données/Fitré par/Vue/Groupé par, le non accord des participes passés jure un peu... Je propose Données/Fitre/Vue/Aggrégation
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
-msgstr "Filtre"
+msgstr "Gefilterd op"
 
-#. Bonjour Fabrice, je propose de conserver "Vue" comme tu l'avais indiqué la première fois dans le générateur de requête on aurait alors : "Données" / "Filtrées par" / "Vue" / "Groupées par".
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
-msgstr "Vue"
+msgstr "Bekijk"
 
-#. Si l'on tient à l'enchaînement Données/Fitré par/Vue/Groupé par, le non accord des participes passés jure un peu... Je propose Données/Fitre/Vue/Aggrégat
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
-msgstr "Agrégat"
+msgstr "Gegroepeerd op"
 
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
-msgstr "Aucun"
+msgstr "Geen"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
-msgstr "Cette question est écrite en {0}."
+msgstr "Deze vraag is geschreven in {0}."
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
-msgstr "Masquer l'éditeur"
+msgstr "Verberg editor"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
-msgstr "Masquer la requête"
+msgstr "Query verbergen"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
-msgstr "Ouvrir l'éditeur"
+msgstr "Editor openen"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
-msgstr "Montrer la requête"
+msgstr "Query weergeven"
 
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "This metric has been retired.  It's no longer available for use."
-msgstr "La métrique a été retirée. Elle n'est plus utilisable."
+msgstr "Deze metriek is gestopt. Het is niet langer beschikbaar voor gebruik."
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:34
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:46
 msgid "Download full results"
-msgstr "Télécharger le résultat complet"
+msgstr "Download volledige resultaten"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:35
 msgid "Download this data"
-msgstr "Télécharger ces données"
+msgstr "Download deze data"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:46
 msgid "Warning"
-msgstr "Avertissement"
+msgstr "Waarschuwing"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
-msgstr "Votre réponse a un grand nombre de lignes et pourrait prendre un certain temps à télécharger."
+msgstr "Je antwoord heeft een groot aantal rijen, het downloaden kan even duren."
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
-msgstr "La taille maximum de téléchargement est d'un million de lignes."
+msgstr "Er kunnen maximaal 1 miljoen rijen worden gedownload"
 
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
-msgstr "Modifier la question"
+msgstr "Vraag wijzigen"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:249
 msgid "SAVE CHANGES"
-msgstr "SAUVEGARDER LES MODIFICATIONS"
+msgstr "WIJZIGINGEN OPSLAAN"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:263
 msgid "CANCEL"
-msgstr "SUPPRIMER"
+msgstr "ANNULEREN"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:276
 msgid "Move question"
-msgstr "Déplacer la question"
+msgstr "Vraag verplaatsen"
 
 #: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
-msgstr "Dans quelle collection cela devrait-il aller ?"
+msgstr "In welke collectie moet deze komen?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
 #: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
-msgstr "Variables"
+msgstr "Variabelen"
 
 #: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
-msgstr "En savoir plus sur vos données"
+msgstr "Leer meer over je data"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:460
 msgid "Alerts are on"
-msgstr "Les alertes sont actives"
+msgstr "Meldingen staan aan"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:522
 msgid "started from"
-msgstr "démarré depuis"
+msgstr "gestart vanaf"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:48
 msgid "SQL"
@@ -5164,169 +5151,169 @@ msgstr "SQL"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:48
 msgid "native query"
-msgstr "question native"
+msgstr "native query"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:52
 msgid "Not Supported"
-msgstr "Non pris(e) en charge"
+msgstr "Niet ondersteund"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:58
 msgid "View the {0}"
-msgstr "Voir le {0}"
+msgstr "Bekijk de {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:59
 msgid "Switch to {0}"
-msgstr "Passer à/au {0}"
+msgstr "Wissel naar {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:62
 msgid "Switch to Builder"
-msgstr "Passer au générateur de questions"
+msgstr "Wissen naar bewerker"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:87
 msgid "{0} for this question"
-msgstr "{0} pour cette question"
+msgstr "{0} voor deze vraag"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:111
 msgid "Convert this question to {0}"
-msgstr "Convertir cette question en {0}"
+msgstr "Converteer deze vraag om naar {0}"
 
 #: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
-msgstr "Cette question prendra approximativement {0} à se rafraîchir"
+msgstr "Het vernieuwen van deze vraag zou ongeveer {0} duren"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
-msgstr "{0} Mis à jour"
+msgstr "Bijgewerkt {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:141
 msgid "row"
 msgid_plural "rows"
-msgstr[0] "ligne"
-msgstr[1] "lignes"
+msgstr[0] "rij"
+msgstr[1] "rijen"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:148
 msgid "Showing first {0} {1}"
-msgstr "Affiche les {0} premières {1}"
+msgstr "Weergave {0} {1}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:151
 msgid "Showing {0} {1}"
-msgstr "Affiche {0} {1}"
+msgstr "Weergave {0} {1}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
-msgstr "Calcul en cours"
+msgstr "Wetenschap aan het doen"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
-msgstr "Si vous me donnez du grain à moudre, je peux vous montrer quelque chose de sympa. Lancez une requête !"
+msgstr "Als je me wat gegevens geeft kan ik je iets cools laten zien. Voer een zoekopdracht uit!"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:299
 msgid "How do I use this thing?"
-msgstr "Comment utiliser ceci ?"
+msgstr "Hoe gebruik ik dit ding?"
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
-msgstr "Obtenir la réponse"
+msgstr "Antwoord krijgen"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:12
 msgid "It's okay to play around with saved questions"
-msgstr "Il n'y aucun souci à s'amuser avec les questions sauvegardées"
+msgstr "Het is prima om met opgeslagen vragen te spelen"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:14
 msgid "You won't make any permanent changes to a saved question unless you click the edit icon in the top-right."
-msgstr "Vous ne ferez aucune modification permanente à une question sauvegardée tant que vous ne cliquez pas sur le bouton de modification en haut à droite."
+msgstr "Er worden geen permanente wijzigingen aangebracht aan een opgeslagen vraag totdat je op het wijzig pictogram drukt."
 
 #: frontend/src/metabase/query_builder/components/SearchBar.jsx:28
 msgid "Search for"
-msgstr "Rechercher"
+msgstr "Zoeken naar"
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:158
 msgid "Advanced..."
-msgstr "Avancé ..."
+msgstr "Geavanceerd..."
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:167
 msgid "Sorry. Something went wrong."
-msgstr "Désolé, quelque chose s'est mal passé."
+msgstr "Sorry. Er ging iets mis."
 
 #: frontend/src/metabase/query_builder/components/TimeGroupingPopover.jsx:40
 msgid "Group time by"
-msgstr "Aggréger le temps par"
+msgstr "Groepeer tijd bij"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
-msgstr "Votre question a pris trop longtemps"
+msgstr "Het laden van je vraag duurde te lang"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
-msgstr "Nous n'avons pas eu de réponse de votre base de données à temps, nous avons donc arrêté le traitement. Vous pouvez réessayer dans une minute, ou si le problème persiste, envoyez un courriel à un administrateur."
+msgstr "We hebben niet op tijd antwoord gekregen van de database, we hebben je vraag helaas moeten staken. Je kunt het over een ongeveer een minuut nog maals proberen. Mocht dit een probleem blijven kun je de beheerder op de hoogte stellen."
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
-msgstr "Nous rencontrons des problèmes sur le serveur"
+msgstr "We ondervinden serverproblemen"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
-msgstr "Essayez de rafraîchir la page après une ou deux minutes d'attente. Si le problème persiste, nous vous recommandons de contacter une administrateur."
+msgstr "Probeer de pagina over enkele minuten te vernieuwen. Als het probleem zich blijft voordoen, raden we je aan om contact op te nemen met een beheerder."
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
-msgstr "Il y a eu un problème avec votre question"
+msgstr "Er was een probleem met je vraag"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
-msgstr "Cela est causé la plupart du temps par une sélection invalide ou une mauvaise valeur saisie. Vérifiez à nouveau vos entrées et réessayez."
+msgstr "Meestal wordt dit veroorzaakt door een ongeldige selectie of een onjuiste invoerwaarde. Controleer je invoer en probeer je vraag opnieuw."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
-msgstr "C'est peut-être la réponse que vous recherchez. Sinon, essayez d'enlever ou changer vos filtres pour les rendre moins restrictifs."
+msgstr "Dit is misschien het antwoord wat je zocht? Zo niet, probeer je filters te verwijderen of minder specifiek te maken en probeer het opnieuw."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
-msgstr "Vous pouvez aussi {0} quand il y a des résultats."
+msgstr "Je kunt ook {0} wanneer er resultaten zijn"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
-msgstr "Obtenir une alerte"
+msgstr "een melding ontvangen"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:77
 msgid "Back to last run"
-msgstr "Retourner à la dernière exécution"
+msgstr "Terug naar laatste run"
 
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
-msgstr "Visualisation"
+msgstr "Visualisatie"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
-msgstr "Aucune description."
+msgstr "Geen beschrijving gezet."
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Use for current question"
-msgstr "Utiliser pour la question actuelle"
+msgstr "Gebruik voor huidige vraag"
 
 #: frontend/src/metabase/reference/components/UsefulQuestions.jsx:16
 msgid "Potentially useful questions"
-msgstr "Questions potentiellement utiles"
+msgstr "Mogelijk bruikbare vragen"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
-msgstr "Aggréger par {0}"
+msgstr "Groeperen bij {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:165
 msgid "Sum of all values of {0}"
-msgstr "Somme de toutes les valeurs de {0}"
+msgstr "Som van alle waardes van {0}"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:63
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:51
 msgid "All distinct values of {0}"
-msgstr "Toutes les valeurs distinctes de {0}"
+msgstr "Alle unieke waardes van {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
-msgstr "Nombre de {0} aggrégés par {1}"
+msgstr "Nummer van {0} gegroepeerd bij {1}"
 
 #: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
@@ -5338,344 +5325,338 @@ msgstr "Nombre de {0} aggrégés par {1}"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:24
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:23
 msgid "Data Reference"
-msgstr "Référentiel des données"
+msgstr "Data referentie"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:13
 msgid "Learn more about your data structure to ask more useful questions"
-msgstr "En savoir plus sur la structure des données pour poser des questions plus utiles"
+msgstr "Leer meer over de datastructuur om betere vragen te stellen"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
-msgstr "Impossible de trouver les métadonnées de la table avant de créer une nouvelle question"
+msgstr "Kon de metadata van de tabel niet vinden voor het aanmaken van een nieuwe vraag"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
-msgstr "Voir {0}"
+msgstr "Zie {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
-msgstr "Règles de la métrique"
+msgstr "Metriek definitie"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
-msgstr "Filtrer par {0}"
+msgstr "Filteren bij {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
-msgstr "Nombre de {0}"
+msgstr "Aantal {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
-msgstr "Voir tous les {0}"
+msgstr "Bekijk alle {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
-msgstr "Définition du segment"
+msgstr "Segmentdefinitie"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
 msgid "An error occurred loading the table"
-msgstr "Une erreur est survenue au chargement de la table"
+msgstr "Er is een fout opgetreden tijdens het laden van de tabel"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:74
 msgid "See the raw data for {0}"
-msgstr "Voir les données brutes de {0}"
+msgstr "Bekijk de onbewerkte resultaten voor {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
-msgstr "Plus"
+msgstr "Meer"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:201
 msgid "Invalid expression"
-msgstr "Expression invalide"
+msgstr "Ongeldige expressie"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:276
 msgid "unknown error"
-msgstr "erreur inconnue"
+msgstr "Onbekende foutmelding"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
-msgstr "Formule du champ"
+msgstr "Veld formule"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
-msgstr "Imaginez cela comme étant une sorte de formule de tableur : vous pouvez utiliser des nombres, champs dans la table, opérations mathématiques comme +, et quelques fonctions. Vous pourriez donc écrire quelque chose comme Soustotal - Cout."
+msgstr "Zie dit als het schrijven van een formule in een spreadsheetprogramma: je kunt getallen, velden in deze tabel, wiskundige symbolen zoals + en sommige functies gebruiken. Dus je zou iets kunnen typen als Subtotaal - Kosten."
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
-msgstr "En savoir plus"
+msgstr "Lees meer"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
-msgstr "Donner un nom"
+msgstr "Geef het een naam"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
-msgstr "Quelque chose de sympa et descriptif"
+msgstr "Iets moois en omschrijvend"
 
 #: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:60
 msgid "Add a custom field"
-msgstr "Ajouter un champ personnalisé"
+msgstr "Voeg een aangepast veld toe"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:17
 msgid "Include {0}"
-msgstr "Inclure {0}"
+msgstr "Inclusief {0}"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:19
 msgid "Case sensitive"
-msgstr "Sensible à la casse"
+msgstr "Hoofdletter gevoelig"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:23
 msgid "today"
-msgstr "aujourd'hui"
+msgstr "Vandaag"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:24
 msgid "this week"
-msgstr "cette semaine"
+msgstr "Deze week"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:25
 msgid "this month"
-msgstr "ce mois"
+msgstr "Deze maand"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:26
 msgid "this year"
-msgstr "cette année"
+msgstr "Dit jaar"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:27
 msgid "this minute"
-msgstr "cette minute"
+msgstr "Deze minuut"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:28
 msgid "this hour"
-msgstr "cette heure"
+msgstr "Dit uur"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:290
 msgid "not implemented {0}"
-msgstr "{0} non implémenté {0"
+msgstr "Niet geïmplementeerd"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:291
 msgid "true"
-msgstr "vrai"
+msgstr "Waar"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:291
 msgid "false"
-msgstr "faux"
+msgstr "Onwaar"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
-msgstr "Ajouter un filtre"
+msgstr "Filter toevoegen"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
 msgid "Item"
-msgstr "Elément"
+msgstr "Item"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
-msgstr "Précédent"
+msgstr "Vorige"
 
-#. C'est le 'Current' du widget de sélection des dates
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
-msgstr "Période en cours"
+msgstr "Huidige"
 
-#. C'est le 'On' du widget de filtrage des dates
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
-msgstr "Le"
+msgstr "Op"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx:47
 msgid "Enter desired number"
-msgstr "Saisir le nombre désiré"
+msgstr "Voer het gewenste getal in"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
-msgstr "Vide"
+msgstr "Leeg"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
 msgid "Find a value"
-msgstr "Trouver une valeur"
+msgstr "Vind een waarde"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:113
 msgid "Hide calendar"
-msgstr "Masquer le calendrier"
+msgstr "Kalender verbergen"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:113
 msgid "Show calendar"
-msgstr "Afficher le calendrier"
+msgstr "Kalender weergeven"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx:97
 msgid "You can enter multiple values separated by commas"
-msgstr "Vous pouvez saisir plusieurs valeurs séparées par des virgules"
+msgstr "Je kunt meerdere waardes toevoegen gescheiden met een komma"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx:38
 msgid "Enter desired text"
-msgstr "Saisir le texte désiré"
+msgstr "Voer gewenste tekst in"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
-msgstr "L'essayer"
+msgstr "Probeer het"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
-msgstr "A quoi ça sert ?"
+msgstr "Waar is dit voor?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
-msgstr "Les variables dans les requêtes natives vous permettent de remplacer dynamiquement les valeurs dans vos requêtes à l'aide de widgets de filtrage ou depuis l'URL."
+msgstr "Met variabelen in native query's kun je waarden in uw query's dynamisch vervangen met behulp van filterwidgets of via de URL."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
-msgstr "{0} crée une variable dans ce patron SQL nommée \"variable_name\". Les variables peuvent être typées dans le panneau latéral, ce qui change leur comportement. Tout type de variable différent de \"Filtre de champ\" provoquera automatiquement le placement d'un élément visuel filtre sur cette question; c'est optionnel pour les filtres de champ. Quand ce filtre est renseigné, sa valeur remplace la variable dans le patron SQL."
+msgstr "{0} maakt een variabele in deze SQL-sjabloon met de naam \"variable_name\". Variabelen kunnen in het zijpaneel typen krijgen, die hun gedrag veranderen. Alle variabeletypes behalve \"Veldfilter\" zorgen er automatisch voor dat een filterwidget op deze vraag wordt geplaatst; met veldfilters is dit optioneel. Wanneer deze filterwidget wordt ingevuld, vervangt die waarde de variabele in de SQL-sjabloon."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
-msgstr "Filtres de champ"
+msgstr "Veld filters"
 
-#. générateur de requête devraient être au pluriel comme dans les autres traduction --> générateur de requêtes
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
-msgstr "Donner à une variable le type \"Filtre de champ\" vous permet :\n"
-"- dans un tableau de bord, de lier une carte contenant la question SQL à un filtre\n"
-"- dans la question, d'élargir le choix des types de filtre. \n"
-"Une variable de type filtre de champ insère du SQL similaire à celui du générateur de requêtes lors de l'ajout d'un filtre sur une colonne existante."
+msgstr "Door een variabele van het type \"Veldfilter\" aan te maken, kun je SQL-kaarten koppelen aan dashboardfilterwidgets of meer soorten filterwidgets gebruiken voor de SQL-query. Een veldfiltervariabele voegt SQL in, vergelijkbaar met die gegenereerd door de GUI-querybuilder bij het toevoegen van filters op bestaande kolommen."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
-msgstr "Une variable de type \"Filtre de champ\" doit être liée à une colonne de table spécifique. Vous pouvez alors choisir d'afficher un filtre dans votre question, mais même si vous ne faites pas, vous pouvez lier votre variable \"Filtre de champ\" à un filtre de tableau de bord contenant une carte avec cette question. les Filtres de champ devraient être utilisés dans le bloc WHERE du patron SQL."
+msgstr "Wanneer je een veldfiltervariabele toevoegt, moet deze aan een specifiek veld worden toegewezen. Je kunt er vervolgens voor kiezen om een filterwidget bij de vraag weer te geven, maar zelfs als je dat niet doet, kun je een veldfiltervariabele toewijzen aan een dashboardfilter wanneer je deze vraag toevoegt aan een dashboard. Veldfilters moeten worden gebruikt binnen een \"WHERE\" -clausule."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
-msgstr "Clauses optionnelles"
+msgstr "Optionele clausules"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:132
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr "des crochets carrés [] autour d'un(e) {0} rendent optionnelle une clause dans le patron SQL. Si la variable est valuée, alors la clause est insérée dans la requête. Sinon, elle est ignorée."
+msgstr "haakjes rond een {0} maak een clausule optioneel. Als \"variabele\" is ingesteld, wordt de hele clausule in het sjabloon geplaatst. Zo niet, dan wordt de hele clausule genegeerd."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
-msgstr "Pour utiliser plusieurs clauses optionnelles, vous pouvez inclure au moins une clause dans le bloc WHERE suivie des clauses optionnelles préfixées par AND"
+msgstr "Als u meerdere optionele clausules wilt gebruiken, kun je ten minste één niet-optionele WHERE-clausule opnemen, gevolgd door optionele clausules die beginnen met \"AND\". Om foutmeldingen te voorkomen."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
-msgstr "Lire la documentation complète"
+msgstr "Lees de volledige documentatie"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
-msgstr "Libellé du filtre"
+msgstr "Filter label"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
-msgstr "Type de variable"
+msgstr "Variabel type"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:143
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
-msgstr "Texte"
+msgstr "Tekst"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:119
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
-msgstr "Date"
+msgstr "Datum"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
-msgstr "Filtre de champ"
+msgstr "Veld filter"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
-msgstr "Champ lié à"
+msgstr "Veld om te koppelen"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
-msgstr "Type de filtre"
+msgstr "Filter widget type"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
-msgstr "Obligatoire ?"
+msgstr "Verplicht?"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
-msgstr "Valeur du filtre par défaut"
+msgstr "Standaard filter widget waarde"
 
 #: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
-msgstr "Archiver cette question?"
+msgstr "Deze vraag archiveren?"
 
 #: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
-msgstr "Cette question sera retirée de tous les tableaux de bords ou pulses qui l'utilisent."
+msgstr "Deze vraag zal verwijderd worden van elk dashboard of puls waar deze gebruikt wordt."
 
 #: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
-msgstr "Question"
+msgstr "Vraag"
 
 #: frontend/src/metabase/questions/containers/AddToDashboard.jsx:11
 msgid "Pick a question to add"
-msgstr "Choisissez une question à ajouter"
+msgstr "Kies een vraag om toe te voegen"
 
 #: frontend/src/metabase/reference/components/EditHeader.jsx:19
 msgid "You are editing this page"
-msgstr "Vous modifiez cette page"
+msgstr "Je ben bezig met het bewerken van deze pagina"
 
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:101
 #: frontend/src/metabase/reference/components/ReferenceHeader.jsx:63
 msgid "See this {0}"
-msgstr "Voir ce {0}"
+msgstr "Bekijk dit {0}"
 
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
-msgstr "Un sous ensemble de"
+msgstr "een deelverzameling van"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
-msgstr "Choisir un type de champ"
+msgstr "Selecteer een veld type"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
-msgstr "Pas de type de champ"
+msgstr "Geen veld type"
 
 #: frontend/src/metabase/reference/components/FieldToGroupBy.jsx:22
 msgid "by"
-msgstr "par"
+msgstr "bij"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
 #: frontend/src/metabase/reference/databases/FieldList.jsx:155
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
-msgstr "Type de champ"
+msgstr "Veld type"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
-msgstr "Choisir une clé étrangère"
+msgstr "Selecteer een foreign key"
 
 #: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
-msgstr "Afficher la formule {0}"
+msgstr "Bekijk de {0} formule"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:80
 msgid "Why this {0} is important"
-msgstr "Pourquoi cet {0} est important"
+msgstr "Waarom is {0} belangrijk?"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:81
 msgid "Why this {0} is interesting"
-msgstr "Pourquoi ce/cet/cette {0} est intéressant(e)"
+msgstr "Waarom is {0} interessant?"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:87
 msgid "Nothing important yet"
-msgstr "Rien d'important pour l'instant"
+msgstr "Nog niets belangrijks"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
@@ -5685,13 +5666,12 @@ msgstr "Rien d'important pour l'instant"
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
-msgstr "Rien d'intéressant pour l'instant"
+msgstr "Nog niets interessants"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:93
 msgid "Things to be aware of about this {0}"
-msgstr "Choses dont il faut être conscient à propos de ce/cette {0}"
+msgstr "Dingen om op te letten over {0}"
 
-#. liaison
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:246
@@ -5700,79 +5680,78 @@ msgstr "Choses dont il faut être conscient à propos de ce/cette {0}"
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
-msgstr "Rien de connu pour l'instant"
+msgstr "Nog niks om op te letten."
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:103
 msgid "Explore this metric"
-msgstr "Explorer cette métrique"
+msgstr "Verken deze metriek"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:105
 msgid "View this metric"
-msgstr "Voir cette métrique"
+msgstr "Bekijk deze metriek"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:112
 msgid "By {0}"
-msgstr "Par {0}"
+msgstr "Bij {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:146
 msgid "Remove item"
-msgstr "Retirer l'élément"
+msgstr "Verwijder item"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:155
 msgid "Why is this dashboard the most important?"
-msgstr "Pourquoi ce tableau de bord est-il le plus important ?"
+msgstr "Waarom is dit dashboard het meest belangrijkst?"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:156
 msgid "What is useful or interesting about this {0}?"
-msgstr "Quoi d'utile ou d'intéressant à propos de ce/cette {0} ?"
+msgstr "Wat is er bruikbaar of interessant aan {0}?"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:160
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:174
 msgid "Write something helpful here"
-msgstr "Ecrivez quelque chose d'utile ici"
+msgstr "Schrijf hier iets wat helpt"
 
-#. Je propose "Y a-t-il" à la place de Y a t'il https://www.lalanguefrancaise.com/orthographe/y-a-t-il-orthographe/
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:169
 msgid "Is there anything users of this dashboard should be aware of?"
-msgstr "Y a-t-il quelque chose dont les utilisateurs de ce tableau de bord devraient être conscients ?"
+msgstr "Is er iets waar gebruikers van dit dashboard op moeten letten?"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:170
 msgid "Anything users should be aware of about this {0}?"
-msgstr "Quelque chose dont les utilisateurs devraient être conscient à propos de ce/cette {0} ?"
+msgstr "Iets waar gebruikers van dit {0} op moeten letten?"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:182
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:26
 msgid "Which 2-3 fields do you usually group this metric by?"
-msgstr "Quels champs (3 max.) regroupez-vous habituellement pour cette métrique ?"
+msgstr "Welke 2-3 velden gebruik je normaal gesproken om deze metriek te groeperen?"
 
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:23
 msgid "This is the perfect place to start if you’re new to your company’s data, or if you just want to check in on what’s going on."
-msgstr "C'est l'endroit idéal où commencer si vous êtes novice dans les données de votre société, ou si vous voulez seulement voir ce qu'il s'y passe."
+msgstr "Dit is de perfecte plek om te starten wanneer je nog niet bekend bent met de data van de organisatie of wanneer je gewoon wilt controleren wat er aan de hand is."
 
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:65
 msgid "Most useful fields to group this metric by"
-msgstr "Champs regroupés le plus souvent pour cette métrique"
+msgstr "Meest bruikbare velden om deze metriek bij te groeperen"
 
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:32
 msgid "Reason for changes"
-msgstr "Raisons des modifications"
+msgstr "Reden voor veranderingen"
 
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:36
 msgid "Leave a note to explain what changes you made and why they were required"
-msgstr "Laisser un mot d'explication sur vos modifications et leurs motivations"
+msgstr "Laat een bericht achter om uit te leggen wat je hebt aangepast en waarom dit nodig was."
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
-msgstr "Pourquoi cette base de données est intéressante"
+msgstr "Waarom is deze database interessant"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
-msgstr "Choses dont on doit être conscient à propos de cette base de données"
+msgstr "Dingen waarop je moet letten bij deze database"
 
 #: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
-msgstr "Bases de données et tables"
+msgstr "Database en tabellen"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
@@ -5786,1288 +5765,1279 @@ msgstr "Bases de données et tables"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
-msgstr "Détails"
+msgstr "Details"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
 #: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
-msgstr "Tables dans {0}"
+msgstr "Tabellen in {0}"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:203
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
-msgstr "Nom réel dans la base de données"
+msgstr "Daadwerkelijke naam in database"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
-msgstr "Pourquoi ce champ est intéressant"
+msgstr "Waarom is dit veld interessant?"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
-msgstr "Choses dont on doit être conscient à propos de ce champ"
+msgstr "Dingen om op te letten bij dit veld"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
 #: frontend/src/metabase/reference/databases/FieldList.jsx:158
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
-msgstr "Type de donnée"
+msgstr "Data type"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:39
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:39
 msgid "Fields in this table will appear here as they're added"
-msgstr "Les champs de cette table apparaîtront ici au fur et à mesure de leur ajout"
+msgstr "Velden in deze tabel worden weergegeven zoals ze zijn toegevoegd"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:137
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
-msgstr "Champs dans {0}"
+msgstr "Velden in {0}"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:152
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
-msgstr "Nom du champ"
+msgstr "Veldnaam"
 
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:49
 msgid "X-ray this field"
-msgstr "Radiographier ce champ"
+msgstr "X-ray dit veld"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:8
 msgid "Metabase is no fun without any data"
-msgstr "Metabase n'est pas amusant sans aucune donnée"
+msgstr "Metabase is niet leuk zonder data"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:9
 msgid "Your databases will appear here once you connect one"
-msgstr "Vos bases de données apparaîtront ici une fois connectées"
+msgstr "Je databases worden hier getoond zodra je verbonden bent met een database"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:10
 msgid "Databases will appear here once your admins have added some"
-msgstr "Les bases de données apparaîtrons ici une fois que vos administrateurs en auront ajoutées"
+msgstr "Databases worden hier weergegeven zodra een beheerder toegang heeft gegeven"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:12
 msgid "Connect a database"
-msgstr "Se connecter à une base de données"
+msgstr "Verbinding maken met database"
 
 #. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
 #. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
-msgstr "Nombre de {0}"
+msgstr "Aantal {0}"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:47
 msgid "See raw data for {0}"
-msgstr "Voir les données brutes pour {0}"
+msgstr "Zie onbewerkte data van {0}"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
-msgstr "Pourquoi cette table est intéressante"
+msgstr "Waarom is deze tabel interessant"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
-msgstr "Choses dont on doit être conscient à propos de cette table"
+msgstr "Dingen waar je op moet letten bij deze tabel"
 
 #: frontend/src/metabase/reference/databases/TableList.jsx:30
 msgid "Tables in this database will appear here as they're added"
-msgstr "Les tables de cette base apparaîtront ici au fur et à mesure de leur ajout"
+msgstr "Tabellen in de database worden hier weergegeven zodra deze zijn toegevoegd"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
 msgid "Questions about this table will appear here as they're added"
-msgstr "Les questions à propos de cette table apparaîtront ici au fur et à mesure de leur ajout"
+msgstr "Vragen m.b.t deze tabel worden hier weergegeven zodra deze zijn toegevoegd"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
-msgstr "Questions sur {0}"
+msgstr "Vragen met betrekking tot {0}"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
-msgstr "{0} créé par {1}"
+msgstr "Toegevoegd {0} door {1}"
 
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:40
 msgid "Fields in this table"
-msgstr "Champs de cette table"
+msgstr "Velden in deze tabel"
 
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:48
 msgid "Questions about this table"
-msgstr "Questions à propos de cette table"
+msgstr "Vragen met betrekking tot deze tabel"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
-msgstr "Aidez votre équipe à se familiariser avec vos données"
+msgstr "Help je team op weg met je data."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
-msgstr "Mettez en avant le plus important pour votre équipe en choisissant vos meilleurs tableaux de bords, métriques et segments."
+msgstr "Laat je team weten wat het belangrijkst is door je top dashboards, metrieken en segmenten te kiezen."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
-msgstr "Commencer"
+msgstr "Begin nu"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
-msgstr "Notre plus important tableau de bord"
+msgstr "Ons meest belangrijke dashboard"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
-msgstr "Chiffres auxquels nous payons attention"
+msgstr "Nummers waar we op letten"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
-msgstr "Les métriques sont les chiffres les plus importants pour votre entreprise. Elles représentent le plus souvent les indicateurs essentiels qui mesurent la performance de votre business."
+msgstr "Metrieken zijn belangrijke nummers waar je bedrijf op let. Vaak geeft dit een goed beeld over hoe het gaat met het bedrijf."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
-msgstr "Voir toutes les métriques"
+msgstr "Bekijk alle metrieken"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
-msgstr "Segments et tables"
+msgstr "Segmenten en tabellen"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:83
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
-msgstr "Tables"
+msgstr "Tabellen"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
-msgstr "Les segments et les table sont les éléments constitutifs des données de votre entreprise. Les tables sont des collections d'informations brutes tandis que les segments sont des tranches spécifiques avec des significations spécifiques, telles que {0}"
+msgstr "Segmenten en tabellen zijn de bouwstenen van de data van je bedrijf. Tabellen zijn collectie van onbewerkte informatie terwijl segmenten specifieke gedeeltes zijn met een specifieke betekenis, zoals {0}"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
-msgstr "Les table sont les blocs de construction des données de votre entreprise."
+msgstr "Tabellen zijn de bouwstenen van de data van je bedrijf. "
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
-msgstr "Voir tous les segments"
+msgstr "Bekijk alle segmenten"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
-msgstr "Voire toutes les tables"
+msgstr "Bekijk alle tabellen"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
-msgstr "Autres choses à savoir sur nos données"
+msgstr "Andere zaken om te weten over je data"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
-msgstr "Trouvez plus de choses"
+msgstr "Meer te weten komen"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
-msgstr "Une bonne façon d'apprendre à connaître vos données est de passer un peu de temps à explorer les diverses tables et autres informations disponibles. Il se peut que cela prenne du temps, mais vous commencerez à reconnaître les noms et significations avec le temps."
+msgstr "Een goede manier om meer te weten te komen over je data is om wat tijd te investeren in het verkennen van verschillende tabellen en andere informatie. Het duurt misschien even, maar je zult al snel namen en betekenissen herkennen na een tijdje."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
-msgstr "Explorez vos données"
+msgstr "Verken onze data"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
-msgstr "Avez vous des questions?"
+msgstr "Heb je vragen?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
-msgstr "Contacter {0}"
+msgstr "Contact {0}"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
-msgstr "Aider les nouveaux utilisateurs de Metabase à trouver leur chemin."
+msgstr "Help nieuwe Metabase gebuikers op weg"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
-msgstr "Le guide de démarrage met en avant les tableaux de bord, métriques, segments et tables qui comptent le plus, et fournit des informations importantes aux utilisateurs avant qu'ils ne commencent à creuser les données."
+msgstr "De handleiding \"Aan de slag\" markeert het dashboard, de statistieken, segmenten en tabellen die er het meest toe doen en informeert je gebruikers over belangrijke dingen die ze moeten weten voordat ze in de gegevens duiken."
 
-#. Existe-t-il ? https://www.lalanguefrancaise.com/orthographe/y-a-t-il-orthographe/
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
-msgstr "Existe-t-il un tableau de bord important pour votre équipe ?"
+msgstr "Is er een belangrijk dashboard voor je team?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
-msgstr "Créer un nouveau tableau de bord maintenant"
+msgstr "Maak nu een nieuw dashboard aan"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
-msgstr "Quel est votre plus important tableau de bord ?"
+msgstr "Wat is het meest belangrijke dashboard>"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
-msgstr "Avez-vous des métriques fréquemment référencées ?"
+msgstr "Heb je vaak bekeken metrieken?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
-msgstr "Apprenez comment définir une métrique"
+msgstr "Leer meer over het definiëren van een metriek."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
-msgstr "Quelles sont vos 3-5 métriques les plus fréquemment référencées ?"
+msgstr "Wat zijn de 3-5 meest gebruikte metrieken?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
-msgstr "Ajouter une autre métrique"
+msgstr "Voeg nog een metriek toe"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
-msgstr "Avez vous des segments fréquemment référencés ?"
+msgstr "Heb je meest bezochte segmenten of tabellen?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
-msgstr "Apprendre comment créer un segment"
+msgstr "Leer meer over het aanmaken van een segment"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
-msgstr "Quelles sont vos 3-5 segments les plus fréquemment référencés ?"
+msgstr "Wat zijn de 3-5 meest bezochte segmenten of tabellen welke het bruikbaarst zijn voor deze doelgroep?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
-msgstr "Ajouter un nouveau segment ou une nouvelle table"
+msgstr "Voeg nog een segment of tabel toe"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
-msgstr "Que devraient comprendre vos utilisateurs avant de commencer à accéder aux données ?"
+msgstr "Is er iets wat je gebruikers moeten weten voordat ze kunnen starten met het bekijken van de data?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
-msgstr "Que devrait savoir un utilisateur de cette donnée avant de commencer à y accéder ?"
+msgstr "Wat zou een gebruiker moeten weten over deze data voordat ze er mee aan de gang gaan?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
-msgstr "Par exemple : Règles d'usage et de confidentialité, erreurs et malentendus fréquents, temps de réponse de l'entrepôt, mentions légales, etc."
+msgstr "Bijvoorbeeld verwachtingen ten aanzien van gegevensprivacy en -gebruik, veelvoorkomende valkuilen of misverstanden, informatie over de prestaties van het datawarehouse, juridische kennisgevingen, etc."
 
-#. Y a-t-il ? https://www.lalanguefrancaise.com/orthographe/y-a-t-il-orthographe/
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
-msgstr "Y a-t-il une personne que vos utilisateurs pourraient contacter s'ils ont besoin d'éclaircissements à propos de ce guide ?"
+msgstr "Is er iemand waar gebruikers contact mee kunnen opnemen voor hulp of wanneer ze iets niet begrijpen uit deze handleiding?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
-msgstr "A qui les utilisateurs pourraient demander de l'aide s'ils ont besoin d'éclaircissements sur ces données ?"
+msgstr "Met wie zouden gebruikers contact op moeten nemen wanneer ze niet uit de data komen?"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:75
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:95
 msgid "Please enter a revision message"
-msgstr "Veuillez saisir un commentaire de révision"
+msgstr "Voeg een omschrijving toe aan deze revisie"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
-msgstr "Pourquoi cette métrique est interessante ?"
+msgstr "Waarom is deze metriek interessant"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
-msgstr "Tout ce qu'il faut savoir sur cette métrique"
+msgstr "Zaken om op te letten over deze metriek"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
-msgstr "Comment cette métrique est calculée"
+msgstr "Hoe wordt deze metriek berekend"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
-msgstr "Rien sur la façon dont c'est calculé pour le moment"
+msgstr "Nog niks over hoe dit berekend wordt."
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
-msgstr "Autres champs d'agrégation possibles pour cette métrique"
+msgstr "Andere velden die gegroepeerd kunnen worden bij deze metriek"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
-msgstr "Champs sur lesquels vous pouvez aggréger cette métrique"
+msgstr "Velden waarop je dit metriek kunt groeperen"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
-msgstr "Les métriques sont les chiffres officiels dont s'occupe votre équipe"
+msgstr "Metrieken zijn de officiële cijfers waar je team om geeft"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
-msgstr "Les métriques apparaîtront ici une fois que les administrateurs en auront créé"
+msgstr "Metrieken worden hier weergegeven zodra je beheerder er een paar hebben aangemaakt"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
-msgstr "Apprendre comment créer des métriques"
+msgstr "Leer meer over het aanmaken van metrieken"
 
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
 msgid "Questions about this metric will appear here as they're added"
-msgstr "Les questions à propos de cette métrique apparaîtront ici au fil du temps"
+msgstr "Vragen met betrekking tot deze metriek komen hier te staan zodra ze zijn toegevoegd"
 
 #: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:29
 msgid "There are no revisions for this metric"
-msgstr "Il n'y pas de modifications pour cette métrique"
+msgstr "Er zijn geen revisies voor deze metriek"
 
 #: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
-msgstr "Historique des modifications pour {0}"
+msgstr "Revisie historie voor {0}"
 
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:43
 msgid "X-ray this metric"
-msgstr "Radiographier cette métrique"
+msgstr "X-ray deze metriek"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
-msgstr "Pourquoi ce segment est intéressant"
+msgstr "Waarom is dit segment interessant"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
-msgstr "Choses dont on doit être conscient à propos de ce segment"
+msgstr "Dingen waarop je moet letten bij dit segment"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
-msgstr "Les segments sont des sous-ensembles remarquables de table"
+msgstr "Segmenten zijn interessante subsets van tabellen"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
-msgstr "Définir des segments communs à votre équipe rend les questions encore plus facile à poser"
+msgstr "Het definiëren van veel gebruikte segmenten helpt je team om nog gemakkelijker nieuwe vragen aan te maken"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
-msgstr "Les segments apparaîtront ici une fois que les administrateurs en auront créé"
+msgstr "Segmenten worden hier getoond zodra je beheerders er een paar hebben aangemaakt."
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
-msgstr "Apprendre comment créer des segments"
+msgstr "Leer meer over het aanmaken van segmenten"
 
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
 msgid "Questions about this segment will appear here as they're added"
-msgstr "Les questions à propos de ce segment apparaîtront ici au fil du temps"
+msgstr "Vragen over dit segment worden hier getoond zodra deze zijn toegevoegd"
 
 #: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:29
 msgid "There are no revisions for this segment"
-msgstr "Il n'y pas de modifications pour ce segment"
+msgstr "Er zijn geen revisies voor dit segment"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:36
 msgid "Fields in this segment"
-msgstr "Champs utilisés dans ce segment"
+msgstr "Velden in dit segment"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:42
 msgid "Questions about this segment"
-msgstr "Questions sur ce segment"
+msgstr "Vragen over dit segment"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:49
 msgid "X-ray this segment"
-msgstr "Radiographier ce segment"
+msgstr "X-ray dit segment"
 
 #: frontend/src/metabase/routes.jsx:182
 msgid "Login"
-msgstr "Se connecter"
+msgstr "Inloggen"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
-msgstr "Rechercher"
+msgstr "Zoeken"
 
 #: frontend/src/metabase/routes.jsx:217
 msgid "Dashboard"
-msgstr "Tableau de bord"
+msgstr "Dashboard"
 
 #: frontend/src/metabase/routes.jsx:228
 msgid "New Question"
-msgstr "Nouvelle question"
+msgstr "Nieuwe vraag"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:125
 msgid "Select the type of Database you use"
-msgstr "Sélectionner le type de base de données que vous utilisez"
+msgstr "Selecteer het type database dat je wilt"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
-msgstr "Ajoutez vos données"
+msgstr "Voeg je data toe"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
-msgstr "J'ajouterai mes données plus tard"
+msgstr "Ik voeg mijn eigen data later toe"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
-msgstr "Connexion en cours à {0}"
+msgstr "Verbinding maken met {0}"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
-msgstr "Vous aurez besoin de quelques informations sur votre base de données, comme le nom d'utilisateur et son mot de passe. Si vous ne les avez pas maintenant, Metabase est aussi fourni avec un jeu de données d'exemple avec lequel vous pouvez démarrer."
+msgstr "Je hebt wat informatie nodig van van je database, zoals de gebruikersnaam en wachtwoord. Metabase komt met een voorbeeld dataset, dus wanneer je deze gegevens nu nog niet hebt kun je al wel starten."
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
-msgstr "J'ajouterai mes données plus tard"
+msgstr "Ik voeg mijn data later toe"
 
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
-msgstr "Contrôler les analyses automatiques"
+msgstr "Automatische scans beheren"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
-msgstr "Préférences relatives aux données d'utilisation"
+msgstr "Gebruiksdatavoorkeuren"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
-msgstr "Merci de nous aider à améliorer Metabase"
+msgstr "Bedankt dat je ons helpt te verbeteren"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
-msgstr "Nous ne collecterons aucun évènement d'utilisation"
+msgstr "We verzamelen geen gebruiker interacties"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
-msgstr "Pour nous aider à améliorer Metabase, nous voudrions collecter certaines données concernant son usage via Google Analytics."
+msgstr "Om ons te helpen Metabase te verbeteren, willen we bepaalde gegevens over het gebruik verzamelen via Google Analytics."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
-msgstr "Voici la liste complète de ce que nous collectons et pourquoi"
+msgstr "Hier is een volledige lijst van alles wat we bijhouden en waarom."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
-msgstr "Permettre à Metabase de collecter anonymement les événements d'utilisation"
+msgstr "Laat Metabase anoniem gebruiksgebeurtenissen verzamelen"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
-msgstr "Metabase {0} ne collecte rien concernant vos données ou les réponses de vos questions."
+msgstr "Metabase verzamelt {0} je gegevens of vraagresultaten."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
-msgstr "jamais"
+msgstr "nooit"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
-msgstr "Toute la collection est complètement anonyme"
+msgstr "Alle collecties zijn volledig anoniem"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
-msgstr "La collection peut être désactivée à tout moment dans vos paramètres d'administration."
+msgstr "Verzameling kan op elk moment in je beheerdersinstellingen worden uitgeschakeld."
 
 #: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
-msgstr "Si vous vous sentez coincé"
+msgstr "Als je er niet uitkomt"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
-msgstr "notre guide de démarrage"
+msgstr "onze beknopte handleiding"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
-msgstr "est à portée de clic."
+msgstr "is slechts een klik verwijderd."
 
 #: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
-msgstr "Bienvenue sur Metabase"
+msgstr "Welkom bij Metabase"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
-msgstr "Tout semble fonctionner. À présent, dites-nous qui vous êtes, connectez vos données et commencez à trouver des réponses !"
+msgstr "Het lijkt er op dat alles werkt. Laten we kennis maken, verbinding maken met je data en starten met het vinden van wat antwoorden!"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
-msgstr "C'est parti"
+msgstr "Laten we starten"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
-msgstr "Tout est configuré !"
+msgstr "Je bent er helemaal klaar voor!"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
-msgstr "Emmenez-moi dans Metabase"
+msgstr "Breng me naar Metabase"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:155
 msgid "What should we call you?"
-msgstr "Comment devez-nous vous appeler ?"
+msgstr "Hoe moeten we je noemen?"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:156
 msgid "Hi, {0}. nice to meet you!"
-msgstr "Bonjour, {0}, ravi de vous rencontrer !"
+msgstr "Hi {0}. leuk om je te ontmoeten!"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:243
 msgid "Create a password"
-msgstr "Créer un mot de passe"
+msgstr "Maak een wachtwoord"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
-msgstr "Chut ..."
+msgstr "Sssssst..."
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:269
 msgid "Confirm password"
-msgstr "Confirmez le mot de passe"
+msgstr "Bevestig wachtwoord"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:278
 msgid "Shhh... but one more time so we get it right"
-msgstr "Chut... une seconde fois de façon à s'en assurer"
+msgstr "Sssssst... maar nog een keer zodat we het zeker weten"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:287
 msgid "Your company or team name"
-msgstr "Votre nom d'entreprise ou d'équipe"
+msgstr "Je bedrijfsnaam of team naam"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:296
 msgid "Department of awesome"
-msgstr "Bureau des prodiges"
+msgstr "Geweldige afdeling"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:26
 msgid "Metabot is admiring your integers…"
-msgstr "MetaBot est en admiration devant vos chiffres..."
+msgstr "Metabot bewondert je getallen..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:27
 msgid "Metabot is performing billions of differential equations…"
-msgstr "MetaBot effectue des milliards d'équations différentielles ..."
+msgstr "Metabot voert miljarden differentiaalvergelijkingen uit..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:28
 msgid "Metabot is doing science…"
-msgstr "MetaBot fait de la science ..."
+msgstr "Metabot doet aan wetenschap..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:29
 msgid "Metabot is checking out your metrics…"
-msgstr "MetaBot vérifie vos métriques ..."
+msgstr "Metabot controleert je statistieken..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:30
 msgid "Metabot is looking for trends and outliers…"
-msgstr "MetaBot recherche des tendances et des valeurs aberrantes ..."
+msgstr "Metabot is op zoek naar trends en uitbijters..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:31
 msgid "Metabot is consulting the quantum abacus…"
-msgstr "MetaBot consulte l'abaque quantique ..."
+msgstr "Metabot raadpleegt het kwantum telraam..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:32
 msgid "Metabot is feeling pretty good about all this…"
-msgstr "MetaBot se sent bien dans tout ça ..."
+msgstr "Metabot voelt zich behoorlijk goed over dit alles..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:52
 msgid "We’ll show you some interesting explorations of your data in\n"
 "just a few minutes."
-msgstr " Nous vous montrerons quelques explorations intéressantes de vos données en quelques minutes."
+msgstr "We laten je enkele interessante verkenningen van je gegevens zien binnen enkele minuten."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:72
 msgid "This seems to be taking a while. In the meantime, you can check out one of these example explorations to see what Metabase can do for you."
-msgstr "Cela semble prendre un certain temps. En attendant, vous pouvez consulter l'une de ces explorations pour voir ce que Metabase peut faire pour vous."
+msgstr "Dit lijkt even te duren. Ondertussen kun je een van deze voorbeeldverkenningen bekijken om te zien wat Metabase voor je kan doen."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:86
 msgid "I took a look at the data you just connected, and I have some explorations of interesting things I found. Hope you like them!"
-msgstr "J'ai jeté un coup d'oeil aux données que vous venez de connecter et j'ai des explorations  intéressantes à vous montrer. J'espère que vous les aimerez!"
+msgstr "Ik heb de gegevens bekeken die je zojuist hebt toegevoegd, enkele verkenningen uitgevoerd en interessante dingen gevonden. Ik hoop dat je ze leuk vindt!"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:98
 msgid "I'm done exploring for now"
-msgstr "J'ai fini d'explorer pour l'instant"
+msgstr "Ik ben kaar met verkennen voor nu"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:20
 msgid "Welcome to the Query Builder!"
-msgstr "Bienvenue dans le générateur de requêtes!"
+msgstr "Welkom bij de Query Builder!"
 
-#. proposition pour fluidifier la formulation
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:22
 msgid "The Query Builder lets you assemble questions (or \"queries\") to ask about your data."
-msgstr "Le générateur de requêtes vous permet d'assembler des questions (ou des «requêtes») pour interroger vos données."
+msgstr "Met Query Builder kun je vragen (of \"query's\") samenstellen om je gegevens op te vragen."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:26
 msgid "Tell me more"
-msgstr "Dites-m'en plus"
+msgstr "Vertel me meer"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:43
 msgid "Start by picking the table with the data that you have a question about."
-msgstr "Commencez par choisir la table contenant les données à questionner."
+msgstr "Begin met het kiezen van de tabel met de gegevens waarover je een vraag hebt."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:45
 msgid "Go ahead and select the \"Orders\" table from the dropdown menu."
-msgstr "Lancez vous et sélectionnez la table \"Orders\" dans le menu déroulant."
+msgstr "Ga je gang en selecteer de tabel \"Orders\" in het vervolgkeuzemenu."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:78
 msgid "Filter your data to get just what you want."
-msgstr "Filtrez vos données pour obtenir exactement ce que vous voulez."
+msgstr "Filter de gegevens om precies te krijgen wat je wilt."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:79
 msgid "Click the plus button and select the \"Created At\" field."
-msgstr "Cliquez sur le bouton plus et sélectionnez le champ \"Created at\"."
+msgstr "Klik op de plusknop en selecteer het veld \"Created At\"."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:93
 msgid "Here we can pick how many days we want to see data for, try 10"
-msgstr "Ici nous pouvons choisir sur combien de jours passés nous voulons voir les données, essayez 10"
+msgstr "Hier kunnen we kiezen voor hoeveel dagen we gegevens willen zien, probeer eens 10"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:116
 msgid "Here's where you can choose to add or average your data, count the number of rows in the table, or just view the raw data."
-msgstr "Ici, vous pouvez choisir d'ajouter ou agréger vos données, compter le nombre de lignes dans la table ou simplement afficher les données brutes."
+msgstr "Hier kun je ervoor kiezen om gegevens toe te voegen, een gemiddelde te maken, het aantal rijen in de tabel te tellen of gewoon de onbewerkte gegevens te bekijken."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:118
 msgid "Try it: click on <strong>Raw Data</strong> to change it to <strong>Count of rows</strong> so we can count how many orders there are in this table."
-msgstr "Essayez : cliquez sur \"Données brutes\" pour le changer en \"Nombre de lignes\" de façon à compter combien de commandes il y a dans cette table."
+msgstr "Probeer het: klik op <strong> Onbewerkte gegevens </strong> om het te wijzigen in <strong> Aantal rijen </strong> zodat we kunnen tellen hoeveel bestellingen er in deze tabel staan."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:142
 msgid "Add a grouping to break out your results by category, day, month, and more."
-msgstr "Ajoutez une agrégation pour éclater vos résultats par catégorie, jour, mois et plus."
+msgstr "Voeg een groep toe om uw resultaten te splitsen op categorie, dag, maand en meer."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:144
 msgid "Let's do it: click on <strong>Add a grouping</strong>, and choose <strong>Created At: by Week</strong>."
-msgstr "Faisons cela : cliquons sur \"Ajouter une agrégation\", et choisissons \"Created At: par Semaine\""
+msgstr "Laten we het doen: klik op <strong> Een groep toevoegen </strong> en kies <strong> Gemaakt op: per week </strong>."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:152
 msgid "Click on \"by day\" to change it to \"Week.\""
-msgstr "Cliquez sur \"par jour\" pour le changer en \"Semaine\"."
+msgstr "Klik op 'overdag' om het te wijzigen in 'Week'."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:173
 msgid "Run Your Query."
-msgstr "Exécuter votre requête."
+msgstr "Voer uw zoekopdracht uit."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:175
 msgid "You're doing so well! Click <strong>Run query</strong> to get your results!"
-msgstr "Vous faites si bien ! Cliquez sur <strong>Lancer la requête</strong> pour obtenir vos résultats !"
+msgstr "Je doet het zo goed! Klik op <strong> Zoekopdracht uitvoeren </strong> om de resultaten te krijgen!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:192
 msgid "You can view your results as a chart instead of a table."
-msgstr "Vous pouvez afficher vos résultats sous forme de graphique au lieu d'un tableau."
+msgstr "Je kunt de resultaten bekijken als een grafiek in plaats van een tabel."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:194
 msgid "Everbody likes charts! Click the <strong>Visualization</strong> dropdown and select <strong>Line</strong>."
-msgstr "Tout le monde aime les graphiques ! Cliquez sur le menu déroulant <strong>Visualisation</strong> et sélectionnez <strong>Courbe</strong>"
+msgstr "Iedereen houdt van grafieken! Klik op de keuzelijst <strong> Visualisatie </strong> en selecteer <strong> Lijn </strong>."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:216
 msgid "Well done!"
-msgstr "Bien joué!"
+msgstr "Goed gedaan!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:218
 msgid "That's all! If you still have questions, check out our"
-msgstr "C'est tout! Si vous avez encore des questions, consultez notre"
+msgstr "Dat is alles! Als je nog vragen hebt, bekijk dan onze"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "User's Guide"
-msgstr "Guide de l'utilisateur"
+msgstr "handleiding"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "Have fun exploring your data!"
-msgstr "Amusez-vous à explorer vos données!"
+msgstr "Veel plezier met het verkennen van je gegevens!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:226
 msgid "Thanks"
-msgstr "Merci"
+msgstr "Bedankt!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:235
 msgid "Save Your Questions"
-msgstr "Sauvegardez vos questions"
+msgstr "Sla je vraag op"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:237
 msgid "By the way, you can save your questions so you can refer to them later. Saved Questions can also be put into dashboards or Pulses."
-msgstr "Par ailleurs, vous pouvez sauvegarder votre question pour la retrouver plus tard. Les questions sauvegardées peuvent aussi être aujoutées aux tableaux de bords ou aux Pulses."
+msgstr "Trouwens, je kunt je vragen opslaan zodat je ze later kunt raadplegen. Opgeslagen vragen kunnen ook in dashboards of pulsen worden geplaatst."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:241
 msgid "Sounds good"
-msgstr "Ça m'a l'air bien"
+msgstr "Klinkt goed"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:248
 msgid "Whoops!"
-msgstr "Oups!"
+msgstr "Whoeps"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:249
 msgid "Sorry, it looks like something went wrong. Please try restarting the tutorial in a minute."
-msgstr "Désolé, il semble que quelque chose se soit mal passé. Essayez s'il vous plaît de redémarrer cette présentation dans une minute."
+msgstr "Sorry, het lijkt erop dat er iets mis is gegaan. Probeer de tutorial zo opnieuw te starten."
 
 #: frontend/src/metabase/user/actions.js:34
 msgid "Password updated successfully!"
-msgstr "Mot de passe mis à jour avec succès!"
+msgstr "Wachtwoord succesvol bijgewerkt!"
 
 #: frontend/src/metabase/user/actions.js:53
 msgid "Account updated successfully!"
-msgstr "Compte mis à jour avec succès!"
+msgstr "Account succesvol bijgewerkt!"
 
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:107
 msgid "Current password"
-msgstr "Mot de passe actuel"
+msgstr "Huidig wachtwoord"
 
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:137
 msgid "Sign in with Google Email address"
-msgstr "Se connecter avec Google"
+msgstr "Log in met je Google E-mailadres"
 
 #: frontend/src/metabase/user/components/UserSettings.jsx:65
 msgid "User Details"
-msgstr "Détails de l'utilisateur"
+msgstr "Gebruikersdetails"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
-msgstr "Réinitialiser"
+msgstr "Terugzetten naar standaard waardes"
 
 #: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
-msgstr "carte inconnue"
+msgstr "Onbekende kaart"
 
 #: frontend/src/metabase/visualizations/components/LeafletGridHeatMap.jsx:26
 msgid "Grid map requires binned longitude/latitude."
-msgstr "Une carte à quadrillage nécessite un regroupement (binning) de la latitude et de la longitude."
+msgstr "Voor een rasterkaart is lengte- / breedtegraad vereist."
 
 #: frontend/src/metabase/visualizations/components/LegendVertical.jsx:112
 msgid "more"
-msgstr "plus"
+msgstr "Meer"
 
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
-msgstr "Quels champs voulez-vous utiliser pour les axes X et Y ?"
+msgstr "Welke velden wil je gebruiken voor de X- en Y-assen?"
 
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
-msgstr "Choisissez les champs"
+msgstr "Velden kiezen"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
-msgstr "Sauvegarder comme vue par défaut"
+msgstr "Opslaan als standaard weergave"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
-msgstr "Dessiner un rectangle d'intérêt pour filtrer"
+msgstr "Teken een box om te filteren"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
-msgstr "Annuler le filtre"
+msgstr "Annuleer filter"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:47
 msgid "Pin Map"
-msgstr "Carte à épîngles"
+msgstr "Kaart pinnen"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
-msgstr "Désactiver"
+msgstr "Leegmaken"
 
 #: frontend/src/metabase/visualizations/components/TableSimple.jsx:253
 msgid "Rows {0}-{1} of {2}"
-msgstr "Lignes {0}-{1} parmi {2}"
+msgstr "Rijen {0}-{1} van {2}"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
-msgstr "Données tronquées à {0} lignes."
+msgstr "Gegevens afgekapt tot {0} rijen."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
-msgstr "Impossible de trouver la visualisation"
+msgstr "Kan visualisatie niet vinden"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
-msgstr "Impossible d'afficher cet graphique avec ces données."
+msgstr "Kan deze grafiek niet met deze gegevens weergeven."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
-msgstr "Pas de résultat!"
+msgstr "Geen resultaten"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
-msgstr "Toujours en attente..."
+msgstr "Nog steeds bezig met wachten..."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
-msgstr "Cela prend habituellement en moyenne {0}."
+msgstr "Dit duurt meestal gemiddeld {0}."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
-msgstr "(C'est un peu long pour un tableau de bord)"
+msgstr "(Dit is een beetje lang voor een dashboard)"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:503
 msgid "This is usually pretty fast but seems to be taking awhile right now."
-msgstr "C'est habituellement rapide mais il semble que cela commence à durer maintenant."
+msgstr "Dit is meestal vrij snel, maar lijkt nu even te duren."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:36
 msgid "Select a field"
-msgstr "Sélectionner un champ"
+msgstr "Selecteer een veld"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:45
 msgid "error"
-msgstr "erreur"
+msgstr "fout"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
-msgstr "Cliquer et Glisser pour changer leur ordre"
+msgstr "Klik en versleep om de volgorde te veranderen"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
-msgstr "Ajouter des champs depuis la liste ci-dessous"
+msgstr "Voeg velden toe van de lijst hieronder"
 
-#. Quand une cellule de cette colonne est...
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:24
 msgid "less than"
-msgstr "inférieure"
+msgstr "Minder dan"
 
-#. Quand une cellule de cette colonne est...
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:25
 msgid "greater than"
-msgstr "supérieure"
+msgstr "Groter dan"
 
-#. Quand une cellule de cette colonne est...
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "less than or equal to"
-msgstr "inférieure ou égale"
+msgstr "Minder dan of gelijk aan"
 
-#. Quand une cellule de cette colonne est...
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "greater than or equal to"
-msgstr "supérieure ou égale"
+msgstr "Groter dan of gelijk aan"
 
-#. Quand une cellule de cette colonne est...
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:28
 msgid "equal to"
-msgstr "égale à"
+msgstr "Gelijk aan"
 
-#. Quand une cellule de cette colonne est...
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:29
 msgid "not equal to"
-msgstr "différente de"
+msgstr "Niet gelijk aan"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:191
 msgid "Conditional formatting"
-msgstr "Formatage conditionnel"
+msgstr "Conditionele opmaak"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:193
 msgid "You can add rules to make the cells in this table change color if\n"
 "they meet certain conditions."
-msgstr "Vous pouvez ajouter des règles pour faire changer les cellules de couleur dans cette table, si elles remplissent certaines conditions."
+msgstr "Je kan condities toevoegen om cellen in de tabel van kleur te laten veranderen wanneer deze hieraan voldoen."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:203
 msgid "Add a rule"
-msgstr "Ajouter une règle"
+msgstr "Een regel toevoegen"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:208
 msgid "Rules will be applied in this order"
-msgstr "Les règles seront appliquées dans cet ordre"
+msgstr "Condities worden in deze volgorde uitgevoerd"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:209
 msgid "Click and drag to reorder."
-msgstr "Cliquer et glisser pour changer l'ordre"
+msgstr "Klik en versleep om te verplaaten"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:242
 msgid "No columns selected"
-msgstr "Pas de colonne sélectionnée"
+msgstr "Geen kolommen geselecteerd"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:290
 msgid "Cells in this column will be tinted based on their values."
-msgstr "Les cellules de cette colonne seront teintées selon leur valeur."
+msgstr "Cellen in deze kolom zullen ingekleurd worden op basis van hun waardes."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:279
 msgid "When a cell in these columns is {0} it will be tinted this color."
-msgstr "Quand une cellule dans ces colonnes est {0} elle sera teinté de cette couleur."
+msgstr "Wanneer een cel in deze kolom {0} is wordt deze ingekleurd."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:313
 msgid "Which columns should be affected?"
-msgstr "Quelles colonnes devraient être affectées ?"
+msgstr "Welke kolommen moeten worden beïnvloed?"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:335
 msgid "Formatting style"
-msgstr "Style de formatage"
+msgstr "Opmaakstijl"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:339
 msgid "Single color"
-msgstr "Couleur unique"
+msgstr "Enkele kleur"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:340
 msgid "Color range"
-msgstr "Plage de couleur"
+msgstr "Kleuren reeks"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:312
 msgid "When a cell in this column is…"
-msgstr "Quand une cellule de cette colonne est ..."
+msgstr "Wanneer een cel in deze kolom is..."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:376
 msgid "…turn its background this color:"
-msgstr "... changer son arrière-plan dans cette couleur :"
+msgstr "...verander de achtergrond in deze kleur:"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:382
 msgid "Highlight the whole row"
-msgstr "Surligner toute la ligne"
+msgstr "Markeer de hele rij"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
-msgstr "Couleurs"
+msgstr "Kleuren"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:404
 msgid "Start the range at"
-msgstr "Commencer la plage à"
+msgstr "Start de reeks met"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:409
 msgid "Smallest value in this column"
-msgstr "Plus petite valeur dans cette colonne"
+msgstr "De laagste waarde in deze kolom"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:411
 msgid "Smallest value in each column"
-msgstr "Plus petite valeur dans chaque colonne"
+msgstr "De laagste waarde in elke kolom"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:413
 msgid "Smallest value in all of these columns"
-msgstr "Plus petite valeur dans toutes ces colonnes"
+msgstr "De laagste waarde van al deze kolommen"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:417
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:441
 msgid "Custom value"
-msgstr "Valeur personnalisée"
+msgstr "Aangepaste waarde"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:428
 msgid "End the range at"
-msgstr "Arrêter la plage à"
+msgstr "Eindig de reeks met"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:433
 msgid "Largest value in this column"
-msgstr "Plus grande valeur dans cette colonne"
+msgstr "De hoogste waarde in deze kolom"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:435
 msgid "Largest value in each column"
-msgstr "Plus grande valeur dans chaque colonne"
+msgstr "De hoogste waarde in elke kolom"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:437
 msgid "Largest value in all of these columns"
-msgstr "Plus grande valeur dans toutes ces colonnes"
+msgstr "De hoogste waarde van al deze kolommen"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:471
 msgid "Add rule"
-msgstr "Ajouter une règle"
+msgstr "Regel toevoegen"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:471
 msgid "Update rule"
-msgstr "Mettre à jour la règle"
+msgstr "Regel bewerken"
 
 #: frontend/src/metabase/visualizations/index.js:33
 msgid "Visualization is null"
-msgstr "La visualisation est nulle"
+msgstr "Visualisatie is leeg"
 
 #: frontend/src/metabase/visualizations/index.js:38
 msgid "Visualization must define an 'identifier' static variable: "
-msgstr "La visualisation doit définir une variable statique d'identifiant : "
+msgstr "Visualisatie moet een statische variabele 'identifier' definiëren:"
 
 #: frontend/src/metabase/visualizations/index.js:44
 msgid "Visualization with that identifier is already registered: "
-msgstr "Une visualisation avec cet identifiant est déjà enregistrée : "
+msgstr "Visualisatie met deze identificatie is al geregistreerd:"
 
 #: frontend/src/metabase/visualizations/index.js:72
 msgid "No visualization for {0}"
-msgstr "Aucune visualisation pour {0}"
+msgstr "Geen visualisatie voor {0}"
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
-msgstr "\"{0}\" est un champ non agrégé : S'il a plus d'une valeur pour une abscisse donnée, les valeurs seront additionnées."
+msgstr "\"{0}\" is een niet-geaggregeerd veld: als het op een punt op de x-as meer dan één waarde heeft, worden de waarden opgeteld."
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
-msgstr "Ce type de graphique nécessite au moins 2 colonnes."
+msgstr "Voor dit grafiektype zijn minimaal 2 kolommen vereist."
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
-msgstr "Ce type de graphique ne prend pas en charge plus de {0} séries de données."
+msgstr "Dit grafiektype ondersteunt niet meer dan {0} gegevensreeksen."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:297
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
-msgstr "Objectif"
+msgstr "Doel"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
-msgstr "Le résultat de votre requête n'est pas adapté au rendu choisi. Cette visualisation nécessite au moins {0} {1} de données."
+msgstr "Doh! De gegevens van je zoekopdracht passen niet in de gekozen weergave. Deze visualisatie vereist ten minste {0} {1} aan gegevens."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgid_plural "columns"
-msgstr[0] "colonne"
-msgstr[1] "colonnes"
+msgstr[0] "Kolom"
+msgstr[1] "Kolommen"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "No dice. We have {0} data {1} to show and that's not enough for this visualization."
-msgstr "Peine perdue. Nous avons {0} donnée {1} à présenter et ce n'est pas assez pour cette visualisation."
+msgstr "Geen idee. We hebben {0} gegevens {1} om te tonen en dat is niet genoeg voor deze visualisatie."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "point"
 msgid_plural "points"
-msgstr[0] "point"
-msgstr[1] "points"
+msgstr[0] "punt"
+msgstr[1] "punten"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:35
 msgid "Bummer. We can't actually do a pin map for this data because we require both a latitude and longitude column."
-msgstr "Nous ne pouvons pas construire une carte à épingles pour cette donnée car cela nécessite à la fois une colonne de latitude et une colonne de longitude."
+msgstr "Jammer. We kunnen eigenlijk geen pinmap maken voor deze gegevens omdat we zowel een lengte- als een breedtegraadkolom nodig hebben."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:55
 msgid "Please configure this chart in the chart settings"
-msgstr "Configurez s'il vous plaît ce graphique"
+msgstr "Configureer deze grafiek in de grafiekinstellingen"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:57
 msgid "Edit Settings"
-msgstr "Modifier les paramètres de configuration"
+msgstr "Instellingen wijzigen"
 
 #: frontend/src/metabase/visualizations/lib/fill_data.js:37
 msgid "xValues missing!"
-msgstr "Des valeurs sont manquantes !"
+msgstr "xWaardes missen!"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
-msgstr "Abscisses"
+msgstr "X-as"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
-msgstr "Eclater en plusieurs séries..."
+msgstr "Voeg een serie breakout toe ..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
-msgstr "Ordonnées"
+msgstr "Y-as"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
-msgstr "Ajouter une autre série..."
+msgstr "Voeg nog een serie toe"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
-msgstr "Taille des bulles"
+msgstr "Bubble grootte"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:16
 msgid "Line"
-msgstr "Ligne"
+msgstr "Lijn"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:72
 msgid "Curve"
-msgstr "Courbe"
+msgstr "Boog"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
-msgstr "Etape"
+msgstr "Stap"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:170
 msgid "Show point markers on lines"
-msgstr "Afficher des puces sur les lignes"
+msgstr "Toon puntmarkeringen op lijnen"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
-msgstr "Empilement"
+msgstr "Stapelen"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
-msgstr "Ne pas empiler"
+msgstr "Niet stapelen"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
-msgstr "Empiler (Diagramme à bandes en effectifs)"
+msgstr "Stapelen"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
-msgstr "Empiler - 100% (Diagramme à bandes en fréquence)"
+msgstr "100% stapelen"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
-msgstr "Afficher l'objectif"
+msgstr "Doel weergeven"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
-msgstr "Valeur de l'objectif"
+msgstr "Doel waarde"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:103
 msgid "Replace missing values with"
-msgstr "Remplacer les valeurs manquantes par"
+msgstr "Vervang missende waardes met"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:107
 msgid "Zero"
-msgstr "Zéro"
+msgstr "Nul"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:108
 msgid "Nothing"
-msgstr "Rien"
+msgstr "Niks"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:109
 msgid "Linear Interpolated"
-msgstr "Interpolation linéaire"
+msgstr "Lineaire geïnterpoleerd"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
-msgstr "Echelle des abscisses"
+msgstr "X-as schaal"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
-msgstr "Séries temporelles"
+msgstr "Tijdreeksen"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:381
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
-msgstr "Linéaire"
+msgstr "Lineair"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:383
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
-msgstr "Exponentielle"
+msgstr "machtsverheffen"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:384
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
-msgstr "Logarithmique"
+msgstr "logaritmisch"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
-msgstr "Histogramme"
+msgstr "Histogram"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
-msgstr "Ordinal"
+msgstr "Rangschikkend"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
-msgstr "Echelle des ordonnées"
+msgstr "Y-as schaal"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
-msgstr "Afficher l'axe des abscisses et ses graduations"
+msgstr "X-aslijn en markeringen weergeven"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
-msgstr "Compacte"
+msgstr "Compact"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
-msgstr "Tourner de 45°"
+msgstr "Roteer 45°"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
-msgstr "Tourner de 90°"
+msgstr "Roteer 90°"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
-msgstr "Afficher l'axe des ordonnées et ses graduations"
+msgstr "Y-aslijn en markeringen weergeven"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
-msgstr "Mise à l'échelle automatique des ordonnées"
+msgstr "Automatisch Y-as bereik"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
-msgstr "Utiliser deux axes d'ordonnées si nécessaire"
+msgstr "Gebruik indien nodig een gesplitste Y-as"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
-msgstr "Afficher le libellé des abscisses"
+msgstr "Labels weergeven op X-as"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
-msgstr "Libellé des abscisses"
+msgstr "X-as label"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
-msgstr "Afficher le libellé des ordonnées"
+msgstr "Label weergeven op Y-as"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
-msgstr "Libellé des ordonnées"
+msgstr "Y-as label"
 
 #: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
-msgstr "Ecart-type"
+msgstr "Standaardafwijking"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
-msgstr "Surface"
+msgstr "Vlak"
 
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
-msgstr "Histogramme"
+msgstr "vlakdiagram"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
-msgstr "Histogramme"
+msgstr "Staaf"
 
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
-msgstr "diagramme en colonnes"
+msgstr "staaf diagram"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
-msgstr "Quels champs voulez-vous utiliser ?"
+msgstr "Welke velden wil je gebruiken?"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
-msgstr "Entonnoir"
+msgstr "Trechter"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
-msgstr "Mesure"
+msgstr "Maatstaaf"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
-msgstr "Type d'entonnoir"
+msgstr "Trechter type"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
-msgstr "Diagramme en colonnes"
+msgstr "Staaf diagram"
 
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:19
 msgid "line chart"
-msgstr "Courbe"
+msgstr "Lijn diagram"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
-msgstr "Choisissez s'il vous plaît les colonnes de longitude et latitude."
+msgstr "Selecteer lengte- en breedtegraadkolommen in de grafiekinstellingen."
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
-msgstr "Choisissez s'il vous plaît une carte régionale."
+msgstr "Selecteer een regio"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 msgid "Please select region and metric columns in the chart settings."
-msgstr "Choisissez s'il vous plaît les colonnes de métrique et de région."
+msgstr "Selecteer een regio en kolommen in de grafiek instellingen"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
-msgstr "Carte"
+msgstr "Kaart"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
-msgstr "Type de carte"
+msgstr "Kaart type"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
-msgstr "Carte régionale"
+msgstr "Regio kaart"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
-msgstr "Carte à épingles"
+msgstr "Marker kaart"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
-msgstr "Type d'épingle"
+msgstr "Marker type"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
-msgstr "Tuiles"
+msgstr "Tegels"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
-msgstr "Puces"
+msgstr "Markers"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
-msgstr "Champ latitude"
+msgstr "Latitude veld"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
-msgstr "Champ longitude"
+msgstr "Longitude veld"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
-msgstr "Champ de métrique"
+msgstr "Metriek veld"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
-msgstr "Champ de région"
+msgstr "Regio veld"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
-msgstr "Rayon"
+msgstr "Redius"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
-msgstr "Flouter"
+msgstr "Blur"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
-msgstr "Opacité minimale"
+msgstr "Minimale doorzichtigheid"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
-msgstr "Zoom maximum"
+msgstr "Maximale zoom"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
-msgstr "Aucune relation trouvée."
+msgstr "Geen relaties gevonden"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
@@ -7075,197 +7045,197 @@ msgstr "via {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
-msgstr "Ce/cette {0} est relié(e) à :"
+msgstr "Deze {0} is verbonden aan"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
-msgstr "Détail de l'objet"
+msgstr "Object detail"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
-msgstr "objet"
+msgstr "object"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
-msgstr "Total"
+msgstr "Totaal"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
-msgstr "Quelles colonnes voulez-vous utiliser ?"
+msgstr "Welke kolommen wil je gebruiken?"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
-msgstr "Pie"
+msgstr "Taart"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
-msgstr "Dimension"
+msgstr "Dimensie"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
-msgstr "Montrer la légende"
+msgstr "Legenda tonen"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
-msgstr "Montrer les pourcentages en légende"
+msgstr "Percentages weergeven in legende"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
-msgstr "Pourcentage minimum d'une part"
+msgstr "Minimaal percentage per vlak"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
-msgstr "Objectif atteint"
+msgstr "Doel bereikt"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
-msgstr "Objectif dépassé"
+msgstr "Doel overschreden"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
-msgstr "Objectif {0}"
+msgstr "Doel {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
-msgstr "La visualisation en barre de progession nécessite un nombre."
+msgstr "Vooruitgangsvisualisatie vereist een nummer."
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:27
 msgid "Progress"
-msgstr "Barre de progession"
+msgstr "Vooruitgang"
 
 #: frontend/src/metabase/entities/collections.js:109
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
-msgstr "Couleur"
+msgstr "Kleur"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row Chart"
-msgstr "Graphique en lignes"
+msgstr "Rij grafiek"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
-msgstr "graphique en lignes"
+msgstr "rij grafiek"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
-msgstr "Style de séparateur"
+msgstr "Separator-stijl"
 
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:88
 msgid "Number of decimal places"
-msgstr "Nombre de décimales"
+msgstr "Aantal decimalen"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
-msgstr "Ajouter un préfixe"
+msgstr "Voorvoegsel toevoegen"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
-msgstr "Ajouter un suffixe"
+msgstr "Achtervoegsel toevoegen"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
-msgstr "Coefficient multiplicateur"
+msgstr "Vermenigvuldig met een getal"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
-msgstr "Nuage de points"
+msgstr "Spreiding"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
-msgstr "nuage de points"
+msgstr "spreidingsplot"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
-msgstr "Pivoter cette table"
+msgstr "Draai de tabel"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:73
 msgid "Visible fields"
-msgstr "Champs visibles"
+msgstr "Zichtbare velden"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
 msgid "Write here, and use Markdown if you'd like"
-msgstr "Saisissez du texte ici, et utiliser du Markdown si vous le souhaitez"
+msgstr "Schrijf hier en gebruik Markdown als je wilt"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
 msgid "Vertical Alignment"
-msgstr "Alignement vertical"
+msgstr "Verticale uitlijning"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:77
 msgid "Top"
-msgstr "Haut"
+msgstr "Boven"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:78
 msgid "Middle"
-msgstr "Milieu"
+msgstr "Midden"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:79
 msgid "Bottom"
-msgstr "Bas"
+msgstr "Onder"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:86
 msgid "Horizontal Alignment"
-msgstr "Alignement horizontal"
+msgstr "Horizontale uitlijning"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:126
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:90
 msgid "Left"
-msgstr "Gauche"
+msgstr "Links"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:91
 msgid "Center"
-msgstr "Centrer"
+msgstr "Midden"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:127
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:92
 msgid "Right"
-msgstr "Droite"
+msgstr "Rechts"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:99
 msgid "Show background"
-msgstr "Montrer l'arrière plan"
+msgstr "Achtergrond weergeven"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
-msgstr[0] "{0} cellule"
-msgstr[1] "{0} cellules"
+msgstr[0] "bak"
+msgstr[1] "bakken"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:731
 msgid "Auto binned"
-msgstr "Binning automatique"
+msgstr "Automatisch toegevoegd aan bak"
 
 #: src/metabase/api/alert.clj
 msgid "DELETE /api/alert/:id is deprecated. Instead, change its `archived` value via PUT /api/alert/:id."
-msgstr "l'usage de DELETE /api/alert/:id n'est plus encouragé. A la place, changez sa valeur à `archived` via PUT /api/alert/:id."
+msgstr "DELETE /api/alert/:id is verouderd. Wijzig in plaats daarvan de `gearchiveerde` waarde via PUT /api/alert/:id"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid show value"
-msgstr "Valeur de présentation invalide"
+msgstr "ongeldige showwaarde"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid value for prefix"
-msgstr "Valeur de préfixe invalide"
+msgstr "ongeldige waarde voor voorvoegsel"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid value for rule name"
-msgstr "Valeur de nom de règle invalide"
+msgstr "ongeldige waarde voor regelnaam"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "value couldn''t be parsed as base64 encoded JSON"
-msgstr "la valeur n'a pas pu être analysée comme du JSON encodé en base64"
+msgstr "waarde kon niet worden ontleed als base64 gecodeerde JSON"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid entity type"
-msgstr "Type d'entité invalide"
+msgstr "Ongeldig entiteitstype"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid comparison entity type. Can only be one of \"table\", \"segment\", or \"adhoc\""
-msgstr "Type d'entité de comparaison invalide. Peut seulement prendre ses valeurs dans \"table\", \"segment\" ou \"adhoc\""
+msgstr "Ongeldig type vergelijkingsentiteit. Kan alleen een van 'tabel', 'segment' of 'adhoc' zijn"
 
 #: src/metabase/query_processor/async.clj
 msgid "Error running query to determine Card result metadata:"
-msgstr "Erreur lors de la détermination des métadonnées du résultat de la Carte :"
+msgstr "Fout bij uitvoeren van zoekopdracht om kaartmetagegevens te bepalen:"
 
 #: src/metabase/api/card.clj
 msgid "DELETE /api/card/:id is deprecated. Instead, change its `archived` value via PUT /api/card/:id."
@@ -7273,92 +7243,92 @@ msgstr "DELETE /api/card/:id is deprecated. Instead, change its `archived` value
 
 #: src/metabase/api/common.clj src/metabase/api/common/internal.clj
 msgid "Invalid field: {0}"
-msgstr "Champ invalide : {0}"
+msgstr "Ongeldig veld: {0}"
 
 #: src/metabase/api/common.clj
 msgid "Invalid value ''{0}'' for ''{1}'': {2}"
-msgstr "Valeur invalide \"{0}\" pour \"{1}\" : {2}"
+msgstr "Ongeldige waarde ''{0}'' voor ''{1}'': {2}"
 
 #: src/metabase/api/common.clj
 msgid "must be one of: {0}"
-msgstr "doit prendre ses valeurs parmi : {0}"
+msgstr "Moet een van {0} zijn"
 
 #: src/metabase/api/common.clj
 msgid "Invalid Request."
-msgstr "Requête invalide"
+msgstr "Ongeldig verzoek."
 
 #: src/metabase/api/common.clj
 msgid "Not found."
-msgstr "Non trouvé."
+msgstr "Niet gevonden"
 
 #: src/metabase/api/common.clj
 msgid "You don''t have permissions to do that."
-msgstr "Vous n'avez pas les permissions requises."
+msgstr "U hebt geen rechten om dat te doen."
 
 #: src/metabase/api/common.clj
 msgid "Internal server error."
-msgstr "Erreur interne du serveur."
+msgstr "Interne server foutmelding"
 
 #: src/metabase/api/common.clj
 msgid "Warning: endpoint {0}/{1} does not have a docstring."
-msgstr "Avertissement : l'endpoint {0}/{1} n'a pas de docstring."
+msgstr "Waarschunwing: endpoint {0}/{1} heeft geen docstring."
 
 #: src/metabase/api/common.clj
 msgid "starting streaming request"
-msgstr "démarrage de la requête de flux"
+msgstr "Starten met streamen van request"
 
 #: src/metabase/async/api_response.clj
 msgid "connection closed, canceling request"
-msgstr "connexion fermée, requête en cours d'annulation"
+msgstr "Connectie gesloten, verzoek annuleren"
 
 #. a newline padding character as it's harmless and will allow us to check if the client is connected. If
 #. sending this character fails because the connection is closed, the chan will then close.  Newlines are
 #. no-ops when reading JSON which this depends upon.
 #: src/metabase/async/api_response.clj
 msgid "Response not ready, writing one byte & sleeping..."
-msgstr "Réponse pas encore prête, écriture d'un octet & mise en sommeil..."
+msgstr "Reactie is niet klaar, 1 byte schrijven & slapen..."
 
 #: src/metabase/api/common.clj
 msgid "Public sharing is not enabled."
-msgstr "Le partage public n'est pas activé."
+msgstr "Publiek delen is niet ingeschakeld."
 
 #: src/metabase/api/common.clj
 msgid "Embedding is not enabled."
-msgstr "L'intégration n'est pas activé."
+msgstr "Embedden is niet ingeschakeld."
 
 #: src/metabase/api/common.clj
 msgid "The object has been archived."
-msgstr "L' objet a été archivé."
+msgstr "Dit object is gearchiveerd. "
 
 #: src/metabase/api/common/internal.clj
 msgid "Attempted to return a boolean as an API response. This is not allowed!"
-msgstr "Tentative de retour d'un booléen comme réponse d'API. Cela est interdit !"
+msgstr "Geprobeerd om een boolean terug te sturen als API response. Dit is niet toegestaan!"
 
 #: src/metabase/api/dataset.clj
 msgid "Source query for this query is Card {0}"
-msgstr "La requête source pour cette requête est la Carte {0}"
+msgstr "Bron query voor deze query kaart  is {0}"
 
 #: src/metabase/api/dataset.clj
 msgid "Invalid export format: {0}"
-msgstr "Format d'exportation invalide : {0}"
+msgstr "Invalide export formaat: {0}"
 
 #: src/metabase/api/geojson.clj
 msgid "Invalid JSON URL or resource: {0}"
-msgstr "Le contenu JSON de cette URL ou de cette ressource est invalide : {0}"
+msgstr "Invalide JSON URL of object: {0}"
 
 #: src/metabase/api/geojson.clj
 msgid "JSON containing information about custom GeoJSON files for use in map visualizations instead of the default US State or World GeoJSON."
-msgstr "Fichiers GeoJSON personnalisés à utiliser dans les visualisations de type Carte à la place des GeoJSON des états d'Amérique ou du monde fournis par défaut."
+msgstr "JSON met informatie over aangepaste GeoJSON-bestanden voor gebruik in kaartvisualisaties in plaats van de standaard US State of World GeoJSON."
 
 #: src/metabase/api/geojson.clj
 msgid "Invalid custom GeoJSON key: {0}"
-msgstr "Clé du GeoJSON personnalisé invalide : {0}"
+msgstr "Invalide aangepaste GeoJSON sleutel: {0}"
 
 #. ...but if we *still* couldn't find a match, throw an Exception, because we don't want people
 #. trying to inject new params
 #: src/metabase/api/public.clj
 msgid "Invalid param: {0}"
-msgstr "Paramètre invalide : {0}"
+msgstr "Invalide parameter: {0}"
 
 #: src/metabase/api/pulse.clj
 msgid "DELETE /api/pulse/:id is deprecated. Instead, change its `archived` value via PUT /api/pulse/:id."
@@ -7366,103 +7336,103 @@ msgstr "DELETE /api/pulse/:id is deprecated. Instead, change its `archived` valu
 
 #: src/metabase/api/routes.clj
 msgid "API endpoint does not exist."
-msgstr "l'endpoint d'API n'existe pas."
+msgstr "API endpoint bestaat niet"
 
 #: src/metabase/api/session.clj
 msgid "Password did not match stored password."
-msgstr "Le mot de passe ne correspondait pas à celui sauvegardé."
+msgstr "Wachtwoord komt niet overheen met opgeslagen wachtwoord."
 
 #: src/metabase/api/session.clj
 msgid "did not match stored password"
-msgstr "ne correspondait pas au mot de passe sauvegardé"
+msgstr "Komt niet overheen met opgeslagen wachtwoord"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fallback to local authentication {0}"
-msgstr "Problème à la connexion au serveur LDAP, procédure de repli vers l'authentification locale {0}"
+msgstr "Probleem met het verbinden met de LDAP server, teruggevallen op lokale authenticatie {0}"
 
 #: src/metabase/api/session.clj
 msgid "Invalid reset token"
-msgstr "Token de réinitialisation invalide"
+msgstr "Invalide reset token"
 
 #: src/metabase/api/session.clj
 msgid "Client ID for Google Auth SSO. If this is set, Google Auth is considered to be enabled."
-msgstr "ID Client pour Google Auth SSO. S'il est renseigné, Google Auth est supposé être activé."
+msgstr "Client-ID voor Google Auth SSO. Als dit is ingesteld, wordt Google Auth als ingeschakeld beschouwd."
 
 #: src/metabase/api/session.clj
 msgid "When set, allow users to sign up on their own if their Google account email address is from this domain."
-msgstr "Si indiqué, autorise les utilisateurs à se connecter avec leur compte Google si leur adresse correspond à ce domaine."
+msgstr "Als dit is ingesteld, sta je gebruikers toe zich zelf aan te melden als het e-mailadres van hun Google-account afkomstig is van dit domein."
 
 #: src/metabase/api/session.clj
 msgid "Invalid Google Auth token."
-msgstr "Jeton Google Auth invalide."
+msgstr "Ongeldig Google Auth-token."
 
 #: src/metabase/api/session.clj
 msgid "Email is not verified."
-msgstr "L' adresse électronique n'est pas vérifié."
+msgstr "E-mailadres is niet geverifieerd."
 
 #: src/metabase/api/session.clj
 msgid "You''ll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Vous aurez besoin qu'un administrateur crée un compte Metabase avant de puvoir utiliser Google pour vous connecter."
+msgstr "Je hebt een beheerder nodig om een Metabase-account te maken voordat je Google kunt gebruiken om in te loggen."
 
 #: src/metabase/api/session.clj
 msgid "Successfully authenticated Google Auth token for: {0} {1}"
-msgstr "Réussite de l'authentification du jeton Google Auth pour : {0} {1}"
+msgstr "Google Auth-token succesvol geverifieerd voor: {0} {1}"
 
 #: src/metabase/api/setup.clj
 msgid "Add a database"
-msgstr "Ajouter une base de données"
+msgstr "Database toevoegen"
 
 #: src/metabase/api/setup.clj
 msgid "Get connected"
-msgstr "Connectez-vous"
+msgstr "Maak verbinding"
 
 #: src/metabase/api/setup.clj
 msgid "Connect to your data so your whole team can start to explore."
-msgstr "Connectez-vous à vos données pour que l'ensemble de votre équipe puisse commencer à les explorer."
+msgstr "Verbind je data zodat je hele team kan verkennen"
 
 #: src/metabase/api/setup.clj
 msgid "Set up email"
-msgstr "Configurer la messagerie électronique"
+msgstr "E-mail instellen"
 
 #: src/metabase/api/setup.clj
 msgid "Add email credentials so you can more easily invite team members and get updates via Pulses."
-msgstr "Configurez la messagerie électronique pour inviter plus facilement des membres de votre équipe et obtenir des mises à jour via les Pulses."
+msgstr "Voeg e-mail instellingen toe zodat je eenvoudig teamleden kan uitnodigen en aan de gang kan met pulsen."
 
 #: src/metabase/api/setup.clj
 msgid "Set Slack credentials"
-msgstr "Régler les identifiants Slack"
+msgstr "Slack omgeving koppelen"
 
 #: src/metabase/api/setup.clj
 msgid "Does your team use Slack? If so, you can send automated updates via pulses and ask questions with MetaBot."
-msgstr "Votre équipe utilise Slack ? Vous pouvez envoyer des mises à jour automatiques via les pulses et poser des questions avec MetaBot."
+msgstr "Gebruikt je team Slack? Wanneer dit het geval is kun je automatisch pulsen ontvangen en vragen stellen met MetaBot."
 
 #: src/metabase/api/setup.clj
 msgid "Invite team members"
-msgstr "Inviter des membres de l'équipe"
+msgstr "Teamleden uitnodigen"
 
 #: src/metabase/api/setup.clj
 msgid "Share answers and data with the rest of your team."
-msgstr "Partagez des réponses et des données avec le reste de votre équipe."
+msgstr "Deel je antwoorden en data met de rest van je team"
 
 #: src/metabase/api/setup.clj
 msgid "Hide irrelevant tables"
-msgstr "Masquer les tables non pertinentes"
+msgstr "Verberg irrelevante tabellen"
 
 #: src/metabase/api/setup.clj
 msgid "Curate your data"
-msgstr "Organisez vos données"
+msgstr "Beheer je gegevens"
 
 #: src/metabase/api/setup.clj
 msgid "If your data contains technical or irrelevant info you can hide it."
-msgstr "Si votre donnée contient des informations techniques ou non pertinentes vous pouvez la masquer."
+msgstr "Als je gegevens technische of irrelevante informatie bevatten, kun je deze verbergen."
 
 #: src/metabase/api/setup.clj
 msgid "Organize questions"
-msgstr "Organiser les questions"
+msgstr "Vragen organiseren"
 
 #: src/metabase/api/setup.clj
 msgid "Have a lot of saved questions in {0}? Create collections to help manage them and add context."
-msgstr "Vous avez beaucoup de questions sauvegardées dans {0} ? Créez des collections pour vous aider à les gérer et les mettre en contexte."
+msgstr "Heb je veel vragen opgeslagen in {0}? Maak collecties om ze te helpen beheren en context toe te voegen."
 
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
@@ -7473,316 +7443,316 @@ msgstr "Metabase"
 
 #: src/metabase/api/setup.clj
 msgid "Create metrics"
-msgstr "Créer des métriques"
+msgstr "Metrieken aanmaken"
 
 #: src/metabase/api/setup.clj
 msgid "Define canonical metrics to make it easier for the rest of your team to get the right answers."
-msgstr "Définissez des métriques pour aider votre équipe à obtenir les bonnes réponses."
+msgstr "Definieer canonieke statistieken om het voor de rest van je team gemakkelijker te maken om de juiste antwoorden te krijgen."
 
 #: src/metabase/api/setup.clj
 msgid "Create segments"
-msgstr "Créer des segments"
+msgstr "Segmenten aanmaken"
 
 #: src/metabase/api/setup.clj
 msgid "Keep everyone on the same page by creating canonical sets of filters anyone can use while asking questions."
-msgstr "Gagnez en cohésion en créant des jeux communs de filtres utilisables par tous lors de la rédaction de questions."
+msgstr "Houd iedereen op de hoogte door canonieke sets filters te maken die iedereen kan gebruiken bij het stellen van vragen."
 
 #: src/metabase/api/table.clj
 msgid "Table ''{0}'' is now visible. Resyncing."
-msgstr "La table \"{0}\" n'est pas visible. Resynchronisation en cours."
+msgstr "Tabel \"{0}\" is nu zichtbaar. Hersynchroniseren."
 
 #: src/metabase/api/table.clj
 msgid "Auto bin"
-msgstr "Binning automatique"
+msgstr "Automatische prullenbak"
 
 #: src/metabase/api/table.clj
 msgid "Don''t bin"
-msgstr "Aucun binning"
+msgstr "Verwijder niet"
 
 #: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
-msgstr[0] "Jour"
-msgstr[1] "Jours"
+msgstr[0] "Dag"
+msgstr[1] "Dagen"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
 #: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
-msgstr[0] "Minute"
-msgstr[1] "Minutes"
+msgstr[0] "Minuut"
+msgstr[1] "Minuten"
 
 #: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
-msgstr[0] "Heure"
-msgstr[1] "Heures"
+msgstr[0] "Uur"
+msgstr[1] "Uren"
 
 #: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
-msgstr[0] "Trimestre"
-msgstr[1] "Trimestres"
+msgstr[0] "Kwartaal"
+msgstr[1] "Kwartalen"
 
 #: src/metabase/api/table.clj
 msgid "Minute of Hour"
-msgstr "Minute dans l'heure"
+msgstr "Minuut van uur"
 
 #: src/metabase/api/table.clj
 msgid "Hour of Day"
-msgstr "Heure dans le jour"
+msgstr "Uur van dag"
 
 #: src/metabase/api/table.clj
 msgid "Day of Week"
-msgstr "Jour de la semaine"
+msgstr "Dag van de week"
 
 #: src/metabase/api/table.clj
 msgid "Day of Month"
-msgstr "Jour du mois"
+msgstr "Dag van de maand"
 
 #: src/metabase/api/table.clj
 msgid "Day of Year"
-msgstr "Jour dans l'année"
+msgstr "Dag van jaar"
 
 #: src/metabase/api/table.clj
 msgid "Week of Year"
-msgstr "Semaine de l'année"
+msgstr "Week van jaar"
 
 #: src/metabase/api/table.clj
 msgid "Month of Year"
-msgstr "Mois dans l'année"
+msgstr "Maand van jaar"
 
 #: src/metabase/api/table.clj
 msgid "Quarter of Year"
-msgstr "Semestre dans l'année"
+msgstr "Kwartaal van jaar"
 
 #: src/metabase/api/table.clj
 msgid "10 bins"
-msgstr "10 cellules"
+msgstr "10 verwijderd"
 
 #: src/metabase/api/table.clj
 msgid "50 bins"
-msgstr "50 cellules"
+msgstr "50 verwijderd"
 
 #: src/metabase/api/table.clj
 msgid "100 bins"
-msgstr "100 cellules"
+msgstr "100 verwijderd"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 0.1 degrees"
-msgstr "Binner tous les 0,1 degrés"
+msgstr "Verwijder elke 0.1 graden"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 1 degree"
-msgstr "Binner tous les degrés"
+msgstr "Verwijder elke 1 graad"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 10 degrees"
-msgstr "Binner tous les 10 degrés"
+msgstr "Verwijder elke 10 graden"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 20 degrees"
-msgstr "Binner tous les 20 degrés"
+msgstr "Verwijder elke 20 graden"
 
 #. returns `true` if successful -- see JavaDoc
 #: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
-msgstr "Pas de sortie d'image appropriée trouvée !"
+msgstr "Geen geschikte beeldschrijver gevonden!"
 
 #: src/metabase/api/user.clj
 msgid "Email address already in use."
-msgstr "Adresse électronique déjà utilisée"
+msgstr "E-mailadres is al in gebruik."
 
 #: src/metabase/api/user.clj
 msgid "Email address already associated to another user."
-msgstr "Cette adresse électronique est déjà associée à un autre utilisateur."
+msgstr "E-mailadres is al in gebruik door een andere gebruiker."
 
 #: src/metabase/api/user.clj
 msgid "Not able to reactivate an active user"
-msgstr "Impossible de réactiver un utilisateur actif"
+msgstr "Kan een actieve gebruiker niet opnieuw activeren"
 
 #: src/metabase/api/user.clj
 msgid "Invalid password"
-msgstr "Mot de passe incorrect"
+msgstr "Ongeldig wachtwoord"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "All {0}"
-msgstr "Tous/Toutes les {0}"
+msgstr "Alle {0}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "{0}, all {1}"
-msgstr "{0}, tous/toutes les {1}"
+msgstr "{0}, alle {1}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "Comparison of {0} and {1}"
-msgstr "Comparaison de {0} avec {1}"
+msgstr "Vergelijk {0} en {1}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "Automatically generated comparison dashboard comparing {0} and {1}"
-msgstr "Tableau de bord de comparaison généré automatiquement et comparant {0} à {1}"
+msgstr "Automatisch gegenereerd vergelijkingsdashboard dat {0} en {1} vergelijkt"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "sum"
-msgstr "somme"
+msgstr "som"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "average"
-msgstr "moyenne"
+msgstr "gemiddelde"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "minumum"
-msgstr "minimum"
+msgstr "Minimum"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "maximum"
-msgstr "maximum"
+msgstr "Maximum"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "distinct count"
-msgstr "Nombre de valeurs distinctes"
+msgstr "Unieke rijen"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "standard deviation"
-msgstr "ecart-type"
+msgstr "standaardafwijking"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative count"
-msgstr "nombre cumulé"
+msgstr "cumulatieve telling"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative sum"
-msgstr "somme cumulée"
+msgstr "cumulatieve som"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} and {1}"
-msgstr "{0} et {1}"
+msgstr "{0} en {1}"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
-msgstr "{0} parmi {1}"
+msgstr "{0} of {1}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
-msgstr "{0} par {1}"
+msgstr "{0} bij {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} in the {1} segment"
-msgstr "{0} dans le segment {1}"
+msgstr "{0} in het {1} segment"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} segment"
-msgstr "le segment {0}"
+msgstr "{0} segment"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
 msgid_plural "{0} metrics"
-msgstr[0] "la métrique {0}"
-msgstr[1] "les métriques {0}"
+msgstr[0] "metriek"
+msgstr[1] "metriek"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
-msgstr "le champ {0}"
+msgstr "{0} veld"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "\"{0}\" question"
-msgstr "la question \"{0}\""
+msgstr "\"{0}\" vraag"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Compare with {0}"
-msgstr "Comparer avec {0}"
+msgstr "Vergelijk met {0}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Compare with entire dataset"
-msgstr "Comparer avec le jeu de données complet"
+msgstr "Vergelijk met volledige dataset"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Applying heuristic %s to %s."
-msgstr "Application de l'heuristique %s à %s."
+msgstr "Heuristische %s toepassen op %s."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Dimensions bindings:n%s"
-msgstr "Liens de dimensions : %s"
+msgstr "Dimensies binden: n%s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Using definitions:nMetrics:n%snFilters:n%s"
-msgstr "Utilisation des définitions : Métriques %s, Filtres %s"
+msgstr "Using definitions:nMetrics:n%snFilters:n%s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Can''t create dashboard for {0}"
-msgstr "Impossible de créer un tableau de bord pour {0}"
+msgstr "Kan geen dashboard aanmaken voor {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}st"
-msgstr "premier {0}"
+msgstr "{0}ste"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}nd"
-msgstr "second {0}"
+msgstr "{0}e"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}rd"
-msgstr "troisième {0}"
+msgstr "{0}e"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}th"
-msgstr "{0} ième"
+msgstr "{0}e"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "at {0}"
-msgstr "à {0}"
+msgstr "{0}e"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "on {0}"
-msgstr "le {0}"
+msgstr "op {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in {0} week - {1}"
-msgstr "en {0} semaine - {1}"
+msgstr "in {0} week - {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in {0}"
-msgstr "en {0}"
+msgstr "in {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in Q{0} - {1}"
-msgstr "au semestre {0} - {1}"
+msgstr "in Q{0} - {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Q{0}"
-msgstr "au {0} semestre"
+msgstr "Q{0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is {1}"
-msgstr "{0} vaut {1}"
+msgstr "{0} is {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is between {1} and {2}"
-msgstr "{0} est compris entre {1} et {2}"
+msgstr "{0} ligt tussen {1} en {2}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is between {1} and {2}; and {3} is between {4} and {5}"
-msgstr "{0}est compris entre {1} et {2}; et {3} entre {4} et {5}"
+msgstr "{0} ligt tussen {1} en {2}; en {3} ligt tussen {4} en {5}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "where {0}"
-msgstr "où {0}"
+msgstr "waar {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "A closer look at {0}"
-msgstr "Voir {0} de plus près"
+msgstr "{0} nader bekijken"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "A closer look at the {0}"
-msgstr "Voir le/les {0} de plus près"
+msgstr "{0} nader bekijken"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding %s cards to dashboard %s:n%s"
-msgstr "Ajout de %s cartes au tableau de bord %s : n%s"
+msgstr "%s kaarten toevoegen aan dashboard %s:n%s"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "0 <= score <= {0}"
@@ -7790,51 +7760,51 @@ msgstr "0 <= score <= {0}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "1 <= width <= {0}"
-msgstr "1 <= largeur <= {0}"
+msgstr "1 <= breedte <= {0}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid metrics references"
-msgstr "Références de métriques valides"
+msgstr "Geldige metriekreferenties"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid filters references"
-msgstr "Références de filtres valides"
+msgstr "Geldige filtersreferenties"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid group references"
-msgstr "Références de groupe valides"
+msgstr "Geldige groepsreferenties"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid order_by references"
-msgstr "Références de tri valides"
+msgstr "Geldige sorteren bij referenties"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid dashboard filters references"
-msgstr "Références de filtres de tableau de bord valides"
+msgstr "Geldige dashboard filter referenties"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid dimension references"
-msgstr "Références de dimension valides"
+msgstr "Geldige dimensiereferenties"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid card dimension references"
-msgstr "Références de dimension de carte valides"
+msgstr "Geldige kaart dimensiereferenties"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Error parsing %s:n%s"
-msgstr "Erreur lors de l'analyse %s : n%s"
+msgstr "Fout bij het behandelen van %s:n%s"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "No user found with email address ''{0}''. "
-msgstr "Aucun utilisateur trouvé avec l'adresse électronique \"{0}\". "
+msgstr "Geen gebruiker gevonden met e-mailadres \"{0}\""
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Please check the spelling and try again."
-msgstr "Vérifiez s'il vous plaît l'orthographe et essayez à nouveau."
+msgstr "Controleer de spelling en probeer het opnieuw."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Resetting password for {0}..."
-msgstr "Mot de passe de {0} en cours de réinitialisation .."
+msgstr "Wachtwoord wordt opnieuw ingesteld voor {0}..."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "OK [[[{0}]]]"
@@ -7842,1297 +7812,1299 @@ msgstr "OK [[[{0}]]]"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "FAIL [[[{0}]]]"
-msgstr "ECHEC [[[{0}]]]"
+msgstr "FAIL [[[{0}]]]"
 
 #: src/metabase/core.clj
 msgid "Please use the following URL to setup your Metabase installation:"
-msgstr "Utilisez s'il vous plaît l'URL suivante pour configurer votre installation Metabase :"
+msgstr "Gebruik de volgende URL voor je Metabase installatie:"
 
 #: src/metabase/core.clj
 msgid "Metabase Shutting Down ..."
-msgstr "Metabase en cours d'arrêt..."
+msgstr "Metabase wordt afgesloten..."
 
 #: src/metabase/core.clj
 msgid "Metabase Shutdown COMPLETE"
-msgstr "Arrêt de Metabase EFFECTIF"
+msgstr "Metabase is afgesloten"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase version {0} ..."
-msgstr "Démarrage de Metabase version {0}..."
+msgstr "Metabase versie {0} wordt gestart..."
 
 #: src/metabase/core.clj
 msgid "System timezone is ''{0}'' ..."
-msgstr "Le fuseau horaire du système est \"{0}\"..."
+msgstr "Tijdzone van het systeem is \"{0}\"..."
 
 #. startup database.  validates connection & runs any necessary migrations
 #: src/metabase/core.clj
 msgid "Setting up and migrating Metabase DB. Please sit tight, this may take a minute..."
-msgstr "Configuration et migration de la base de données Metabase. Faites s'il vous plaît preuve de patience, cela peut prendre une minute..."
+msgstr "Bezig met initialiseren en migreren van de database. Even geduld, er is tijd voor een bakje koffie..."
 
 #: src/metabase/core.clj
 msgid "Looks like this is a new installation ... preparing setup wizard"
-msgstr "I semble que ce soit une nouvelle installation... Préparation de l'assistant de configuration"
+msgstr "Het lijkt er op dat dit een nieuwe installatie is, bezig met het voorbereiden van de installatiewizard. "
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization COMPLETE"
-msgstr "Initialisation de Metabase EFFECTIVE"
+msgstr "Metabase Initialization COMPLETE"
 
 #: src/metabase/server.clj
 msgid "Launching Embedded Jetty Webserver with config:"
-msgstr "Lancement du serveur web Jetty intégré avec la configuration :"
+msgstr "Launching Embedded Jetty Webserver with config:"
 
 #: src/metabase/server.clj
 msgid "Shutting Down Embedded Jetty Webserver"
-msgstr "Arrêt du serveur web Jetty intégré"
+msgstr "Shutting Down Embedded Jetty Webserver"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase in STANDALONE mode"
-msgstr "Démarrage de Metabase en mode AUTONOME"
+msgstr "Starting Metabase in STANDALONE mode"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization FAILED"
-msgstr "L'Initialisation de Metabase a ECHOUE"
+msgstr "Metabase Initialization FAILED"
 
 #: src/metabase/db.clj
 msgid "Database has migration lock; cannot run migrations."
-msgstr "La base de données a un verrou de migration; impossible de lancer les migrations."
+msgstr "Database has migration lock; cannot run migrations."
 
 #: src/metabase/db.clj
 msgid "You can force-release these locks by running `java -jar metabase.jar migrate release-locks`."
-msgstr "Vous pouvez forcer la libération de ces verrous en lançant `java -jar metabase.jar migrate release-locks`."
+msgstr "You can force-release these locks by running `java -jar metabase.jar migrate release-locks`."
 
 #: src/metabase/db.clj
 msgid "Checking if Database has unrun migrations..."
-msgstr "Vérification de la présence de migrations non appliquées sur la base de données"
+msgstr "Checking if Database has unrun migrations..."
 
 #: src/metabase/db.clj
 msgid "Database has unrun migrations. Waiting for migration lock to be cleared..."
-msgstr "La base de données a des migrations non appliquées. En attente de la libération du verrou de migration..."
+msgstr "Database has unrun migrations. Waiting for migration lock to be cleared..."
 
 #: src/metabase/db.clj
 msgid "Migration lock is cleared. Running migrations..."
-msgstr "Le verrou est libéré. Application des migrations..."
+msgstr "Migration lock is cleared. Running migrations..."
 
 #: src/metabase/db.clj
 msgid "Migration lock cleared, but nothing to do here! Migrations were finished by another instance."
-msgstr "Verrou de migration libéré, mais rien à faire ici ! Les Migrations ont été appliquées par une autre instance."
+msgstr "Migration lock cleared, but nothing to do here! Migrations were finished by another instance."
 
 #. Set up liquibase and let it do its thing
 #: src/metabase/db.clj
 msgid "Setting up Liquibase..."
-msgstr "Configuration de Liquibase..."
+msgstr "Setting up Liquibase..."
 
 #: src/metabase/db.clj
 msgid "Liquibase is ready."
-msgstr "Liquibase est prêt."
+msgstr "Liquibase is ready."
 
 #: src/metabase/db.clj
 msgid "Verifying {0} Database Connection ..."
-msgstr "Vérification de la connexion à la base de données {0}..."
+msgstr "Verifying {0} Database Connection ..."
 
 #: src/metabase/db.clj
 msgid "Verify Database Connection ... "
-msgstr "Vérifier la connexion à la base de données... "
+msgstr "Verify Database Connection..."
 
 #: src/metabase/db.clj
 msgid "Running Database Migrations..."
-msgstr "Application des migrations de base de données..."
+msgstr "Running Database Migrations..."
 
 #: src/metabase/db.clj
 msgid "Database Migrations Current ... "
-msgstr "Migrations de la base de données en cours... "
+msgstr "Database Migrations Current ..."
 
 #: src/metabase/driver/common.clj
 msgid "Hmm, we couldn''t connect to the database."
-msgstr "Hum, nous n'avons pas pu nous connecter à la base de données"
+msgstr "Hmmm, we konden geen verbinding maken met de database."
 
 #: src/metabase/driver/common.clj
 msgid "Make sure your host and port settings are correct"
-msgstr "Assurez-vous que les réglages d'hôte et de numéro de port sont corrects"
+msgstr "Controleer de ingestelde host en poort instellingen."
 
 #: src/metabase/driver/common.clj
 msgid "We couldn''t connect to the ssh tunnel host."
-msgstr "Nous n'avons pas pu ouvrir le tunnel ssh."
+msgstr "We konden geen verbinding maken met de SSH tunnel host."
 
 #: src/metabase/driver/common.clj
 msgid "Check the username, password."
-msgstr "Vérifier le nom d'utilisateur, son mot de passe."
+msgstr "Controleer de gebruikersnaam en het wachtwoord."
 
 #: src/metabase/driver/common.clj
 msgid "Check the hostname and port."
-msgstr "Vérifier le nom d'hôte et son numéro de port."
+msgstr "Controleer de host en poort."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like the database name is incorrect."
-msgstr "Il semble que le nom de la base de données soit incorrect."
+msgstr "Het lijkt er op dat de databasenaam niet klopt."
 
 #: src/metabase/driver/common.clj
 msgid "It looks like your host is invalid."
-msgstr "Il semble que votre hôte soit invalide."
+msgstr "Het lijkt er op dat de host ongeldig is."
 
 #: src/metabase/driver/common.clj
 msgid "Please double-check it and try again."
-msgstr "Faîtes s'il vous plaît une contre-vérification et essayez à nouveau."
+msgstr "Controleer de gegevens en probeer het opnieuw."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like your password is incorrect."
-msgstr "Il semble que votre mot de passe soit incorrect."
+msgstr "Het lijkt er op dat het wachtwoord niet klopt."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like you forgot to enter your password."
-msgstr "Il semble que vous ayez oublié de saisir votre mot de passe."
+msgstr "Het lijkt er op dat je vergeten bent om het wachtwoord in te vullen."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like your username is incorrect."
-msgstr "Il semble que votre nom d'utilisateur soit incorrect."
+msgstr "Het lijkt er op dat je gebruikersnaam niet klopt."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like the username or password is incorrect."
-msgstr "Il semble que le nom d'utilisateur ou le mot de passe soit incorrect."
+msgstr "Het lijkt er op dat je gebruikersnaam of wachtwoord niet juist is."
 
 #. ## CONFIG
 #: src/metabase/driver.clj
 msgid "Connection timezone to use when executing queries. Defaults to system timezone."
-msgstr "Fuseau horaire de connexion à utiliser lors de l'exécution de requêtes. Positionné au fuseau système par défaut."
+msgstr "Connection timezone to use when executing queries. Defaults to system timezone."
 
 #: src/metabase/driver.clj
 msgid "Registered driver {0} {1}"
-msgstr "Gestionnaire enregistré {0} {1}"
+msgstr "Registered driver {0} {1}"
 
 #: src/metabase/driver.clj
 msgid "No -init-driver function found for ''{0}''"
-msgstr "Pas de fonction -init-driver trouvé pour \"{0}\""
+msgstr "No -init-driver function found for ''{0}''"
 
 #: src/metabase/driver/common.clj
 msgid "Unable to parse date string ''{0}'' for database engine ''{1}''"
-msgstr "Dans l'incapacité d'analyser la date représentée par \"{0}\" dans le moteur de base de données \"{1}\""
+msgstr "Unable to parse date string ''{0}'' for database engine ''{1}''"
 
 #. all-NULL columns in DBs like Mongo w/o explicit types
 #: src/metabase/driver/common.clj
 msgid "Don''t know how to map class ''{0}'' to a Field base_type, falling back to :type/*."
-msgstr "Pas de connaissance sur la façon d'associer la classe \"{0}\" à un \"base_type\" de champ, solution de repli vers : type/*"
+msgstr "Don''t know how to map class ''{0}'' to a Field base_type, falling back to :type/*."
 
 #: src/metabase/driver/util.clj
 msgid "Failed to connect to database: {0}"
-msgstr "Echec de connexion à la base de données : {0}"
+msgstr "Verbinden met database mislukt: {0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Invalid BigQuery identifier: ''{0}''"
-msgstr "Identifiant BigQuery invalide : \"{0}\""
+msgstr "Invalid BigQuery identifier: ''{0}''"
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can't be parameterized!"
-msgstr "Les instructions BigQuery n'acceptent pas de paramètre !"
+msgstr "BigQuery statements can't be parameterized!"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone:"
-msgstr "Echec du réglage du fuseau horaire :"
+msgstr "Instellen van tijdzone mislukt:"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "You must enable the Google Analytics API. Use this link to go to the Google Developers Console: {0}"
-msgstr "Vous devez activer l'API Google Analytics. Utilisez ce lien pour vous rendre sur la Google Developers Console : {0}"
+msgstr "Je moet de Google Analytics API inschakelen. Gebruik deze link om naar de Google Developers Console te gaan: {0}"
 
 #: src/metabase/driver/h2.clj
 msgid "Running SQL queries against H2 databases using the default (admin) database user is forbidden."
-msgstr "Exécuter des requêtes SQL sur des bases de données H2 en utilisant l'utilisateur de base de données par défaut (admin) est interdit."
+msgstr "SQL queries uitvoeren op een H2 database met de standaard admin gebruiker is niet toegestaan. "
 
 #: src/metabase/driver/sparksql.clj
 msgid "Error: metabase.driver.FixedHiveDriver is registered, but JDBC does not seem to be using it."
-msgstr "Ereur : metabase.driver.FixedHiveDriver est enregistré, mais JDBC ne semble pas l'utiliser."
+msgstr "Error: metabase.driver.FixedHiveDriver is registered, but JDBC does not seem to be using it."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Found metabase.driver.FixedHiveDriver."
-msgstr "metabase.driver.FixedHiveDriver trouvé."
+msgstr "Found metabase.driver.FixedHiveDriver."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Successfully registered metabase.driver.FixedHiveDriver with JDBC."
-msgstr "metabase.driver.FixedHiveDriver enregistré avec succès dans JDBC."
+msgstr "Successfully registered metabase.driver.FixedHiveDriver with JDBC."
 
 #. CONFIG
 #. TODO - smtp-port should be switched to type :integer
 #: src/metabase/email.clj
 msgid "Email address you want to use as the sender of Metabase."
-msgstr "Adresse électronique que vous souhaitez utiliser comme expéditeur."
+msgstr "E-mailadres die je wilt gebruiker als afzender van Metabase."
 
 #: src/metabase/email.clj
 msgid "The address of the SMTP server that handles your emails."
-msgstr "L'adresse du serveur SMTP qui gère vos courriels."
+msgstr "Het adres van de SMTP server die uw e-mail verstuurt."
 
 #: src/metabase/email.clj
 msgid "SMTP username."
-msgstr "Nom d'utilisateur SMTP."
+msgstr "SMTP gebruikersnaam."
 
 #: src/metabase/email.clj
 msgid "SMTP password."
-msgstr "Mot de passe SMTP."
+msgstr "SMTP wachtwoord."
 
 #: src/metabase/email.clj
 msgid "The port your SMTP server uses for outgoing emails."
-msgstr "Le port que votre serveur SMTP utilise pour les courriels sortants."
+msgstr "De poort van de SMTP server die uw e-mail verstuurt."
 
 #: src/metabase/email.clj
 msgid "SMTP secure connection protocol. (tls, ssl, starttls, or none)"
-msgstr "Protocole de connexion sécurisée SMTP. (tls, ssl, starttls ou aucun)"
+msgstr "SMTP beveiligde protocol. (tls, ssl, starttls, of geen)"
 
 #: src/metabase/email.clj
+#, fuzzy
 msgid "none"
-msgstr "aucun"
+msgstr "geen"
 
 #: src/metabase/email.clj
 msgid "SMTP host is not set."
-msgstr "L'hôte SMTP n'est pas défini."
+msgstr "SMTP host is niet ingesteld."
 
 #: src/metabase/email.clj
 msgid "Failed to send email"
-msgstr "Impossible d'envoyer le courriel"
+msgstr "E-mail verzenden mislukt"
 
 #: src/metabase/email.clj
 msgid "Error testing SMTP connection"
-msgstr "Erreur lors du test de la connexion SMTP"
+msgstr "Foutmelding bij het testen van SMTP verbinding"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Enable LDAP authentication."
-msgstr "Activer l'authentification LDAP."
+msgstr "LDAP authenticatie ingeschakeld."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Server hostname."
-msgstr "Nom d'hôte du serveur"
+msgstr "Server hostnaam."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Server port, usually 389 or 636 if SSL is used."
-msgstr "port du serveur, habituellement 389, ou 636 si SSL est utilisé."
+msgstr "Server poort, vaak 389 of 636 wanneer SSL wordt gebruikt."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Use SSL, TLS or plain text."
-msgstr "Utiliser SSL, TLS ou plain texte."
+msgstr "Gebruik SSL, TLS of platte tekst."
 
 #: src/metabase/integrations/ldap.clj
 msgid "The Distinguished Name to bind as (if any), this user will be used to lookup information about other users."
-msgstr "Le \"Distinguished Name\" avec lequel se lier (si présent), cet utilisateur sera utilisé pour récupérer les informations des autres utilisateurs."
+msgstr "De onderscheidende naam om te binden (wanneer aanwezig), deze gebruiker wordt gebruikt om informatie op te halen van andere gebruikers."
 
 #: src/metabase/integrations/ldap.clj
 msgid "The password to bind with for the lookup user."
-msgstr "Le mot de passe à utiliser pour l'utilisateur de recherche."
+msgstr "Het wachtwoord om te binden voor het opzoeken van gebruikers."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Search base for users. (Will be searched recursively)"
-msgstr "Base de recherche pour les utilisateurs. (Sera recherché récursivement)"
+msgstr "Zoekbasis voor gebruikers. (Wordt recursief doorzocht)"
 
-#. 'variable' est peut-être plus explicite que 'emplacement réservé' (pour invalides de guerre) ?
 #: src/metabase/integrations/ldap.clj
 msgid "User lookup filter, the placeholder '{login}' will be replaced by the user supplied login."
-msgstr "Filtre de recherche d’utilisateur, la variable '{login}' y sera remplacée par le login fourni par l’utilisateur."
+msgstr "Filter voor gebruikersopzoeking, de tijdelijke aanduiding '{login}' wordt vervangen door de door de gebruiker opgegeven login."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user's email. (usually ''mail'', ''email'' or ''userPrincipalName'')"
-msgstr "Attribut correspondant à l'e-mail de l'utilisateur. (le plus souvent \"mail\", \"email\" ou \"userPrincipalName\")"
+msgstr "Kenmerk om te gebruiken voor de e-mail van de gebruiker. (meestal \"mail\", \"email\" of \"userPrincipalName\")"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user''s first name. (usually ''givenName'')"
-msgstr "Attribut à utiliser pour le prénom de l'utilisateur."
+msgstr "Attribuut om te gebruiken voor de voornaam van de gebruiker. (meestal \"givenName\")"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user''s last name. (usually ''sn'')"
-msgstr "Attribut à utiliser pour le nom de famille de l'utilisateur."
+msgstr "Attribuut om te gebruiken voor de achternaam van de gebruiker. (meestal \"sn\")"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Enable group membership synchronization with LDAP."
-msgstr "Activer la synchronisation des appartenances aux groupes entre Metabase et LDAP."
+msgstr "Synchronisatie van groepslidmaatschap met LDAP inschakelen."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Search base for groups, not required if your LDAP directory provides a ''memberOf'' overlay. (Will be searched recursively)"
-msgstr "Base de recherche pour les groupes, non requis si votre annuaire LDAP fournis la surcouche \"memberOf\". (Recherchera récursivement)"
+msgstr "Zoekbasis voor groepen, niet vereist als uw LDAP-directory een overap met \"memberOf\" biedt. (Wordt recursief doorzocht)"
 
 #. Should be in the form: {"cn=Some Group,dc=...": [1, 2, 3]} where keys are LDAP groups and values are lists of MB groups IDs
 #: src/metabase/integrations/ldap.clj
 msgid "JSON containing LDAP to Metabase group mappings."
-msgstr "JSON contenant les correspondances entre groupes Metabase et LDAP."
+msgstr "JSON met LDAP naar Metabase-groepstoewijzingen."
 
 #. Define a setting which captures our Slack api token
 #: src/metabase/integrations/slack.clj
 msgid "Slack API bearer token obtained from https://api.slack.com/web#authentication"
-msgstr "Jeton de l'API Slack obtenu à partir de https://api.slack.com/web#authentication"
+msgstr "Bearer token van Slack, verkregen van https://api.slack.com/web#authentication"
 
 #: src/metabase/metabot.clj
 msgid "Enable MetaBot, which lets you search for and view your saved questions directly via Slack."
-msgstr "Activer MetaBot, qui vous permet de rechercher et voir vos questions sauvegardées directement via Slack."
+msgstr "Schakel MetaBot in, waarmee je opgeslagen vragen rechtstreeks via Slack kunt zoeken en bekijken."
 
 #: src/metabase/metabot/instance.clj
 msgid "Last MetaBot checkin was {0} ago."
-msgstr "La dernière vérification MetaBot a eu lieu il y a {0}."
+msgstr "De laatste check-in van MetaBot was {0} geleden."
 
 #: src/metabase/metabot/instance.clj
 msgid "This instance will now handle MetaBot duties."
-msgstr "Cette instance gérera désormais les tâches MetaBot."
+msgstr "Deze instantie zal nu MetaBot-taken afhandelen."
 
 #: src/metabase/metabot.clj
 msgid "Here''s what I can {0}:"
-msgstr "Voici ce que je peux {0} :"
+msgstr "Dit is wat ik kan {0}:"
 
 #: src/metabase/metabot.clj
 msgid "I don''t know how to {0} `{1}`.n{2}"
-msgstr "Je ne sais pas comment {0} `{1}`.n{2}"
+msgstr "Ik weet niet hoe ik {0} `{1}` .n {2}"
 
 #: src/metabase/metabot/slack.clj
 msgid "Uh oh! :cry:n> {0}"
-msgstr "Uh oh! : cry:n> {0}"
+msgstr "Oh Oh! : cry: n> {0}"
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s your {0} most recent cards:n{1}"
-msgstr "Voici vos {0} plus récentes Cartes : n{1}"
+msgstr "Hier zijn je {0} meest recente kaarten: n {1}"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific? I found these cards with names that matched:n{0}"
-msgstr "Pourriez-vous être un peu plus précis ? J'ai trouvé ces cartes au nom correspondant : {0}"
+msgstr "Zou je wat specifieker kunnen zijn? Ik heb deze kaarten gevonden met namen die overeenkomen:n{0}"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know what Card `{0}` is. Give me a Card ID or name."
-msgstr "Je ne sais pas ce qu'est la Carte `{0}`. Donnez-moi un ID ou un nom de Carte."
+msgstr "Ik weet niet wat Kaart `{0}` is. Geef me een kaart-ID of naam."
 
 #: src/metabase/metabot/command.clj
 msgid "Show which card? Give me a part of a card name or its ID and I can show it to you. If you don''t know which card you want, try `metabot list`."
-msgstr "Quelle carte montrer ? Donnez-moi une partie de son nom ou son ID et je peux vous la présenter. Si vous ne savez pas quelle carte vous souhaitez, essayez `metabot list`."
+msgstr "Welke kaart tonen? Geef me een deel van een kaartnaam of zijn ID en ik kan het je laten zien. Als je niet weet welke kaart je wilt, probeer dan `metabotlijst`."
 
 #: src/metabase/metabot/command.clj
 msgid "Ok, just a second..."
-msgstr "D'accord, une seconde s'il vous plaît..."
+msgstr "Oké, een momentje..."
 
 #: src/metabase/metabot/command.clj
 msgid "Not Found"
-msgstr "Recherche infructueuse"
+msgstr "Niet gevonden"
 
 #: src/metabase/metabot/command.clj
 msgid "Loading Kanye quotes..."
-msgstr "Chargement des citations de Kanye..."
+msgstr "Kanye-quotes laden..."
 
 #: src/metabase/metabot/events.clj
 msgid "Evaluating Metabot command:"
-msgstr "Evaluation de la commande MetaBot :"
+msgstr "Metabot-opdracht evalueren:"
 
 #: src/metabase/metabot.clj
 msgid "Go home websocket, you're drunk."
-msgstr "Rentre chez toi websocket, tu es saoûle."
+msgstr "Ga naar huis websocket, je bent dronken."
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error launching metabot:"
-msgstr "Erreur au lancement de MetaBot :"
+msgstr "Fout bij starten van metabot:"
 
 #: src/metabase/metabot/websocket.clj
 msgid "MetaBot WebSocket is closed. Reconnecting now."
-msgstr "La websocket MetaBot est fermée. Reconnexion en cours."
+msgstr "MetaBot WebSocket is gesloten. Opnieuw verbinden."
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error connecting websocket:"
-msgstr "Erreur lors de la connexion de la websocket :"
+msgstr "Fout bij het verbinden van websocket:"
 
 #: src/metabase/metabot/instance.clj
 msgid "This instance is performing MetaBot duties."
-msgstr "Cette instance effectue les tâches MetaBot"
+msgstr "Deze instantie voert MetaBot-taken uit."
 
 #: src/metabase/metabot/instance.clj
 msgid "Another instance is already handling MetaBot duties."
-msgstr "Une autre instance gère déjà les tâches MetaBot."
+msgstr "Een andere instantie is al bezig met MetaBot-taken."
 
 #: src/metabase/metabot.clj
 msgid "Starting MetaBot threads..."
-msgstr "Démarrage des fils d'exécution de MetaBot..."
+msgstr "MetaBot-threads starten..."
 
 #: src/metabase/metabot.clj
 msgid "Stopping MetaBot...  🤖"
-msgstr "Arrêt de MetaBot... 🤖"
+msgstr "MetaBot aan het stoppen..."
 
 #: src/metabase/metabot.clj
 msgid "MetaBot already running. Killing the previous WebSocket listener first."
-msgstr "MetaBot est déjà en route. Arrêt préliminaire du précédent écouteur de websocket."
+msgstr "MetaBot is al actief. Eerst de vorige WebSocket-luisteraar wordt afgesloten."
 
 #: src/metabase/middleware/security.clj
 msgid "Base-64 encoded public key for this site's SSL certificate."
-msgstr "Clé publique encodée en base64 du certificat SSL de ce site."
+msgstr "Base-64 gecodeerde openbare sleutel voor het SSL-certificaat van deze site."
 
 #: src/metabase/middleware/security.clj
 msgid "Specify this to enable HTTP Public Key Pinning."
-msgstr "Activer l'épinglage des clés publiques HTTP."
+msgstr "Geef dit op om HTTP Public Key Pinning in te schakelen."
 
 #: src/metabase/middleware/security.clj
 msgid "See {0} for more information."
-msgstr "Consulter {0} pour plus d'information."
+msgstr "Zie {0} voor meer informatie."
 
 #: src/metabase/models/card.clj
 msgid "Cannot save Question: source query has circular references."
-msgstr "Incapable de sauvegarder la Question : la requête source contient des références circulaires."
+msgstr "Kan vraag niet opslaan Vraag: bronquery heeft cirkelvormige verwijzingen."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
-msgstr "La Carte {0} n'existe pas."
+msgstr "Kaart {0} bestaat niet."
 
 #: src/metabase/models/card.clj
 msgid "You do not have permissions to run ad-hoc native queries against Database {0}."
-msgstr "Vous n'avez pas les permissions pour exécuter des requêtes natives ad-hoc sur cette base de données {0}."
+msgstr "Je hebt geen rechten om native ad-hocquery's uit te voeren voor Database {0}."
 
 #: src/metabase/models/collection.clj
 msgid "Invalid color"
-msgstr "Couleur invalide"
+msgstr "Invalide kleur"
 
 #: src/metabase/models/collection.clj
 msgid "must be a valid 6-character hex color code"
-msgstr "doit être un code couleur hexadécimal sur 6 caractères"
+msgstr "moet een geldige hex-kleurcode van 6 tekens zijn"
 
 #: src/metabase/models/collection.clj
 msgid "Collection name cannot be blank!"
-msgstr "Le nom de collection ne peut être vide !"
+msgstr "Verzamelingsnaam kan niet leeg zijn!"
 
 #: src/metabase/models/collection.clj
 msgid "cannot be blank"
-msgstr "ne peut être vide"
+msgstr "kan niet leeg zijn"
 
 #: src/metabase/models/collection.clj
 msgid "Invalid Collection location: path is invalid."
-msgstr "Emplacement de collection invalide : le chemin est invalide."
+msgstr "Ongeldige afhaallocatie: pad is ongeldig."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Personal Collection."
-msgstr "Vous ne pouvez déplacer une collection personnelle."
+msgstr "Je kunt een persoonlijke collectie niet verplaatsen."
 
 #: src/metabase/models/collection.clj
 msgid "Invalid Collection location: some or all ancestors do not exist."
-msgstr "Emplacement de collection invalide : au moins un ancêtre n'existe pas."
+msgstr "Ongeldige verzamellocatie: sommige of alle bovenliggende items bestaan niet."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot archive the Root Collection."
-msgstr "Vous ne pouvez archiver la collection racine."
+msgstr "Je kunt de rootcollectie niet archiveren."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot archive a Personal Collection."
-msgstr "Vous ne pouvez archiver une collection personnelle."
+msgstr "Het is niet mogelijk om een persoonlijke verzameling te archiveren."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move the Root Collection."
-msgstr "Vous ne pouvez déplacer la collection racine."
+msgstr "Je kunt de rootcollectie niet verplaatsen."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection into itself or into one of its descendants."
-msgstr "Vous ne pouvez déplacer une collection vers elle-même ou vers un de ses descendants."
+msgstr "Je kunt een verzameling niet naar zichzelf of naar een van zijn afstammelingen verplaatsen."
 
 #. first move this Collection
 #: src/metabase/models/collection.clj
 msgid "Moving Collection {0} and its descendants from {1} to {2}"
-msgstr "Déplacement de la collection {0} et de ses descendants depuis {1} vers {2}"
+msgstr "Collectie {0} en zijn nakomelingen verplaatsen van {1} naar {2}"
 
 #: src/metabase/models/collection.clj
 msgid "You're not allowed to change the owner of a Personal Collection."
-msgstr "Vous n'êtes pas autorisé à changer le propriétaire d'une collection personnelle."
+msgstr "Het is niet toegestaan om de eigenaar van een persoonlijke verzameling te wijzigen."
 
 #: src/metabase/models/collection.clj
 msgid "You're not allowed to move a Personal Collection."
-msgstr "Vous n'êtes pas autorisé à déplacer une collection personnelle."
+msgstr "Het is niet toegestaan om een persoonlijke verzameling te verplaatsen."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection and archive it at the same time."
-msgstr "Vous ne pouvez en même temps déplacer et archiver une collection."
+msgstr "Je kunt een verzameling niet verplaatsen en tegelijkertijd archiveren."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot delete a Personal Collection!"
-msgstr "Vous ne pouvez supprimer une collection personnelle !"
+msgstr "U kunt een persoonlijke verzameling niet verwijderen!"
 
 #: src/metabase/models/collection.clj
 msgid "{0} {1}''s Personal Collection"
-msgstr "Collection personnelle de {0} {1}"
+msgstr "{0} {1}'s persoonlijke verzameling"
 
 #: src/metabase/models/collection_revision.clj
 msgid "You cannot update a CollectionRevision!"
-msgstr "Vous ne pouvez modifier une Révision de collection !"
+msgstr "U kunt een CollectionRevision niet bijwerken!"
 
 #: src/metabase/models/field_values.clj
 msgid "Field {0} was previously automatically set to show a list widget, but now has {1} values."
-msgstr "Le champ {0} était précédemment défini automatiquement pour afficher une liste, mais il contient désormais {1} valeurs."
+msgstr "Veld {0} was voorheen automatisch ingesteld om een lijstwidget weer te geven, maar heeft nu {1} waarden."
 
 #: src/metabase/models/field_values.clj
 msgid "Switching Field to use a search widget instead."
-msgstr "Transformation du champ en un élément visuel de recherche."
+msgstr "Veld wijzigen om een zoekwidget te gebruiken."
 
 #: src/metabase/models/field_values.clj
 msgid "Storing updated FieldValues for Field {0}..."
-msgstr "Stockage des valeurs mises à jour du champ {0}..."
+msgstr "Bijgewerkte FieldValues opslaan voor veld {0} ..."
 
 #: src/metabase/models/field_values.clj
 msgid "Storing FieldValues for Field {0}..."
-msgstr "Stockage des valeurs du champ {0}..."
+msgstr "Veldwaarden opslaan voor veld {0} ..."
 
 #: src/metabase/models/humanization.clj
 msgid "Metabase can attempt to transform your table and field names into more sensible, human-readable versions, e.g. \"somehorriblename\" becomes \"Some Horrible Name\"."
-msgstr "Metabase peut tenter de transformer les noms de table et de champ en une version plus naturelle et lisible; \"unhorriblenom\" deviendrait par exemple \"Un Horrible Nom\"."
+msgstr "Metabase kan proberen uw tabel- en veldnamen om te zetten in voor mensen leesbare versies, b.v. \"somehorriblename\" wordt \"Some Horrible Name\"."
 
 #: src/metabase/models/humanization.clj
 msgid "This doesn’t work all that well if the names are in a language other than English, however."
-msgstr "Cela ne donnera de bon résultats que pour des noms en anglais."
+msgstr "Dit werkt echter niet zo goed voor de namen in een andere taal dan het Engels."
 
 #: src/metabase/models/humanization.clj
 msgid "Do you want us to take a guess?"
-msgstr "Voulez-vous que nous l'estimions ?"
+msgstr "Wil je dat we raden?"
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot create or revoke permissions for the 'Admin' group."
-msgstr "Vous ne pouvez accorder ou retirer des permissions au groupe 'Admin'."
+msgstr "Het is niet mogelijk om rechten van de 'Beheerders' groep weg te nemen."
 
 #: src/metabase/models/permissions.clj
 msgid "Invalid permissions object path: ''{0}''."
-msgstr "Chemin d'objet invalide : \"{0}\"."
+msgstr "Ongeldige rechten voor object pad: \"{0}\"."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot update a permissions entry!"
-msgstr "Vous ne pouvez pas mettre à jour une entrée de permissions !"
+msgstr "U kunt geen rechten bewerken!"
 
 #: src/metabase/models/permissions.clj
 msgid "Delete it and create a new one."
-msgstr "Supprimez la et créez-en une nouvelle."
+msgstr "Verwijder een creëer een nieuwe."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot edit permissions for a Personal Collection or its descendants."
-msgstr "Vous ne pouvez modifier les permissions d'une collection personnelle ou de ses descendants."
+msgstr "Je kunt geen rechten bewerken voor een persoonlijke verzameling of de nakomelingen ervan."
 
 #: src/metabase/models/permissions.clj
 msgid "Looks like someone else edited the permissions and your data is out of date."
-msgstr "Il semble que quelqu'un d'autre ait modifié les permissions et que vos données soient obsolètes."
+msgstr "Het lijkt erop dat iemand anders de rechten heeft bewerkt en uw gegevens verouderd zijn."
 
 #: src/metabase/models/permissions.clj
 msgid "Please fetch new data and try again."
-msgstr "Récupérez s'il vous plaît de nouvelles données et essayez à nouveau."
+msgstr "Haal nieuwe gegevens op en probeer het opnieuw."
 
 #: src/metabase/models/permissions_group.clj
 msgid "Created magic permissions group ''{0}'' (ID = {1})"
-msgstr "Groupe de permissions magique \"{0}\" (ID = {1}) créé"
+msgstr "Magische machtigingengroep '' {0} '' gemaakt (ID = {1})"
 
 #: src/metabase/models/permissions_group.clj
 msgid "A group with that name already exists."
-msgstr "Un groupe avec ce nom existe déjà."
+msgstr "Een groep met deze naam bestaad reeds."
 
 #: src/metabase/models/permissions_group.clj
 msgid "You cannot edit or delete the ''{0}'' permissions group!"
-msgstr "Vous ne pouvez pas modifier ou supprimer le groupe d'autorisations '' {0} ''!"
+msgstr "Je kunt de groep '' {0} '' machtigingen niet bewerken of verwijderen!"
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'MetaBot' group."
-msgstr "Vous ne pouvez pas ajouter (resp. supprimer) d'utilisateur au (resp. du) groupe 'MetaBot'."
+msgstr "Je kunt geen gebruikers toevoegen aan of verwijderen uit de groep 'MetaBot'."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'All Users' group."
-msgstr "Vous ne pouvez pas ajouter ou supprimer des utilisateurs du groupe \"Tous les utilisateurs\"."
+msgstr "Je kunt geen gebruikers toevoegen aan of verwijderen uit de groep 'Alle gebruikers'."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the 'Admin' group!"
-msgstr "Vous ne pouvez pas supprimer le dernier membre du groupe 'Admin' !"
+msgstr "Je kunt het laatste lid van de groep 'Beheerder' niet verwijderen!"
 
 #: src/metabase/models/permissions_revision.clj
 msgid "You cannot update a PermissionsRevision!"
-msgstr "Vous ne pouvez mettre à jour une révision de permissions"
+msgstr "Je kunt een machtigingsherziening niet bijwerken!"
 
 #. if there's still not a Card, throw an Exception!
 #: src/metabase/models/pulse.clj
 msgid "Invalid Alert: Alert does not have a Card assoicated with it"
-msgstr "Alerte invalide : l'alerte n'a aucune question d'associée"
+msgstr "Ongeldigheidswaarschuwing: aan Alert is geen kaart gekoppeld"
 
 #: src/metabase/models/pulse.clj
 msgid "value must be a map with the keys `{0}`, `{1}`, and `{2}`."
-msgstr "La valeur doit être une association contenant les clés `{0}`, `{1}`, et `{2}`."
+msgstr "waarde moet een kaart zijn met de sleutels `{0}`, `{1}` en `{2}`."
 
 #: src/metabase/models/pulse.clj
 msgid "value must be a map with the following keys `({0})`"
-msgstr "La valeur doit être une association contenant les clés `({0})`"
+msgstr "waarde moet een kaart zijn met de volgende sleutels `({0})`"
 
 #: src/metabase/models/query/permissions.clj
 msgid "Error calculating permissions for query: {0}"
-msgstr "Erreur lors du calcul des permissions de la requête : {0}"
+msgstr "Fout bij het berekenen van machtigingen voor zoekopdracht: {0}"
 
 #: src/metabase/models/query/permissions.clj
 msgid "Invalid query type: {0}"
-msgstr "Type de requête invalide : {0}"
+msgstr "Ongeldige query type"
 
 #: src/metabase/models/query_execution.clj
 msgid "You cannot update a QueryExecution!"
-msgstr "Vous ne pouvez mettre à jour une exécution de requête !"
+msgstr "Je kunt een QueryExecution niet bijwerken!"
 
 #: src/metabase/models/revision.clj
 msgid "You cannot update a Revision!"
-msgstr "Vous ne pouvez mettre à jour une révision !"
+msgstr "Je kunt een revisie niet bewerken!"
 
 #: src/metabase/models/setting.clj
 msgid "Setting {0} does not exist.nFound: {1}"
-msgstr "Le réglage {0} n'existe pas. nRéglage trouvé : {1}"
+msgstr "Instelling {0} bestaat niet. Gevonden: {1}"
 
 #: src/metabase/models/setting/cache.clj
 msgid "Updating value of settings-last-updated in DB..."
-msgstr "Mise à jour de la valeur de `settings-last-updated` en base de données..."
+msgstr "Waarde van instellingen bijwerken - laatst bijgewerkt in DB ..."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Checking whether settings cache is out of date (requires DB call)..."
-msgstr "Vérification de la péremption du cache des réglages (nécessite un appel à la base de données)..."
+msgstr "Controleren of instellingencache verouderd is (vereist DB-oproep) ..."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Settings have been changed on another instance, and will be reloaded here."
-msgstr "Les réglages ont été changés sur une autre instance, et seront rechargés sur celle-ci."
+msgstr "Instellingen zijn in een andere instantie gewijzigd en worden hier opnieuw geladen."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Refreshing Settings cache..."
-msgstr "Rafraîchissement du cache des réglages..."
+msgstr "Cache voor instellingen vernieuwen ..."
 
 #: src/metabase/models/setting.clj
 msgid "Invalid value for string: must be either \"true\" or \"false\" (case-insensitive)."
-msgstr "Représentation d'un valeur booléenne invalide : seules \"true\" ou \"false\" sont autorisées (et insensible à la casse)."
+msgstr "Ongeldige waarde voor tekenreeks: moet \"waar\" of \"onwaar\" (niet hoofdlettergevoelig) zijn."
 
 #: src/metabase/models/setting.clj
 msgid "You cannot update `settings-last-updated` yourself! This is done automatically."
-msgstr "Vous ne pouvez mettre à jour `settings-last-updated` vous-même ! C'est fait automatiquement."
+msgstr "Je kunt `settings-last-updated` niet zelf bijwerken! Dit gebeurt automatisch."
 
 #. go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
 #: src/metabase/models/setting.clj
 msgid "Error inserting a new Setting:"
-msgstr "Erreur à l'insertion d'un nouveau réglage :"
+msgstr "Fout bij het invoegen van een nieuwe instelling:"
 
 #: src/metabase/models/setting.clj
 msgid "Assuming Setting already exists in DB and updating existing value."
-msgstr "Mise à jour d'une valeur existante en présupposant que le réglage existe déjà en base de données."
+msgstr "Er wordt vanuit gegaan dat de instelling al bestaat in de database. De huidige waarde wordt bijgewerkt."
 
 #: src/metabase/models/user.clj
 msgid "value must be a map with each value either a string or number."
-msgstr "la valeur doit être une association aux valeurs de type chaîne de caractère ou numérique."
+msgstr "waarde moet een kaart zijn met elke waarde een tekenreeks of nummer."
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in directory {0}..."
-msgstr "Chargement des plugins du répertoire {0}..."
+msgstr "Plug-ins laden vanuit map {0} ..."
 
 #: src/metabase/plugins.clj
 msgid "Loading plugin {0}... "
-msgstr "Chargement du plugin {0}..."
+msgstr "Plugin {0} laden..."
 
 #: src/metabase/plugins.clj
 msgid "It looks like you have some external dependencies in your Metabase plugins directory."
-msgstr "Il semble que vous ayez des dépendances externes dans le répertoire de vos plugins Metabase."
+msgstr "Het lijkt erop dat u externe afhankelijkheden hebt in uw Metabase-plug-insmap."
 
 #: src/metabase/plugins.clj
 msgid "With Java 9 or higher, Metabase cannot automatically add them to your classpath."
-msgstr "Depuis Java 9, Metabase peut automatiquement les ajouter à votre classpath."
+msgstr "Met Java 9 of hoger kan Metabase ze niet automatisch toevoegen aan uw klassenpad."
 
 #: src/metabase/plugins.clj
 msgid "Instead, you should include them at launch with the -cp option. For example:"
-msgstr "Vous devriez plutôt les inclure au lancement avec l'option -cp. Par exemple :"
+msgstr "In plaats daarvan moet u ze bij de lancering opnemen met de optie -cp. Bijvoorbeeld:"
 
 #: src/metabase/plugins.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#java-versions for more details."
-msgstr "Consulter https://metabase.com/docs/latest/operations-guide/start.html#java-versions pour plus de détails."
+msgstr "Zie https://metabase.com/docs/latest/operations-guide/start.html#java-versions voor meer informatie."
 
 #: src/metabase/plugins.clj
 msgid "(If you're already running Metabase this way, you can ignore this message.)"
-msgstr "(Si vous faites déjà tourner Metabase de cette façon, vous pouvez ignorer ce message.)"
+msgstr "(Als je Metabase al op deze manier gebruikt, kunt u dit bericht negeren.)"
 
 #: src/metabase/public_settings.clj
 msgid "Identify when new versions of Metabase are available."
-msgstr "Identifie quand de nouvelles versions de Metabase sont disponibles."
+msgstr "Bepaal wanneer nieuwe versies van Metabase beschikbaar zijn."
 
 #: src/metabase/public_settings.clj
 msgid "Information about available versions of Metabase."
-msgstr "Information sur les versions de Metabase disponibles."
+msgstr "Informatie over beschikbare versies van Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "The name used for this instance of Metabase."
-msgstr "Le nom utilisé pour cette instance de Metabase."
+msgstr "De naam die gebruikt wordt voor deze installatie van Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "The base URL of this Metabase instance, e.g. \"http://metabase.my-company.com\"."
-msgstr "L'URL de base de cette instance de Metabase, par exemple : \"http://metabase.mon-entreprise.com\"."
+msgstr "De basis-URL van deze Metabase-instantie, b.v. \"http://metabase.mijn-bedrijf.nl\"."
 
 #: src/metabase/public_settings.clj
 msgid "The default language for this Metabase instance."
-msgstr "Le langage par défaut de cette instance de Metabase."
+msgstr "De standaardtaal voor deze Metabase installatie."
 
 #: src/metabase/public_settings.clj
 msgid "This only applies to emails, Pulses, etc. Users'' browsers will specify the language used in the user interface."
-msgstr "S'applique uniquement aux courriels, Pulses, etc. La langue du navigateur de l'utilisateur est utilisée pour afficher l'interface web."
+msgstr "Dit is alleen van toepassing op e-mails, pulsen, enz. Browsers van gebruikers geven de taal op die wordt gebruikt in de gebruikersinterface."
 
 #: src/metabase/public_settings.clj
 msgid "The email address users should be referred to if they encounter a problem."
-msgstr "Adresse électronique que les utilisateurs contacteront s'ils rencontrent un problème."
+msgstr "Het e-mailadres wat gebruikers te zien krijgt wanneer zij een probleem tegenkomen."
 
 #: src/metabase/public_settings.clj
 msgid "Enable the collection of anonymous usage data in order to help Metabase improve."
-msgstr "Activer la collecte de données d'utilisation anonymes nous permettant d'améliorer Metabase."
+msgstr "Schakel het verzamelen van anonieme gebruiksgegevens in om Metabase te helpen verbeteren."
 
 #: src/metabase/public_settings.clj
 msgid "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox."
-msgstr "Le patron d'URL du serveur de tuiles de cartes utilisé dans les visualisations de carte, par exemple depuis OpenStreetMap ou MapBox."
+msgstr "De URL-sjabloon van de kaarttegelserver die wordt gebruikt in kaartvisualisaties, bijvoorbeeld van OpenStreetMaps of MapBox."
 
 #: src/metabase/public_settings.clj
 msgid "Enable admins to create publicly viewable links (and embeddable iframes) for Questions and Dashboards?"
-msgstr "Activer la création - par les administrateurs - de liens publics (et d'iframes intégrées) vers les questions et les tableaux de bord ?"
+msgstr "Beheerders toestaan om openbaar zichtbare koppelingen (en insluitbare iframes) voor vragen en dashboards te maken?"
 
 #: src/metabase/public_settings.clj
 msgid "Allow admins to securely embed questions and dashboards within other applications?"
-msgstr "Autoriser l'intégration sécurisée - par les administrateurs - des questions et tableaux de bord dans d'autres applications ?"
+msgstr "Beheerders toestaan om vragen en dashboards veilig in andere applicaties in te sluiten?"
 
 #: src/metabase/public_settings.clj
 msgid "Allow using a saved question as the source for other queries?"
-msgstr "Autoriser l'utilisation d'une question sauvegardée comme source d'autres questions ?"
+msgstr "Staat het gebruik van een opgeslagen vraag toe als bron voor andere zoekopdrachten?"
 
 #: src/metabase/public_settings.clj
 msgid "Enabling caching will save the results of queries that take a long time to run."
-msgstr "Activer le cache sauvegardera les résultats des requêtes qui prennent longtemps à s'exécuter."
+msgstr "Door het inschakelen van caching zullen resultaten van queries die lang draaien opgeslagen worden."
 
 #: src/metabase/public_settings.clj
 msgid "The maximum size of the cache, per saved question, in kilobytes:"
-msgstr "La taille maximum du cache, par question sauvegardée, en Ko :"
+msgstr "De maximale grootte van de cache, per opgeslagen vraag, in kilobytes:"
 
 #: src/metabase/public_settings.clj
 msgid "The absolute maximum time to keep any cached query results, in seconds."
-msgstr "La durée maximum absolue de conservation en cache des résultats de requête, en secondes."
+msgstr "De absolute maximale tijd om resultaten in de cache te bewaren, in seconden."
 
 #: src/metabase/public_settings.clj
 msgid "Metabase will cache all saved questions with an average query execution time longer than this many seconds:"
-msgstr "Metabase mettra en cache toutes les questions sauvegardées qui ont une durée d'exécution moyenne plus longue que ce nombre de secondes :"
+msgstr "Metabase slaat alle opgeslagen vragen op in de cache met een gemiddelde uitvoeringstijd van een query langer dan zoveel seconden:"
 
 #: src/metabase/public_settings.clj
 msgid "To determine how long each saved question''s cached result should stick around, we take the query''s average execution time and multiply that by whatever you input here."
-msgstr "Pour déterminer la durée de conservation du résultat d'une question sauvegardée, nous pondérons sa durée moyenne d'exécution par le coefficient multiplicateur que vous saisissez ici."
+msgstr "Om te bepalen hoe lang het in de cache opgeslagen resultaat van elke opgeslagen vraag moet blijven, nemen we de gemiddelde uitvoeringstijd van de query en vermenigvuldigen die met wat u hier invoert."
 
 #: src/metabase/public_settings.clj
 msgid "So if a query takes on average 2 minutes to run, and you input 10 for your multiplier, its cache entry will persist for 20 minutes."
-msgstr "Ainsi avec un coefficient 10, le résultat d'une requête prenant en moyenne 2 minutes à s'exécuter persistera en cache pendant 20 minutes."
+msgstr "Dus als het uitvoeren van een zoekopdracht gemiddeld 2 minuten duurt en je 10 invoert voor de vermenigvuldiger, blijft de cache-invoer 20 minuten bestaan."
 
 #: src/metabase/public_settings.clj
 msgid "When using the default binning strategy and a number of bins is not provided, this number will be used as the default."
-msgstr "Valeur par défaut du nombre de cellules (bins) pour le binning"
+msgstr "Wanneer de standaardbinningstrategie wordt gebruikt en een aantal bins niet is opgegeven, wordt dit nummer als standaard gebruikt."
 
 #: src/metabase/public_settings.clj
 msgid "When using the default binning strategy for a field of type Coordinate (such as Latitude and Longitude), this number will be used as the default bin width (in degrees)."
-msgstr "Valeur par défaut en degrés du côté d'une cellule (bin) pour le binning d'un champ de type Coordonnées (tels que Latitude ou Longitude)."
+msgstr "Wanneer u de standaardbinningstrategie gebruikt voor een veld van het type Coördinaat (zoals Breedtegraad en Lengtegraad), wordt dit nummer gebruikt als de standaard bin-breedte (in graden)."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token."
-msgstr "Impossible de valider le jeton."
+msgstr "Kan token niet valideren."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error fetching token status:"
-msgstr "Ereur à la récupération du statut du jeton :"
+msgstr "Fout bij het ophalen van de tokenstatus:"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid."
-msgstr "Il y a eu une erreur à la vérification de la validité du jeton."
+msgstr "Er is een fout opgetreden bij het controleren of deze token geldig was."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token validation timed out."
-msgstr "Dépassement de la durée maximum fixée pour la validation du jeton."
+msgstr "Tokenvalidatie is verlopen."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Invalid token: token isn't in the right format."
-msgstr "Jeton invalide : le jeton n'est pas dans le bon format."
+msgstr "Ongeldig token: token heeft niet de juiste indeling."
 
 #. attempt to query the metastore API about the status of this token. If the request doesn't complete in a
 #. reasonable amount of time throw a timeout exception
 #: src/metabase/public_settings/metastore.clj
 msgid "Checking with the MetaStore to see whether {0} is valid..."
-msgstr "Vérification dans le MetaStore de la validité de {0}..."
+msgstr "Bij de MetaStore controleren of {0} geldig is ..."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium embedding. Go to the MetaStore to get yours!"
-msgstr "Jeton pour l'intégration Premium. Rendez-vous dans le MetaStore pour obtenir le votre !"
+msgstr "Token voor premium insluiting. Ga naar de MetaStore om de jouwe te krijgen!"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token is valid."
-msgstr "Le jeton est valide."
+msgstr "Token is geldig."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error setting premium embedding token"
-msgstr "Erreur au réglage du jeton d'intégration Premium."
+msgstr "Fout bij instellen van premium insluittoken"
 
 #: src/metabase/pulse.clj
 msgid "Unable to compare results to goal for alert."
-msgstr "Dans l'incapacité de comparer les résultats à l'objectif pour générer une alerte."
+msgstr "Kan resultaten niet vergelijken voor een doel waarschuwing."
 
 #: src/metabase/pulse.clj
 msgid "Question ID is ''{0}'' with visualization settings ''{1}''"
-msgstr "L'ID de question est \"{0}\" avec les réglages de Visualisation \"{1}\""
+msgstr "Vraag-ID is \"{0}\" met visualisatie-instellingen \"{1}\""
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized alert with condition ''{0}''"
-msgstr "Alerte non reconnue de condition \"{0}\""
+msgstr "Onbekende melding met voorwaarde '' {0} ''"
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized channel type {0}"
-msgstr "Type de canal {0} non reconnu"
+msgstr "Onbekend kanaaltype {0}"
 
 #: src/metabase/pulse.clj
 msgid "Error sending notification!"
-msgstr "Erreur à l'envoi de la notification !"
+msgstr "Fout bij het verzenden van melding!"
 
 #: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
-msgstr "Dans l'incapacité de trouver le sélecteur de couleur JS à \"{0}\""
+msgstr "Can't find JS color selector at ''{0}''"
 
 #: src/metabase/pulse/render.clj
 msgid "Card has errors: {0}"
-msgstr "Questions en erreur : {0}"
+msgstr "Kaard heeft fouten: {0}"
 
 #: src/metabase/pulse/render.clj
 msgid "Pulse card render error"
-msgstr "Erreur au rendu de la carte de Pulse"
+msgstr "Pulskaart renderfout"
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Trimming trailing comment from card with id {0}"
-msgstr "Découpage du commentaire final de la question d'ID {0}"
+msgstr "Opmerking van kaart wordt bijgewerkt met ID {0}"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Can't find field with ID: {0}"
-msgstr "Dans l'incapacité de trouver le champ d'ID : {0}"
+msgstr "Kan veld met ID niet vinden: {0}"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "''{0}'' is a required param."
-msgstr "\"{0}\" est un paramètre obligatoire."
+msgstr "\"{0}\" is een vereiste parameter."
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Found ''{0}'' with no terminating ''{1}'' in query ''{2}''"
-msgstr "Identification d'un \"{0}\" sans terminaison \"{1}\" dans la requête \"{2}\""
+msgstr "'' {0} '' gevonden zonder \"{1}\" af te sluiten in zoekopdracht '' {2} ''"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Unable to substitute ''{0}'': param not specified.nFound: {1}"
-msgstr "Dans l'incapacité de substituer \"{0}\" : paramètre non spécifié. nValeur trouvée : {1}"
+msgstr "Kan \"{0}\" niet vervangen: parameter niet opgegeven. Gevonden: {1}"
 
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "You do not have permissions to view Card {0}."
-msgstr "Vous n'êtes pas autorisé à afficher la question {0}."
+msgstr "Je hebt onvoldoende rechten om Kaart {0} te bekijken."
 
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "You do not have permissions to run this query."
-msgstr "Vous n'êtes pas autorisé à exécuter cette requête."
+msgstr "Je hebt onvoldoende rechten om deze query uit te voeren."
 
 #: src/metabase/sync/analyze.clj
 msgid "Fingerprint updates attempted {0}, updated {1}, no data found {2}, failed {3}"
-msgstr "{0} mise(s) à jour d'empreintes tentée(s), {1} mise(s) à jour effective(s), {2} sans donnée correspondante, {3} en échec"
+msgstr "Bijwerken van vingerafdruk geprobeerd {0}, bijgewerkt {1}, geen gegevens gevonden {2}, mislukt {3}"
 
 #: src/metabase/sync/analyze.clj
 msgid "Total number of fields classified {0}, {1} failed"
-msgstr "{0} champs classifié(s), {1} échec(s)"
+msgstr "Totaal aantal geclassificeerde velden {0}, {1} is mislukt"
 
 #: src/metabase/sync/analyze.clj
 msgid "Total number of tables classified {0}, {1} updated"
-msgstr "Nombre total de tables classifiées {0}, {1} mises à jour"
+msgstr "Totaal aantal tabellen geclassificeerd {0}, {1} bijgewerkt"
 
 #: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
 msgid "Error generating fingerprint for {0}"
-msgstr "Erreur à la génération de l'empreinte pour {0}"
+msgstr "Fout bij het genereren van vingerafdruk voor {0}"
 
 #: src/metabase/sync/field_values.clj
 msgid "Updated {0} field value sets, created {1}, deleted {2} with {3} errors"
-msgstr "{0} ensemble de valeurs mis à jour, {1} crée(s), {2} supprimée(s), dont {3} en erreur"
+msgstr "Bijgewerkte {0} veldwaardesets, {1} gemaakt, {2} verwijderd met {3} fouten"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of fields sync''d {0}, number of fields updated {1}"
-msgstr "{0} champ(s) synchronisé(s), {1} champ(s) mis à jour"
+msgstr "Totaal aantal gesynchroniseerde velden {0}, aantal bijgewerkte velden {1}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of tables sync''d {0}, number of tables updated {1}"
-msgstr "{0} table(s) synchronisée(s), {1} table(s) mise(s) à jour"
+msgstr "Totaal aantal gesynchroniseerde tabellen {0}, aantal bijgewerkte tabellen {1}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Found timezone id {0}"
-msgstr "Identification d'un fuseau horaire d' ID {0}"
+msgstr "Tijdzone-ID gevonden {0}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of foreign keys sync''d {0}, {1} updated and {2} tables failed to update"
-msgstr "{0} clé(s) étrangère(s) synchronisée(s), {1} clé(s) étrangère(s) mise(s) à jour et {2} table(s) non mises à jour à cause d'un erreur"
+msgstr "Totaal aantal gesynchroniseerde foreign keys {0}, {1} bijgewerkt en {2} tabellen konden niet worden bijgewerkt"
 
 #: src/metabase/sync/util.clj
 msgid "{0} Database {1} ''{2}''"
-msgstr "{0} Base de données {1} ''{2}''"
+msgstr "{0} Database {1} ''{2}''"
 
 #: src/metabase/sync/util.clj
 msgid "Table {0} ''{1}''"
-msgstr "Table {0} ''{1}''"
+msgstr "Tabel {0} \"{1}\""
 
 #: src/metabase/sync/util.clj
 msgid "Field {0} ''{1}''"
-msgstr "Champ {0} ''{1}''"
+msgstr "Veld {0} \"{1}\""
 
 #: src/metabase/sync/util.clj
 msgid "Field ''{0}''"
-msgstr "Champ '' {0} ''"
+msgstr "Veld \"{0}\""
 
 #: src/metabase/sync/util.clj
 msgid "step ''{0}'' for {1}"
-msgstr "étape ''{0}'' pour {1}"
+msgstr "stap \"{0}\" voor {1}"
 
 #: src/metabase/sync/util.clj
 msgid "Completed {0} on {1}"
-msgstr "Terminé {0} le {1}"
+msgstr "Voltooid in {0} op {1}"
 
 #: src/metabase/sync/util.clj
 msgid "Start: {0}"
-msgstr "Début : {0}"
+msgstr "Start: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "End: {0}"
-msgstr "Fin : {0}"
+msgstr "Einde: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "Duration: {0}"
-msgstr "Durée : {0}"
+msgstr "Tijdsduur: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "Completed step ''{0}''"
-msgstr "Etape \"{0}\" effectuée"
+msgstr "Stap \"{0}\" voltooid"
 
 #: src/metabase/task.clj
 msgid "Loading tasks namespace:"
-msgstr "Chargement de l'espace de nommage des tâches :"
+msgstr "Loading tasks namespace:"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler"
-msgstr "Démarrage du planificateur Quartz"
+msgstr "Starting Quartz Scheduler"
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler"
-msgstr "Arrêt du planificateur Quartz"
+msgstr "Stopping Quartz Scheduler"
 
 #: src/metabase/task.clj
 msgid "Job already exists:"
-msgstr "Le job existe déjà :"
+msgstr "Taak bestaat al:"
 
 #. This is the very first log message that will get printed.  It's here because this is one of the very first
 #. namespaces that gets loaded, and the first that has access to the logger It shows up a solid 10-15 seconds before
 #. the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
 #: src/metabase/util.clj
 msgid "Loading Metabase..."
-msgstr "Chargement de Metabase..."
+msgstr "Metabase wordt geladen..."
 
 #: src/metabase/util/date.clj
 msgid "Possible timezone conflict found on database {0}."
-msgstr "Possible conflit de fuseau horaire dans la base de données {0}."
+msgstr "Possible timezone conflict found on database {0}."
 
 #: src/metabase/util/date.clj
 msgid "JVM timezone is {0} and detected database timezone is {1}."
-msgstr "Le fuseau horaire de la JVM est {0} et celui détecté dans la base de données est {1}."
+msgstr "JVM timezone is {0} and detected database timezone is {1}."
 
 #: src/metabase/util/date.clj
 msgid "Configure a report timezone to ensure proper date and time conversions."
-msgstr "Configurer un fuseau horaire de restitution pour s'assurer d'une conversion correcte des dates et heures."
+msgstr "Configure a report timezone to ensure proper date and time conversions.\n"
+""
 
 #: src/metabase/util/embed.clj
 msgid "Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints."
-msgstr "Clé secrète utilisée pour signer les \"JSON Web Tokens\" dans les requêtes aux endpoints `/api/embed`."
+msgstr "Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints."
 
 #: src/metabase/util/encryption.clj
 msgid "MB_ENCRYPTION_SECRET_KEY must be at least 16 characters."
-msgstr "MB_ENCRYPTION_SECRET_KEY doit comporter au moins 16 caractères."
+msgstr "MB_ENCRYPTION_SECRET_KEY must be at least 16 characters."
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is ENABLED for this Metabase instance."
-msgstr "Le chiffrement des informations d'identification enregistrées est ACTIVÉ pour cette instance de Metabase."
+msgstr "Saved credentials encryption is ENABLED for this Metabase instance."
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is DISABLED for this Metabase instance."
-msgstr "Le chiffrement des informations d'identification enregistrées est DÉSACTIVÉ pour cette instance de Metabase."
+msgstr "Saved credentials encryption is DISABLED for this Metabase instance."
 
 #: src/metabase/util/encryption.clj
 msgid "nFor more information, see"
-msgstr "nPour plus d'informations, voir"
+msgstr "nFor more information, see"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer."
-msgstr "la valeur doit être un integer."
+msgstr "waarde moet een nummer zijn."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a string."
-msgstr "la valeur doit être une chaîne de caractères. "
+msgstr "waarde moet tekst zijn."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a boolean."
-msgstr "la valeur doit être un booléen."
+msgstr "waarde moet een boolean zijn."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a string that matches the regex `{0}`."
-msgstr "la valeur doit être une chaîne de caractères qui correspond à l'expression régulière {0}."
+msgstr "waarde moet een string zijn die voldoet aan de volgende regex: \"{0}\"."
 
 #: src/metabase/util/schema.clj
 msgid "value must satisfy one of the following requirements: "
-msgstr "la valeur doit satisfaire une des exigences suivantes : "
+msgstr "waarde moet voldoen aan een van de volgende vereisten:"
 
 #: src/metabase/util/schema.clj
 msgid "value may be nil, or if non-nil, {0}"
-msgstr "la valeur peut être nil, ou si non-nil, {0}"
+msgstr "waarde kan nul zijn of, indien niet nul, {0}"
 
 #: src/metabase/util/schema.clj
 msgid "value must be one of: {0}."
-msgstr "les valeurs possibles sont : {0}."
+msgstr "waarde moet een van de volgende zijn: {0}."
 
 #: src/metabase/util/schema.clj
 msgid "value must be an array."
-msgstr "la valeur doit être un tableau."
+msgstr "waarde moet een array zijn."
 
 #: src/metabase/util/schema.clj
 msgid "Each {0}"
-msgstr "Chaque {0}"
+msgstr "Iedere {0}"
 
 #: src/metabase/util/schema.clj
 msgid "The array cannot be empty."
-msgstr "Le tableau ne peut être vide."
+msgstr "De array kan niet leeg zijn"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a non-blank string."
-msgstr "la valeur doit être une chaîne de caractères non vide."
+msgstr "waarde moet inhoud bevatten."
 
 #: src/metabase/util/schema.clj
 msgid "Integer greater than zero"
-msgstr "Un entier supérieur à zéro"
+msgstr "Nummer groter dan nul"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer greater than zero."
-msgstr "la valeur doit être un entier supérieur à zéro."
+msgstr "waarde moet een nummer zijn groter dan nul."
 
 #: src/metabase/util/schema.clj
 msgid "Number greater than zero"
-msgstr "Un nombre supérieur à zéro"
+msgstr "Nummer groter dan nul"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a number greater than zero."
-msgstr "la valeur doit être un nombre supérieur à zéro."
+msgstr "waarde moet een nummer zijn groter dan nul."
 
 #: src/metabase/util/schema.clj
 msgid "Keyword or string"
-msgstr "Mot clé ou chaîne de caractères"
+msgstr "Sleutelwoord of tekst"
 
 #: src/metabase/util/schema.clj
 msgid "Valid field type"
-msgstr "type de champ valide"
+msgstr "Valide veldtype"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid field type."
-msgstr "la valeur doit être un type de champ valide."
+msgstr "waarde moet een valide veldtype zijn."
 
 #: src/metabase/util/schema.clj
 msgid "Valid field type (keyword or string)"
-msgstr "Type de champ valide (mot clé ou chaîne de caractères)"
+msgstr "Geldig veldtype (trefwoord of string)"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid field type (keyword or string)."
-msgstr "la valeur doit être un type de champ valide (mot clé ou chaîne de caractères)."
+msgstr "waarde moet een geldig veldtype zijn (trefwoord of string)."
 
 #: src/metabase/util/schema.clj
 msgid "Valid entity type (keyword or string)"
-msgstr "type d'entité valide (mot clé ou chaîne de caractères)"
+msgstr "Geldig entiteitstype (trefwoord of string)"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid entity type (keyword or string)."
-msgstr "la valeur doit être un type d'entité valide (mot clé ou chaîne de caractères)."
+msgstr "waarde moet een geldig entiteitstype zijn (trefwoord of string)."
 
 #: src/metabase/util/schema.clj
 msgid "Valid map"
-msgstr "Association valide"
+msgstr "Geldige kaart"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a map."
-msgstr "la valeur doit être une association."
+msgstr "waarde moet een kaart zijn."
 
 #: src/metabase/util/schema.clj
 msgid "Valid email address"
-msgstr "Adresse électronique valide"
+msgstr "Valide e-mailadres"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid email address."
-msgstr "cette valeur doit être une adresse électronique valide."
+msgstr "waarde moet een valide e-mailadres zijn."
 
 #: src/metabase/util/schema.clj
 msgid "Insufficient password strength"
-msgstr "Force de mot de passe insuffisante"
+msgstr "Onvoldoende wachtwoordsterkte"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer."
-msgstr "la valeur doit être un entier."
+msgstr "waarde moet een valide nummer zijn."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer greater than zero."
-msgstr "la valeur doit être un entier supérieur à zéro."
+msgstr "waarde moet een geldige integer en groter dan 0 zijn."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid boolean string (''true'' or ''false'')."
-msgstr "la valeur doit être un booléen représenté par \"true\" ou \"false\"."
+msgstr "waarde moet een geldige boolean zijn (\"true\" of \"false\")."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid JSON string."
-msgstr "la valeur doit être du JSON valide."
+msgstr "waarde moet een geldige JSON-string zijn."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid embedding params map."
-msgstr "la valeur doit être une association de paramètres d'intégration valide."
+msgstr "waarde moet een geldige embedding params-map zijn."
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx:12
 msgid "Data permissions"
-msgstr "Permissions sur les données"
+msgstr "Datarechten"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx:13
 msgid "Collection permissions"
-msgstr "Permissions sur la collection"
+msgstr "Verzamelingsrechten"
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
-msgstr "Voir toutes les permissions sur la collection"
+msgstr "Toon alle verzamelingsrechten"
 
 #: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
-msgstr "Changer aussi les sous-collections"
+msgstr "Wijzig ook subcollecties"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
-msgstr "Peut modifier cette collection et son contenu"
+msgstr "Kan deze verzameling en de inhoud ervan bewerken"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
-msgstr "Peut voir les items de cette collection"
+msgstr "Kan items in deze collectie bekijken"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
-msgstr "Accès à la collection"
+msgstr "Verzamelingstoegang"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
-msgstr "Ce groupe a la permission de voir au moins une sous-collection de cette collection."
+msgstr "Deze groep heeft toestemming om ten minste één deelcollectie van deze verzameling te bekijken."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
-msgstr "Ce groupe a le droit de modifier au moins une sous-collection de cette colleciton."
+msgstr "Deze groep heeft toestemming om ten minste één subcollectie van deze verzameling te bewerken."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
-msgstr "Voir les sous-collections"
+msgstr "Toon subverzamelingen"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
-msgstr "Se souvenir de moi"
+msgstr "Onthoud mij"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
-msgstr "Radiographier ce schéma"
+msgstr "X-ray dit schema"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:258
 msgid "Edit the permissions for this collection"
-msgstr "Modifier les permissions sur cette collection"
+msgstr "Bewerk de rechten voor deze verzameling"
 
 #: frontend/src/metabase/containers/AddToDashSelectDashModal.jsx:55
 msgid "Add this question to a dashboard"
-msgstr "Ajouter cette question au tableau de bord"
+msgstr "Voeg deze vraag toe aan een dashboard"
 
 #: frontend/src/metabase/containers/AddToDashSelectDashModal.jsx:65
 msgid "Create a new dashboard"
-msgstr "Créer un nouveau tableau de bord"
+msgstr "Maak een nieuw dashboard"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:45
 msgid "The page you asked for couldn't be found."
-msgstr "La page que vous avez demandé n'a pas pu être trouvée."
+msgstr "De pagina die u heeft opgevraagd bestaat niet."
 
 #: frontend/src/metabase/containers/ItemSelect.jsx:30
 msgid "Select a {0}"
-msgstr "Sélectionner un(e) {0}"
+msgstr "Selecteer een {0}"
 
 #: frontend/src/metabase/containers/Overworld.jsx:185
 msgid "Save dashboards, questions, and collections in \"{0}\""
-msgstr "Sauvegarder les tableaux de bord, questions et collections de \"{0}\""
+msgstr "Dashboards, vragen en collecties opslaan in \"{0}\""
 
 #: frontend/src/metabase/containers/Overworld.jsx:188
 msgid "Access dashboards, questions, and collections in \"{0}\""
-msgstr "Accéder aux tableaux de bord, questions et collections de \"{0}\""
+msgstr "Toegang tot dashboards, vragen en collecties in \"{0}\""
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
-msgstr "Comparer"
+msgstr "Vergelijk"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
-msgstr "Voir moins"
+msgstr "Uitzoomen"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
-msgstr "En lien"
+msgstr "Gerelateerd"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
-msgstr "Plus de radiographies"
+msgstr "Meer x-rays"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:40
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
-msgstr "Pas de résultats"
+msgstr "Geen resultaten"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
-msgstr "Metabase n'a trouvé aucun résultat à votre recherche."
+msgstr "Metabase kon geen resultaten vinden voor uw zoekopdracht."
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
-msgstr "Aucune métrique"
+msgstr "Geen metrieken"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
 msgid "Aggregations"
-msgstr "Agrégations"
+msgstr "Aggregaties"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
 msgid "Operators"
-msgstr "Opérateurs"
+msgstr "operators"
 
 #: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
 msgid "Custom fields"
-msgstr "Champs personnalisés"
+msgstr "Aangepaste velden"
 
 #. 2. Create the new collections.
 #: src/metabase/db/migrations.clj
 msgid "Migrated Dashboards"
-msgstr "Tableaux de bord migrés"
+msgstr "Gemigreerde dashboards"
 
 #: src/metabase/db/migrations.clj
 msgid "Migrated Pulses"
-msgstr "Pulses migrés"
+msgstr "Pulsen gemigreerd"
 
 #: src/metabase/db/migrations.clj
 msgid "Migrated Questions"
-msgstr "Questions migrées"
+msgstr "Gemigreerde vragen"
 
 #. 4. move everything not in this Collection to a new Collection
 #: src/metabase/db/migrations.clj
 msgid "Moving instances of {0} that aren't in a Collection to {1} Collection {2}"
-msgstr "Déplacement des instances de {0} qui ne sont pas dans une collection vers {1} collection {2}"
+msgstr "Instanties van {0} die zich niet in een verzameling bevinden, verplaatsen naar {1} verzameling {2}"
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions: {0}"
-msgstr "Echec de l'attribution de permissions : {0}"
+msgstr "Toekennen van rechten mislukt: {0}"
 
 #: src/metabase/util/encryption.clj
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
-msgstr "Impossible de déchiffrer la chaîne chiffrée. Avez-vous changé ou oublié de régler MB_ENCRIPTION_SECRET_KEY ?"
+msgstr "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
 
 #: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
-msgstr "Toutes les collections personnelles"
+msgstr "Alle persoonlijke verzamelingen"
 
 #: src/metabase/driver/common.clj
 msgid "Host"
-msgstr "Hôte"
+msgstr "Host"
 
 #: src/metabase/driver/common.clj
 msgid "Port"
-msgstr "Port"
+msgstr "Poort"
 
 #: src/metabase/driver/common.clj
 msgid "Database username"
-msgstr "Nom utilisateur de la base de données"
+msgstr "Database gebruikersnaam"
 
 #: src/metabase/driver/common.clj
+#, fuzzy
 msgid "What username do you use to login to the database?"
-msgstr "Quel nom d'utilisateur utilisez-vous pour vous connecter à la base de données?"
+msgstr "Welke gebruikersnaam gebruikt u om bij de database aan te melden?"
 
 #: src/metabase/driver/common.clj
 msgid "Database password"
-msgstr "Mot de passe de la base de données"
+msgstr "Databasewachtwoord"
 
 #: src/metabase/driver/common.clj
 msgid "Database name"
-msgstr "Nom de la base de données"
+msgstr "Databasenaam"
 
 #: src/metabase/driver/common.clj
 msgid "birds_of_the_world"
@@ -9140,11 +9112,11 @@ msgstr "birds_of_the_world"
 
 #: src/metabase/driver/common.clj
 msgid "Use a secure connection (SSL)?"
-msgstr "Utiliser une connexion sécurisée (SSL) ?"
+msgstr "Gebruik een beveiligde verbinding (SSL)?"
 
 #: src/metabase/driver/common.clj
 msgid "Additional JDBC connection string options"
-msgstr "Options additionnelles de la chaîne de connexion JDBC"
+msgstr "Extra JDBC-verbindingsreeksopties"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Project ID"
@@ -9152,7 +9124,7 @@ msgstr "Project ID"
 
 #: src/metabase/driver/bigquery.clj
 msgid "praxis-beacon-120871"
-msgstr " praxis-beacon-120871"
+msgstr "praxis-beacon-120871"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Dataset ID"
@@ -9160,75 +9132,75 @@ msgstr "Dataset ID"
 
 #: src/metabase/driver/bigquery.clj
 msgid "toucanSightings"
-msgstr "\"toucanSightings\""
+msgstr "toucanSightings"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Client ID"
-msgstr "ID client"
+msgstr "Client ID"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Client Secret"
-msgstr "Client Secret"
+msgstr "Client geheim"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Auth Code"
-msgstr "Auth Code"
+msgstr "Authenticatiecode"
 
 #: src/metabase/driver/crate.clj
 msgid "Hosts"
-msgstr "Hôtes"
+msgstr "Host"
 
 #: src/metabase/driver/druid.clj
 msgid "Broker node port"
-msgstr "port du nœud de courtage (broker)"
+msgstr "Broker node port"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "Google Analytics Account ID"
-msgstr "ID du compte Google Analytics"
+msgstr "Google Analytics Account ID"
 
 #: src/metabase/driver/h2.clj
 msgid "Connection String"
-msgstr "Chaîne de connexion"
+msgstr "Connection String"
 
 #: src/metabase/driver/h2.clj
 msgid "Users/camsaul/bird_sightings/toucans"
-msgstr "\"Users/camsaul/bird_sightings/toucans\""
+msgstr "Users/camsaul/bird_sightings/toucans"
 
 #: src/metabase/driver/mongo.clj
 msgid "carrierPigeonDeliveries"
-msgstr "\"carrierPigeonDeliveries\""
+msgstr "carrierPigeonDeliveries"
 
 #: src/metabase/driver/mongo.clj
 msgid "Authentication Database"
-msgstr "Base de données d'authentification"
+msgstr "Database voor authenticatie"
 
 #: src/metabase/driver/mongo.clj
 msgid "Optional database to use when authenticating"
-msgstr "Base de données optionnelle à utiliser lors de l'authentificaiton"
+msgstr "Optionele database die gebruikt wordt bij authenticeren"
 
 #: src/metabase/driver/mongo.clj
 msgid "Additional Mongo connection string options"
-msgstr "Options additionnelles de la chaîne de connexion MongoDB"
+msgstr "Extra Mongo-verbindingsreeksopties"
 
 #: src/metabase/driver/oracle.clj
 msgid "Oracle system ID (SID)"
-msgstr "ID Oracle (SID)"
+msgstr "Oracle system ID (SID)"
 
 #: src/metabase/driver/oracle.clj
 msgid "Usually something like ORCL or XE."
-msgstr "Généralement quelque chose comme ORCL ou XE"
+msgstr "Meestal zoiets als ORCL of XE."
 
 #: src/metabase/driver/oracle.clj
 msgid "Optional if using service name"
-msgstr "Optionnel si vous utilisez un nom de service"
+msgstr "Optioneel als u een service naam gebruikt"
 
 #: src/metabase/driver/oracle.clj
 msgid "Oracle service name"
-msgstr "Nom de service Oracle"
+msgstr "Oracle service naam"
 
 #: src/metabase/driver/oracle.clj
 msgid "Optional TNS alias"
-msgstr "Alias TNS optionnel"
+msgstr "Optionele TNS alias"
 
 #: src/metabase/driver/presto.clj
 msgid "hive"
@@ -9244,15 +9216,15 @@ msgstr "toucan_sightings"
 
 #: src/metabase/driver/sparksql.clj
 msgid "default"
-msgstr "défaut"
+msgstr "standaard"
 
 #: src/metabase/driver/sqlite.clj
 msgid "Filename"
-msgstr "Nom de fichier"
+msgstr "Bestandsnaam"
 
 #: src/metabase/driver/sqlite.clj
 msgid "/home/camsaul/toucan_sightings.sqlite 😋"
-msgstr " /home/camsaul/toucan_sightings.sqlite 😋"
+msgstr "/home/camsaul/toucan_sightings.sqlite 😋"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "BirdsOfTheWorld"
@@ -9260,39 +9232,39 @@ msgstr "BirdsOfTheWorld"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "Database instance name"
-msgstr "Nom de l'instance de base de données"
+msgstr "Naam van database instantie"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "N/A"
-msgstr "N/A"
+msgstr "N/B"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "Windows domain"
-msgstr "Nom de domaine Windows"
+msgstr "Windows domein"
 
-#. Il semble que ce soit le libellé d'un des onglets : Données/Visualisation/Axes/Libellés
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:490
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:499
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
-msgstr "Libellés"
+msgstr "Labels"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
+#, fuzzy
 msgid "Add members"
-msgstr "Ajouter des membres"
+msgstr "Voeg leden toe"
 
 #: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
-msgstr "La collection est enregistrée dans"
+msgstr "Collectie waarin het is opgeslagen"
 
 #: frontend/src/metabase/lib/groups.js:4
 msgid "All Users"
-msgstr "Tous les utilisateurs"
+msgstr "Alle gebruikers"
 
 #: frontend/src/metabase/lib/groups.js:5
 msgid "Administrators"
-msgstr "Administrateurs"
+msgstr "Beheerders"
 
 #: frontend/src/metabase/lib/groups.js:6
 msgid "MetaBot"
@@ -9300,9 +9272,8 @@ msgstr "MetaBot"
 
 #: frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx:290
 msgid "Sharing"
-msgstr "Partage"
+msgstr "Delen"
 
-#. Il semble que ce soit le libellé d'un des onglets : Données/Visualisation/Axes/Libellés
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:218
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:251
@@ -9322,7 +9293,7 @@ msgstr "Partage"
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
-msgstr "Affichage"
+msgstr "Weergave"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:358
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:393
@@ -9333,112 +9304,113 @@ msgstr "Affichage"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:447
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
-msgstr "Axes"
+msgstr "Assen"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
 #: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
-msgstr "Formatage"
+msgstr "Opmaak"
 
 #: frontend/src/metabase/containers/Overworld.jsx:102
 msgid "Try these x-rays based on your data."
-msgstr "Essayez ces radiographies basées sur vos données."
+msgstr "Probeer deze x-rays op basis van je data."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:36
 msgid "There was a problem displaying this chart."
-msgstr "Un problème est survenu lors de l'affichage de ce graphique."
+msgstr "Er was een probleem bij het weergeven van deze grafiek."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:37
 msgid "Sorry, you don't have permission to see this card."
-msgstr "Désolé, vous n'êtes pas autorisé à voir cette question."
+msgstr "Sorry, u heeft geen toestemming om deze kaart te zien."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:55
 msgid "Just a heads up:"
-msgstr "Juste un aperçu :"
+msgstr "Even een waarschuwing:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:63
 msgid "{0} without the Sample Dataset, the Query Builder tutorial won't work. You can always restore the Sample Dataset, but any questions you've saved using this data will be lost."
-msgstr "{0} sans le jeu de données exemple, le didacticiel du générateur de requêtes ne fonctionnera pas. Vous pouvez restaurer le jeu de données, mais toutes les questions que vous avez enregistrées à l'aide de ces données seront perdues."
+msgstr "{0} zonder de voorbeeldgegevensset werkt de Query Builder-zelfstudie niet. Je kunt de voorbeeldgegevensset altijd herstellen, maar alle vragen die je met deze gegevens hebt opgeslagen, gaan verloren."
 
 #: frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx:33
 msgid "X-ray"
-msgstr "Radiographie"
+msgstr "X-ray"
 
 #: frontend/src/metabase/modes/components/drill/CompareToRestDrill.js:34
 msgid "Compare to the rest"
-msgstr "Comparer au reste"
+msgstr "Vergelijk met de rest"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
-msgstr "Utiliser le fuseau horaire de la machine virtuelle Java (JVM)"
+msgstr "Gebruik de Java Virtual Machine (JVM) tijdzone"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
-msgstr "Nous vous suggérons de le laisser cela désactivé à moins que vous ne procédiez à un paramétrage manuel du fuseau horaire dans la plupart de vos requêtes avec ces données."
+msgstr "We raden je aan om dit uit te schakelen tenzij er handmatig tijdzone casting wordt uitgevoerd voor de meeste van de vragen met deze gegevens."
 
 #: frontend/src/metabase/containers/Overworld.jsx:312
+#, fuzzy
 msgid "Your team's most important dashboards go here"
-msgstr "Les tableaux de bord les plus importants pour votre équipe vont ici"
+msgstr "Uw team's belangrijkste dashboards komen hier"
 
 #: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
-msgstr "Épingler les tableaux de bord dans {0} pour qu'ils apparaissent dans cet espace pour tout le monde"
+msgstr "Zet dashboards vast in {0} zodat ze voor iedereen in deze ruimte verschijnen"
 
 #: src/metabase/db.clj
 msgid "Unable to release the Liquibase lock after a migration failure"
-msgstr "Impossible de libérer le verrou Liquibase après un échec de migration"
+msgstr "Unable to release the Liquibase lock after a migration failure"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Use JVM Time Zone"
-msgstr "Utiliser le fuseau horaire de la JVM"
+msgstr "Gebruik JVM tijdzone"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:29
 msgid "We're currently analyzing the tables and fields to help you explore your data."
-msgstr "Nous sommes en cours d'analyse des tables et champs pour vous aider à explorer vos données."
+msgstr "We analyseren momenteel de tabellen en velden om je te helpen met het verkennen van je gegevens."
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
-msgstr "Astuce:␣"
+msgstr "Tip:"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
-msgstr "Sélectionnez un type de devise"
+msgstr "Selecteer een valutatype"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
-msgstr "Type de champ"
+msgstr "Ved type"
 
 #: frontend/src/metabase/admin/routes.jsx:109
 #: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
-msgstr "Dépannage"
+msgstr "Probleemoplossen"
 
 #: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
-msgstr "Activer la radiographie"
+msgstr "X-ray functionaliteit inschakelen"
 
 #: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
-msgstr "Options de mise en forme"
+msgstr "Opmaakopties"
 
 #: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
-msgstr "Détails de la tâche"
+msgstr "Taak details"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:29
 msgid "Troubleshooting logs"
-msgstr "Journaux de dépannage"
+msgstr "Probleemoplossing logs"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:31
 msgid "Trying to get to the bottom of something? This section shows logs of Metabase's background tasks, which can help shed light on what's going on."
-msgstr "Vous voulez voir le côté obscur ? Cette section affiche les journaux des tâches en arrière-plan de Metabase, qui peuvent aider à mieux comprendre ce qui se passe."
+msgstr "Probeert je iets uit te zoeken? Deze sectie toont logboeken van de achtergrondtaken van Metabase, die kunnen helpen licht te werpen op wat er aan de hand is."
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:56
 msgid "Task"
-msgstr "Tâche"
+msgstr "Taak"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:57
 msgid "DB ID"
@@ -9446,115 +9418,115 @@ msgstr "DB ID"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:58
 msgid "Started at"
-msgstr "Commencé à"
+msgstr "Gestart op"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:59
 msgid "Ended at"
-msgstr "Terminé à"
+msgstr "Afgerond op "
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:60
 msgid "Duration (ms)"
-msgstr "Durée (ms)"
+msgstr "Duur (ms)"
 
 #: frontend/src/metabase/lib/core.js:45
 msgid "Currency"
-msgstr "Devise"
+msgstr "Valuta"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
-msgstr "Choisissez un utilisateur ou un canal ..."
+msgstr "Kies een gebruiker of kanaal ..."
 
 #: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
-msgstr "Aucun paramètre de formatage"
+msgstr "Geen opmaak instellingen"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:81
 msgid "Label for this range (optional)"
-msgstr "Libellé pour cet intervalle (facultatif)"
+msgstr "Label voor dit bereik (optioneel)"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:93
 msgid "Add a range"
-msgstr "Ajouter un intervalle"
+msgstr "Bereik toevoegen"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "is less than"
-msgstr "est inférieur à"
+msgstr "is minder dan"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "is greater than"
-msgstr "est supérieur à"
+msgstr "is groter dan"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:28
 msgid "is less than or equal to"
-msgstr "est inférieur ou égal à"
+msgstr "is minder dan of gelijk aan"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:29
 msgid "is greater than or equal to"
-msgstr "est supérieur ou égal à"
+msgstr "is groter dan of gelijk aan"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:37
 msgid "is equal to"
-msgstr "est égal à"
+msgstr "is gelijk aan"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:31
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:38
 msgid "is not equal to"
-msgstr "n'est pas égal à"
+msgstr "is niet gelijk aan"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:32
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:39
 msgid "is null"
-msgstr "est nul"
+msgstr "is leeg"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:33
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:40
 msgid "is not null"
-msgstr "n'est pas nul"
+msgstr "is niet leeg"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:41
 msgid "contains"
-msgstr "contient"
+msgstr "bevat"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:42
 msgid "does not contain"
-msgstr "ne contient pas"
+msgstr "bevat niet"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:43
 msgid "starts with"
-msgstr "commence avec"
+msgstr "begint met"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:44
 msgid "ends with"
-msgstr "se termine par"
+msgstr "eindigt met"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:292
 msgid "When a cell in these columns {0} it will be tinted this color."
-msgstr "Lorsqu'une cellule de ces colonnes {0} sera colorée de cette couleur."
+msgstr "Een cel wordt gekleurd in deze kleur wanneer de cel in deze kolommen {0}."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:351
 msgid "When a cell in this column…"
-msgstr "Lorsqu'une cellule de cette colonne..."
+msgstr "Wanneer een cel in deze kolom..."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:42
 msgid "This visualization requires you to group by a field."
-msgstr "Cette visualisation requiert une aggrégation sur un des champs."
+msgstr "Met deze visualisatie is het verplicht om een veld te groeperen."
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:178
 msgid "Date style"
-msgstr "Format de date"
+msgstr "Datum stijl"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:196
 msgid "Date separators"
-msgstr "Séparateur de date"
+msgstr "Datum scheiding"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:215
 msgid "Abbreviate names of days and months"
-msgstr "Abréger le nom des jours et mois"
+msgstr "Verkort namen van dagen en maanden"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:225
 msgid "Show the time"
-msgstr "Afficher l'heure"
+msgstr "De tijd weergeven"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:232
 msgid "HH:MM"
@@ -9566,47 +9538,47 @@ msgstr "HH:MM:SS"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:243
 msgid "HH:MM:SS.MS"
-msgstr "HH:MM:SS.MS"
+msgstr "HH:MM:SS:MS"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:254
 msgid "Time style"
-msgstr "Format de l'heure"
+msgstr "Tijd format"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:300
 msgid "Unit of currency"
-msgstr "Unité monétaire"
+msgstr "Munteenheid"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
-msgstr "Style de libellé de devises"
+msgstr "Valuta labelstijl"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
-msgstr "Où afficher l'unité monétaire"
+msgstr "Waar de munteenheid wordt weergegeven"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
-msgstr "Nombre minimum de décimales"
+msgstr "Minimaal aantal decimalen"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
-msgstr "Type de graphique empilé"
+msgstr "Gestapeld grafiektype"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
-msgstr "Libellé d'objectif"
+msgstr "Doellabel"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
-msgstr "Afficher la tendance"
+msgstr "Trendlijn tonen"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:67
 msgid "Line style"
-msgstr "Format de ligne"
+msgstr "Lijn stijl"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:84
 msgid "Show dots on lines"
-msgstr "Afficher les points sur les lignes"
+msgstr "Punten en lijnen weergeven"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
@@ -9615,327 +9587,327 @@ msgstr "Auto"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:120
 msgid "Which axis?"
-msgstr "Quel axe ?"
+msgstr "Welke assen?"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
 msgid "Line + Bar"
-msgstr "Linéaire + À barres"
+msgstr "Lijn en staaf"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:19
 msgid "line and bar chart"
-msgstr "graphique linéaire et à barres"
+msgstr "Lijn en staaf grafiek"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
-msgstr "La visualisation par jauge nécessite un nombre."
+msgstr "Voor visualisatie van de meter is een nummer vereist."
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:60
 msgid "Gauge"
-msgstr "Jauge"
+msgstr "Meter"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
-msgstr "Intervalle de jauge"
+msgstr "Meter bereik"
 
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
-msgstr "Champ à afficher"
+msgstr "Veld om weer te geven"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
-msgstr "dernier {0}"
+msgstr "Laatste {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
-msgstr "{0} était {1} {2}"
+msgstr "{0} was {1} {2}"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
-msgstr "Agréger par un champ temporel pour voir comment cela a changé au fil du temps"
+msgstr "Groeperen bij een tijdveld om te kijken hoe dit veranderd is over de tijd"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
-msgstr "Changer les couleurs positives / négatives ?"
+msgstr "Schakelen tussen positieve / negatieve kleuren?"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
-msgstr "Colonne du pivot"
+msgstr "Draaikolom"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
-msgstr "Cellule de colonne"
+msgstr "Celkolom"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
-msgstr "Colonnes visibles"
+msgstr "Zichtbare kolommen"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
-msgstr "Formatage conditionnel"
+msgstr "Conditionele opmaak"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
-msgstr "Titre de colonne"
+msgstr "Kolomtitel"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
-msgstr "Afficher un mini-graph à barres"
+msgstr "Toon een mini-staafdiagram"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
-msgstr "Lien"
+msgstr "Link"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
-msgstr "Lien email"
+msgstr "E-mail link"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
-msgstr "Image"
+msgstr "Afbeelding"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
-msgstr "Automatique"
+msgstr "Automatisch"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
-msgstr "Voir comme lien ou image"
+msgstr "Bekijk as link of afbeelding"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
-msgstr "Lien texte"
+msgstr "Link tekst"
 
 #: src/metabase/api/common/internal.clj
 msgid "Not a valid integer: ''{0}''"
-msgstr "\"{0}\" n'est pas un entier valide."
+msgstr "Geen geldige integer: \"{0}\""
 
 #: src/metabase/api/embed.clj
 msgid "Embedding is not enabled for this object."
-msgstr "L'intégration n'est pas activée pour cet objet."
+msgstr "Embedden is niet ingeschakeld voor dit object."
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fallback to local authentication: {0}"
-msgstr "Un problème de connexion au serveur LDAP entraîne le recours à l'authentification locale : {0}"
+msgstr "Probleem met het verbinden van de LDAP server, valt terug op lokale authenticatie: {0}"
 
 #: src/metabase/api/task.clj
 msgid "When including an offset, a limit must also be included."
-msgstr "Lorsque vous incluez un décalage, vous devez également inclure une limite."
+msgstr "Bij het opnemen van een offset moet ook een limiet worden opgenomen."
 
 #: src/metabase/api/task.clj
 msgid "When including a limit, an offset must also be included."
-msgstr "Lorsque vous incluez une limite, un décalage doit également être inclus."
+msgstr "Bij het opnemen van een limiet moet ook een offset worden opgenomen."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Applying heuristic {0} to {1}."
-msgstr "Application de l'heuristique {0} à {1}."
+msgstr "Heuristisch {0} toepassen op {1}."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Dimensions bindings:n{0}"
-msgstr "Définition des dimensions : n{0}"
+msgstr "Dimensies bindingen: n {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Using definitions:nMetrics:n{0}nFilters:n{1}"
-msgstr "Utilisation de définitions : :nMetrics: n{0} nFilters: n{1}"
+msgstr "Definities gebruiken: nMetrieken:n{0}nFilters:n{1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "minute"
-msgstr "minute"
+msgstr "minuut"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "hour"
-msgstr "heure"
+msgstr "uur"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of week"
-msgstr "jour de la semaine"
+msgstr "dag van de week"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of month"
-msgstr "jour du mois"
+msgstr "dag van de maand"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of year"
-msgstr "jour de l'année"
+msgstr "dag van jaar"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "week"
-msgstr "semaine"
+msgstr "week"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "month"
-msgstr "mois"
+msgstr "maand"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "quarter"
-msgstr "trimestre"
+msgstr "kwartaal"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding {0} cards to dashboard {1}:n{2}"
-msgstr "Ajouter la question {0} au tableau de bord {1}:n{2}"
+msgstr "{0} kaarten toevoegen aan dashboard {1}: n {2}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Error parsing {0}:n{1}"
-msgstr "Erreur lors de l'analyse de {0}:n{1}"
+msgstr "Fout bij parsen {0}: n {1}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Filtering only works on dimensions! ''{0}'' is a metric. Ignoring filter."
-msgstr "AVERTISSEMENT: le filtrage ne fonctionne que sur les dimensions! ''{0}'' est une métrique. Le filtre est ignoré."
+msgstr "WAARSCHUWING: Filteren werkt alleen op dimensies! '' {0} '' is een metriek. Filter negeren."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: A date can't belong to multiple discrete intervals, so ANDing them together doesn't make sense."
-msgstr "AVERTISSEMENT: une date ne peut pas appartenir à plusieurs intervalles, les joindre avec un ET n'a pas de sens."
+msgstr "WAARSCHUWING: een datum kan niet tot meerdere afzonderlijke intervallen behoren, dus het is niet logisch deze samen te voegen."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Ignoring these intervals: {0}"
-msgstr "Ignorer ces intervalles : {0}"
+msgstr "Deze intervallen: {0} worden genegeerd"
 
 #. We should never get to this point since the all non-string negations should get automatically rewritten
 #. by the query expander.
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Don't know how to negate: {0}"
-msgstr "AVERTISSEMENT: je ne sais pas comment annuler : {0}"
+msgstr "WAARSCHUWING: Weet niet hoe de volgende waardes ontkend moet worden: {0}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Sorting with Druid is only allowed in queries that have one or more breakout columns. Ignoring :order-by clause."
-msgstr "Le tri avec Druid n'est autorisé que dans les requêtes comportant une ou plusieurs colonnes de séparation. Le tri est ignoré."
+msgstr "Sorteren met Druid is alleen toegestaan in query's met een of meer breakout-kolommen. Negeren: order-by-clausule."
 
 #. TODO - this is not really true, is it
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: It only makes sense to specify :fields for a query with no aggregation. Ignoring the clause."
-msgstr "AVERTISSEMENT: il est uniquement utile de spécifier les champs d'une requête sans agrégation. J'ignore la clause."
+msgstr "WAARSCHUWING: Het heeft alleen zin om :fields op te geven in een query zoekopdracht zonder aggregatie. De clausule wordt genegeerd."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid doenst allow limitSpec in timeseries queries. Ignoring the LIMIT clause."
-msgstr "AVERTISSEMENT: Druid n'autorise pas les requêtes limitSpec dans les séries chronologiques. J'ignore la clause LIMIT."
+msgstr "WAARSCHUWING: Druid staat limitSpec niet toe in tijdreeksquery's. Negeren van de LIMIT-clausule."
 
 #: src/metabase/driver/sql/query_processor.clj
 msgid "HoneySQL Form:"
-msgstr "Formulaire HoneySQL :"
+msgstr "HoneySQL Form:"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Unable to parse date ''{0}''"
-msgstr "Impossible d'évaluer la date \"{0}\""
+msgstr "Kan datum \"{0}\" niet parsen"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, cancelling query"
-msgstr "Connexion fermée, annulation de la requête"
+msgstr "Client heeft verbinding verbroken, zoekopdracht wordt geannuleerd"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Setting timezone with statement: {0}"
-msgstr "Définition du fuseau horaire avec l'instruction : {0}"
+msgstr "Tijdzone instellen met statement: {0}"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid "Multiple date filters are not supported"
-msgstr "Les filtres de dates multiples ne sont pas pris en charge."
+msgstr "Meerdere datum filters zijn niet toegestaan"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid ":not is not yet implemented"
-msgstr ":not n'est pas encore implémenté"
+msgstr ":not is nog niet geïmplementeerd"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid "Only one Google Analytics segment allowed at a time."
-msgstr "Seulement un segment Google Analytics est supporté."
+msgstr "Maar een Google Analytics segment toegestaan per keer."
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "MONGO AGGREGATION PIPELINE:"
-msgstr "MONGO AGGREGATION PIPELINE :"
+msgstr "MONGO AGGREGATION PIPELINE:"
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "Error: mismatched columns in results! Expected: {0} Got: {1}"
-msgstr "Erreur: colonnes incompatibles dans les résultats ! Attendu : {0} obtenu : {1}"
+msgstr "Fout: niet-overeenkomende kolommen in resultaten! Verwacht: {0} Got: {1}"
 
 #: src/metabase/email/messages.clj
 msgid "Unable to create temp file in `{0}` for email attachments "
-msgstr "Impossible de créer le fichier temporaire `{0}` pour la pièce jointe "
+msgstr "Kan geen tijdelijk bestand maken in `{0}` voor e-mailbijlagen"
 
 #: src/metabase/events/activity_feed.clj
 msgid "Error preprocessing query:"
-msgstr "Erreur de pré-traitement de la requête :"
+msgstr "Fout bij het verwerken van de query:"
 
 #: src/metabase/mbql/normalize.clj
 msgid "Illegal filter clause: {0}"
-msgstr "Mauvaise clause de filtre : {0}"
+msgstr "Illegale filterclausule: {0}"
 
 #: src/metabase/mbql/normalize.clj
 msgid "Invalid clause:"
-msgstr "Clause invalide :"
+msgstr "Ongeldige clausule:"
 
 #: src/metabase/mbql/util.clj
 msgid "Error: query's source query has not been resolved. You probably need to `preprocess` the query first."
-msgstr "Erreur : la requête source cette requête n'a pas été résolue. Vous devez probablement «prétraiter» la requête en premier."
+msgstr "Fout: de bronquery van de zoekopdracht is niet opgelost. Waarschijnlijk moet je eerst de query `preprocessen '."
 
 #: src/metabase/mbql/util.clj
 msgid "No expression named ''{0}''"
-msgstr "Aucune expression nommée \"{0}\""
+msgstr "Geen expressie met de naam '' {0} ''"
 
 #: src/metabase/mbql/util.clj
 msgid "No aggregation at index: {0}"
-msgstr "Aucun aggregat à l'index : {0}"
+msgstr "Geen aggregatie bij index: {0}"
 
 #: src/metabase/models/field_values.clj
 msgid "Field values total length is {0} (max {1})."
-msgstr "La longueur totale des valeurs de champ est {0} (max {1})."
+msgstr "De totale lengte van veldwaarden is {0} (max {1})."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues are allowed for this Field."
-msgstr "Filtres de champ autorisé pour ce champ."
+msgstr "Veldwaarden zijn toegestaan voor dit veld."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues are NOT allowed for this Field."
-msgstr "Filtres de champ NON autorisé pour ce champ."
+msgstr "Veldwaarden zijn NIET toegestaan voor dit veld."
 
 #: src/metabase/models/field_values.clj
 msgid "Field {0} ''{1}'' should have FieldValues and belongs to a Database with On-Demand FieldValues updating."
-msgstr "Le champ {0} \"{1}\" devrait avoir un filtre et correspondre à une base de données avec mise à jour manuelle des filtres."
+msgstr "Veld {0} '' {1} '' moet FieldValues hebben en hoort bij een database met on-demand FieldValues-updates."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot create or revoke permissions for the ''Admin'' group."
-msgstr "Vous ne pouvez pas créer ou révoquer des autorisations pour le groupe ''Admin''."
+msgstr "Je kunt geen machtigingen voor de groep '' Beheerder 'maken of intrekken."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the ''MetaBot'' group."
-msgstr "Vous ne pouvez pas ajouter ou supprimer des utilisateurs du groupe ''MetaBot\"."
+msgstr "Je kunt geen gebruikers toevoegen aan of verwijderen uit de groep \"MetaBot\"."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the ''All Users'' group."
-msgstr "Vous ne pouvez pas ajouter ou supprimer des utilisateurs du groupe \"Tous les utilisateurs\"."
+msgstr "Je kunt geen gebruikers toevoegen aan of verwijderen uit de groep '' Alle gebruikers ''."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the ''Admin'' group!"
-msgstr "Vous ne pouvez pas supprimer le dernier membre du groupe \"Admin\" !"
+msgstr "Je kunt het laatste lid van de groep '' Beheerder 'niet verwijderen!"
 
 #. go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
 #: src/metabase/models/setting/cache.clj
 msgid "Error inserting a new Setting: {0}"
-msgstr "Erreur dans l'ajout du nouveau paramètre : {0}"
+msgstr "Fout bij het invoegen van een nieuwe instelling: {0}"
 
 #: src/metabase/models/setting.clj
 msgid "defsetting descriptions strings must be `:internal?` or internationalized, found: `{0}`"
-msgstr "Les chaînes de description de définition doivent être `:internal?` ou internationalisées, trouvées: `{0}`"
+msgstr "tekenreeksen voor defsetting-beschrijvingen moeten zijn:: intern? of geïnternationaliseerd, gevonden: `{0}`"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugin {0}... {1}"
-msgstr "Chargement du plugin {0}... {1}"
+msgstr "Plugin {0} laden... {1}"
 
 #: src/metabase/public_settings.clj
 msgid "Object keyed by type, containing formatting settings"
-msgstr "Objet indexé par type, contenant les paramètres de formatage"
+msgstr "Object mapped bij type, bevat format instellingen"
 
 #: src/metabase/public_settings.clj
 msgid "Allow users to explore data using X-rays"
-msgstr "Autoriser les utilisateurs à radiographier les données"
+msgstr "Gebruikers toestaan om data te verkennen met X-rays"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Using this URL to check token: {0}"
-msgstr "Utilisation de cette URL pour vérifier le jeton : {0}"
+msgstr "Gebruik deze URL om token te controleren: {0}"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token: 404 not found."
-msgstr "Impossible de valider un jeton : 404 non trouvé"
+msgstr "Kan token niet valideren: 404 niet gevonden."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid:"
-msgstr "Une erreur s'est produite lors de la vérification de la validité de ce jeton :"
+msgstr "Er is een fout opgetreden bij het controleren of deze token geldig is:"
 
 #. +----------------------------------------------------------------------------------------------------------------+
 #. |                                             SETTING & RELATED FNS                                              |
@@ -9943,270 +9915,270 @@ msgstr "Une erreur s'est produite lors de la vérification de la validité de ce
 #. TODO - rename this to premium-features-token?
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium features. Go to the MetaStore to get yours!"
-msgstr "Jeton pour les fonctionnalités premium. Allez au \"MetaStore\" pour obtenir le vôtre!"
+msgstr "Token voor premium functies. Ga naar de MetaStore om de jouwe te krijgen!"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token format is invalid. Token should be 64 hexadecimal characters."
-msgstr "Le format du jeton est invalide. Le jeton doit comporter 64 caractères hexadécimaux."
+msgstr "Token-indeling is ongeldig. Het token moet 64 hexadecimale tekens zijn."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error setting premium features token"
-msgstr "Erreur lors de la définition du jeton de fonctionnalités premium"
+msgstr "Fout bij het instellen van het premium-functietoken"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error validating token:"
-msgstr "Erreur de validation du jeton :"
+msgstr "Fout bij het valideren van token:"
 
 #: src/metabase/query_processor.clj
 msgid "Error preprocessing query"
-msgstr "Erreur de requête de prétraitement"
+msgstr "Fout bij het verwerken van de query"
 
 #: src/metabase/query_processor.clj
 msgid "No native form returned."
-msgstr "Aucun formulaire natif retourné."
+msgstr "Geen native vorm geretourneerd."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
-msgstr "Réponse invalide du pilote de base de données. Aucun :status fourni."
+msgstr "Ongeldig antwoord van databasestuurprogramma. Geen :status opgegeven."
 
 #: src/metabase/query_processor.clj
 msgid "General error"
-msgstr "Erreur générale"
+msgstr "Algemene fout"
 
 #: src/metabase/query_processor.clj
 msgid "Missing query hash!"
-msgstr "hachage de requête manquant!"
+msgstr "Ontbrekende query hash!"
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Table ''{0}'' has no Fields associated with it."
-msgstr "La table ''{0}'' n'est associée à aucun champ."
+msgstr "Aan tabel \"{0}\" zijn geen velden gekoppeld."
 
 #: src/metabase/query_processor/middleware/add_query_throttle.clj
 msgid "Max concurrent query limit reached"
-msgstr "Limite maximum de requêtes simultanées atteinte"
+msgstr "Maximale limiet voor gelijktijdige zoekopdracht bereikt"
 
 #. we should never reach this if our patterns are written right so this is more to catch code mistakes than
 #. something the user should expect to see
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Don't know how to get information about Field:"
-msgstr "Je ne sais pas comment obtenir des informations sur le champ:"
+msgstr "Weet niet hoe je informatie over het volgende veld kunt krijgen:"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "metabase.query-processor.interface/*driver* is unbound."
-msgstr "metabase.query-processor.interface/*driver* n'est pas lié."
+msgstr "metabase.query-processor.interface/*driver* is unbound."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: mismatched number of columns in query and results."
-msgstr "Erreur du processeur de requêtes: nombre dépareillés de colonnes dans la requête et les résultats."
+msgstr "Fout in queryprocessor: aantal kolommen in query en resultaten komt niet overeen."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} fields, got {1}"
-msgstr "Attendu {0} champs, obtenu {1}"
+msgstr "Verwachtte {0} velden, kreeg {1}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected: {0}"
-msgstr "Attendu: {0}"
+msgstr "Verwacht: {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Actual: {0}"
-msgstr "Actuel: {0}"
+msgstr "Werkelijk: {0}"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Unable to bin Field without a min/max value"
-msgstr "Impossible de regrouper le champ sans valeur min/max"
+msgstr "Kan veld niet binden zonder een min / max-waarde"
 
 #: src/metabase/query_processor/middleware/check_features.clj
 msgid "{0} is not supported by this driver."
-msgstr "{0} n'est pas pris en charge par ce pilote."
+msgstr "{0} wordt niet ondersteund door dit stuurprogramma."
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Segment {0} does not exist, or is invalid."
-msgstr "Le segment {0} n'existe pas ou est invalide."
+msgstr "Segment {0} bestaat niet of is ongeldig."
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Metric {0} does not exist, or is invalid."
-msgstr "La métrique {0} n'existe pas ou n'est pas valide."
+msgstr "Metriek {0} bestaat niet, of is ongeldig."
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Missing source query in Card {0}"
-msgstr "Requête source manquante dans la carte {0}"
+msgstr "Bron query mist in kaart {0}"
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Fetched source query from Card {0}:"
-msgstr "Requête source extraite de la carte {0} :"
+msgstr "Bron query opgehaald voor kaar {0}"
 
 #: src/metabase/query_processor/middleware/mbql_to_native.clj
 msgid "Error transforming MBQL query to native:"
-msgstr "Erreur lors de la transformation de la requête MBQL en version native :"
+msgstr "Fout bij het transformeren van MBQL-query naar native:"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Cannot run query: could not find source table {0}."
-msgstr "Impossible d'exécuter la requête: impossible de trouver la table source {0}."
+msgstr "Kan zoekopdracht niet uitvoeren: kan brontabel {0} niet vinden."
 
 #: src/metabase/query_processor/middleware/results_metadata.clj
 msgid "Error recording results metadata for query:"
-msgstr "Erreur lors de l’enregistrement des métadonnées des résultats pour la requête:"
+msgstr "Fout bij het vastleggen van resultaten en metagegevens voor zoekopdracht:"
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Query Processor store is not initialized."
-msgstr "Erreur: le stockage du processeur de requêtes n'est pas initialisé."
+msgstr "Fout: de Query Processor Store is niet geïnitialiseerd."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Table {0} is not present in the Query Processor Store."
-msgstr "Erreur: la table {0} n'est pas présente dans le stockage du processeur de requêtes."
+msgstr "Fout: tabel {0} is niet aanwezig in de Query Processor Store."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Field {0} is not present in the Query Processor Store."
-msgstr "Erreur: le champ {0} n'est pas présent dans le stockage du processeur de requêtes."
+msgstr "Fout: veld {0} is niet aanwezig in de Query Processor Store."
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were {0}deleted"
-msgstr "Tâche de nettoyage de l'historique réussie, {0} lignes ont été supprimées"
+msgstr "Taakgeschiedenis succesvol opgeruimd, {0} rijen zijn verwijderd"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "not"
-msgstr "aucune"
+msgstr "niet"
 
 #: src/metabase/util/encryption.clj
 msgid "For more information, see"
-msgstr "Pour plus d'informations, voir"
+msgstr "Voor meer informatie, zie"
 
 #: src/metabase/util/schema.clj
 msgid "Integer greater than or equal to zero"
-msgstr "Entier supérieur ou égal à zéro"
+msgstr "Getal groter dan of gelijk aan nul"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer greater than or equal to zero."
-msgstr "La valeur doit être un entier supérieur ou égal à zéro."
+msgstr "waarde moet een getal zijn dat groter is of gelijk is aan nul."
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer zero or greater."
-msgstr "la valeur doit être un entier zéro ou supérieur."
+msgstr "waarde moet een getal zijn van nul of hoger."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer greater than or equal to zero."
-msgstr "La valeur doit être un entier valide supérieur ou égal à zéro."
+msgstr "waarde moet een geldige integer zijn dat groter is of gelijk is aan nul."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "New users per state in the last 30 days"
-msgstr "Nouveaux utilisateurs par état au cours des 30 derniers jours"
+msgstr "Nieuwe gebruikers per staat in de laatste 30 dagen"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by day of the week"
-msgstr "Date de création par jour de la semaine"
+msgstr "Aangemaakt per dag van de week"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by quarter of the year"
-msgstr "Date de création par trimestre"
+msgstr "Aangemaakt per kwartaal van het jaar"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per country"
-msgstr "[[this.short-name]] par pays"
+msgstr "[[this.short-name]] per land"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Users per source"
-msgstr "Utilisateurs par source"
+msgstr "Gebruikers per bron"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "The top external pages that brought users to your site"
-msgstr "Les principales pages externes qui ont amené les utilisateurs sur votre site"
+msgstr "De populairste externe pagina's die gebruikers naar je site hebben geleid"
 
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
-msgstr "Comment [[this]] est distribué et plus."
+msgstr "Hoe [[this]] is gedistribueerd en meer."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "The [[this]] over time"
-msgstr "Le [[this]] au fil du temps"
+msgstr "De [[this]] over de tijd"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "User growth"
-msgstr "Croissance des utilisateurs"
+msgstr "Gebruikersgroei"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Whether or not there are any patterns to when they happen."
-msgstr "Existe t'il ou non des schémas quand ils se produisent."
+msgstr "Of er al dan niet patronen zijn wanneer deze zich voordoen."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Users per state"
-msgstr "Utilisateurs par état"
+msgstr "Gebruikers per staat"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions"
-msgstr "Sessions"
+msgstr "Sessies"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How some of the numbers in [[this]] relate to each other"
-msgstr "Quelle est la relation entre certains chiffres dans [[this]]"
+msgstr "Hoe sommige van de getallen in [[this]] gerelateerd zijn aan elkaar"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per country"
-msgstr "Ventes par pays"
+msgstr "Verkopen per land"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by month of the year"
-msgstr "Date d'inscription par mois de l'année"
+msgstr "Lid geworden per maand van het jaar"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by hour of the day"
-msgstr "[[Timestamp]] par heure de la journée"
+msgstr "[[Timestamp]] per uur van de dag"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "A look at the [[this]]"
-msgstr "Un regard sur le [[this]]"
+msgstr "Een kijkje in [[this]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Bottom 5 per category"
-msgstr "5 derniers par catégories"
+msgstr "Onderste 5 per categorie"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Number of orders"
-msgstr "Nombre de commandes"
+msgstr "Aantal bestellingen"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Event growth"
-msgstr "Croissance des événement"
+msgstr "Gebeurtenissen groei"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "Total [[GenericTable]]"
-msgstr "[[GenericTable]] total"
+msgstr "Totaal [[GenericTable]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Income growth"
-msgstr "Croissance des revenus"
+msgstr "Inkomensgroei"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales in the last 30 days"
-msgstr "Top 10 des pays par ventes au cours des 30 derniers jours"
+msgstr "Top 10 verkoop in landen voor de laatste 30 dagen"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by month of the year"
-msgstr "[[this]] par mois de l'année"
+msgstr "[[this]] per maand van jaar"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per day of the week"
-msgstr "Transactions par jour de la semaine"
+msgstr "Transacties per dag van de week"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by device type"
-msgstr "Sessions par type d'appareil"
+msgstr "Sessies per apparaat type"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Transactions per country"
-msgstr "Transactions par pays"
+msgstr "Transacties per land"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by quarter of the year"
-msgstr "Date d'inscription par trimestre"
+msgstr "Lid geworden per kwartaal van het jaar"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per hour of the day"
-msgstr "Événements par heure de la journée"
+msgstr "Gebeurtenissen per uur van de dag"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Singleton]]"
@@ -10215,20 +10187,20 @@ msgstr "[[Singleton]]"
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Top 5 [[this]]"
-msgstr "[[this]] Top 5"
+msgstr "Top 5 [[this]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Bottom 5 [[this]]"
-msgstr "5 derniers [[this]]"
+msgstr "Laatste 5 [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by day of the month"
-msgstr "[[Timestamp]] par jour du mois"
+msgstr "[[Timestamp]] per dag van de maand"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[GenericCategoryLarge]]"
-msgstr "Par [[GenericCategoryLarge]]"
+msgstr "Per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10236,335 +10208,335 @@ msgstr "Par [[GenericCategoryLarge]]"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Null values"
-msgstr "Valeurs nulles"
+msgstr "Null waardes"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Total events"
-msgstr "Total des événements"
+msgstr "Totaal aantal gebeurtenissen"
 
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "A look at [[GenericTable]] across your [[this]], and how it changes over time."
-msgstr "Un regard sur [[GenericTable]] dans votre [[this]], et comment il change au fil du temps."
+msgstr "Een blik op [[GenericTable]] in je [[this]], en hoe het in de loop van de tijd verandert."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryMedium]]"
-msgstr "[[this]] par [[GenericCategoryMedium]]"
+msgstr "[[this]] per [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] changes with time"
-msgstr "Comment [[this]] évolue avec le temps"
+msgstr "Hoe de [[dit]] met de tijd verandert"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "How they compare by seasonality"
-msgstr "Comment ils se comparent par saisonnalité"
+msgstr "Seizoensinvloeden vergelijken"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average income per transaction"
-msgstr "Revenu moyen par transaction"
+msgstr "Gemiddelde inkomen per transactie"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per country"
-msgstr "[[this]] par pays"
+msgstr "[[this]] per land"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Income per state"
-msgstr "Revenu par état"
+msgstr "Inkomen per staat"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[GenericCategoryMedium]]"
-msgstr "Par [[GenericCategoryMedium]]"
+msgstr "Per [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "A closer look at your [[this]]"
-msgstr "Un regard plus attentif de votre [[this]]"
+msgstr "Je [[this]] nader bekeken"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "How [[GenericNumber]] is distributed"
-msgstr "Comment [[GenericNumber]] est réparti"
+msgstr "Hoe [[GenericNumber]] wordt verdeeld"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by quarter of year"
-msgstr "[[Timestamp]] par trimestre"
+msgstr "[[Timestamp]] per kwartaal van het jaar"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per country"
-msgstr "Événements par pays"
+msgstr "Gebeurtenissen per land"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Weekdays when [[this.short-name]] were added"
-msgstr "Jours de la semaine quand [[this.short-name]] a été ajouté"
+msgstr "Weekdagen wanneer [[this.short-name]]  worden toegevoegd"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Months when [[this.short-name]] were added"
-msgstr "Mois quand [[this.short-name]] a été ajouté"
+msgstr "Maanden wanneer [[this.short-name]] worden toegevoegd"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across different categories"
-msgstr "Comment ils se comparent à travers différentes catégories"
+msgstr "Hoe ze verhouden tot andere categorieën "
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30"
-msgstr "Nouveaux utilisateurs par source au cours des 30 derniers"
+msgstr "Nieuwe gebruikers per bron voor de laatste 30 dagen"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per quarter of the year"
-msgstr "Événements par trimestres"
+msgstr "Gebeurtenissen per kwartaal van het jaar"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Heres a quick look at your [[this]]"
-msgstr "Voici un aperçu de votre [[this]]"
+msgstr "Hier is een snelle blik op je [[this]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryLarge]], top 5"
-msgstr "[[this]] par [[GenericCategoryLarge]], top 5"
+msgstr "[[this]] per [[GenericCategoryLarge]], top 5"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Days when [[this.short-name]] were added"
-msgstr "Jours lorsque [[this.short-name]] a été ajouté"
+msgstr "Dagen waarop [[this.short-name]] is toegevoegd"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Total orders per source"
-msgstr "Total des commandes par source"
+msgstr "Totaal aantal bestellingen per bron"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by quarter of the year"
-msgstr "[[this]] par trimestre"
+msgstr "[[this]] per kwartaal van het jaar"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per [[GenericCategoryMedium]]"
-msgstr "Événements par [[GenericCategoryMedium]]"
+msgstr "Gebeurtenissen per [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per state"
-msgstr "Événements par état"
+msgstr "Gebeurtenissen per staat"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top landing pages"
-msgstr "Top page d'arrivée"
+msgstr "Top bestemmingspagina's"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Heres a closer look at your [[this]] over time"
-msgstr "Voici un aperçu de votre [[this]] au fil du temps"
+msgstr "Hier is uw [[this]] in de loop van de tijd nader bekeken"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Sum of [[this]] by [[Country]]"
-msgstr "Somme de [[this]] par [[Country]]"
+msgstr "Som van [[this]] per [[Country]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "States that are performing best"
-msgstr "États qui fonctionnent le mieux"
+msgstr "Staten die het beste presteren"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by month of the year"
-msgstr "Date de création par mois de l'année"
+msgstr "Aangemaakt per maand van het jaar"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Sum of [[this]] by [[State]]"
-msgstr "Somme de [[this]] par [[State]]"
+msgstr "Som van [[this]] per [[State]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Sum of [[GenericNumber]] per [[this]]"
-msgstr "Somme de [[GenericNumber]] par [[this]]"
+msgstr "Som van [[GenericNumber]] per [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by coordinates"
-msgstr "Événements par coordonnées"
+msgstr "Gebeurtenissen per coördinaat"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top referral pages"
-msgstr "Top pages de référence"
+msgstr "Top verwijzingspagina's"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "An exploration of your users to get you started."
-msgstr "Une exploration de vos utilisateurs pour vous aider à démarrer."
+msgstr "Een verkenning van je gebruikers om je op weg te helpen."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "An overview of your [[this]] and how its distributed across time, place, and categories."
-msgstr "Un aperçu de votre [[this]] et de sa répartition dans le temps, par lieux et catégories."
+msgstr "Een overzicht van je [[this]] en hoe deze is verdeeld over tijd, plaats en categorieën."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average income per state"
-msgstr "Revenu moyen par état"
+msgstr "Gemiddeld inkomen per staat"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
-msgstr "[[this]] par [[GenericCategoryMedium]]"
+msgstr "[[this]] per [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total transactions"
-msgstr "Total des transactions"
+msgstr "Totaal aantal transacties"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] that have joined over time"
-msgstr "[[this.short-name]] qui a rejoint au fil du temps"
+msgstr "[[this.short-name]] die zich in de loop der tijd hebben aangesloten"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "The [[this]] by location"
-msgstr "Le [[this]] par emplacement"
+msgstr "[[this]] per locatie"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per month of the year"
-msgstr "Événements par mois de l'année"
+msgstr "Gebeurtenissen per maand van het jaar"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] by [[GenericNumber]]"
-msgstr "[[this]] par [[GenericNumber]]"
+msgstr "[[this]] per [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] were added"
-msgstr "Trimestres lorsque [[this.short-name]] a été ajouté"
+msgstr "Kwartalen waar [[this.short-name]]  zijn toegevoegd"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "How these [[this.short-name]] are distributed"
-msgstr "Comment ces [[this.short-name]] sont distribués"
+msgstr "Hoe deze [[this.short-name]] verdeeld zijn"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by [[GenericNumber]]"
-msgstr "[[this.short-name]] par [[GenericNumber]]"
+msgstr "[[this.short-name]] per [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where users are coming from"
-msgstr "D'où viennent les utilisateurs"
+msgstr "Waar gebruikers vandaan komen"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "[[this]] comparisons and correlations"
-msgstr "[[this]] comparaisons et corrélations"
+msgstr "[[this]] vergelijkingen en correlaties"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income"
-msgstr "Revenu total"
+msgstr "Totaal inkomen"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income per month"
-msgstr "Revenu total par mois"
+msgstr "Totaal inkomen per maand"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Number of users per source"
-msgstr "Nombre d'utilisateurs par source"
+msgstr "Aantal gebruikers per bron"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Transactions per state"
-msgstr "Transactions par état"
+msgstr "Transacties per staat"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "[[this]] by [[Timestamp]]"
-msgstr "[[this]] par [[Timestamp]]"
+msgstr "[[this]] per [[Timestamp]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30 days"
-msgstr "Nouveaux utilisateurs par source au cours des 30 derniers jours"
+msgstr "Nieuwe gebruikers per bron voor de laatste 30 dagen"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the month"
-msgstr "Date d'inscription par jour de l'année"
+msgstr "Lid geworden per dag van de maand"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount %"
-msgstr "Remise moyenne en %"
+msgstr "Gemiddelde korting in %"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Autogenerated metrics about [[GenericTable]]."
-msgstr "Métriques auto-générées sur [[GenericTable]]."
+msgstr "Automatische metrieken over [[GenericTable]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per day of the month"
-msgstr "[[this]] par jour du mois"
+msgstr "[[this]] per dag van de maand"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions in each country"
-msgstr "Nombre total de sessions dans chaque pays"
+msgstr "Totaal aantal sessies voor elk land"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per month of the year"
-msgstr "Transactions par mois de l'année"
+msgstr "Transacties per maand van het jaar"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per product"
-msgstr "Ventes par produit"
+msgstr "Verkoop per product"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Users in each country"
-msgstr "Utilisateurs dans chaque pays"
+msgstr "Gebruikers in elk land"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by hour of the day"
-msgstr "[[this]] par heure de la journée"
+msgstr "[[this] per uur van de dag"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events in the last 30 days"
-msgstr "Événements des 30 derniers jours"
+msgstr "Gebeurtenissen in de laatste 30 dagen"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Transactions per source"
-msgstr "Transactions par source"
+msgstr "Transacties per bron"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where youve acquired your users"
-msgstr "Où avez-vous acquis vos utilisateurs?"
+msgstr "Wanneer je gebruikers hebt verworven"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare acrosss location"
-msgstr "Comment ils se comparent à travers l'emplacement"
+msgstr "Hoe ze verhouden per locatie"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "[[this]] per product"
-msgstr "[[this]] par produit"
+msgstr "[[this]] per product"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per month of the year"
-msgstr "[[this]] par mois de l'année"
+msgstr "[[this]] per maand van het jaar"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per country"
-msgstr "Par pays"
+msgstr "Bij land"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "A deeper look at how different countries are performing for you."
-msgstr "Un regard plus détaillé sur la performance de différents pays pour vous."
+msgstr "Een uitgebreidere blik in hoe verschillende landen uitpakken voor jou"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per state"
-msgstr "Ventes par états"
+msgstr "Verkoop per staat"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by [[GenericNumber]]"
-msgstr "Événements par [[GenericNumber]]"
+msgstr "Gebeurtenissen per [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales per product [[ProductCategoryMedium]]"
-msgstr "Ventes par produit [[ProductCategoryMedium]]"
+msgstr "Verkoop per product [[ProductCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "User acquisition by country"
-msgstr "Acquisition d'utilisateurs par pays"
+msgstr "Gebruikersacquisitie per land"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "[[this]] per source"
-msgstr "[[this]] par source"
+msgstr "[[this]] per bron"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by day of the week"
-msgstr "[[this]] par jour de la semaine"
+msgstr "[[this]] per dag van de week"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Days of the month when [[this.short-name]] joined"
-msgstr "Jours du mois où [[this.short-name]] s'est inscrit"
+msgstr "Dagen van de maand waarin [[this.short-name]] is toegetreden"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Heres an overview of the people in your [[this]]"
-msgstr "Voici un aperçu des personnes dans votre [[this]]"
+msgstr "Hier is een overzicht van de mensen in je [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "How [[GenericTable]] are distributed across this time field, and if it has any seasonal patterns."
-msgstr "Comment les [[GenericTable]] sont répartis dans ce champ temporel et s'il comporte des modèles saisonniers."
+msgstr "Hoe [[GenericTable]] over dit tijdveld is verdeeld en of het seizoenspatronen heeft."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10575,137 +10547,137 @@ msgstr "Comment les [[GenericTable]] sont répartis dans ce champ temporel et s'
 #: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Overview"
-msgstr "Vue d'ensemble"
+msgstr "Overzicht"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How this metric is distributed across different categories"
-msgstr "Comment cette métrique est répartie sur différentes catégories"
+msgstr "Hoe deze metriek is verdeeld over verschillende categorieën"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per state"
-msgstr "[[this.short-name]] par état"
+msgstr "[[this.short-name]] per staat"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Weekdays when [[this.short-name]] joined"
-msgstr "Jours de la semaine où [[this.short-name]] s'est inscrit"
+msgstr "Weekdagen waarop [[this.short-name]] is toegetreden"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Hours when [[this.short-name]] joined"
-msgstr "Heures où [[this.short-name]] s'est inscrit"
+msgstr "Uren toen [[this.short-name]] toetrad"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Total income by month"
-msgstr "Revenu total par mois"
+msgstr "Totaal inkomen per maand"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "A breakdown of your [[this]] over time, and its min, max, average and more."
-msgstr "Une décomposition de votre [[this]] dans le temps, et ses min, max, moyenne et plus."
+msgstr "Een uitsplitsing van [[dit]] in de tijd, en zijn min, max, gemiddelde en meer."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average quantity per state"
-msgstr "Quantité moyenne par état"
+msgstr "Gemiddelde hoeveelheid per staat"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare by across different numbers"
-msgstr "Comment ils se comparent à travers différents numéros"
+msgstr "Hoe ze verhouden tot verschillende getallen"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "New users per country in the last 30 days"
-msgstr "Nouveaux utilisateurs par pays au cours des 30 derniers jours"
+msgstr "Nieuwe gebruikers per land voor de laatste 30 dagen"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions over time"
-msgstr "Transactions dans le temps"
+msgstr "Transacties over tijd"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategorySmall]]"
-msgstr "[[this]] par [[GenericCategorySmall]]"
+msgstr "[[this]] per [[GenericCategorySmall]]"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Some breakdown"
-msgstr "Quelques pannes"
+msgstr "Een uitsplitsing"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Average of [[this]] by [[State]]"
-msgstr "Moyenne de [[this]] par [[State]]"
+msgstr "Gemiddelde van [[this]] per [[State]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per quarter of the year"
-msgstr "Transactions par trimestre"
+msgstr "Transacties per kwartaal van het jaar"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "By coordinates"
-msgstr "Par coordonnées"
+msgstr "Bij de coördinaten"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Heres a closer look at your [[this]] by products"
-msgstr "Voici un aperçu de votre [[this]] par produits"
+msgstr "Hier is een nadere blik op [[this]] bijproducten"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per quarter of the year"
-msgstr "[[this]] par trimestre de l'année"
+msgstr "[[this]] per kwartaal van het jaar"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Heres an overview of your [[this]] data from Google Analytics"
-msgstr "Voici un aperçu de vos données de [[this]] de Google Analytics"
+msgstr "Hier is een overzicht van [[this]] data van Google Analytics"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] joined"
-msgstr "Trimestres où [[this.short-name]] s'est inscrit"
+msgstr "Kwartalen wanneer [[this.short-name]] is toegetreden"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "New [[this.short-name]] in the last 30 days"
-msgstr "Nouveau [[this.short-name]] dans les 30 derniers jours"
+msgstr "Nieuwe [[this.short-name]] in de laatste 30 dagen"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions by desktop, mobile, or tablet"
-msgstr "Nombre total de sessions par ordinateur de bureau, mobile ou tablette"
+msgstr "Totaal aantal sessies per desktop, mobiel of tablet"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "Indepth example"
-msgstr "Exemple en profondeur"
+msgstr "Verdiepen voorbeeld"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average income per source"
-msgstr "Revenu moyen par source"
+msgstr "Gemiddelde inkomen per bron"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by day of week"
-msgstr "[[Timestamp]] par jour de la semaine"
+msgstr "[[Timestamp]] per dag van de week"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "Heres a closer look at your [[this]]"
-msgstr "Voici un aperçu de votre [[this]]"
+msgstr "Hier is een nadere blik op [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Heres a closer look at your [[this]] field"
-msgstr "Voici un aperçu de votre champ [[this]]"
+msgstr "Hier is een nadere blik op [[dit]] veld"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Summary"
-msgstr "Résumé"
+msgstr "Samenvatting"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] is distributed geographically"
-msgstr "Comment le [[this]] est distribué géographiquement"
+msgstr "Hoe [[this]] geografisch is verdeeld"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "The pages with the most pageviews"
-msgstr "Les pages avec le plus de vues"
+msgstr "De pagina's die het meest worden bekeken"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How [[Number1]] is correlated with [[Number2]]"
-msgstr "Comment [[Number1]] est en corrélation avec [[Number2]]"
+msgstr "Hoe [[Number1]] correleert aan [[Number2]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales in the last 30 days"
-msgstr "Top 10 des états par ventes au cours des 30 derniers jours"
+msgstr "Top 10 staten voor verkoop in de laatste 30 dagen"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales"
-msgstr "Top 10 des états par ventes"
+msgstr "Top 10 staten voor verkoop"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Timestamp]]"
@@ -10713,62 +10685,62 @@ msgstr "[[Timestamp]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Where these transactions happened"
-msgstr "Où ces transactions ont eu lieu"
+msgstr "Waar de transacties plaats hebben gevonden"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales"
-msgstr "Top 10 pays par ventes"
+msgstr "Top 10 landen voor verkoop"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by state"
-msgstr "Ventes par état"
+msgstr "Verkoop per staat"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Where most of your sessions originate from"
-msgstr "D'où viennent la plupart de vos sessions?"
+msgstr "Waar de meeste sessies vandaan komen"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top acquisition channels"
-msgstr "Top canaux d'acquisition"
+msgstr "Top acquisitiekanalen"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "These [[this.short-name]] across time"
-msgstr "Ces [[this.short-name]] à travers le temps"
+msgstr "Deze [[this.short-name]] in de loop van de tijd"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity"
-msgstr "Quantité moyenne"
+msgstr "Gemiddelde hoeveelheid"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per source"
-msgstr "Ventes par source"
+msgstr "Verkoop per bron"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average income per country"
-msgstr "Revenu moyen par pays"
+msgstr "Gemiddelde inkomen per land"
 
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
-msgstr "Comment [[this]] est distribué"
+msgstr "Hoe [[this]] is verdeeld"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Distinct [[FK]]"
-msgstr "Distinct [[FK]]"
+msgstr "Uniek [[FK]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "How these transactions are distributed"
-msgstr "Comment ces transactions sont distribuées"
+msgstr "Hoe deze transacties zijn verdeeld"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per state"
-msgstr "Par état"
+msgstr "Per staat"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "Count of [[GenericCategoryMedium]] by [[this]]"
-msgstr "Nombre de [[GenericCategoryMedium]] par [[this]]"
+msgstr "Aantal [[GenericCategoryMedium]] per [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10783,68 +10755,68 @@ msgstr "Nombre de [[GenericCategoryMedium]] par [[this]]"
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "A look at your [[this]]"
-msgstr "Un coup d'oeil à votre [[this]]"
+msgstr "Een blik op [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "[[GenericNumber]] by [[this]]"
-msgstr "[[GenericNumber]] par [[this]]"
+msgstr "[[GenericNumber]] per [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Sum of [[GenericNumber]] by [[this]]"
-msgstr "Somme de [[GenericNumber]] par [[this]]"
+msgstr "Som van [[GenericNumber]] per [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A look at your [[this]] table"
-msgstr "Un coup d'oeil à votre table [[this]]"
+msgstr "Een blik op [[this]] tabel"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "How many [[GenericTable]] there are per state, and how each state is represented across other categories."
-msgstr "Combien de [[GenericTable]] il y a par état, et comment chaque état est représenté à travers d'autres catégories."
+msgstr "Hoeveel [[GenericTable]] zijn er per staat en hoe elke staat scoort in andere categorieën."
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Most-viewed pages"
-msgstr "Pages les plus vues"
+msgstr "Meest bekeken pagina's"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Example exploration"
-msgstr "Exemple d'exploration"
+msgstr "Voorbeeldverkenning"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales vs. rating"
-msgstr "Ventes vs évaluation"
+msgstr "Verkoop vs. beoordeling"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per hour of the day"
-msgstr "[[this]] par heure de la journée"
+msgstr "[[this]] per uur van de dag"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Where your [[this.short-name]] are"
-msgstr "Où sont vos [[this.short-name]]"
+msgstr "Waar je [[this.short-name]] zich bevinden"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "These are the same for all your [[this.short-name]]"
-msgstr "Ce sont les mêmes pour tous vos [[this.short-name]]"
+msgstr "Deze zijn hetzelfde voor alle [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by different categories"
-msgstr "Événements par différentes catégories"
+msgstr "Gebeurtenissen per verschillende categorie"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Where these [[this.short-name]] are"
-msgstr "Où sont ces [[this.short-name]]"
+msgstr "Waar [[this.short-name]] zich bevinden"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Over time"
-msgstr "Au fil du temps"
+msgstr "Over de tijd"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A summary of the events in your [[this]] table"
-msgstr "Un résumé des événements dans votre table [[this]]"
+msgstr "Een samenvatting van de gebeurtenissen voor [[this]] table"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Transactions per source over time"
-msgstr "Transactions par source au fil du temps"
+msgstr "Transacties per bron over de tijd"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10852,221 +10824,221 @@ msgstr "Transactions par source au fil du temps"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "How the [[this]] is distributed"
-msgstr "Comment le [[this]] est réparti"
+msgstr "Hoe [[this] is verdeeld"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Total income per source"
-msgstr "Revenu total par source"
+msgstr "Totaal inkomen per bron"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Total [[this.short-name]]"
-msgstr "[[this.short-name]] total"
+msgstr "Totaal [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Some metrics we found about your transactions."
-msgstr "Certaines métriques que nous avons trouvés sur vos transactions."
+msgstr "Sommige statistieken die we gevonden hebben over je transacties."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "How your different products are performing."
-msgstr "Quel est la performance de vos différents produits."
+msgstr "Hoe verschillende producten presteren."
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Where these events are happening"
-msgstr "Où ces événements se produisent"
+msgstr "Waar deze gebeurtenissen plaatsvinden"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Which US states are bringing you the most business."
-msgstr "Quels États américains vous apportent le plus d’affaires?"
+msgstr "Welke Amerikaanse staten dragen het meeste bij voor je zaken."
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
-msgstr "Comment ils se comparent à travers le temps"
+msgstr "Hoe ze vergelijken over de tijd"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average transaction income per month"
-msgstr "Revenu de transaction moyen par mois"
+msgstr "Gemiddelde transactie inkomen per maand"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity per month"
-msgstr "Quantité moyenne par mois"
+msgstr "Gemiddelde hoeveelheid per maand"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "Seasonal patterns in the [[this]]"
-msgstr "Tendances saisonnières dans le [[this]]"
+msgstr "Seizoenspatronen in [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events over time"
-msgstr "Événements au fil du temps"
+msgstr "Gebeurtenissen na verloop van tijd"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Orders and income per source"
-msgstr "Commandes et revenus par source"
+msgstr "Bestellingen en inkomsten per bron"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per hour of the day"
-msgstr "Transactions par heure de la journée"
+msgstr "Transacties per uur van de dag"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where most of your traffic is coming from."
-msgstr "D'où provient la plus grande partie de votre trafic."
+msgstr "Waar het meeste verkeer vandaan komt."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Heres a quick look at the [[this]]"
-msgstr "Voici un rapide coup d'œil sur le [[this]]"
+msgstr "Hier is een snelle blik op [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "It looks like your [[this]] has transactions, so heres a look at them"
-msgstr "Il semble que votre [[this]] ait des transactions, alors jetez-y un œil"
+msgstr "Het lijkt erop dat [[this]] transacties heeft, dus hier is een overzicht"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount per month"
-msgstr "Remise moyenne par mois"
+msgstr "Gemiddelde korting per maand"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by month of the year"
-msgstr "[[Timestamp]] par mois de l'année"
+msgstr "[[Timestamp]] per maand van het jaar"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategorySmall]] over time"
-msgstr "[[this]] par [[GenericCategorySmall]] au fil du temps"
+msgstr "[[this]] per [[GenericCategorySmall]] door de tijd heen"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Distribution by coordinates"
-msgstr "Distribution par coordonnées"
+msgstr "Verdeling op coördinaten"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by source"
-msgstr "Ventes par source"
+msgstr "Verkoop per bron"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales for each product category"
-msgstr "Ventes pour chaque catégorie de produit"
+msgstr "Verkoop voor elk product categorie"
 
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "A closer look at the metrics and dimensions used in this saved question."
-msgstr "Un regard plus approfondi des métriques et dimensions utilisées dans cette question enregistrée."
+msgstr "De statistieken en dimensies die in deze opgeslagen vraag zijn gebruikt nader bekijken"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryMedium]]"
-msgstr "[[this.short-name]] par [[GenericCategoryMedium]]"
+msgstr "[[this.short-name]] per [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales per product [[ProductCategoryLarge]]"
-msgstr "Ventes par produit [[ProductCategoryLarge]]"
+msgstr "Verkoop per product [[ProductCategoryLarge]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average quantity per country"
-msgstr "Quantité moyenne par pays"
+msgstr "Gemiddelde hoeveelheid per land"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryLarge]]"
-msgstr "[[this.short-name]] par [[GenericCategoryLarge]]"
+msgstr "[[this.short-name]] per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Heres a closer look at your [[this]] per source"
-msgstr "Voici un aperçu de votre [[this]] par source"
+msgstr "Hier is een nadere blik op [[this]] per bron"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the month"
-msgstr "Événements par jour du mois"
+msgstr "Gebeurtenissen per dag van de maand"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If youre into correlations, this is the x-ray for you."
-msgstr "Si vous êtes dans les corrélations, Voici la radiographie pour vous."
+msgstr "Als je van correlaties houdt, is dit de X-ray voor jou."
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by Country"
-msgstr "Sessions par pays"
+msgstr "Sessies per land"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Some interesting metrics about your GA stats to get you started."
-msgstr "Quelques métriques intéressantes sur vos statistiques de GA pour vous aider à démarrer."
+msgstr "Enkele interessante statistieken over uw GA-statistieken om je op weg te helpen."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per state"
-msgstr "[[this]] par état"
+msgstr "[[this]] per staat"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by quarter of the year"
-msgstr "[[Timestamp]] par trimestre"
+msgstr "[[Timestamp]] per kwartaal van het jaar"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How its distributed across time and other categories."
-msgstr "Comment ils se répartissent dans le temps et d'autres catégories."
+msgstr "Hoe het is verdeeld over tijd en andere categorieën."
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A look at your events over time and by several categories."
-msgstr "Un coup d’œil à vos événements au fil du temps et par plusieurs catégories."
+msgstr "Een blik op gebeurtenissen in de loop van de tijd en voor verschillende categorieën."
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "[[GenericTable]] per [[this]]"
-msgstr "[[GenericTable]] par [[this]]"
+msgstr "[[GenericTable]] per [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average quantity per source"
-msgstr "Quantité moyenne par source"
+msgstr "Gemiddelde hoeveelheid per bron"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Top 5 per category"
-msgstr "Top 5 par catégorie"
+msgstr "Top 5 per categorie"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the week"
-msgstr "Événements par jour de la semaine"
+msgstr "Gebeurtenissen per dag van de week"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "New [[this.short-name]] per month"
-msgstr "Nouveau [[this.short-name]] par mois"
+msgstr "Nieuwe [[this.short-name]] per maand"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top performers"
-msgstr "Meilleures performances"
+msgstr "Top performers"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Transactions in the last 30 days"
-msgstr "Transactions dans les 30 derniers jours"
+msgstr "Transacties in de laatste 30 dagen"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[GenericTable]] by [[this]]"
-msgstr "[[GenericTable]] par [[this]]"
+msgstr "[[GenericTable]] per [[this]]"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Overview of your [[this]] data from Google Analytics"
-msgstr "Vue d'ensemble de vos [[this]] données de Google Analytics"
+msgstr "Overzicht van [[this]] van Google Analytics"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by hour of the day"
-msgstr "Date de création par heure de la journée"
+msgstr "Aangemaakt per uur van de dag"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by month"
-msgstr "Ventes par mois"
+msgstr "Verkoop per maand"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] is distributed across categories"
-msgstr "Comment le [[this]] est réparti entre les catégories"
+msgstr "Hoe [[dit]] is verdeeld over categorieën"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by month of year"
-msgstr "[[Timestamp]] par mois de l'année"
+msgstr "[[Timestamp]] per maand van het jaar"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "How many total sessions vs. how many individual users you had each day."
-msgstr "Nombre total de sessions par rapport au nombre d'utilisateurs individuels que vous avez eu chaque jour."
+msgstr "Totaal aantal sessies vs. de hoeveelheid unieke gebruikers voor elke dag."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How this metric is distributed across different numbers"
-msgstr "Comment cette métrique est répartie sur différents nombres"
+msgstr "Hoe deze metriek verdeeld is over verschillende nummers"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by page where the session began"
-msgstr "Sessions par page où la session a commencé"
+msgstr "Sessies per pagina wanneer de sessie begon"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -11074,20 +11046,20 @@ msgstr "Sessions par page où la session a commencé"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Distinct values"
-msgstr "Valeurs distinctes"
+msgstr "Unieke waardes"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Hours when [[this.short-name]] were added"
-msgstr "Heures lorsque [[this.short-name]] ont été ajoutés"
+msgstr "Uren wanneer [[this.short-name]] toegevoegd zijn"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by day of the week"
-msgstr "[[Timestamp]] par jour de la semaine"
+msgstr "[[Timestamp]] per dag van de week"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[GenericNumber]] over time"
-msgstr "[[GenericNumber]] au fil du temps"
+msgstr "[[GenericNumber]] over de tijd"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
@@ -11096,43 +11068,43 @@ msgstr "[[GenericNumber]] au fil du temps"
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Heres an overview of your [[this]]"
-msgstr "Voici un aperçu de votre [[this]]"
+msgstr "Hier is een overzicht van [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by coordinates"
-msgstr "[[this.short-name]] par coordonnées"
+msgstr "[[this.short-name]] per coördinaten"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Heres a closer look at your [[this]] per state"
-msgstr "Voici un aperçu de votre [[this]] par état"
+msgstr "Hier is een nadere blik op [[this]] per staat"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by day of the month"
-msgstr "Date de création par jour du mois"
+msgstr "Aangemaakt per dag van de maand"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales by coordinates"
-msgstr "Ventes par coordonnées"
+msgstr "Verkoop per coördinaten"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "New [[this.short-name]] over time"
-msgstr "Nouveau [[this.short-name]] au fil du temps"
+msgstr "Nieuwe [[this.short-name]] over de tijd"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by hour of the day"
-msgstr "Date d'inscription par heure de la journée"
+msgstr "Datum toegetreden per uur van de dag"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by hour of day"
-msgstr "[[Timestamp]] par heure de la journée"
+msgstr "[[Timestamp]] per uur van de dag"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions and unique users per day"
-msgstr "Sessions et utilisateurs uniques par jour"
+msgstr "Sessies en unieke gebruikers per dag"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per [[GenericCategoryLarge]]"
-msgstr "Événements par [[GenericCategoryLarge]]"
+msgstr "Gebeurtenissen per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -11141,405 +11113,405 @@ msgstr "Événements par [[GenericCategoryLarge]]"
 #: resources/automagic_dashboards/field/GenericField.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
-msgstr "Comment ils se comparent par la distribution"
+msgstr "In vergelijking tot de verdeling"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Income per country"
-msgstr "Revenu par pays"
+msgstr "Inkomen per land"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Heres a closer look at your [[this]] per country"
-msgstr "Voici un aperçu de votre [[this]] par pays"
+msgstr "Hier is een nadere blik op [[this]] per land"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by product [[ProductCategory]]"
-msgstr "Ventes par produit [[ProductCategory]]"
+msgstr "Verkoop per product in [[ProductCategory]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryLarge]], bottom 5"
-msgstr "[[this]] par [[GenericCategoryLarge]], 5 derniers"
+msgstr "[[this]] per [[GenericCategoryLarge]], laatste 5"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] added in the last 30 days"
-msgstr "[[this.short-name]] ajouté au cours des 30 derniers jours"
+msgstr "[[this.short-name]] toegevoegd in de laatste 30 dagen"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[Source]]"
-msgstr "Par [[Source]]"
+msgstr "Per [[Source]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average item quantity per month"
-msgstr "Quantité moyenne d'articles par mois"
+msgstr "Gemiddelde hoeveelheid per maand"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "The number of [[GenericTable]] per country, and how each country is represented in different categories."
-msgstr "Le nombre de [[GenericTable]] par pays, et comment chaque pays est représenté dans les différentes catégories."
+msgstr "Het aantal [[GenericTable]] per land en hoe elk land wordt vertegenwoordigt in verschillende categorieën."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per day of the week"
-msgstr "[[this]] par jour de la semaine"
+msgstr "[[this]] per dag van de week"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average qunatity per source"
-msgstr "Quantité moyenne par source"
+msgstr "Gemiddelde hoeveelheid per bron"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by [[Timestamp]]"
-msgstr "[[this.short-name]] par [[Timestamp]]"
+msgstr "[[this.short-name]] per [[Timestamp]]"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Summary statistics"
-msgstr "Résumé des statistiques"
+msgstr "Samenvattende statistieken"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per month"
-msgstr "Ventes par mois"
+msgstr "Verkoop per maand"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[GenericNumber]] by join date"
-msgstr "[[GenericNumber]] par date d'inscription"
+msgstr "[[GenericNumber]] per datum van toetreding"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Average of [[this]] by [[Country]]"
-msgstr "Moyenne de [[this]] par [[Country]]"
+msgstr "Gemiddelde van [[dit]] per [[Land]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[this]] over time"
-msgstr "[[this]] au fil du temps"
+msgstr "[[this]] door de tijd heen"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the week"
-msgstr "Joindre la date par le jour de la semaine"
+msgstr "Datum van aanmelding per dag van de week"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "We crunched the numbers for your [[this]]"
-msgstr "Nous avons analysé les chiffres pour votre [[this]]"
+msgstr "We hebben de cijfers voor [[this]] vergeleken"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Months when [[this.short-name]] joined"
-msgstr "Mois où [[this.short-name]] s'est inscrit"
+msgstr "Maanden waarin [[this.short-name]] is lid geworden"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to parse resource `{0}` as JSON"
-msgstr "Impossible d'analyser la ressource `{0}` en tant que JSON"
+msgstr "Kan resource `{0}` niet omzetten naar JSON"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to find JSON via relative path `{0}`"
-msgstr "Impossible de trouver le code JSON via le chemin relatif `{0}`"
+msgstr "Kan JSON niet vinden via relatief pad `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection to host timed out for URL `{0}`"
-msgstr "La connexion à l'hôte a expiré pour l'URL `{0}`"
+msgstr "Verbinding met host verlopen voor URL `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to connect to unknown host at URL `{0}`"
-msgstr "Impossible de se connecter à un hôte inconnu de l'URL `{0}`"
+msgstr "Kan geen verbinding maken met onbekende host voor URL `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to connect to host at URL `{0}`"
-msgstr "Impossible de se connecter à l'hôte de l'URL `{0}`"
+msgstr "Kan geen verbinding maken met host voor URL `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection refused by host at for URL `{0}`"
-msgstr "Connexion refusée par l'hôte pour l'URL `{0}`"
+msgstr "Verbinding geweigerd door host op voor URL `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to retrieve resource at URL `{0}`"
-msgstr "Impossible de récupérer la ressource de l'URL `{0}`"
+msgstr "Kan bron niet ophalen voor URL `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to parse resource at URL `{0}` as JSON"
-msgstr "impossible d'analyser la ressource de l'URL `{0}` en JSON"
+msgstr "Kan bron voor URL `{0}` niet omzetten naar JSON"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fall back to local authentication: {0}"
-msgstr "Problème de connexion au serveur LDAP, de retour à l’authentification locale: {0}"
+msgstr "Probleem bij verbinding maken met LDAP-server, valt terug op lokale authenticatie: {0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can''t be parameterized!"
-msgstr "Les instructions BigQuery ne peuvent pas être paramétrées!"
+msgstr "BigQuery statements can''t be parameterized!"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid does not allow limitSpec in time series queries. Ignoring the LIMIT clause."
-msgstr "AVERTISSEMENT: Druid n'autorise pas les requêtes limitSpec dans les séries chronologiques. La clause LIMIT sera ignorée."
+msgstr "WARNING: Druid does not allow limitSpec in time series queries. Ignoring the LIMIT clause."
 
 #: src/metabase/driver/snowflake.clj
 msgid "Invalid Snowflake connection details: missing DB name."
-msgstr "Détails de connexion Snowflake invalides: nom de base de données manquant."
+msgstr "Invalid Snowflake connection details: missing DB name."
 
 #: src/metabase/email/messages.clj
 msgid "We’d love your feedback."
-msgstr "Nous aimerions vos commentaires."
+msgstr "We stellen je feedback zeer op prijs."
 
 #: src/metabase/email/messages.clj
 msgid "It looks like Metabase wasn’t quite a match for you."
-msgstr "Il semblerait que Metabase ne vous convenait pas tout à fait."
+msgstr "Het lijkt erop dat Metabase niet echt bij je past."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 5 question survey to help the Metabase team understand why and make things better in the future?"
-msgstr "Souhaitez-vous prendre un peur de temps pour répondre à un rapide sondage en 5 questions pour aider l’équipe de Metabase à comprendre pourquoi et à améliorer les choses à l’avenir?"
+msgstr "Zou je 5 korte vragen willen beantwoorden om het Metabase-team beter te helpen begrijpen waarom om zaken in de toekomst beter te maken?"
 
 #: src/metabase/email/messages.clj
 msgid "We hope you''ve been enjoying Metabase."
-msgstr "Nous espérons que vous avez apprécié Metabase."
+msgstr "We hopen dat je geniet van het gebruik van Metabase."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 6 question survey to tell us how it’s going?"
-msgstr "Souhaitez vous prendre un peu de temps pour répondre à un rapide sondage de 6 questions pour nous dire comment ca se passe ?"
+msgstr "Zou je een vragenlijst van 6 vragen willen invullen om ons te vertellen hoe Metabase je bevalt?"
 
 #: src/metabase/email/messages.clj
 msgid "{0} created a Metabase account"
-msgstr "{0} a créé un compte Metabase"
+msgstr "{0} heeft een Metabase-account gemaakt"
 
 #: src/metabase/email/messages.clj
 msgid "{0} accepted their Metabase invite"
-msgstr "{0} a accepté son invitation Metabase"
+msgstr "{0} heeft een Metabase-uitnodiging geaccepteerd"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Password Reset Request"
-msgstr "Requête de réinitialisation de mot de passe [Metabase]"
+msgstr "[Metabase] Verzoek om wachtwoord opnieuw instellen"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Notification"
-msgstr "[Metabase] Notification"
+msgstr "[Metabase] Kennisgeving"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Help make Metabase better."
-msgstr "[Métabase] Aidez à améliorer Metabase."
+msgstr "[Metabase] Help Metabase beter te maken."
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Tell us how things are going."
-msgstr "[Métabase] Dites-nous comment les choses se passent."
+msgstr "[Metabase] Vertel ons hoe het gaat."
 
 #: src/metabase/mbql/util.clj
 msgid "Error: query''s source query has not been resolved. You probably need to `preprocess` the query first."
-msgstr "Erreur: la requête source de la requête n'a pas été résolue. Vous devez probablement «prétraiter» la requête en premier."
+msgstr "Error: query''s source query has not been resolved. You probably need to `preprocess` the query first."
 
 #: src/metabase/models/params.clj
 msgid "Don't know what to do with:"
-msgstr "Je ne sais pas quoi faire avec:"
+msgstr "Weet niet wat te doen met:"
 
-#. Could someone provide context about this string? I cannot figure out where it's used 🤔
 #: src/metabase/models/params.clj
 msgid "Don't know how to wrap:"
-msgstr "Encapsulation inconnue pour :"
+msgstr "Weet niet hoe uit te lijnen:"
 
 #: src/metabase/public_settings.clj
 msgid "Failed setting `query-caching-max-kb` to {0}."
-msgstr "Échec de la définition de `query-caching-max-kb` sur {0}."
+msgstr "Failed setting `query-caching-max-kb` to {0}."
 
 #: src/metabase/public_settings.clj
 msgid "Values greater than {1} are not allowed."
-msgstr "Les valeurs supérieures à {1} ne sont pas autorisées."
+msgstr "Waardes groter dan {1} zijn niet toegestaan."
 
 #: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
-msgstr "La base de données {0} n'existe pas."
+msgstr "Database {0} bestaat niet"
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Database is not present in the Query Processor Store."
-msgstr "Erreur: la base de données n'est pas présente dans le stockage du processeur de requêtes."
+msgstr "\n"
+"Error: Database is not present in the Query Processor Store."
 
 #: src/metabase/util/embed.clj
 msgid "Invalid embedding-secret-key! Secret key must be a hexadecimal-encoded 256-bit key (i.e., a 64-character string)."
-msgstr "Clé d'intégration invalide ! La clé secrète doit être une clé codée en hexadécimal de 256 bits (c'est-à-dire une chaîne de 64 caractères)"
+msgstr "Invalid embedding-secret-key! Secret key must be a hexadecimal-encoded 256-bit key (i.e., a 64-character string)."
 
 #: src/metabase/util/embed.clj
 msgid "JWT is missing `alg`."
-msgstr "Le champ `alg` du JWT est manquant"
+msgstr "JWT is missing `alg`."
 
 #: src/metabase/util/embed.clj
 msgid "JWT `alg` cannot be `none`."
-msgstr "Le champ `alg`du JWT ne peut être `none`"
+msgstr "JWT `alg` cannot be `none`."
 
 #: src/metabase/util/embed.clj
 msgid "The embedding secret key has not been set."
-msgstr "La clé secrète d'intégration n’a pas été définie."
+msgstr "De embed secret key is niet meegegeven."
 
 #: src/metabase/util/embed.clj
 msgid "Token is missing value for keypath"
-msgstr "Le jeton est man"
+msgstr "Token mist een waarde voor het sleutelpad"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "In-depth example"
-msgstr "Exemple en profondeur"
+msgstr "Diepgaand voorbeeld"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:29
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:17
 msgid "Key"
-msgstr "Clé"
+msgstr "Sleutel"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:30
 msgid "Class"
-msgstr "Classe"
+msgstr "Class"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:32
 msgid "Triggers"
-msgstr "Déclencheurs"
+msgstr "Triggers"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:48
 msgid "View triggers"
-msgstr "Voir les déclencheurs"
+msgstr "Triggers bekijken"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
-msgstr "Informations sur le planificateur"
+msgstr "Planner Info"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:20
 msgid "Priority"
-msgstr "Priorité"
+msgstr "Prioriteit"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:21
 msgid "Last Fired"
-msgstr "Dernière exécution"
+msgstr "Laatst uitgevoerd"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:22
 msgid "Next Fire Time"
-msgstr "Prochain déclenchement"
+msgstr "Volgende keer uitvoeren om"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:23
 msgid "Start Time"
-msgstr "Heure de début"
+msgstr "Starttijd"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:24
 msgid "End Time"
-msgstr "Heure de finalisation"
+msgstr "Eindtijd"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:25
 msgid "Final Fire Time"
-msgstr "Dernier déclenchement"
+msgstr "Laatste keer uitvoeren"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:26
 msgid "May Fire Again?"
-msgstr "Peut se déclencher à nouveau ?"
+msgstr "Nogmaals uitvoeren?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
-msgstr "Déclencheurs pour {0}"
+msgstr "Triggers voor {0}"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:25
 msgid "Tasks"
-msgstr "Tâches"
+msgstr "Taken"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:30
 msgid "Jobs"
-msgstr "Tâches"
+msgstr "Jobs"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
-msgstr "Dupliqué {0}"
+msgstr "{0} gedupliceerd"
 
 #: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
-msgstr "Dupliquer cet élément"
+msgstr "Dit item dupliceren"
 
 #: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
-msgstr "Archiver cet élément"
+msgstr "Dit item archiveren"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
-msgstr "Dupliquer le tableau de bord"
+msgstr "Dashboard dupliceren"
 
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:16
 msgid "Duplicate \"{0}\""
-msgstr "Dupliquer \"{0}\""
+msgstr "Dupliceer \"{0}\""
 
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
-msgstr "Dupliquer"
+msgstr "Dupliceer"
 
 #: frontend/src/metabase/lib/query_time.js:115
 msgid "Tomorrow"
-msgstr "Demain"
+msgstr "Morgen"
 
 #: frontend/src/metabase/lib/query_time.js:129
 #: frontend/src/metabase/lib/query_time.js:143
 msgid "This {0}"
-msgstr "Ce {0}"
+msgstr "Deze {0}"
 
 #: frontend/src/metabase/lib/query_time.js:132
 msgid "Next {0}"
-msgstr "Suivant {0}"
+msgstr "Volgende {0}"
 
 #: frontend/src/metabase/lib/query_time.js:135
 msgid "Previous {0}"
-msgstr "Précédent {0}"
+msgstr "Vorige {0}"
 
 #: frontend/src/metabase/lib/query_time.js:139
 msgid "Previous {0} {1}"
-msgstr "Précédent {0} {1}"
+msgstr "Vorige {0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:141
 msgid "Next {0} {1}"
-msgstr "Suivant {0} {1}"
+msgstr "Volgende {0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:171
 msgid "Now"
-msgstr "Maintenant"
+msgstr "Nu"
 
 #: frontend/src/metabase/lib/query_time.js:174
 msgid "{0} {1} ago"
-msgstr "Il y a {0} {1}"
+msgstr "{0} {1} geleden"
 
 #: frontend/src/metabase/lib/query_time.js:175
 msgid "{0} {1} from now"
-msgstr "Il y a {0} {1}"
+msgstr "{0} {1} vanaf nu"
 
 #: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
-msgstr[0] "Période par défaut"
-msgstr[1] "Périodes par défaut"
+msgstr[0] "Standaard periode"
+msgstr[1] "Standaard periodes"
 
 #: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
-msgstr[0] "Minute d'heure"
-msgstr[1] "Minutes d'heure"
+msgstr[0] "Minuut van het uur"
+msgstr[1] "Minuten van het uur"
 
 #: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
-msgstr[0] "Heure du jour"
-msgstr[1] "Heures du jour"
+msgstr[0] "Uur van de dag"
+msgstr[1] "Uren van de dag"
 
 #: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
-msgstr[0] "Jour de la semaine"
-msgstr[1] "Jours de la semaine"
+msgstr[0] "Dag van de week"
+msgstr[1] "Dagen van de week"
 
 #: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
-msgstr[0] "Jour du mois"
-msgstr[1] "Jours du mois"
+msgstr[0] "Dag van de maand"
+msgstr[1] "Dagen van de maand"
 
 #: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
-msgstr[0] "Jour de l'année"
-msgstr[1] "Jours de l'année"
+msgstr[0] "Dag van het jaar"
+msgstr[1] "Dagen van het jaar"
 
 #: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
-msgstr[0] "Semaine de l'année"
-msgstr[1] "Semaines de l'année"
+msgstr[0] "Week van het jaar"
+msgstr[1] "Weken van het jaar"
 
 #: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
-msgstr[0] "Mois de l'année"
-msgstr[1] "Mois de l'année"
+msgstr[0] "Maand van het jaar"
+msgstr[1] "Maanden van het jaar"
 
 #: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
-msgstr[0] "Trimestre de l'année"
-msgstr[1] "Trimestres de l'année"
+msgstr[0] "Kwartaal van het jaar"
+msgstr[1] "Kwartalen van het jaar"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
@@ -11547,8 +11519,8 @@ msgstr[1] "Trimestres de l'année"
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
-msgstr[0] "{0} sélectionné"
-msgstr[1] "{0} sélectionnés"
+msgstr[0] "{0} selectie"
+msgstr[1] "{0} selecties"
 
 #: frontend/src/metabase/parameters/components/widgets/DateQuarterYearWidget.jsx:11
 msgid "[Q]Q"
@@ -11556,221 +11528,221 @@ msgstr "[Q]Q"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:28
 msgid "This"
-msgstr "Ce"
+msgstr "Deze"
 
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
-msgstr "Invalide"
+msgstr "Ongeldig"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
-msgstr "Ajouter une heure"
+msgstr "Voeg een tijd toe"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
-msgstr "Rien à comparer pour les {0} précédents."
+msgstr "Niets om te vergelijken voor de vorige {0}."
 
 #: frontend/src/metabase-lib/lib/Dimension.js:678
 msgid "by {0}"
-msgstr "par {0}"
+msgstr "bij {0}"
 
 #: src/metabase/api/database.clj
 msgid "value must be a valid database engine."
-msgstr "la valeur doit être un miteir de base de données valide"
+msgstr "Waarde moet een geldige database engine zijn."
 
 #: src/metabase/api/geojson.clj
 msgid "Connection refused by host for URL `{0}`"
-msgstr "Connexion refusée par l'hôte pour l'URL `{0}`"
+msgstr "Verbinding geweigerd voor host voor URL `{0}`"
 
 #: src/metabase/db.clj
 msgid "Warning: Postgres connection string with `ssl=true` detected."
-msgstr "Attention : La chaîne de connexion Postgres contient `ssl=true`."
+msgstr "Waarschuwing: Postgres-verbindingsreeks met `ssl = true` gedetecteerd."
 
 #: src/metabase/db.clj
 msgid "You may need to add `?sslmode=require` to your application DB connection string."
-msgstr "Vous devrez peut-être ajouter `?sslmode=true` à la chaîne de connexion de votre application à la base de données."
+msgstr "Mogelijk moet je nog `?sslmode=require` toevoegen aan de DB-verbindingsreeks van de toepassing."
 
 #: src/metabase/db.clj
 msgid "If Metabase fails to launch, please add it and try again."
-msgstr "Si Metabase échoue à démarrer, ajoutez le et essayez à nouveau."
+msgstr "Als Metabase niet kan worden gestart, voeg het dan toe en probeer het opnieuw."
 
 #: src/metabase/db.clj
 msgid "See https://github.com/metabase/metabase/issues/8908 for more details."
-msgstr "Consultez https://github.com/metabase/metabase/issues/8908 pour plus de détails."
+msgstr "Zie https://github.com/metabase/metabase/issues/8908 voor meer informatie."
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recomended for production deployments."
-msgstr "ATTENTION : l'utilisation de base de données H2 n'est pas recommandée en production."
+msgstr "WAARSCHUWING: het gebruik van Metabase met een H2-applicatiedatabase wordt niet aanbevolen voor productie-implementaties."
 
 #: src/metabase/db.clj
 msgid "For production deployments, we highly recommend using Postgres, MySQL, or MariaDB instead."
-msgstr "Pour le déploiement en production, nous recommendons vivement l'utilisation de Postgres, MySQL ou MariaDB à la place."
+msgstr "Voor productie-implementaties raden we ten zeerste aan om in plaats daarvan Postgres, MySQL of MariaDB te gebruiken."
 
 #: src/metabase/db.clj
 msgid "If you decide to continue to use H2, please be sure to back up the database file regularly."
-msgstr "Si vous décidez de continuer à utiliser H2, assurez vous de sauvegarder régulièrement le fichier de base de données"
+msgstr "Als je besluit H2 te blijven gebruiken, moet je regelmatig een back-up van het databasebestand maken."
 
 #: src/metabase/db.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres for more information."
-msgstr "Consultez https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres pour plus de détails"
+msgstr "Zie https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres voor meer informatie."
 
 #: src/metabase/db.clj
 msgid "Unable to connect to Metabase {0} DB."
-msgstr "Impossible de se connecter à la base de données Metabase {0}."
+msgstr "Kan geen verbinding maken met Metabase {0} DB."
 
 #: src/metabase/db/migrations.clj
-#, fuzzy
 msgid "Error adding legacy SQL directive to BigQuery saved Question"
-msgstr "Erreur lors de l'ajout de la directive SQL legacy à la Question sauvegardée sous BigQuery"
+msgstr "Fout bij het toevoegen van oude SQL-instructie aan opgeslagen vraag van BigQuery"
 
 #: src/metabase/driver.clj
 msgid "Failed to notify {0} Database {1} updated"
-msgstr "Impossible de notifier {0} Base de données {1} mise à jour"
+msgstr "Kan {0} database {1} niet bijwerken"
 
 #: src/metabase/driver.clj
 msgid "Loading driver {0} {1}"
-msgstr "Chargement du driver {0} {1}"
+msgstr "Driver aan het laden {0} {1}"
 
 #: src/metabase/driver.clj
 msgid "Load driver {0}"
-msgstr "Chargement du pilote {0}"
+msgstr "Driver laden {0}"
 
 #: src/metabase/driver.clj
 msgid "Driver not registered after loading: {0}"
-msgstr "Pilote non enregistré après le chargement {0}"
+msgstr "Driver niet geregistreerd na het laden: {0}"
 
 #: src/metabase/driver.clj
 msgid "Error: attempting to change {0} property `:abstract?` from {1} to {2}."
-msgstr "Erreur : tentative de changer la propriété {0} `:abstract?` de {1} à {2}."
+msgstr "Fout: poging om {0} eigenschap `:abstract?` te wijzigen van {1} naar {2}."
 
 #: src/metabase/driver.clj
 msgid "Registered abstract driver {0}"
-msgstr "Driver abstract enregistré {0}"
+msgstr "Abstracte driver geregistreerd {0}"
 
 #: src/metabase/driver.clj
 msgid "Registered driver {0}"
-msgstr "Pilote enregistré {0}"
+msgstr "Registreer driver {0}"
 
 #: src/metabase/driver.clj
 msgid "(parents: {0})"
-msgstr "(parents: {0})"
+msgstr "(bovenliggend: {0})"
 
 #: src/metabase/driver.clj
 msgid "Initializing driver {0}..."
-msgstr "Initialisation du pilote {0}"
+msgstr "Driver initialiseren {0}..."
 
 #: src/metabase/driver.clj
 msgid "Reason:"
-msgstr "Raison :"
+msgstr "Reden:"
 
 #: src/metabase/driver.clj
 msgid "Invalid driver feature: {0}"
-msgstr "Fonctionnalité du pilote invalide : {0}"
+msgstr "Invalid driver feature: {0}"
 
 #: src/metabase/driver/sql/query_processor.clj
 msgid "Invalid HoneySQL form:"
-msgstr "Formulaire HoneySQL invalide :"
+msgstr "Invalid HoneySQL form:"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing connection pool for database {0} ..."
-msgstr "Fermeture du pool de connexions pour la base de données {0}..."
+msgstr "Closing connection pool for database {0} ..."
 
 #: src/metabase/driver/util.clj
 msgid "Error loading namespace"
-msgstr "Erreur lors du chargement du namespace"
+msgstr "Error loading namespace"
 
 #: src/metabase/events.clj
 msgid "Starting events listener:"
-msgstr "Début de l'écoute des événements :"
+msgstr "Starting events listener:"
 
 #: src/metabase/events.clj
 msgid "Unexpected error listening on events"
-msgstr "Erreur inattendue lors de l'écoute des événements"
+msgstr "Unexpected error listening on events"
 
 #: src/metabase/events/sync_database.clj
 msgid "Error syncing Database {0}"
-msgstr "Erreur de synchronisation de la base de données {0}"
+msgstr "Fout bij synchroniseren van database {0}"
 
 #: src/metabase/events/sync_database.clj
 msgid "Failed to process sync-database event."
-msgstr "Échec du traitement de l'événement sync-database."
+msgstr "Kan sync-database-gebeurtenis niet verwerken."
 
 #: src/metabase/mbql/util.clj
 msgid "Bad nested-query-level: query does not have a source query"
-msgstr "nested-query-level incorrect: la requête n'a pas de requête source"
+msgstr "Onjuist genest-queryniveau: zoekopdracht heeft geen bronquery"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know how to `{0}`."
-msgstr "Je ne sais pas comment faire `{0}`"
+msgstr "Ik weet niet hoe `{0}` uitgevoerd moet worden."
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s what I can do: "
-msgstr "Voici ce que je peux faire : "
+msgstr "Hier is wat we eraan kunnen doen: "
 
 #: src/metabase/metabot/slack.clj
 msgid "Error in Metabot command"
-msgstr "Erreur dans la commande Metabot"
+msgstr "Fout in Metabot commando"
 
 #: src/metabase/metabot/websocket.clj
 msgid "Websocket associated with this Slack event is different from the websocket we're currently using."
-msgstr "Le websocket associé à cet évènement Slack est différent du websocket que nous utilisons actuellement"
+msgstr "Websocket die aan dit Slack-evenement is gekoppeld, verschilt van de websocket die we momenteel gebruiken."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues for Field {0} remain unchanged. Skipping..."
-msgstr "FieldValues pour Field {0} restent inchangées. Passer..."
+msgstr "Veldwaarden voor veld {0} blijven ongewijzigd. Overslaan ..."
 
 #: src/metabase/models/interface.clj
 msgid "Unable to normalize:"
-msgstr "Impossible de normaliser :"
+msgstr "Kan niet normaliseren:"
 
 #: src/metabase/models/params.clj
 msgid "Could not find matching Field ID for target:"
-msgstr "Impossible de trouver l'ID du champ correspondant pour la cible :"
+msgstr "Kan geen overeenkomende veld-ID voor doel vinden:"
 
 #: src/metabase/plugins.clj
 msgid "Metabase does not have permissions to write to plugins directory {0}"
-msgstr "Metabase n'a pas les droits d'écriture dans le répertoire des plug-ins {0}"
+msgstr "Metabase heeft geen rechten om naar plug-ins directory {0} te schrijven"
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot use the plugins directory {0}"
-msgstr "Metabase ne peut pas utiliser le répertoire des plug-ins {0}"
+msgstr "Metabase kan de map met plug-ins {0} niet gebruiken"
 
 #: src/metabase/plugins.clj
 msgid "Please make sure the directory exists and that Metabase has permission to write to it."
-msgstr "Veuillez vérifier que le dossier existe et que Metabase y a les droits d'écriture"
+msgstr "Zorg ervoor dat de map bestaat en dat Metabase toestemming heeft om ernaar te schrijven."
 
 #: src/metabase/plugins.clj
 msgid "You can change the directory Metabase uses for modules by setting the environment variable MB_PLUGINS_DIR."
-msgstr "Vous pouvez changer le répertoire que Metabase utilise pour les plug-ins en définissant la variable d'environnement MB_PLUGINS_DIR."
+msgstr "Je kunt de map die Metabase voor modules gebruikt wijzigen door de omgevingsvariabele MB_PLUGINS_DIR in te stellen."
 
 #: src/metabase/plugins.clj
 msgid "Falling back to a temporary directory for now."
-msgstr "Retour à un répertoire temporaire pour le moment."
+msgstr "Voorlopig wordt er teruggevallen op een tijdelijke map."
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot write to temporary directory. Please set MB_PLUGINS_DIR to a writable directory and restart Metabase."
-msgstr "Metabase ne peut pas écrire dans le dossier temporaire. Définissez MB_PLUGINS_DIR slvers un dossier accessible en écriture et redémarrez Matebase"
+msgstr "Metabase kan niet naar een tijdelijke map schrijven. Stel MB_PLUGINS_DIR in op een beschrijfbare map en start Metabase opnieuw."
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory."
-msgstr "spark-deps.jar n'est plus nécessaire avec Metabase 1.0+. Vous pouvez le supprimer du répertoire des plugins."
+msgstr "spark-deps.jar is niet langer nodig voor Metabase 1.0+. Je kunt deze verwijderen uit de map met plug-ins."
 
 #: src/metabase/plugins.clj
 msgid "Failied to initialize plugin {0}"
-msgstr "Erreur d'initialisation du plugin {0}"
+msgstr "Kan plug-in {0} niet initialiseren"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in {0}..."
-msgstr "Chargement de plugins dans {0} ..."
+msgstr "Plug-ins laden in {0} ..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using Clojure base loader as shared context classloader: {0}"
-msgstr "Utilisation de Clojure en tant que context classloader partagé : {0}"
+msgstr "\n"
+"Using Clojure base loader as shared context classloader: {0}"
 
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to shared classloader {0}..."
-msgstr "Configuration du context classloader courrant sur le classloader partagé {0}..."
+msgstr "Setting current thread context classloader to shared classloader {0}..."
 
 #. it's important that we deref the promise again here instead of using the one we just created because it is
 #. possible thru a race condition that somebody else delivered the promise before we did; in that case,
@@ -11778,319 +11750,318 @@ msgstr "Configuration du context classloader courrant sur le classloader partag�
 #. value of it rather than one that ends up getting discarded
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to NEWLY CREATED classloader {0}..."
-msgstr "Configuration du context classloader courant sur le nouveau classloader {0}..."
+msgstr "Setting current thread context classloader to NEWLY CREATED classloader {0}..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Added URL {0} to classpath"
-msgstr "URL {0} ajoutée au classpath"
+msgstr "Added URL {0} to classpath"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin {0} declares a dependency that Metabase does not understand: {1}"
-msgstr "Le plugin {0} déclare une dépendance que Metabase ne comprend pas {1}"
+msgstr "Plugin {0} declares a dependency that Metabase does not understand: {1}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Refer to the plugin manifest reference for a complete list of valid plugin dependencies:"
-msgstr "Référez-vous au manifest du plugin pour la liste complète des dépendances valides :"
+msgstr "Refer to the plugin manifest reference for a complete list of valid plugin dependencies:"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Metabase cannot initialize plugin {0} due to required dependencies."
-msgstr "Metabase ne peut pas initialiser le plug-in {0} en raison des dépendances requises."
+msgstr "Metabase cannot initialize plugin {0} due to required dependencies."
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Class not found: {0}"
-msgstr "Classe non trouvée: {0}"
+msgstr "Class not found: {0}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin ''{0}'' depends on plugin ''{1}''"
-msgstr "Le plugin ''{0}'' dépend du plugin ''{1}''"
+msgstr "Plugin ''{0}'' depends on plugin ''{1}''"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "{0} dependency {1} satisfied? {2}"
-msgstr "{0} dépendance {1} satisfaite ? {2}"
+msgstr "{0} dependency {1} satisfied? {2}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugins with unsatisfied deps: {0}"
-msgstr "Plug-ins avec des dépendances non satisfaites : {0}"
+msgstr "Plugins with unsatisfied deps: {0}"
 
 #: src/metabase/plugins/files.clj
 msgid "Extract file {0} -> {1}"
-msgstr "Extraire le fichier {0} -> {1}"
+msgstr "Extract file {0} -> {1}"
 
 #: src/metabase/plugins/files.clj
 msgid "Resource does not exist."
-msgstr "La ressource n'existe pas."
+msgstr "Resource does not exist."
 
 #: src/metabase/plugins/init_steps.clj
 msgid "Loading plugin namespace {0}..."
-msgstr "Chargement du namespace du plugin {0}..."
+msgstr "Loading plugin namespace {0}..."
 
 #: src/metabase/plugins/initialize.clj
 msgid "Dependencies satisfied; these plugins will now be loaded: {0}"
-msgstr "Les dépendances ont été satisfaites ; Ces plug-ins seront désormais chargés : {0}"
+msgstr "Dependencies satisfied; these plugins will now be loaded: {0}"
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Registering JDBC proxy driver for {0}..."
-msgstr "Enregistrement du pilote proxy JDBC pour {0}..."
+msgstr "Registering JDBC proxy driver for {0}..."
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Deregistering original JDBC driver {0}..."
-msgstr "Désenregistrement du pilote JDBC d'origine {0}..."
+msgstr "Deregistering original JDBC driver {0}..."
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Default connection property {0} does not exist."
-msgstr "La propriété de connexion par défaut {0} n'existe pas."
+msgstr "Default connection property {0} does not exist."
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
-#, fuzzy
 msgid "Invalid connection property {0}: not a string or map."
-msgstr "Propriété de connexion invalide {0} : pas un texte ou une carte."
+msgstr "Invalid connection property {0}: not a string or map."
 
 #. ok, do the init steps listed in the plugin mainfest
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Load lazy loading driver {0}"
-msgstr "Chargement du driver {0}"
+msgstr "Load lazy loading driver {0}"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Cannot initialize plugin: missing required property `driver-name`"
-msgstr "Impossible d'initialiser le plug-in: propriété requise manquante `driver-name`"
+msgstr "Cannot initialize plugin: missing required property `driver-name`"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Warning: plugin manifest for {0} does not include connection properties"
-msgstr "Avertissement : le manifeste du plug-in pour {0} n'inclut pas les propriétés de connexion"
+msgstr "Warning: plugin manifest for {0} does not include connection properties"
 
 #. finally, register the Metabase driver
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Registering lazy loading driver {0}..."
-msgstr "Chargement du driver {0}..."
+msgstr "Registering lazy loading driver {0}..."
 
 #: src/metabase/pulse.clj
 msgid "Error running query for Card {0}"
-msgstr "Erreur lors de l'exécution de la requête pour la carte {0}"
+msgstr "Error running query for Card {0}"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
-msgstr "Semaine dernière"
+msgstr "Vorige week"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This week"
-msgstr "Semaine en cours"
+msgstr "Deze week"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
-msgstr "Mois dernier"
+msgstr "Vorige maand"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This month"
-msgstr "Mois en cours"
+msgstr "Deze maand"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
-msgstr "Dernier trimestre"
+msgstr "Vorige kwartaal"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
-msgstr "Ce trimestre"
+msgstr "Dit kwartaal"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
-msgstr "Année dernière"
+msgstr "Vorig jaar"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This year"
-msgstr "Cette année"
+msgstr "Dit jaar"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "*driver* is unbound."
-msgstr "*driver* non consolidé."
+msgstr "*driver* is unbound."
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Error syncing Fields for Table ''{0}''"
-msgstr "Erreur lors de la synchronisation des champs pour la table ''{0}''"
+msgstr "Fout bij het synchroniseren van velden in tabel \"{0}\""
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Hash of {0} matches stored hash, skipping Fields sync"
-msgstr "Le hash de {0} correspond au hash stocké, synchronisation des champs ignorée"
+msgstr "Hash van {0} komt overeen met de opgeslagen hash, velden synchronisatie wordt overgeslagen."
 
 #: src/metabase/sync/sync_metadata/fields/common.clj
 msgid "Field"
-msgstr "Champ"
+msgstr "Veld"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error checking if Fields {0} need to be created or reactivated"
-msgstr "Erreur en vérifiant si les champs {0} ont besoin d'être créés ou réactivés"
+msgstr "Fout bij het controleren of de velden {0} aangemaakt of opnieuw geactiveerd moeten worden."
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Marking Field ''{0}'' as inactive."
-msgstr "Marquage du champ \"{0}\" comme inactif."
+msgstr "Velden \"{0}\" markeren als inactief."
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error retiring {0}"
-msgstr "Erreur lors du retrait du champ {0}"
+msgstr "Fout bij het stoppen van {0}"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Database type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "Le type de base de données {0} est passé de ''{1}'' à ''{2}''."
+msgstr "Databasetype {0} is gewijzigd van \"{1}\"  in \"{2}\"."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Base type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "Le type de base de {0} a changé de \"{1}\" vers \"{2}\""
+msgstr "Basistype van {0} is gewijzigd van \"{1}\" in \"{2}\"."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Special type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "Le type spécial de {0} a changé de \"{1}\" vers \"{2}\""
+msgstr "Het speciale type {0} is gewijzigd van \"{1}\" in \"{2}\"."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Comment has been added for {0}."
-msgstr "Le commentaire a été ajouté pour {0}"
+msgstr "Er is een reactie toegevoegd voor {0}."
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler {0}"
-msgstr "Arrêt du planificateur Quartz {0}"
+msgstr "Quartz planner wordt gestop {0}"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler {0}"
-msgstr "Démarrage du planificateur Quartz {0}"
+msgstr "Quartz planner wordt gestart {0}"
 
 #: src/metabase/task.clj
 msgid "Error loading tasks namespace {0}"
-msgstr "Erreur au chargement de l'espace de nommage des tâches {0}"
+msgstr "Fout bij laden van taak namespace {0}"
 
 #. don't bother logging namespace for now, maybe in the future if there's tasks of the same name in multiple
 #. namespaces we can log it
 #: src/metabase/task.clj
 msgid "Initializing task {0}"
-msgstr "Initialisation de la tâche {0}"
+msgstr "Taak {0} initialiseren"
 
 #: src/metabase/task.clj
 msgid "Error initializing task {0}"
-msgstr "Erreur lors de l'initialisation de la tâche {0}"
+msgstr "Fout bij het initialiseren van taak {0}"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Problem sending abandonment email"
-msgstr "Problème à l'envoi du courriel d'abandon"
+msgstr "Probleem bij het verzenden van verlatingsmail"
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Sending anonymous usage stats."
-msgstr "Envoi des statistiques anonymes d'utilisation."
+msgstr "Anonieme gebruiksstatistieken verzenden."
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Error sending anonymous usage stats"
-msgstr "Erreur durant l'envoi des statistiques anonymes d'utilisation"
+msgstr "Fout bij het verzenden van anonieme gebruiksstatistieken"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Error sending Pulse {0}"
-msgstr "Erreur à l'envoi du Pulse {0}"
+msgstr "Fout bij het versturen van puls {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Sending scheduled pulses..."
-msgstr "Envoi des Pulses planifiés..."
+msgstr "Geplande pulsen verzenden ..."
 
 #: src/metabase/task/send_pulses.clj
 msgid "SendPulses task failed"
-msgstr "La tâche SendPulses a échoué"
+msgstr "De taak SendPulses is mislukt"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to scheduler tasks for Database {0}"
-msgstr "Échec de planification des tâche pour la base de données {0}"
+msgstr "Kan planner van taken voor database {0} niet uitvoeren"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Cleaning up task history"
-msgstr "Nettoyage de l'historique des tâches"
+msgstr "Taakgeschiedenis opschonen"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were deleted"
-msgstr "Historique des tâches nettoyé avec succès, les lignes ont été supprimées"
+msgstr "Taakgeschiedenis opruimen geslaagd, rijen zijn verwijderd"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, no rows were deleted"
-msgstr "Historique des tâches nettoyé avec succès, aucune ligne n'a été supprimée"
+msgstr "Taakgeschiedenis opruimen geslaagd, er zijn geen rijen verwijderd"
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Checking for new Metabase version info."
-msgstr "Vérification des informations de nouvelle version de Metabase."
+msgstr "Zoeken naar nieuwe Metabase-versie-informatie."
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Error fetching version info"
-msgstr "Erreur lors de la récupération des informations de version"
+msgstr "Fout bij het ophalen van versie-informatie"
 
 #: src/metabase/util.clj
 msgid "Maximum memory available to JVM: {0}"
-msgstr "Mémoire maximale disponible pour la JVM: {0}"
+msgstr "Maximum memory available to JVM: {0}"
 
 #: src/metabase/util.clj
 msgid "Not something with an ID: {0}"
-msgstr "Aucun objet n'a pour ID : {0}"
+msgstr "Iets met een ID niet gevonden: {0}"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by month of the year"
-msgstr "[[CreateDate]] par mois de l'année"
+msgstr "[[CreateDate]] bij maand van het jaar"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Here's a quick look at your [[this]]"
-msgstr "Voici un rapide coup d'oeil à votre [[this]]"
+msgstr "Hier is een snelle blik op je [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by hour of the day"
-msgstr "[[CreateTimestamp]] par heures de la journée"
+msgstr "[[CreateTimestamp]] per uur van de dag"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where you've acquired your users"
-msgstr "Où vos utilisateurs ont été acquis"
+msgstr "Waar je gebruikers zijn verworven"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How it's distributed across time and other categories."
-msgstr "Comment est-il réparti dans le temps et dans d'autres catégories."
+msgstr "Hoe het wordt verdeeld over tijd en andere categorieën."
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Here's a closer look at your [[this]] per source"
-msgstr "Voici un aperçu plus précis de [[this]] par source"
+msgstr "Hier is een nadere blik op [[this]] per bron"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Here's a quick look at the [[this]]"
-msgstr "Voici un bref aperçu de [[this]]"
+msgstr "Hier is een snelle blik op de [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by day of the month"
-msgstr "[[CreateTimestamp]] par jours du mois"
+msgstr "[[CreateTimestamp]] per dag van de maand"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Here's an overview of the people in your [[this]]"
-msgstr "Voici une vue d'ensemble des personnes dans votre [[this]]"
+msgstr "Hier is een overzicht van de mensen in [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by quarter of the year"
-msgstr "[[CreateTimestamp]] par trimestre de l'année"
+msgstr "[[CreateTimestamp]] per kwartaal van het jaar"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
-msgstr "Comment ils se comparent par localisation"
+msgstr "Hoe ze verhouden tot verschillende locaties"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Here's a closer look at your [[this]] by products"
-msgstr "Voici un vue plus précise de votre [[this]] par produits"
+msgstr "Hier is een nadere blik op [[this]] per product"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by month of the year"
-msgstr "[[CreateTimestamp]] par mois de l'année"
+msgstr "[[CreateTimestamp]] per maand van het jaar"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "An overview of your [[this]] and how it's distributed across time, place, and categories."
-msgstr "Une vue d'ensemble de votre [[this]] et de leur distribution temporelle, spatiale et catégorielle."
+msgstr "Een overzicht van [[this]] en hoe deze is verdeeld over tijd, plaats en categorieën."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "Here's a closer look at your [[this]]"
-msgstr "Voici un coup d'oeil de plus près à votre [[this]]"
+msgstr "Hier is een nadere blik op je [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by day of the week"
-msgstr "[[CreateTimestamp]] par jour de la semaine"
+msgstr "[[CreateTimestamp]] per dag van de week"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Here's an overview of your [[this]] data from Google Analytics"
-msgstr "Voici une vue d'ensemble de vos données [[this]] de Google Analytics"
+msgstr "Hier is een overzicht van je [[this]] gegevens van Google Analytics"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
@@ -12099,1096 +12070,1095 @@ msgstr "Voici une vue d'ensemble de vos données [[this]] de Google Analytics"
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
-msgstr "Voici une vue d'ensemble de votre [[this]]"
+msgstr "Hier is een overzicht van [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Here's a closer look at your [[this]] field"
-msgstr "Voici une vue plus précise de votre champ [[this]]"
+msgstr "Hier is een nadere blik op je [[this]] veld"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Here's a closer look at your [[this]] per country"
-msgstr "Voici une vue plus précise de votre [[this]] par pays"
+msgstr "Hier is een nadere blik op [[this]] per land"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If you're into correlations, this is the x-ray for you."
-msgstr "Si vous êtes dans les corrélations, ce sont les x-ray pour vous."
+msgstr "Als je van correlaties houdt, is dit de X-ray voor jou."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by day of the week"
-msgstr "[[CreateDate]] par jour de la semaine"
+msgstr "[[CreateDate]] per dag van de week"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "It looks like your [[this]] has transactions, so here's a look at them"
-msgstr "Il semble que votre [[this]] a des transactions, en voici une vue"
+msgstr "Het lijkt erop dat [[this]] transacties heeft, dus hieronder een overzicht"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Here's a closer look at your [[this]] per state"
-msgstr "Voici une vue plus précise de votre [[this]] par état"
+msgstr "Hier is een nadere blik op [[this]] per staat"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by day of the month"
-msgstr "[[CreateDate]] par jour du mois"
+msgstr "[[CreateDate]] per dag van de maand"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTime]] by hour of the day"
-msgstr "[[CreateTime]] par heure de la journée"
+msgstr "[[CreateTime]] per uur van de dag"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Here's a closer look at your [[this]] over time"
-msgstr "Voici une vue plus précise de votre [[this]] au cours du temps"
+msgstr "Hier is een nadere blik op [[this]] in de loop van de tijd"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by quarter of the year"
-msgstr "[[CreateDate]] par semestre de l'année"
+msgstr "[[CreateDate]] per kwartaal van het jaar"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
-msgstr "Modifier l'utilisateur"
+msgstr "Gebruiker wijzigen"
 
 #: frontend/src/metabase/admin/people/containers/NewUserModal.jsx:13
 msgid "New user"
-msgstr "Nouvel utilisateur"
+msgstr "Gebruiker toevoegen"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
-msgstr "Réinitialiser le mot de passe"
+msgstr "Wachtwoord opnieuw instellen"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
-msgstr "Désactiver l'utilisateur"
+msgstr "Gebruiker deactiveren"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:47
 msgid "Reactivate {0}?"
-msgstr "Réactiver {0}?"
+msgstr "Opnieuw activeren {0}?"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:63
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
-msgstr "Nous n'avons pas pu leur envoyer un courriel d'invitation, assurez-vous donc de leur dire de se connecter en utilisant {0} et ce mot de passe généré pour eux:"
+msgstr "We konden geen uitnodiging versturen per mail, zorg er voor dat je ze verteld dat ze kunnen inloggen met {0} en het volgende gegenereerde wachtwoord:"
 
 #: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
-msgstr "collection"
+msgstr "collectie"
 
 #: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
-msgstr "collections"
+msgstr "collecties"
 
 #: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
-msgstr "tableau de bord"
+msgstr "dashboard"
 
 #: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
-msgstr "tableaux de bord"
+msgstr "dashboards"
 
 #: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
-msgstr "Le prénom est obligatoire"
+msgstr "Voornaam is verplicht"
 
 #: frontend/src/metabase/entities/users.js:38
 #: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
-msgstr "Doit être d'au plus 100 caractères de long"
+msgstr "Moet 100 karakters of minder zijn"
 
 #: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
-msgstr "Le nom est requis"
+msgstr "Achternaam is verplicht"
 
 #: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
-msgstr "Email est requis"
+msgstr "E-mailadres is verplicht"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
-msgstr "Les éléments archivés apparaîtront ici"
+msgstr "Gearchiveerde items komen hier te staan."
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:16
 msgid "No description"
-msgstr "Pas de description"
+msgstr "Geen omschrijving"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
-msgstr "Somme de toutes les valeurs"
+msgstr "Som van alle waardes"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
-msgstr "Voir toutes les valeurs uniques"
+msgstr "Bekijk alle unieke waardes"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:12
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started"
-msgstr "Parcourez le contenu de votre base de données ainsi que les tables et colonnes. Choisissez une base de données pour commencer"
+msgstr "Blader door de inhoud van uw databases, tabellen en kolommen. Kies een database om te beginnen"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is VALID. Thanks!"
-msgstr "Les métadonnées des résultats de la card transmises à l'API sont VALIDES. Merci!"
+msgstr "Metagegevens van kaartresultaten die zijn doorgegeven aan API zijn GELDIG. Bedankt!"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is INVALID. Running query to fetch correct metadata."
-msgstr "Les métadonnées des résultats de la card transmises à l'API sont INVALIDES. Lancer la requête pour récupérer les bonnes métadonnées."
+msgstr "Metadata van de kaartresultaten doorgegeven aan API is ONGELDIG. Bezig met uitvoeren van zoekopdracht om juiste metagegevens op te halen."
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is  ISSING. Running query to fetch correct metadata."
-msgstr "Les métadonnées des résultats de la carte transmises à l'API sont MANQUANTES. Requête en cours d'exécution pour récupérer les métadonnées correctes."
+msgstr "Metagegevens van de kaartresultaten die zijn doorgegeven aan API ONTBREKEN. Bezig met uitvoeren van zoekopdracht om juiste metagegevens op te halen."
 
 #: src/metabase/api/email.clj
 msgid "{0} was autocorrected to {1}"
-msgstr "{0} a été automatiquement corrigé par {1}"
+msgstr "{0} is automatisch gecorrigeerd naar {1}"
 
 #: src/metabase/api/metric.clj
 msgid "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id."
-msgstr "DELETE /api/metric/:id est déprécié. À la place, changer sa valeur `archived` via PUT /api/metric/:id."
+msgstr "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id."
 
 #: src/metabase/api/segment.clj
 msgid "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id."
-msgstr "DELETE /api/segment/:id est déprécié. À la place, changer sa valeur `archived` via PUT /api/segment/:id."
+msgstr "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id."
 
 #: src/metabase/api/user.clj
 msgid "Value of is_superuser must correspond to presence of Admin group ID in group_ids."
-msgstr "La valeur is_superuser doit correspondre à la présence de l'ID du groupe Admin dans group_ids."
+msgstr "De waarde van is_superuser moet overeenkomen met de aanwezigheid van de beheerdersgroep-ID in groeps-id's."
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected error writing keepalive characters"
-msgstr "Erreur inattendue lors de l'enregistrement des caractères persistants"
+msgstr "Onverwachte fout bij het schrijven van keepalive-tekens"
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected output in async API response"
-msgstr "Retour inattendu dans la réponse de l'API asynchrone"
+msgstr "Onverwachte uitvoer in async API-reactie"
 
 #: src/metabase/async/api_response.clj
 msgid "starting streaming response"
-msgstr "démarrer la réponse en streaming"
+msgstr "starting streaming response"
 
 #: src/metabase/async/api_response.clj
 msgid "Output chan closed, canceling keepalive request."
-msgstr "Canal sortant fermé, annulation de la requête persistante."
+msgstr "Output chan closed, canceling keepalive request."
 
 #: src/metabase/async/api_response.clj
 msgid "Async response finished, closing channels."
-msgstr "Réponse asynchrone terminée, fermeture des canaux."
+msgstr "Async response finished, closing channels."
 
 #: src/metabase/async/api_response.clj
 msgid "No response after waiting {0}. Canceling request."
-msgstr "Aucune réponse après l'attente de {0}. Annulation de la requête."
+msgstr "No response after waiting {0}. Canceling request."
 
 #: src/metabase/async/api_response.clj
 msgid "Input channel unexpectedly closed."
-msgstr "Canal entrant fermé de façon inattendue."
+msgstr "Input channel unexpectedly closed."
 
-#. The file src/metabase/async/semaphore_channel.clj is no longer exists. Removed by PR#9911 on github.
 #: src/metabase/async/semaphore_channel.clj
 msgid "f finished, permit will be returned"
 msgstr "f finished, permit will be returned"
 
-#. The file src/metabase/async/semaphore_channel.clj is no longer exists. Removed by PR#9911 on github.
 #: src/metabase/async/semaphore_channel.clj
 msgid "request canceled, permit will be returned"
 msgstr "request canceled, permit will be returned"
 
-#. The file src/metabase/async/semaphore_channel.clj is no longer exists. Removed by PR#9911 on github.
 #: src/metabase/async/semaphore_channel.clj
 msgid "Unexpected error attempting to run function after obtaining permit"
 msgstr "Unexpected error attempting to run function after obtaining permit"
 
-#. The file src/metabase/async/semaphore_channel.clj is no longer exists. Removed by PR#9911 on github.
 #: src/metabase/async/semaphore_channel.clj
 msgid "Not running pending function call: output channel already closed."
-msgstr "Non exécution de l'appel de fonction en instance : canal de sortie déjà fermé."
+msgstr "Not running pending function call: output channel already closed."
 
-#. The file src/metabase/async/semaphore_channel.clj is no longer exists. Removed by PR#9911 on github.
 #: src/metabase/async/semaphore_channel.clj
 msgid "Current thread already has a permit for {0}, will not wait to acquire another"
 msgstr "Current thread already has a permit for {0}, will not wait to acquire another"
 
 #: src/metabase/async/util.clj
 msgid "Output channel closed, will skip running {0}."
-msgstr "Canal sortant fermé, ce qui n’exécutera pas {0}."
+msgstr "Output channel closed, will skip running {0}."
 
 #: src/metabase/async/util.clj
 msgid "Running {0} on separate thread..."
-msgstr "Exécution de {0} sur un thread séparé..."
+msgstr "Running {0} on separate thread..."
 
 #: src/metabase/async/util.clj
 msgid "Caught error running {0}"
-msgstr "Erreur interceptée en cours d'exécution {0}"
+msgstr "Caught error running {0}"
 
 #: src/metabase/async/util.clj
 msgid "Request canceled, canceling future"
-msgstr "Requête annulée, annulation des suivantes"
+msgstr "Request canceled, canceling future"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing old connection pool for database {0} ..."
-msgstr "Fermeture de l'ancien pool de connexion pour la base de données {0} ..."
+msgstr "Closing old connection pool for database {0} ..."
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s your {0} most recent cards:"
-msgstr "Voici vos {0} questions les plus récentes :"
+msgstr "Hier zijn je {0} meest recente kaarten:"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
-msgstr "Pourriez-vous être un peu plus précis, ou utiliser l'ID de la question ? J'ai trouvé ces questions avec des noms correspondants :"
+msgstr "Zou je wat specifieker kunnen zijn, of de ID gebruiken? Ik vond deze kaarten met overeenkomende namen:"
 
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
-msgstr "Carte {0} introuvable."
+msgstr "Kaart {0} niet gevonden."
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Exception in API call"
-msgstr "Exception dans l'appel API"
+msgstr "Exception in API call"
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Request canceled before finishing."
-msgstr "Requête annulée avant la fin."
+msgstr "Request canceled before finishing."
 
 #: src/metabase/middleware/json.clj
 msgid "Metabase only supports JSON requests."
-msgstr "Metabase ne prend en charge que les requêtes JSON."
+msgstr "Metabase only supports JSON requests."
 
 #: src/metabase/middleware/json.clj
 msgid "Make sure you set a 'Content-Type: application/json' header."
-msgstr "Vérifiez que le header 'Content-Type: application/json' est configuré."
+msgstr "Make sure you set a 'Content-Type: application/json' header."
 
 #: src/metabase/middleware/misc.clj
 msgid "Setting Metabase site URL to {0}"
-msgstr "Configuration de l'URL de Metabase sur {0}"
+msgstr "Metabase-site-URL instellen op {0}"
 
 #: src/metabase/models/database.clj
 msgid "Error scheduling tasks for DB"
-msgstr "Erreur de planification des tâches pour la DB"
+msgstr "Fout bij het inplannen van taken voor DB"
 
 #: src/metabase/models/database.clj
 msgid "Error unscheduling tasks for DB."
-msgstr "Erreur de déplanification des tâches pour la DB"
+msgstr "Fout bij het verwijderen uit de planning van taken voor DB."
 
 #: src/metabase/models/database.clj
 msgid "{0} Database ''{1}'' sync/analyze schedules have changed!"
-msgstr "{0} Les planifications sync/analyze de la base de données \"{1}\" ont changé!"
+msgstr "{0} Database '' {1} '' planningen voor synchronisatie / analyse zijn gewijzigd!"
 
 #: src/metabase/models/database.clj
 msgid "Sync metadata was: ''{0}'' is now: ''{1}''"
-msgstr "Les métadonnées synchronisées : \"{0}\" sont maintenant : \"{1}\""
+msgstr "Synchronisatie-metadata was: '' {0} '' is nu: '' {1} ''"
 
 #: src/metabase/models/database.clj
 msgid "Cache FieldValues was: ''{0}'', is now: ''{1}''"
-msgstr "Le cache des filtres de champs était : \"{0}\", est maintenant : \"{1}\""
+msgstr "Cache FieldValues was: ''{0}'', is nu: ''{1}''"
 
 #: src/metabase/models/metric.clj
 msgid "You cannot update the creator_id of a Metric."
-msgstr "Vous ne pouvez pas mettre à jour le creator_id d'une métrique."
+msgstr "Je kunt de creator_id van een metriek niet bijwerken."
 
 #: src/metabase/models/permissions.clj
 msgid "MetaBot can only have Collection permissions."
-msgstr "MetaBot ne peut avoir qu'une permission de type Collection"
+msgstr "MetaBot kan alleen collectie rechten hebben."
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions"
-msgstr "Impossible d'octroyer les permissions"
+msgstr "Geen machtigingen verleend"
 
 #: src/metabase/models/permissions.clj
 msgid "Changing permissions"
-msgstr "Changement des permissions"
+msgstr "Rechten wijzigen"
 
 #: src/metabase/models/permissions.clj
 msgid "FROM:"
-msgstr "DE:"
+msgstr "VAN:"
 
 #: src/metabase/models/permissions.clj
 msgid "TO:"
-msgstr "POUR:"
+msgstr "NAAR:"
 
 #: src/metabase/models/segment.clj
 msgid "You cannot update the creator_id of a Segment."
-msgstr "Vous ne pouvez pas mettre à jour le creator_id d'un segment."
+msgstr "Je kunt de creator_id van een segment niet bijwerken."
 
 #: src/metabase/models/setting.clj
 msgid "Attempted to set Setting {0} to obfuscated value. Ignoring change."
-msgstr "Vous avez tenté de définir le paramètre {0} sur une valeur occultée. Changement ignoré."
+msgstr "Poging om instelling {0} op verborgen waarde in te stellen. Verandering wordt genegeerd."
 
 #: src/metabase/models/setting.clj
 msgid "Using value of env var {0}"
-msgstr "Utilise la valeur de env var"
+msgstr "De waarde van env var {0} gebruiken"
 
 #: src/metabase/models/user.clj
 msgid "Adding User {0} to All Users permissions group..."
-msgstr "Ajout de l'utilisateur {0} au groupe d'autorisations \"Tous les utilisateurs\"..."
+msgstr "Gebruiker {0} toevoegen aan de machtigingengroep Alle gebruikers ..."
 
 #: src/metabase/models/user.clj
 msgid "Adding User {0} to Admin permissions group..."
-msgstr "Ajout de l'utilisateur {0} au groupe d'autorisations \"Admin\"..."
+msgstr "Gebruiker {0} toevoegen aan beheerdersgroep ..."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
-msgstr "Erreur de la requête"
+msgstr "Query mislukt"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
-msgstr "Nombre maximal de requêtes simultanées à autoriser par base de données connectée."
+msgstr "Maximaal aantal gelijktijdige zoekopdrachten per aangesloten database."
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
-msgstr "Expire après {0} millisecondes."
+msgstr "Time-out na {0} milliseconden."
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
 msgid "Misfire Instruction"
-msgstr "Mauvaise instruction"
+msgstr "Misfire instructie"
 
 #: frontend/src/metabase/components/ArchiveModal.jsx:31
 msgid "Archive this?"
-msgstr "Archiver ?"
+msgstr "Dit archiveren?"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:244
 msgid "Learn about our data"
-msgstr "Apprenez de vos données"
+msgstr "Leer meer over je data"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
 msgid "Use DNS SRV when connecting"
-msgstr "Utiliser DNS SRV lors de la connexion"
+msgstr "Gebruik DNS SRV bij het verbinden"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
 msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
 "an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
 "leave this disabled."
-msgstr "L'utilisation de cette option nécessite que l'hôte fourni soit un FQDN. Si vous vous connectez à un cluster Atlas, vous devrez peut-être activer cette option. Si vous ne savez pas ce que cela signifie, laissez-la désactivée."
+msgstr "Als je deze optie gebruikt, moet de geleverde host een FQDN zijn. Als u verbinding maakt met\n"
+"een Atlas-cluster, moet u deze optie mogelijk inschakelen. Als je niet weet wat dit betekent,\n"
+"laat dit uitgeschakeld."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
 msgid "Automatically run queries when doing simple filtering and summarizing"
-msgstr "Exécuter automatiquement les requêtes lors de filtrages ou de synthèses simples"
+msgstr "Voer automatisch query's uit wanneer u eenvoudig filtert en samenvat"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
 msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "Lorsque cette option est activée, Metabase exécute automatiquement des requêtes lorsque les utilisateurs effectuent des explorations simples à l'aide des boutons \"Résumer\" et \"Filtrer\" lors de l'affichage d'un tableau ou d'un graphique. Vous pouvez désactiver cette option si les requêtes de cette base de données sont lentes. Ce paramètre n’affecte pas les accès aux détails ni les requêtes SQL."
+msgstr "Wanneer dit is ingeschakeld, voert Metabase automatisch zoekopdrachten uit wanneer gebruikers eenvoudige verkenningen doen met de knoppen Samenvatting en Filter bij het bekijken van een tabel of grafiek. U kunt dit uitschakelen als het opvragen van deze database langzaam is. Deze instelling heeft geen invloed op drill-throughs of SQL-query's."
 
 #: frontend/src/metabase/containers/Overworld.jsx:247
 msgid "Learn about this database"
-msgstr "En savoir plus sur cette base de données"
+msgstr "Meer informatie over deze database"
 
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
 msgid "Archive this dashboard?"
-msgstr "Archiver ce tableau de bord?"
+msgstr "Dit dashboard archiveren?"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:113
 msgid "All results"
-msgstr "Tous les résultats"
+msgstr "Alle resultaten"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:180
 msgid "Our Analytics"
-msgstr "Nos analyses"
+msgstr "Onze analyse"
 
 #: frontend/src/metabase/lib/schema_metadata.js:500
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
-msgstr "Somme cumulée de toutes les valeurs d'une colonne. \\ne.x. chiffre d'affaires total dans le temps."
+msgstr "Additieve som van alle waarden van een kolom. \\ Bijvoorbeeld totale omzet in de loop van de tijd."
 
 #: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
-msgstr "Compte cumulé du nombre de lignes. \\ne.x. nombre total de ventes dans le temps."
+msgstr "Optelling van het aantal rijen. \\ Bijvoorbeeld totaal aantal verkopen in de loop van de tijd."
 
 #: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
 msgid "Filter"
-msgstr "Filtre"
+msgstr "Filter"
 
 #: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
 msgid "record"
 msgid_plural "records"
-msgstr[0] "enregistrement"
-msgstr[1] "enregistrements"
+msgstr[0] "resultaat"
+msgstr[1] "resultaten"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:346
 msgid "Browse Data"
-msgstr "Parcourir les données"
+msgstr "Browsen door data"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:376
 msgid "Write SQL"
-msgstr "Ecrire le SQL"
+msgstr "SQL schrijven"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
 msgid "Simple question"
-msgstr "Question simple"
+msgstr "Simpele vraag"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
-msgstr "Choisissez des données, affichez-les et filtrez-les, résumez-les et visualisez-les facilement."
+msgstr "Kies een aantal gegevens, bekijk deze en filter, vat samen en visualiseer deze eenvoudig."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
 msgid "Custom question"
-msgstr "Question personnalisée"
+msgstr "Aangepaste vraag"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
-msgstr "Utilisez l'éditeur de bloc-notes avancé pour joindre des modèles de données, créer des colonnes personnalisées, faire des calculs et bien plus encore."
+msgstr "Gebruik de geavanceerde notebookeditor om gegevens samen te voegen, aangepaste kolommen te maken, wiskunde uit te voeren en meer."
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
 msgid "Basic Metrics"
-msgstr "Métriques de base"
+msgstr "Basisstatistieken"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
 msgid "Custom…"
-msgstr "Personnalisé..."
+msgstr "Aangepast.."
 
 #: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
 msgid "Add grouping"
-msgstr "Ajouter un groupement"
+msgstr "Groepering toevoegen"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
 msgid "Pick a limit"
-msgstr "Choisir une limite"
+msgstr "Een limiet kiezen"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
 msgid "Show maximum"
-msgstr "Afficher le maximum"
+msgstr "Maximum weergeven"
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Preview"
-msgstr "Prévisualiser"
+msgstr "Voorbeeld verkrijgen"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
 msgid "Back to previous results"
-msgstr "Retour aux résultats précédents"
+msgstr "Terig naar vorige resultaten"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Sample values"
-msgstr "Valeurs d'échantillon"
+msgstr "Voorbeeld waardes"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
-msgstr "Parcourez le contenu de vos bases de données, tables et colonnes. Choisissez une base de données pour commencer."
+msgstr "Blader door de inhoud van uw databases, tabellen en kolommen. Kies een database om te beginnen."
 
 #: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
 msgid "Visualize"
-msgstr "Visualiser"
+msgstr "Visualiseren "
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
 msgid "Join data"
-msgstr "Joindre des données"
+msgstr "Gegevens joinen"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
 msgid "Custom column"
-msgstr "colonne personnalisée"
+msgstr "Aangepaste kolom"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
 msgid "Summarize"
-msgstr "Résumer"
+msgstr "Samenvatten"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
 msgid "Aggregate"
-msgstr "agréger"
+msgstr "Samenvoegen"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
 msgid "Breakout"
-msgstr "Éclater"
+msgstr "Uitbreken"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
 msgid "Pick the metric you want to see"
-msgstr "Choisissez la métrique que vous voulez voir"
+msgstr "Kies de metriek die je wilt zien"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
 #: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
 msgid "Pick a column to group by"
-msgstr "Choisissez une colonne d'agrégation"
+msgstr "Kies een kolom om op te groeperen"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
 msgid "Pick your starting data"
-msgstr "Choisissez vos données de départ"
+msgstr "Kies je startgegevens"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
 msgid "Select None"
-msgstr "Ne rien sélectionner"
+msgstr "Niets selecteren"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
 msgid "Select All"
-msgstr "Tout sélectionner"
+msgstr "Alles selecteren"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
 msgid "Pick a table..."
-msgstr "Choisissez une table..."
+msgstr "Kies een tabel..."
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
 msgid "Enter a limit"
-msgstr "Indiquer une limite"
+msgstr "Een limiet invoeren"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
 msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr "Des crochets autour d'un {0} créent une clause optionnelle dans le patron. Si la \"variable\" est positionnée, alors toute la clause est placée dans le patron. Sinon, toute la clause est ignorée."
+msgstr "Haakjes rond een {0} maken een optionele clausule in het sjabloon. Als \"variabele\" is ingesteld, wordt de hele clausule in de sjabloon geplaatst. Zo niet, dan wordt de hele clausule genegeerd."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
 msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
-msgstr "A l'usage d'un Filtre de champ, le nom de colonne ne devrait pas être inclu dans le SQL. A la place, la variable devrait être mise en correspondance avec un champ dans le panneau latéral."
+msgstr "Wanneer je een veldfilter gebruikt, mag de kolomnaam niet worden opgenomen in de SQL. In plaats daarvan moet de variabele worden toegewezen aan een veld in het zijpaneel."
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
 msgid "View the native query"
-msgstr "Voir la requête native"
+msgstr "Bekijk de native query"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
 msgid "Native query for this question"
-msgstr "Requête native pour cette question"
+msgstr "Native query voor deze vraag"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
 msgid "Convert this question to a native query"
-msgstr "Convertir la question en requête native"
+msgstr "Zet deze vraag om naar een native query"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
 msgid "SQL for this question"
-msgstr "Requête SQL pour cette question"
+msgstr "SQL voor deze vraag"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
 msgid "Convert this question to SQL"
-msgstr "Convertir cette question en requête SQL"
+msgstr "Zet deze vraag om naar SQL"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
 msgid "Get alerts"
-msgstr "Récupérer les alertes"
+msgstr "Krijg meldingen"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
 msgid "{0} breakout"
 msgid_plural "{0} breakouts"
-msgstr[0] "décomposition de {0}"
-msgstr[1] "Décompositions de {0}"
+msgstr[0] "{0} breakout"
+msgstr[1] "{0} breakouts"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
 msgid "Hide filters"
-msgstr "Cacher les filtres"
+msgstr "Filters verbergen"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
 msgid "Show filters"
-msgstr "Afficher les filtres"
+msgstr "Filters weergeven"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
 msgid "Started from"
-msgstr "A partir de"
+msgstr "Gestart van"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
 msgid "{0} row"
 msgid_plural "{0} rows"
-msgstr[0] "{0} ligne"
-msgstr[1] "{0} lignes"
+msgstr[0] "{0} rij"
+msgstr[1] "{0} rijen"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
 msgid "Show all rows"
-msgstr "Afficher toutes les lignes"
+msgstr "Alle rijen weergeven"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
 msgid "Show {0}"
-msgstr "Afficher {0}"
+msgstr "{0} weergeven"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
 msgid "Showing first {0}"
-msgstr "Affichage du premier {0}"
+msgstr "Eerste {0} weergeven"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
 msgid "Showing {0}"
-msgstr "Affichage de {0}"
+msgstr "Weergave {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
 msgid "Summarized"
-msgstr "Résumé"
+msgstr "Samenvattend"
 
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
 msgid "Hide editor"
-msgstr "Cacher l'éditeur"
+msgstr "Editor verbergen"
 
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
 msgid "Show editor"
-msgstr "Montrer l'éditeur"
+msgstr "Editor weergeven"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
 msgid "Pick the metric you'd like to see"
-msgstr "Choisissez la métrique que vous voudriez voir"
+msgstr "Kies de metriek die je wilt zien"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
 msgid "{0} options"
-msgstr "options de {0}"
+msgstr "{0} opties"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
 msgid "Choose a visualization"
-msgstr "Choisissez une représentation"
+msgstr "Kies een visualisatie"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
 msgid "Filter by"
-msgstr "Filtrer par"
+msgstr "Filteren bij"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
 msgid "Summarize by"
-msgstr "Agréger par"
+msgstr "Samenvatten bij"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
 msgid "Group by"
-msgstr "Grouper par"
+msgstr "Groeperen bij"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
 msgid "Add a metric"
-msgstr "Ajouter un métrique"
+msgstr "Voeg een metriek toe"
 
 #: frontend/src/metabase/user/components/UserSettings.jsx:57
 msgid "Profile"
-msgstr "Profil"
+msgstr "Profiel"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:548
 msgid "This is usually pretty fast but seems to be taking a while right now."
-msgstr "C'est habituellement agréablement rapide mais semble prendre un moment désormais."
+msgstr "Dit is meestal vrij snel, maar lijkt nu even te duren."
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
 msgid "Combo"
-msgstr "Menu déroulant"
+msgstr "Combinatie"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
-msgstr "Ligne"
+msgstr "Rij"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
 msgid "Trend"
-msgstr "Tendance"
+msgstr "Trend"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:129
 msgid "Boolean"
-msgstr "Booléen"
+msgstr "Boolean"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
 msgid "Unknown Segment"
-msgstr "Segment inconnu"
+msgstr "Onbekende segment"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
 msgid "Unknown Filter"
-msgstr "Filtre inconnu"
+msgstr "Onbekende filter"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
 msgid "Left outer join"
-msgstr "Jointure externe gauche (left outer join)"
+msgstr "Left outer join"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
 msgid "Right outer join"
-msgstr "Jointure externe droite (right outer join)"
+msgstr "Right outer join"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
 msgid "Inner join"
-msgstr "Jointure interne (inner join)"
+msgstr "Inner join"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
 msgid "Full outer join"
-msgstr "Jointure externe complète (full outer join)"
+msgstr "Full outer join"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
-msgstr "Les métadonnées des résultats de la carte transmises à l'API sont MANQUANT. Requête en cours d'exécution pour récupérer les métadonnées correctes."
+msgstr "Metagegevens van de kaartresultaten die zijn doorgegeven aan API ONTBREKEN. Bezig met uitvoeren van zoekopdracht om juiste metagegevens op te halen."
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fall back to local authentication"
-msgstr "Problème à la connexion au serveur LDAP, Repli vers vers l'authentification locale"
+msgstr "Probleem bij het verbinding maken met LDAP-server, valt terug op lokale authenticatie"
 
 #: src/metabase/api/setup.clj
 msgid "Cannot create Database: cannot find driver {0}."
-msgstr "Incapable de créer la base de données: incapable de trouver le pilote {0}."
+msgstr "Kan database niet aanmaken: kan driver niet vinden {0}"
 
 #: src/metabase/api/tiles.clj
 msgid "Query failed"
-msgstr "La requête a échoué"
+msgstr "Query mislukt"
 
 #: src/metabase/async/util.clj
 msgid "Warning: {0} returned `nil`"
-msgstr "Avertissement: {0} a retourné 'nil'"
+msgstr "Warning: {0} returned `nil`"
 
 #: src/metabase/async/util.clj
 msgid "Unexpected error writing result to output channel: already closed"
-msgstr "Erreur inattendue à l'écriture du résultat dans le canal de sortie: déjà fermé"
+msgstr "Unexpected error writing result to output channel: already closed"
 
 #: src/metabase/async/util.clj
 msgid "Unexpected error writing exception to output channel: already closed"
-msgstr "Erreur inattendue à l'écriture de l'exception dans le canal de sortie: déjà fermé"
+msgstr "Unexpected error writing exception to output channel: already closed"
 
 #: src/metabase/async/util.clj
 msgid "Request canceled, canceling future."
-msgstr "Requête annulée, annulation de la planification."
+msgstr "Request canceled, canceling future."
 
 #: src/metabase/cmd/load_from_h2.clj
 msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
-msgstr "Metabase peut transférer ses données depuis H2 uniquement vers Postgres ou MySQL/MariaDB."
+msgstr "Metabase kan alleen gegevens overbrengen van H2 naar Postgres of MySQL / MariaDB."
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
-msgstr "AVERTISSEMENT: L'utilisation de Metabase avec une base H2 n'est pas recommandé dans les déploiements en production."
+msgstr "WAARSCHUWING: Het gebruik van Metabase met een H2-applicatiedatabase wordt niet aanbevolen voor productie-implementaties."
 
 #: src/metabase/db.clj
 msgid "Application database setup"
-msgstr "Installation de la base de données"
+msgstr "Applicatie database instellen"
 
 #: src/metabase/driver.clj
 msgid "Could not find {0} driver."
-msgstr "Impossible de trouver le driver {0}"
+msgstr "Kon driver {0} niet vinden."
 
 #: src/metabase/driver.clj
 msgid "Abstract drivers cannot derive from concrete parent drivers."
-msgstr "Les pilotes abstraits ne peuvent pas dériver (hériter) de pilotes concrets."
+msgstr "\n"
+"Abstract drivers cannot derive from concrete parent drivers."
 
 #: src/metabase/driver/mysql.clj
 msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
-msgstr "Il se peut que vous deviez ajouter 'trustServerCertificate=true' aux options additionnelles de connexion pour pouvoir vous connecter avec SSL."
+msgstr "Mogelijk moet je 'trustServerCertificate=true' toevoegen aan de verbindingsopties om verbinding te maken met SSL."
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don't know how to alias {0}, expected an Identifer."
-msgstr "Je ne sais pas comment créer un alias à {0}, j'attendais un identifiant."
+msgstr "Don't know how to alias {0}, expected an Identifer."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, canceling query"
-msgstr "Le client a fermé la connection, requête annulée"
+msgstr "Client heeft verbinding verbroken, zoekopdracht wordt geannuleerd"
 
 #: src/metabase/integrations/ldap.clj
 msgid "{0} is not a valid DN."
-msgstr "{0} n'est pas un nom absolu valide"
+msgstr "{0} is geen geldige DN."
 
 #: src/metabase/middleware/log.clj
 msgid "Error logging API request"
-msgstr "Erreur à l'inscription d'une requête API dans le log"
+msgstr "Fout bij het registreren van API-aanvraag"
 
 #: src/metabase/middleware/misc.clj
 msgid "Failed to set site-url"
-msgstr "Echec lors de la mise en place de site-url"
+msgstr "Kan site-url niet instellen"
 
 #: src/metabase/models/database.clj
 msgid "Error destroying thread pool for DB."
-msgstr "Erreur lors de la destruction du réservoir de fils d'exécution pour la DB."
+msgstr "Fout bij het vernietigen van thread pool voor DB."
 
 #: src/metabase/models/humanization.clj
 msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
-msgstr "Mise à jour du libellé pour {0} \"{1}\": \"{2}\" -> \"{3}\""
+msgstr "Weergavenaam voor {0} '' {1} '' bijwerken: '' {2} '' -> '' {3} ''"
 
 #: src/metabase/models/humanization.clj
 msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
-msgstr "\"{0}\" est une stratégie d'humanisation invalide. Les stratégies valides sont : {1}"
+msgstr "Ongeldige humaniseringsstrategie '' {0} ''. Geldige strategieën zijn: {1}"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr "Changement de la stratégie d'humanisation des noms de champs et de tables depuis \"{0}\" vers \"{1}\""
+msgstr "Humanisatie-strategie voor tabel- en veldnamen wijzigen van '' {0} '' in '' {1} ''"
 
 #: src/metabase/models/task_history.clj src/metabase/sync/util.clj
 msgid "Error saving task history"
-msgstr "Erreur à la sauvegarde de l'historique des tâches"
+msgstr "Fout bij het opslaan van taakgeschiedenis"
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
-msgstr "spark-deps.jar n'est plus utilisé par Metabase 0.32.0+. Vous pouvez donc le supprimer du dossier d'extensions."
+msgstr "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
-msgstr "Utilisation d'un classloader nouvellement créé comme classloader de contexte partagé: {0}"
+msgstr "Using NEWLY CREATED classloader as shared context classloader: {0}"
 
 #: src/metabase/plugins/files.clj
 msgid "Failed to copy file"
-msgstr "Impossible de copier le fichier"
+msgstr "Fout bij het kopiëren van bestand"
 
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
-msgstr "URL de site web invalide: {0}"
+msgstr "Ongeldige site-URL: {0}"
 
 #: src/metabase/public_settings.clj
 msgid "site-url is invalid; returning nil for now. Will be reset on next request."
-msgstr "site-url est invalide; renvoi de nil pour le moment. Sera repositionné à la prochaine requête."
+msgstr "site-url is ongeldig; voorlopig nul. Wordt bij het volgende verzoek gereset."
 
 #: src/metabase/pulse/render/body.clj
 msgid "More results have been included as a file attachment"
-msgstr "Plus d'information a été inclue dans un fichier en attachement"
+msgstr "Meer resultaten zijn opgenomen als bestandsbijlage"
 
 #: src/metabase/pulse/render/body.clj
 msgid "This question has been included as a file attachment"
-msgstr "Cette question a été inclue dans un fichier en attachement"
+msgstr "Deze vraag is als bijlage toegevoegd"
 
 #: src/metabase/pulse/render/body.clj
 msgid "We were unable to display this Pulse."
-msgstr "Nous avons été incapable d'afficher ce Pulse."
+msgstr "We konden deze puls niet weergeven."
 
 #: src/metabase/pulse/render/body.clj
 msgid "Please view this card in Metabase."
-msgstr "Visualisez s'il vous plaît cette carte dans Metabase."
+msgstr "Bekijk deze kaart in Metabase."
 
 #: src/metabase/pulse/render/body.clj
 msgid "An error occurred while displaying this card."
-msgstr "Une erreur s'est produite lors de l'affichage de cette carte."
+msgstr "Er is een fout opgetreden bij het weergeven van deze kaart."
 
 #: src/metabase/query_processor.clj
 msgid "Can only determine expected columns for MBQL queries."
-msgstr "Je peux seulement déterminer les colonnes attendues pour les requêtes MBQL."
+msgstr "Kan alleen verwachte kolommen bepalen voor MBQL-query's."
 
 #: src/metabase/query_processor.clj
 msgid "No columns returned."
-msgstr "Pas de colonnes retournées."
+msgstr "Geen kolommen ontvangen."
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
-msgstr "Avertissement: je ne peux pas déterminer les champs d'une requête source explicite 'source-query' à moins que vous incluiez les métadonnées 'source-metadata'"
+msgstr "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
-msgstr "Incapable de résoudre {0}: le champ n'existe pas, ou sa table appartient à une autre base de données."
+msgstr "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
-msgstr "Impossible de résoudre :field-literal dans :fk-> à moins d'utiliser un inside join avec :alias explicite."
+msgstr "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot find Table ID for {0}"
-msgstr "Incapable de trouver l'ID de table pour {0}"
+msgstr "\n"
+"Cannot find Table ID for {0}"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found."
-msgstr "Pas d'information concordante trouvée."
+msgstr "Geen overeenkomende info gevonden."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Could not resolve {0}"
-msgstr "Incapable de résoudre {0}"
+msgstr "Could not resolve {0}"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Invalid fk-> clause: nowhere to add corresponding join."
-msgstr "Clause fk-> invalide: aucun endroit pour ajouter la jointure correspondante."
+msgstr "Invalid fk-> clause: nowhere to add corresponding join."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "{0} driver does not support foreign keys."
-msgstr "Le driver {0} ne supporte pas les clés étrangères."
+msgstr "driver {0} ondersteund geen foreign keys."
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
 msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
-msgstr "Incapable d'inférer ':source-metadata' pour une requête source native sans métadonnées."
+msgstr "Cannot infer `:source-metadata` for source query with native source query without source metadata."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: number of columns returned by driver does not match results."
-msgstr "Erreur dans le processeur de requête: le nombre de colonnes retourné par le pilote ne correspond pas aux résultats."
+msgstr "Query processor error: number of columns returned by driver does not match results."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} columns, but first row of resuls has {1} columns."
-msgstr "J'attendais {0} colonnes, mais la première ligne de résultats en a  {1}."
+msgstr "Verwachtte {0} kolommen, maar eerste rij heeft {1} kolommen."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "No expression named {0} found. Found: {1}"
-msgstr "Je n'ai trouvé aucune expression nommée {0}, mais plutôt {1}"
+msgstr "Geen expressie met de naam {0} gevonden. Gevonden: {1}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Distinct values of {0}"
-msgstr "Valeurs distinctes de {0}"
+msgstr "Unieke waardes van {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Average of {0}"
-msgstr "Moyenne de {0}"
+msgstr "Gemiddelde van {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0}"
-msgstr "Somme de {0}"
+msgstr "Som van {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "SD of {0}"
-msgstr "Ecart-type de {0}"
+msgstr "SD van {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Min of {0}"
-msgstr "Min de {0}"
+msgstr "Minimum van {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Max of {0}"
-msgstr "Max de {0}"
+msgstr "Maximum van {0}"
 
 #. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0} matching condition"
-msgstr "Somme des {0} vérifiant la condition"
+msgstr "Som van {0} met overeenkomende voorwaarde"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Share of rows matching condition"
-msgstr "Part des lignes vérifiant la condition"
+msgstr "Aandeel rijen met overeenkomende voorwaarde"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of rows matching condition"
-msgstr "Nombre de lignes vérifiant la condition"
+msgstr "Aantal rijen met overeenkomende voorwaarde"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Request already canceled, will not run synchronous QP code."
-msgstr "Requête déjà annulée, le code QP synchrone ne sera pas exécuté."
+msgstr "Request already canceled, will not run synchronous QP code."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unexpectedly got `nil` Query Processor response."
-msgstr "le processeur de requête a répondu 'nil' de façon inattendue."
+msgstr "Unexpectedly got `nil` Query Processor response."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Got InterruptedException. Canceling query."
-msgstr "InterruptedException. Annulation de la requête."
+msgstr "Got InterruptedException. Canceling query."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
-msgstr "Exception non gérée, le middleware 'catch-exceptions' aurait dû la gérer."
+msgstr "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Query timed out after %s"
-msgstr "La requête a expiré après %s"
+msgstr "Query timed out after %s"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Creating new query thread pool for Database {0}"
-msgstr "Création d'un nouveau réservoir de fils d'exécution de requête pour la base de données {0}"
+msgstr "Creating new query thread pool for Database {0}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Destroying query thread pool for Database {0}"
-msgstr "Destruction du réservoir de fils d'exécution de requête pour la base de données {0}"
+msgstr "Destroying query thread pool for Database {0}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Request canceled, canceling pending query"
-msgstr "Requête annulée, annulation de la requête en attente"
+msgstr "Request canceled, canceling pending query"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: query is missing source-metadata"
-msgstr "Incapable de mettre à jour le champ binné: la requête manque de métadonnées source"
+msgstr "Cannot update binned field: query is missing source-metadata"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
-msgstr "Dans l'incapacité de mttre à jour le champ binné: métadonnées correspondantes non trouvées pour le champ \"{0}\"\n"
-""
+msgstr "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Using query processor cache backend: {0}"
-msgstr "Utilisation du cache du processeur de requête: {0}"
+msgstr "Using query processor cache backend: {0}"
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Invalid metric: {0} reason: {1}"
-msgstr "Métrique invalide: {0}, raison: {1}"
+msgstr "Invalid metric: {0} reason: {1}"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unknown error"
-msgstr "Erreur inconnue"
+msgstr "Onbekende fout"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unexpected nil response from query processor."
-msgstr "Le processeur de requête a répondu 'nil' de façon inattendue."
+msgstr "Unexpected nil response from query processor."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query canceled"
-msgstr "Requête annulée"
+msgstr "Query geannuleerd"
 
 #: src/metabase/query_processor/middleware/resolve_driver.clj
 msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
-msgstr "Incapable de résoudre le pilote pour la requête: ID de la base de données manquant ou invalide."
+msgstr "Unable to resolve driver for query: missing or invalid `:database` ID."
 
 #: src/metabase/query_processor/middleware/resolve_driver.clj
 msgid "Unable to resolve driver for query: Database {0} does not exist."
-msgstr "Incapable de résoudre le pilote pour la requête: la base de données {0} n'existe pas."
+msgstr "Unable to resolve driver for query: Database {0} does not exist."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
-msgstr "Impossible d'utiliser :fields :all dans un join avec la requête source sauf si elle a :source-metadata."
+msgstr "\n"
+"Cannot use :fields :all in join against source query unless it has :source-metadata."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
-msgstr "Mauvaise clause :join-field : la jointure avec l'alias ''{0}'' n'existe pas. Trouvé : {1}"
+msgstr "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
-msgstr "Non valide :source-table ''{0}'' : doit maintenant être résolu en un Table ID."
+msgstr "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
 
 #: src/metabase/query_processor/store.clj
 msgid "Cannot store Tables or Fields before Database is stored."
-msgstr "Incapable de stocker des tables ou des champs avant qu'une base de données soit stockée."
+msgstr "Kan tabellen of velden niet opslaan voordat de database is opgeslagen."
 
 #: src/metabase/query_processor/store.clj
 msgid "Attempting to fetch second Database. Queries can only reference one Database."
-msgstr "Tentative de lire une seconde base de données. Les requêtes ne peuvent en référencer qu'une seule."
+msgstr "Poging om tweede database op te halen. Query's kunnen slechts naar één database verwijzen."
 
 #: src/metabase/query_processor/store.clj
 msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
-msgstr "Incapable de lire la table {0}: elle n'existe pas, ou appartient à une base de données différente."
+msgstr "Kan tabel {0} niet ophalen: tabel bestaat niet of behoort tot een andere database."
 
 #: src/metabase/query_processor/store.clj
 msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
-msgstr "Incapable de lire le champ {0}: il n'existe pas, ou appartient à une base de données différente."
+msgstr "Kan veld {0} niet ophalen: veld bestaat niet of behoort tot een andere database."
 
 #: src/metabase/routes/index.clj
 msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
-msgstr "Incapable de charger le patron \"{0}\": Avez-vous pensé à construire la devanture Metabase ?"
+msgstr "Kan template '' {0} '' niet laden. Heb je eraan gedacht om de Metabase-frontend te bouwen?"
 
 #: src/metabase/sample_data.clj
 msgid "Sample dataset DB file ''{0}'' cannot be found."
-msgstr "Le fichier \"{0}\" de la base de données d'exemple est introuvable."
+msgstr "Voorbeelddataset DB-bestand '' {0} '' kan niet worden gevonden."
 
 #: src/metabase/sample_data.clj
 msgid "Loading sample dataset..."
-msgstr "Chargement du jeu de données d'exemple..."
+msgstr "Voorbeeldgegevensset laden ..."
 
 #: src/metabase/sample_data.clj
 msgid "Failed to load sample dataset"
-msgstr "Impossible de charger les données d'exemple"
+msgstr "Kan voorbeeldgegevensset niet laden"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Found new tables:"
-msgstr "Nouvelles tables trouvées:"
+msgstr "Nieuwe tabellen gevonden:"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Marking tables as inactive:"
-msgstr "Marquage des tables comme inactives:"
+msgstr "Tabellen worden als inactief gemarkeerd:"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Updating description for tables:"
-msgstr "Mise à jour de la description des tables:"
+msgstr "Beschrijving bijwerken voor tabellen:"
 
 #: src/metabase/task.clj
 msgid "Rescheduling job {0}"
-msgstr "Replanification du job {0}"
+msgstr "Job {0} opnieuw inplannen"
 
 #: src/metabase/task.clj
 msgid "Error rescheduling job"
-msgstr "Erreur à la replanification du job"
+msgstr "Fout bij het opnieuw instellen van job"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Starting Pulse Execution: {0}"
-msgstr "Démarrage de l'exécution du Pulse: {0}"
+msgstr "Starten van pulsuitvoering: {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Finished Pulse Execution: {0}"
-msgstr "Exécution du Pulse terminée: {0}"
+msgstr "Pulsuitvoering uitgevoerd: {0}"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to schedule tasks for Database {0}"
-msgstr "Echec à la planification des tâches pour la base de données {0}"
+msgstr "Kan taken voor database {0} niet plannen"
 
 #: src/metabase/util/schema.clj
 msgid "All elements must be distinct."
-msgstr "Tous les éléments doivent être distincts."
+msgstr "Alle elementen moeten uniek zijn."
 
 #: 
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
-msgstr "Choisissez les colonnes concernées"
+msgstr "Kies de kolommen die je mee wilt nemen"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "Lorsque cette option est activée, Metabase exécute automatiquement des requêtes lorsque les utilisateurs effectuent des explorations simples à l'aide des boutons Résumer et Filtrer lors de l'affichage d'un tableau ou d'un graphique. Vous pouvez désactiver cette option si l'interrogation de cette base de données est lente. Ce paramètre n’affecte pas les accès au détail ni les requêtes SQL."
+msgstr "Wanneer dit is ingeschakeld, voert Metabase automatisch query's uit wanneer gebruikers eenvoudige verkenningen doen met de knoppen Samenvatting en Filter bij het bekijken van een tabel of diagram. Je kunt dit uitschakelen als het opvragen van deze database lang duurt. Deze instelling heeft geen invloed op drill-throughs of SQL-query's."
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
 msgid "Change join type"
-msgstr "Changez le type de jointure"
+msgstr "Wijzig het join-type"
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don't know how to alias {0}, expected an Identifier."
-msgstr "Impossible de savoir comment alias {0}, un Identifier était attendu."
+msgstr "Weet niet hoe je alias {0} kunt gebruiken, verwacht een ID."
 
 #: src/metabase/integrations/common.clj
 msgid "Error adding User {0} to Group {1}"
-msgstr "Erreur lors de l'ajout de l'utilisateur {0} au groupe {1}"
+msgstr "Fout bij toevoegen van gebruiker {0} aan groep {1}"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr "Modification de la stratégie d'humanisation des noms de Table et de Champ de ''{0}'' à ''{1}''"
+msgstr "Humanisatie-strategie voor tabel- en veldnamen wijzigen van '' {0} '' in '' {1} ''"
 
 #: src/metabase/query_processor.clj
 msgid "Infinite loop detected: recursively preprocessed query {0} times."
-msgstr "Boucle infinie détectée: requête pré-traitée récursivement {0} fois."
+msgstr "Oneindige lus gedetecteerd: recursief de query {0} keer verwerkt."
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
-msgstr "Attention: impossible de déterminer les champs pour une `source-query` explicite à moins d'inclure également `source-metadata`."
+msgstr "Waarschuwing: kan geen velden bepalen voor een expliciete `source-query` tenzij je ook` source-metadata` opneemt."
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
 msgid "Error determining expected columns for query"
-msgstr "Erreur lors de la détermination des colonnes attendues pour la requête"
+msgstr "Fout bij het bepalen van verwachte kolommen voor query"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
-msgstr "Exception non gérée, aurait du être prise en charge par le middleware `catch-exceptions`."
+msgstr "Onbehandelde exceptie, `catch-exceptions` middleware werd verwacht om dit af te handelen."
 

--- a/locales/pl.po
+++ b/locales/pl.po
@@ -28,18 +28,19 @@ msgstr "Przejrzyj dane"
 msgid "Select a database type"
 msgstr "Wybierz typ bazy danych"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:75
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:401
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:71
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:182
+#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:410
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:74
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:203
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:180
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:197
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:193
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:171
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:180
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:164
 msgid "Save"
 msgstr "Zapisz"
@@ -60,7 +61,7 @@ msgstr "Jest to lekki proces, który sprawdza aktualizacje schematu tej bazy dan
 "W większości przypadków powinno być dobrze pozostawiając ten zestaw do synchronizacji godzinowej."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:184
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
 msgid "Scan"
 msgstr "Skanuj"
 
@@ -77,127 +78,129 @@ msgstr "Metabase  może skanować wartości znajdujące się w każdym z pól w 
 " aby włączyć filtry pól wyboru w pulpitach nawigacyjnych i zapytaniach.\n"
 " Może to być proces nieco intensywnie korzystający z zasobów, szczególnie jeśli masz bardzo dużą bazę danych."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:159
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Kiedy Metabase powinien automatycznie skanować i buforować wartości pól?"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:164
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
 msgstr "Regularnie, według harmonogramu"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:195
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
 msgstr "Tylko w przypadku dodawania nowego widżetu filtru"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:199
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
 msgstr "Gdy użytkownik doda nowy filtr do pulpitu nawigacyjnego lub zapytania SQL, \n"
 " Metabase będzie skanować pola mapowane do tego filtru w celu wyświetlenia listy wartości do wyboru."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:210
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
 msgid "Never, I'll do this manually if I need to"
 msgstr "Nigdy, Zrobię to ręcznie jeżeli będzie potrzeba"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:222
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:222
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:426
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
 msgid "Saving..."
 msgstr "Zapisywanie..."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:39
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
 msgid "Server error encountered"
 msgstr "Napotkano błąd serwera"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:58
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
 msgstr "Usunąć bazę danych?"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
 msgstr "Wszystkie zapisane zapytania, metryki i segmenty, które opierają się na tej bazie danych zostaną utracone."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:67
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
 msgstr "Proces nieodwracalny"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
 msgstr "Jeśli jesteś pewny, proszę wpisać"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:53
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
 msgstr "Usuń"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:71
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
 msgstr "w tym polu:"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:82
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:50
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:93
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:58
-#: frontend/src/metabase/admin/permissions/selectors.js:160
-#: frontend/src/metabase/admin/permissions/selectors.js:170
-#: frontend/src/metabase/admin/permissions/selectors.js:185
-#: frontend/src/metabase/admin/permissions/selectors.js:224
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:355
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:181
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:247
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:61
+#: frontend/src/metabase/admin/permissions/selectors.js:163
+#: frontend/src/metabase/admin/permissions/selectors.js:173
+#: frontend/src/metabase/admin/permissions/selectors.js:188
+#: frontend/src/metabase/admin/permissions/selectors.js:227
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:202
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:268
+#: frontend/src/metabase/components/ArchiveModal.jsx:35
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
-#: frontend/src/metabase/components/form/StandardForm.jsx:61
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:196
+#: frontend/src/metabase/components/form/StandardForm.jsx:62
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:198
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:289
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:162
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:153
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:38
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:189
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:24
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:48
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:41
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:92
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:259
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
-msgstr "Przerwij"
+msgstr "Anuluj"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:88
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:121
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:132
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
 msgstr "Uusń"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:128
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:74
-#: frontend/src/metabase/admin/permissions/selectors.js:320
-#: frontend/src/metabase/admin/permissions/selectors.js:327
-#: frontend/src/metabase/admin/permissions/selectors.js:423
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
+#: frontend/src/metabase/admin/permissions/selectors.js:323
+#: frontend/src/metabase/admin/permissions/selectors.js:330
+#: frontend/src/metabase/admin/permissions/selectors.js:426
 #: frontend/src/metabase/admin/routes.jsx:53
-#: frontend/src/metabase/nav/containers/Navbar.jsx:214
+#: frontend/src/metabase/nav/containers/Navbar.jsx:243
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
 msgstr "Bazy danych"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:129
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
 msgstr "Dodaj bazę danych"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
 msgstr "Połączenie"
@@ -206,107 +209,107 @@ msgstr "Połączenie"
 msgid "Scheduling"
 msgstr "Planowanie"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:78
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:84
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:26
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:221
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
 msgstr "Zapisz zmiany"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:185
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:38
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:38
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
 msgstr "Akcje"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:193
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
 msgstr "Synchronizuj teraz schemat bazy danych"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:194
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:206
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:109
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
 msgstr "Uruchamianie..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:195
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
 msgstr "Nie można zsynchronizować"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
 msgstr "Synchronizacja wyzwolona!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:205
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
 msgstr "Ponowne skanowanie wartości pól teraz"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:207
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
 msgstr "Nie można uruchomić skanowania"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
 msgstr "Rozpoczęto skanowanie!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:215
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:401
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
 msgstr "Niebezpieczna strefa"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:221
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
 msgstr "Odrzuć zapisane wartości pola"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
 msgstr "Usuń tą bazę danych"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:73
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
 msgstr "Dodaj bazę danych"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:85
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:36
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:36
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:122
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:32
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:399
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:446
 #: frontend/src/metabase/containers/EntitySearch.jsx:26
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:218
-#: frontend/src/metabase/entities/collections.js:93
-#: frontend/src/metabase/entities/dashboards.js:145
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:461
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:81
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:220
+#: frontend/src/metabase/entities/collections.js:94
+#: frontend/src/metabase/entities/dashboards.js:142
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
 msgstr "Nazwa"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:86
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
 msgstr "Silnik"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:115
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
 msgstr "Usuwanie..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:145
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
 msgstr "Ładowanie..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:161
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
 msgstr "Przywróć przykładowy zestaw danych"
 
@@ -323,9 +326,9 @@ msgid "Successfully saved!"
 msgstr "Pomyślnie zapisane!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:177
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:197
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
 msgstr "Edycja"
@@ -334,86 +337,90 @@ msgstr "Edycja"
 msgid "Revision History"
 msgstr "Historia weryfikacji"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
 msgstr "Ponów próbę {0}"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
 msgstr "Zapisane zapytania i inne elementy, które zależą od tego elementu {0}, będą nadal działać, ale ten element {1} nie będzie już można wybrać z konstruktora zapytań."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
 msgstr "Jeśli masz pewność, że chcesz wycofać to {0}, wpisz krótkie wyjaśnienie przyczyny jego wycofania:"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
 msgstr "Będzie to widoczne w kanale aktywności i w e-mail, który zostanie wysłany do wszystkich osób w zespole, którzy utworzyli coś, co używa tego {0}."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
 msgstr "Ponów próbę"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
 msgstr "Ponawianie próby"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
 msgstr "Niepowodzenie"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
 msgstr "Sukces"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:91
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
+#: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Podgląd"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
 msgstr "Brak opisu kolumny"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:135
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
 msgstr "Wybierz widoczność pola"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:210
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
 msgstr "Brak specjalnego typu"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:211
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:148
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
 msgstr "Inne"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:231
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Wybierz specjalny typ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:277
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
 msgstr "Wyznacz cel"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:77
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:89
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:106
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:122
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
 msgstr "Kolumny"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Kolumn"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:121
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:306
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
 msgstr "Widoczność"
 
@@ -421,27 +428,27 @@ msgstr "Widoczność"
 msgid "Type"
 msgstr "Typ"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
 msgstr "Aktualna baza danych"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
 msgstr "Pokaż oryginalny schemat"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:45
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
 msgstr "Typ danych"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
 msgstr "Dodatkowe informacje"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
 msgstr "Znajdz schemat"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:51
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "{0} schemat"
@@ -449,27 +456,27 @@ msgstr[1] "{0} schematy"
 msgstr[2] "{0} schematów"
 msgstr[3] "{0} schematów"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
 msgstr "Dlaczego ukryć?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
 msgstr "Dane techniczne"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
 msgstr "Bez znaczenia"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
 msgid "Queryable"
 msgstr "Odpytywalne"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:91
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
 msgstr "Ukryty"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
 msgstr "Brak opisu tabeli"
 
@@ -477,7 +484,7 @@ msgstr "Brak opisu tabeli"
 msgid "Metadata Strength"
 msgstr "Siła meta danych"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} tabela do zapytań"
@@ -485,7 +492,7 @@ msgstr[1] "{0} tabele do zapytań"
 msgstr[2] "{0} tabel do zapytań"
 msgstr[3] "{0} tabel do zapytań"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:96
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} tabela ukryta"
@@ -493,53 +500,55 @@ msgstr[1] "{0} tabele ukryte"
 msgstr[2] "{0} tabel ukrytych"
 msgstr[3] "{0} tabel ukrytych"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
 msgstr "Szukaj tabeli"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
 msgstr "Schematy"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:24
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:137
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:68
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:56
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:190
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
 msgstr "Metryki"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
 msgstr "Dodaj metrykę"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:37
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Definicja"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Stwórz metryki, aby dodać je do listy rozwijanej widoku w konstruktorze zapytań"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:24
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:930
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:952
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:56
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segmenty"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
 msgstr "Dodaj segment"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Stwórz segmenty w celu dodania ich do Filtru w konstruktorze zapytań"
 
@@ -567,53 +576,53 @@ msgstr "modyfikował(a) "
 msgid "made some changes"
 msgstr "zrobiłem kilka zmian"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
-#: frontend/src/metabase/home/components/Activity.jsx:80
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:332
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/home/components/Activity.jsx:82
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
 msgstr "Ty"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
 msgstr "Model danych"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
 msgstr "Historia"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:48
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
 msgstr "Historia wersji dla"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:239
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
 msgstr "{0} — ustawienia pól"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
 msgstr "Gdzie to pole pojawi się w Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:329
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filtrowanie w tym polu"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Kiedy to pole jest używane w filtrze, jakie osoby powinny używać do wprowadzania wartości, którą chce filtrować?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:453
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Brak opisu dla pola"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:379
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
 msgstr "Wartość oruginalna"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:380
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
 msgid "Mapped value"
 msgstr "Mapowane wartości"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:423
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
 msgstr "Wpisz wartość"
 
@@ -630,7 +639,7 @@ msgid "Custom mapping"
 msgstr "Mapowanie niestandardowe"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:155
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
 msgid "Unrecognized mapping type"
 msgstr "Nierozpoznany typ mapowania"
 
@@ -638,23 +647,23 @@ msgstr "Nierozpoznany typ mapowania"
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Bieżące pole nie jest kluczem obcym lub brak jest tabeli docelowej"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:187
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
 msgstr "Wybrane pole nie jest kluczem obcym"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:347
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
 msgstr "Wyświetl wartości"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:348
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Wybierz aby pokazać oryginalną wartość z bazy danych lub wyświetlić pole skojarzone lub niestandardowe informacje."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:268
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
 msgstr "Wybierz pole"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:289
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
 msgstr "Wybierz kolumnę, której chcesz użyć do wyświetlenia."
 
@@ -662,16 +671,16 @@ msgstr "Wybierz kolumnę, której chcesz użyć do wyświetlenia."
 msgid "Tip:"
 msgstr "Porada:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Możesz zaktualizować nazwę pola, aby upewnić się, że nadal ma sens na podstawie opcji ponownego mapowania."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:364
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:102
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
 msgstr "Buforowane wartości pola"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:365
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase może skanować wartości tego pola, aby włączyć filtry pól wyboru w pulpitach nawigacyjnych i zapytaniach."
 
@@ -680,167 +689,168 @@ msgid "Re-scan this field"
 msgstr "Ponownie przeskanuj to pole"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
 msgstr "Odrzuć buforowane wartości pola"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:118
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
 msgstr "Nie można odrzucić wartości"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard triggered!"
 msgstr "Odrzuć wywołane!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:105
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Wybierz dowolną tabelę, aby zobaczyć jej schemat i dodać lub edytować metadane."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:37
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:34
-#: frontend/src/metabase/entities/collections.js:96
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "Nazwa jest wymagana"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:40
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
 msgstr "Opis jest wymagany"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:44
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:41
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
 msgstr "Wymagany jest komunikat poprawki"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:50
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
 msgstr "Agregacja jest wymagana"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
 msgstr "Edytuj metryki"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
 msgstr "Utwórz metryki"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:115
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Wprowadź zmiany w metrykę i pozostaw notatkę wyjaśniającą."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Można utworzyć zapisane metryki, aby dodać do tej tabeli opcję o nazwie metryki. Zapisane metryki obejmują typ agregacji, pole zagregowane i opcjonalnie dowolny dodany filtr. Na przykład, można użyć tego, aby utworzyć coś jak oficjalny sposób obliczania \"Średnia cena\" dla tabeli zamówienia."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
 msgstr "Wynik:"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
 msgstr "Nazwij swoje metryki"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
 msgstr "Nadaj metrykom nazwę aby ułatwić innym znalezienie jej"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:162
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
 msgstr "Coś opisowego, ale nie za długie"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
 msgstr "Opisz swoje metryki"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Opisz swoje metryki aby ułatwić ich zrozumienie dla innych"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Jest to dobre miejsce, aby być bardziej szczegółowe o mniej oczywiste reguły metryczne"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:179
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
 msgstr "Powód do zmian"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:177
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Zostaw notatkę, aby wyjaśnić, jakie zmiany zostały wprowadzone i dlaczego były wymagane."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "To pojawi się w historii zmian dla tej metryki, aby pomóc wszystkim pamiętać, dlaczego rzeczy zmienił"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
 msgstr "Co najmniej jeden filtr jest wymagany"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
 msgstr "Edytuj segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
 msgstr "Utwórz swój segment"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:121
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Wprowadź zmiany w segmencie i pozostaw notatkę wyjaśniającą."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Wybieranie i Dodawanie filtrów w celu utworzenia nowego segmentu dla tabeli {0}"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
 msgstr "Nadaj nazwę segmentowi"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:162
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
 msgstr "Nadaj swojemu segmentowi nazwę, aby pomóc innym w jego znalezieniu."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:170
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
 msgstr "Opisanie segmentu"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Nadaj segmentowi opis, aby pomóc innym w zrozumieniu jego informacji."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:175
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Jest to dobre miejsce, aby być bardziej szczegółowe o mniej oczywiste reguły segmentu"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:185
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Będzie to widoczne w historii zmian dla tego segmentu, aby pomóc wszystkim pamiętać, dlaczego rzeczy zmienił"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:266
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:87
-#: frontend/src/metabase/nav/containers/Navbar.jsx:199
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:269
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:91
+#: frontend/src/metabase/nav/containers/Navbar.jsx:228
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:103
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase może skanować wartości w tej tabeli, aby włączyć filtry CheckBox w pulpitach nawigacyjnych i zapytaniach."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:108
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
 msgstr "Skanuj ponownie tabele"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:253
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
 msgstr "Dodaj"
 
@@ -849,20 +859,22 @@ msgstr "Dodaj"
 msgid "Not a valid formatted email address"
 msgstr "Niepoprawny adres email"
 
+#: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:100
 msgid "First name"
 msgstr "Imię"
 
+#: frontend/src/metabase/entities/users.js:42
 #: frontend/src/metabase/setup/components/UserStep.jsx:203
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:117
 msgid "Last name"
 msgstr "Nazwisko"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:77
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:158
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:161
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:470
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:481
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
@@ -876,35 +888,36 @@ msgstr "Grupa uprawnień"
 msgid "Make this user an admin"
 msgstr "Nadaj uprawnienia administratora"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:32
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
 msgstr "Wszyscy użytkownicy należą do grupy {0} i nie można ich z niej usunąć. Ustawienie uprawnień dla tej grupy to świetny sposób, \n"
 "aby upewnić się, że wiesz, co nowi użytkownicy Metabase będą mogli zobaczyć."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:41
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
 msgstr "Jest to specjalna Grupa, której członkowie mogą zobaczyć wszystko w wystąpieniu Metabase i kto może uzyskać dostęp i wprowadzać zmiany do ustawień w panelu administracyjnym, w tym zmieniać uprawnienia! Tak, Dodaj ludzi do tej grupy z troską."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:45
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
 msgstr "Aby upewnić się, że Metabase nie jest zablokowana, zawsze musi istnieć co najmniej jeden użytkownik w tej grupie."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
 msgstr "Członkowie"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:124
-#: frontend/src/metabase/admin/settings/selectors.js:113
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
+#: frontend/src/metabase/admin/settings/selectors.js:110
+#: frontend/src/metabase/entities/users.js:50
 #: frontend/src/metabase/lib/core.js:55
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
 msgstr "Email"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:203
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
 msgstr "Grupa jest tak dobra jak jej członkowie"
 
@@ -915,8 +928,8 @@ msgid "Admin"
 msgstr "Admin"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:237
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:290
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
 msgstr "i"
 
@@ -948,13 +961,13 @@ msgstr "Czy na pewno? Wszyscy członkowie tej grupy utraci wszelkie ustawienia u
 "Nie można cofnąć."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
 msgstr "Tak"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
 msgstr "Nie"
 
@@ -973,10 +986,11 @@ msgstr "Usuń grupę"
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:107
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:327
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:395
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:265
+#: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
 msgstr "Gotowe"
 
@@ -986,9 +1000,9 @@ msgstr "Nazwa grupy"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:131
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:88
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
 msgstr "Grupy"
 
@@ -1017,9 +1031,9 @@ msgid "Deactivate"
 msgstr "Deaktywuj"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:93
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
-#: frontend/src/metabase/nav/containers/Navbar.jsx:204
+#: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
 msgstr "Ludzie"
 
@@ -1059,7 +1073,6 @@ msgid "We've re-sent {0}'s invite"
 msgstr "Zaproszenie do {0} zostało ponownie wysłane"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
-#: frontend/src/metabase/tutorial/Tutorial.jsx:253
 msgid "Okay"
 msgstr "Ok"
 
@@ -1091,13 +1104,13 @@ msgstr "Będą mogli ponownie się zalogować, a zostaną one umieszczone z powr
 msgid "Reset {0}'s password?"
 msgstr "Zresetować hasło {0}?"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:77
+#: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
 msgstr "Resetuj"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:44
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
 msgstr "Czy jesteś pewien?"
 
@@ -1113,40 +1126,40 @@ msgstr "Oto hasło tymczasowe za pomocą którego można się zalogować a póź
 msgid "We've sent them an email with instructions for creating a new password."
 msgstr "Wysłaliśmy im wiadomość z instrukcją utworzenia nowego hasła"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:101
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
 msgstr "Aktywny"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:127
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
 msgstr "Nieaktywny"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:115
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
-msgstr "Dodaj trochę"
+msgstr "Dodaj użytkownika"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
 msgstr "Ostatnie logowanie"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:153
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
 msgstr "Zapisz się za pomocą Googla"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:158
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
 msgstr "Zapisz się za pomocą LDAP"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:170
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
 msgstr "Ponowne uaktywnianie tego konta"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:193
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
 msgstr "Nigdy"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:27
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
@@ -1155,36 +1168,38 @@ msgstr[1] "{0} tabele"
 msgstr[2] "{0} tabele"
 msgstr[3] "{0} tabele"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:45
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
 msgstr " będą "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:48
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
 msgstr "daj dostęp do"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:53
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
 msgstr ",_i_,"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:56
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
 msgstr "odebrany dostęp do"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:70
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
 msgstr " nie będzie już w stanie "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:71
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
 msgstr " będzie teraz w stanie "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:79
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
 msgstr " natywne zapytania dla "
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
-#: frontend/src/metabase/nav/containers/Navbar.jsx:219
+#: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
 msgstr "Uprawnienia"
 
@@ -1209,15 +1224,15 @@ msgstr "Nie zostaną wprowadzone żadne zmiany w uprawnieniach."
 msgid "You've made changes to permissions."
 msgstr "Wprowadzono zmiany w uprawnieniach."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:52
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
 msgstr "Uprawnienia dla tej kolekcji"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
 msgstr "Masz niezapisane zmiany"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:54
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
 msgstr "Chcesz opuścić stronę baz zapisywania zmian?"
 
@@ -1237,119 +1252,119 @@ msgstr "Każdy użytkownik Metabase należy do grupy Wszyscy użytkownicy. Jeśl
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
 msgstr "MetaBot jest botem Metabase Slack. Możesz wybrać to, jaki ma tutaj dostęp."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:119
+#: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
 msgstr "Grupa \"{0}\" może mieć dostęp do innego zestawu {1} niż ta grupa, co może dać tej grupie dodatkowy dostęp do niektórych {2}."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:124
+#: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
 msgstr "Grupa \"{0}\" ma wyższy poziom dostępu niż ten, który zastąpi to ustawienie. Należy ograniczyć lub cofnąć dostęp grupy \"{1}\" do tego elementu."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
 msgstr "Limit"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
 msgstr "Unieważnij"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:156
+#: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
 msgstr "dostęp mimo że \"{0}\" ma większy dostęp?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:258
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
 msgstr "Ogranicz dostęp"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:223
-#: frontend/src/metabase/admin/permissions/selectors.js:266
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:226
+#: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
 msgstr "Odbierz dostęp"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:168
+#: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
 msgstr "Ograniczyć dostęp do tej bazy danych?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:169
+#: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
 msgstr "Zmień"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:182
+#: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
 msgstr "Czy zezwolić na Pisanie Zapytań?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:183
+#: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
 msgstr "Spowoduje to również zmianę dostępu do danych tej grupy do dla tej niezarejestrowanej bazy danych."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:184
+#: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
 msgstr "Pozwól"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:221
+#: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
 msgstr "Odbrać dostęp do wszystkich tabel?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:222
+#: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
 msgstr "Spowoduje to również cofnięcie dostępu tej grupie do zapytań dla tej bazy danych."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:251
+#: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
 msgstr "Udziel nieograniczonego dostępu"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:252
+#: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
 msgstr "Nieograniczony dostęp"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:259
+#: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
 msgstr "Ogranicz dostęp"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:267
+#: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
 msgstr "Brak dostępu"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:273
+#: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
 msgstr "Pisanie zapytań"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:274
+#: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
 msgstr "Można pisać zapytania "
 
-#: frontend/src/metabase/admin/permissions/selectors.js:281
+#: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
 msgstr "Kolekcja kuratorów"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:288
+#: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
 msgstr "Zobacz kolekcję"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:331
-#: frontend/src/metabase/admin/permissions/selectors.js:427
-#: frontend/src/metabase/admin/permissions/selectors.js:524
+#: frontend/src/metabase/admin/permissions/selectors.js:334
+#: frontend/src/metabase/admin/permissions/selectors.js:430
+#: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
 msgstr "Dostęp do danych"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:492
-#: frontend/src/metabase/admin/permissions/selectors.js:649
-#: frontend/src/metabase/admin/permissions/selectors.js:654
+#: frontend/src/metabase/admin/permissions/selectors.js:495
+#: frontend/src/metabase/admin/permissions/selectors.js:652
+#: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
 msgstr "Wyświetl tabele"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:590
+#: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
 msgstr "Zapytania SQL"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:660
+#: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
 msgstr "Wyświetl schematy"
 
 #: frontend/src/metabase/admin/routes.jsx:59
-#: frontend/src/metabase/nav/containers/Navbar.jsx:209
+#: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
 msgstr "Model danych"
 
@@ -1358,30 +1373,30 @@ msgstr "Model danych"
 msgid "Sign in with Google"
 msgstr "Zaloguj przez Google"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:13
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
 msgstr "Umożliwia użytkownikom z istniejącymi kontami Metabase logowanie się za pomocą konta Google, które oprócz nazwy użytkownika i hasła Metabase odpowiada ich adresom e-mail."
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:17
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
 msgstr "Konfiguruj"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
-#: frontend/src/metabase/admin/settings/selectors.js:207
+#: frontend/src/metabase/admin/settings/selectors.js:204
 msgid "LDAP"
 msgstr "LDAP"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:25
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
 msgstr "Umożliwia użytkownikom w katalogu LDAP zalogować się do Metabase przy użyciu poświadczeń LDAP i umożliwia automatyczne mapowanie grup LDAP na grupy Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
-#: frontend/src/metabase/admin/settings/selectors.js:160
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
 msgstr "Niepoprawy adres email"
 
@@ -1419,7 +1434,7 @@ msgstr "Wyczyść"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:202
+#: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
 msgstr "Uwierzytelnianie"
 
@@ -1483,21 +1498,21 @@ msgstr "Tworzenie użytkownika Slack bot dla MetaBot"
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Gdy już tam jesteś, nadaj mu nazwę i kliknij {0}. Następnie skopiuj i wklej token API bota w polu poniżej. Gdy skończysz, utworzyć \"metabase_files\" kanał w Slack. Metabase wymaga tego, aby przesyłać wykresy."
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:90
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
 msgstr "Używasz Metabase {0}, która jest najnowsza i Najlepsza!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:99
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Dostępny jest Metabase {0}.  Używasz {1}"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:112
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
 msgstr "Aktualizuj"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:116
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
 msgstr "Co się zmieniło:"
 
@@ -1510,80 +1525,80 @@ msgstr "Dodaj mapę"
 msgid "URL"
 msgstr "URL"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:199
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
 msgstr "Usuń niestandardową mapę"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:327
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:40
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:181
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
 msgstr "Usuń"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:226
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:187
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:241
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:246
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
 msgstr "Pobierz..."
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:241
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
 msgstr "Testowe wartości:"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
 msgstr "Dodaj nową mapę"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
 msgstr "Edytuj mapę"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:280
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
 msgstr "Jak byś chciał nazwać tą mapę?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
 msgstr "np. United Kingdom, Brazil, Mars"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:292
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
 msgstr "Adres URL pliku GEOJSON, którego chcesz użyć"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:298
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
 msgstr "Jak https://My-MB-Server.com/maps/my-map.JSON"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:33
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
 msgstr "Odśwież"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
 msgstr "Załąduj"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:315
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
 msgstr "Która Właściwość określa identyfikator regionu?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:324
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
 msgstr "Która Właściwość określa nazwę wyświetlaną regionu?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:345
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
 msgstr "Wczytanie pliku GEOJSON w celu wyświetlenia podglądu"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
 msgstr "Zapisz mapę"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
 msgstr "Dodaj mapę"
 
@@ -1595,11 +1610,11 @@ msgstr "Użyj embeda"
 msgid "By enabling embedding you're agreeing to the embedding license located at"
 msgstr "Włączając osadzenie wyrażasz zgodę na osadzanie licencji znajdującej się na"
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:19
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
 msgstr "W zwykłym języku angielskim podczas osadzania wykresów lub pulpitów nawigacyjnych z Metabase we własnej aplikacji Aplikacja ta nie podlega Affero ogólnej licencji publicznej, która obejmuje resztę Metabase, pod warunkiem zachowania logo Metabasei \"Powered by Metabase\" widoczne na tych osadza. Należy jednak przeczytać tekst licencyjny powyżej, jak to jest rzeczywista licencja, że będzie zgadzając się po włączeniu tej funkcji."
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:32
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
 msgstr "Włącz"
 
@@ -1623,25 +1638,25 @@ msgstr "Kup token"
 msgid "Enter a token"
 msgstr "Wpisz token"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:134
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
 msgstr "Edytowanie mapowań"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:140
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
 msgstr "Mapowania grup"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:147
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
 msgstr "Tworzenie mapowania"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
 msgstr "Mapowania umożliwiają Metabase  automatyczne dodawanie i usuwanie użytkowników z grup na podstawie informacji o członkostwie udostępnianych przez serwer katalogowy. Członkostwo w grupie administracyjnej może być przyznane za pośrednictwem mapowań, ale nie zostanie automatycznie usunięte jako zabezpieczenie bezawaryjne."
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
 msgstr "Wyróżniona nazwa (DN)"
 
@@ -1653,43 +1668,43 @@ msgstr "Publiczny link"
 msgid "Revoke Link"
 msgstr "Odwołaj łącze"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:121
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
 msgstr "Wyłączyć ten link?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:122
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
 msgstr "Nie będą już działać i nie można ich odtworzyć, ale można tworzyć nowe łącza."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
 msgstr "Lista publicznych pulpitów nawigacyjnych"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:152
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
 msgstr "Żadne pulpity nawigacyjne zostały jeszcze publicznie udostępnione."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:160
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
 msgstr "Lista kart publicznych"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:163
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
 msgstr "Żadne zapytania nie zostały jeszcze publicznie udostępnione."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:172
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
 msgstr "Osadzony pulpit nawigacyjny"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
 msgstr "Żadne panele nie zostały jeszcze osadzone."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:183
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
 msgstr "Wbudowane Karty"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:184
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
 msgstr "Żadne zapytania nie zostały jeszcze osadzone."
 
@@ -1710,18 +1725,17 @@ msgid "Generate Key"
 msgstr "Wygeneruj klucz"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:78
-#: frontend/src/metabase/admin/settings/selectors.js:87
+#: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
 msgstr "Włącz"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:83
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:103
+#: frontend/src/metabase/admin/settings/selectors.js:82
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Zablokowany"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:116
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
 msgstr "Nieznane ustawienie {0}"
 
@@ -1729,7 +1743,7 @@ msgstr "Nieznane ustawienie {0}"
 msgid "Setup"
 msgstr "Ustawienia"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
 msgstr "Ogólny"
@@ -1758,11 +1772,11 @@ msgstr "Domyślna baza danych"
 msgid "Select a timezone"
 msgstr "Wybierz strefę czasową"
 
-#: frontend/src/metabase/admin/settings/selectors.js:55
+#: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Nie wszystkie bazy danych obsługują strefy czasowe, w którym to przypadku to ustawienie nie zostanie uwzględnione."
 
-#: frontend/src/metabase/admin/settings/selectors.js:60
+#: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
 msgstr "Język"
 
@@ -1770,202 +1784,202 @@ msgstr "Język"
 msgid "Select a language"
 msgstr "Wybierz język"
 
-#: frontend/src/metabase/admin/settings/selectors.js:70
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
 msgstr "Anonimowe śledzenie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:75
+#: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
 msgstr "Przyjazne nazwy tabel i pól"
 
-#: frontend/src/metabase/admin/settings/selectors.js:81
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Zastępowanie spacjami podkreśleń i myślników"
 
-#: frontend/src/metabase/admin/settings/selectors.js:91
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
 msgstr "Włącz kwerendy zagnieżdżone"
 
-#: frontend/src/metabase/admin/settings/selectors.js:102
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
 msgstr "Aktualizacje"
 
-#: frontend/src/metabase/admin/settings/selectors.js:107
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
 msgstr "Sprawdz aktualizację"
 
-#: frontend/src/metabase/admin/settings/selectors.js:118
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
 msgstr "SMTP Host"
 
-#: frontend/src/metabase/admin/settings/selectors.js:126
+#: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
 msgstr "SMTP Port"
 
-#: frontend/src/metabase/admin/settings/selectors.js:130
-#: frontend/src/metabase/admin/settings/selectors.js:230
+#: frontend/src/metabase/admin/settings/selectors.js:127
+#: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
 msgstr "Niepoprawny numer portu"
 
-#: frontend/src/metabase/admin/settings/selectors.js:134
+#: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
 msgstr "Zabezpieczenia SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:142
+#: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
 msgstr "Użytkownik SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
 msgstr "Hasło SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
 msgstr "Z adresu"
 
-#: frontend/src/metabase/admin/settings/selectors.js:170
+#: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
 msgstr "Slack API Token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:172
+#: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
 msgstr "Wpisz token który otrzymałeś na Slacku"
 
-#: frontend/src/metabase/admin/settings/selectors.js:189
+#: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
 msgstr "Logowanie jednokrotne"
 
-#: frontend/src/metabase/admin/settings/selectors.js:213
+#: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
 msgstr "Uwierzytelnianie LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:219
+#: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
 msgstr "LDAP Host"
 
-#: frontend/src/metabase/admin/settings/selectors.js:227
+#: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
 msgstr "LDAP Port"
 
-#: frontend/src/metabase/admin/settings/selectors.js:234
+#: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
 msgstr "Zabezpieczenia LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
 msgstr "Użytkownik lub DN"
 
-#: frontend/src/metabase/admin/settings/selectors.js:247
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:188
-#: frontend/src/metabase/user/components/UserSettings.jsx:72
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:191
+#: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
 msgstr "Hasło"
 
-#: frontend/src/metabase/admin/settings/selectors.js:252
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "User search base"
 msgstr "Baza wyszukiwania użytkowników"
 
-#: frontend/src/metabase/admin/settings/selectors.js:258
+#: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
 msgstr "Filtr użytkownika"
 
-#: frontend/src/metabase/admin/settings/selectors.js:264
+#: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
 msgstr "Sprawdź nawiasy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:270
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
 msgstr "Ustawienie mail"
 
-#: frontend/src/metabase/admin/settings/selectors.js:275
+#: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
 msgstr "Atrybut Imienia"
 
-#: frontend/src/metabase/admin/settings/selectors.js:280
+#: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
 msgstr "Atrybut Nazwiska"
 
-#: frontend/src/metabase/admin/settings/selectors.js:285
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
 msgstr "Synchronizowanie członkostwa w grupach"
 
-#: frontend/src/metabase/admin/settings/selectors.js:291
+#: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
 msgstr "Baza wyszukiwania grupowego"
 
-#: frontend/src/metabase/admin/settings/selectors.js:300
+#: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
 msgstr "Mapy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
 msgstr "Adres URL serwera kafelków mapy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:306
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Domyślnie Metabase korzysta z OpenStreetMaps."
 
-#: frontend/src/metabase/admin/settings/selectors.js:311
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
 msgstr "Dodatkowe mapy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:312
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Dodawanie własnych plików GeoJSON w celu włączenia różnych wizualizacji map regionu"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
 msgstr "Udostępnianie publiczne"
 
-#: frontend/src/metabase/admin/settings/selectors.js:336
+#: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
 msgstr "Włącz udostępnianie publiczne"
 
-#: frontend/src/metabase/admin/settings/selectors.js:341
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
 msgstr "Udostępnione pulpity nawigacyjne"
 
-#: frontend/src/metabase/admin/settings/selectors.js:347
+#: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
 msgstr "Wspólne zapytania"
 
-#: frontend/src/metabase/admin/settings/selectors.js:354
+#: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
 msgstr "Osadzanie w innych aplikacjach"
 
-#: frontend/src/metabase/admin/settings/selectors.js:381
+#: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Włącz osadzanie Metabase w innych aplikacjach"
 
-#: frontend/src/metabase/admin/settings/selectors.js:391
+#: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
 msgstr "Osadzanie klucza tajnego"
 
-#: frontend/src/metabase/admin/settings/selectors.js:397
+#: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
 msgstr "Osadzone pulpity nawigacyjne"
 
-#: frontend/src/metabase/admin/settings/selectors.js:403
+#: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
 msgstr "Osadzone zapytania"
 
-#: frontend/src/metabase/admin/settings/selectors.js:410
+#: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
 msgstr "Buforowanie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:415
+#: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
 msgstr "Włącz buforowanie"
 
-#: frontend/src/metabase/admin/settings/selectors.js:420
+#: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
 msgstr "Minimalny czas trwania kwerendy"
 
-#: frontend/src/metabase/admin/settings/selectors.js:427
+#: frontend/src/metabase/admin/settings/selectors.js:424
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Mnożnik czasu wygaśnięcia (TTL) pamięci podręcznej"
 
-#: frontend/src/metabase/admin/settings/selectors.js:434
+#: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
 msgstr "Maksymalny rozmiar wpisu w pamięci podręcznej"
 
@@ -1981,11 +1995,11 @@ msgstr "Alert został zaktualizowany."
 msgid "The alert was successfully deleted."
 msgstr "Alert został pomyślnie usunięty."
 
-#: frontend/src/metabase/auth/auth.js:33
+#: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
 msgstr "Podaj poprawny sformatowany adres e-mail."
 
-#: frontend/src/metabase/auth/auth.js:116
+#: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
@@ -2027,90 +2041,87 @@ msgstr "Wyślij e-mail resetowania hasła"
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Sprawdz email w poszukiwaniu instrukcji do resetu hasła"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:128
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
 msgstr "Zaloguj do Metabase"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:138
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
 msgstr "LUB"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:157
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
 msgstr "Nazwa użytkownika lub adres email"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:217
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
 msgstr "Zaloguj"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:230
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
 msgstr "Chyba zapomniałem hasła"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
 msgstr "zażądaj o nowy email z resetem hasła"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:120
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
 msgstr "Ups, ten link wygasł"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:122
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
 msgstr "Ze względów bezpieczeństwa, linki resetowania hasła wygasają po chwili. Jeśli nadal musisz zresetować hasło, możesz {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:147
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
 msgstr "Nowe hasło"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:149
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
 msgstr "Aby zapewnić bezpieczeństwo danych, hasła {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:163
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
 msgstr "Stwórz nowe hasło"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:170
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:141
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
 msgstr "Upewnij się, że jego bezpieczne jak instrukcje powyżej"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:184
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:150
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
 msgstr "Potwierdź nowe hasło"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:191
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:159
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
 msgstr "Upewnij się że pasuje do wpisanego wcześniej"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:216
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
 msgstr "Twoje hasło zostało zresetowane"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:222
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:227
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
 msgstr "Zaloguj się nowym hasłem"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:182
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:251
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Zapis się nie powiódł"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:183
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:129
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:225
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:252
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
 msgstr "Zapisane"
 
@@ -2118,24 +2129,22 @@ msgstr "Zapisane"
 msgid "Ok"
 msgstr "Ok"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:38
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
 msgstr "Archiwizować tą Kolekcję?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:43
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
-msgstr "Pulpity nawigacyjne, kolekcje i impulsy w tej kolekcji również zostaną zarchiwizowane."
+msgstr "Pulpity nawigacyjne, kolekcje i pulsy w tej kolekcji również zostaną zarchiwizowane."
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
-#: frontend/src/metabase/components/CollectionLanding.jsx:624
+#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: frontend/src/metabase/components/CollectionLanding.jsx:620
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:47
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:195
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:200
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:40
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:53
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
 msgstr "Archiwum"
@@ -2144,28 +2153,27 @@ msgstr "Archiwum"
 msgid "This {0} has been archived"
 msgstr "{0} zostało zarchiwizowane"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:715
+#: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
 msgstr "Wyświetl archiwum"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:43
+#: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
 msgstr "Przywróć to {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:70
-#: frontend/src/metabase/components/BrowseApp.jsx:132
-#: frontend/src/metabase/components/BrowseApp.jsx:225
+#: frontend/src/metabase/components/BrowseApp.jsx:39
+#: frontend/src/metabase/components/BrowseApp.jsx:102
+#: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
 msgstr "Nasze dane"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:169
+#: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
 msgstr "Prześwietl X-ray ta tabelę"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:183
-#: frontend/src/metabase/containers/Overworld.jsx:246
+#: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
 msgstr "Dowiedz się więcej"
 
@@ -2183,31 +2191,31 @@ msgstr "Zapisane!"
 msgid "Saving failed."
 msgstr "Zapis się nie powiódł"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
 msgstr "Nd"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
 msgstr "Pon"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
 msgstr "Wt"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
 msgstr "Śr"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
 msgstr "Czw"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
 msgstr "Pi"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
 msgstr "Sob"
 
@@ -2252,27 +2260,26 @@ msgstr "Pulsy umożliwiają wysyłanie najnowszych danych do zespołu według ha
 msgid "Questions are a saved look at your data."
 msgstr "Zapytania są zapisanymi analizami twoich danych."
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:287
+#: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
 msgstr "Przypięcia"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:341
+#: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
 msgstr "Przeciągnij coś tutaj, aby przypiąć go do góry"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:737
-#: frontend/src/metabase/components/CollectionLanding.jsx:353
-#: frontend/src/metabase/home/containers/SearchApp.jsx:35
-#: frontend/src/metabase/home/containers/SearchApp.jsx:92
+#: frontend/src/metabase/admin/permissions/selectors.js:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:352
+#: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
 msgstr "Kolekcje"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:432
-#: frontend/src/metabase/components/CollectionLanding.jsx:455
+#: frontend/src/metabase/components/CollectionLanding.jsx:431
+#: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
 msgstr "Przeciągnij tutaj, aby odpiąć"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:490
+#: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
 msgstr[0] "{0} wybrany element"
@@ -2280,35 +2287,36 @@ msgstr[1] "{0} wybrane elementy"
 msgstr[2] "{0} wybrane elementy"
 msgstr[3] "{0} wybrane elementy"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:522
+#: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
 msgstr "Przenieść {0} elementy?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:523
+#: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
 msgstr "Przenieść \"{0}\"?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:631
+#: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
 msgstr "Przesuń"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:692
+#: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
 msgstr "Edytuj tą kolekcję"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:700
+#: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
 msgstr "Zarchiwizuj tą kolekcję"
 
-#: frontend/src/metabase/components/CollectionList.jsx:64
-#: frontend/src/metabase/entities/collections.js:155
+#: frontend/src/metabase/components/CollectionList.jsx:67
+#: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
 msgstr "Moje kolekcje"
 
-#: frontend/src/metabase/components/CollectionList.jsx:106
+#: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
 msgstr "Nowa kolekcja"
 
@@ -2316,11 +2324,11 @@ msgstr "Nowa kolekcja"
 msgid "Copied!"
 msgstr "Skopiiowane!"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:216
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Użyj tunelu SSH dla tego połączenia z bazą danych"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
@@ -2328,75 +2336,76 @@ msgstr "Do niektórych instalacji baz danych można uzyskać dostęp tylko poprz
 "Ta opcja zapewnia również dodatkową warstwę zabezpieczeń, gdy sieć VPN nie jest dostępna.\n"
 "Włączenie tego jest zwykle wolniejsze niż bezpośrednie połączenie."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:271
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Jest to duża baza danych, więc pozwól mi wybrać, kiedy Metabase synchronizuje i skanuje"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:273
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Domyślnie Metabase wykonuje lekką synchronizację godzinową i intensywnie codziennie skanuje wartości pól.\n"
 "W przypadku dużej bazy danych zaleca się włączenie tej funkcji i sprawdzenie, kiedy i jak często ma miejsce skanowanie wartości pola."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:289
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0}, aby wygenerować identyfikator klienta i klucz tajny klienta dla projektu."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:291
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:353
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
 msgstr "Kliknij tutaj"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Wybierz \"Other\" jako typ aplikacji. Nazwij to, co chcesz."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:316
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
 msgstr "{0} w celu uzyskania kodu autoryzacji"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:328
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
 msgstr "z uprawnieniami dysku Google"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:348
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Aby użyć Metabase z tymi danymi, należy włączyć dostęp do interfejsu API w konsoli programisty Google."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:351
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0}, aby przejść do konsoli, jeśli jeszcze tego nie zrobiono."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
 msgstr "Jak chcesz referować do tej bazy?"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:427
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:237
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:188
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:74
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:194
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:79
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
 msgstr "Następny"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:52
+#: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
 msgstr "Skasuj {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:43
+#: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
 msgstr "Przypnij ten element"
 
-#: frontend/src/metabase/components/EntityItem.jsx:49
+#: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
 msgstr "Przesuń ten element"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
 msgstr "Edytuj to zapytanie"
 
@@ -2409,6 +2418,7 @@ msgstr "Rodzaj zmiany"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
 msgstr "Wyświetl historię zmian"
 
@@ -2424,8 +2434,7 @@ msgstr "Archiwizuj akcję"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:329
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:342
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
 msgstr "Dodaj do panelu"
 
@@ -2449,13 +2458,12 @@ msgstr "Inny typ akcji"
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:449
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:454
 msgid "Get alerts about this"
 msgstr "Otrzymuj alerty o tym"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
 msgstr "Wyświetl SQL"
 
@@ -2475,43 +2483,43 @@ msgstr "Oto cały błąd"
 msgid "Hi, Metabot here."
 msgstr "Cześć, tu Metabot"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:95
+#: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
 msgstr "Na podstawie schematu"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:174
+#: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
 msgstr "Zobacz na"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:234
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
 msgstr "Wyszukiwanie na liście"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:238
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
 msgstr "Szukaj według {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
 msgstr " lub wprowadź ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
 msgstr "Wipsz IP"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
 msgstr "Wpisz numer"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:248
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
 msgstr "Wpisz jakiś tekst"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:355
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
 msgstr "Nie znaleziono pasującego elementu {0}."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:363
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Włączenie wszystkich opcji w Twoim filtrze nie wygląda na najlepszy pomysł…"
 
@@ -2527,17 +2535,17 @@ msgstr "Ups… znaleźliśmy błąd. Możesz spróbować odświeżyć tę stron�
 #: frontend/src/metabase/components/HeaderBar.jsx:45
 #: frontend/src/metabase/components/ListItem.jsx:37
 #: frontend/src/metabase/reference/components/Detail.jsx:47
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:158
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:213
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:191
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:205
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:209
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:209
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:161
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:216
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:194
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:208
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
 msgstr "Brak opisu"
 
 #: frontend/src/metabase/components/Header.jsx:112
-#: frontend/src/metabase/entities/containers/EntityForm.jsx:43
+#: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
 msgstr "Nowy {0}"
 
@@ -2545,54 +2553,53 @@ msgstr "Nowy {0}"
 msgid "Asked by {0}"
 msgstr "Zapytał {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:13
+#: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
 msgstr "Dziś,"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:15
+#: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
 msgstr "Wczoraj"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:68
+#: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
 msgstr "Pierwsza rewizja"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:70
+#: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
 msgstr "Przywrócono wcześniejszą wersję i {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:82
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:289
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:379
-#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
+#: frontend/src/metabase/components/HistoryModal.jsx:42
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
+#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
 msgstr "Historia zmian"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:90
+#: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
 msgstr "Kiedy"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:91
+#: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
 msgstr "Kto"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:92
+#: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
 msgstr "Co"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:113
+#: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
 msgstr "Przywróć"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:114
+#: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
 msgstr "Przywracanie…"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:115
+#: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
 msgstr "Przywracanie nie powiodło się"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:116
+#: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
 msgstr "Przywrócone"
 
@@ -2601,26 +2608,24 @@ msgid "Everything"
 msgstr "Wszystko"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
-#: frontend/src/metabase/home/containers/SearchApp.jsx:69
 msgid "Dashboards"
 msgstr "Panele"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
-#: frontend/src/metabase/home/containers/SearchApp.jsx:115
 msgid "Questions"
 msgstr "Pytanie"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:321
+#: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
 msgstr "Pulsy"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:103
+#: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
 msgstr "Powrót"
 
-#: frontend/src/metabase/components/ListSearchField.jsx:18
+#: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
 msgstr "Szukanie..."
 
@@ -2657,14 +2662,14 @@ msgid "Temporary Password"
 msgstr "Hasło tymczasowe"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
 msgstr "Ukryj"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:412
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
 msgstr "Pokaż"
 
@@ -2729,7 +2734,7 @@ msgstr "15. (punkt środkowy)"
 msgid "Calendar Day"
 msgstr "Dzień kalendarzowy"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:210
+#: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
 msgstr "strefa czasowa tej instancji Metabase"
 
@@ -2758,11 +2763,11 @@ msgid "A component used to make a selection"
 msgstr "Komponent użyty do wyboru"
 
 #: frontend/src/metabase/components/Select.info.js:20
-#: frontend/src/metabase/components/Select.info.js:28
+#: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
 msgstr "Wybrany"
 
-#: frontend/src/metabase/components/Select.jsx:297
+#: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
 msgstr "Nic do wybrania"
 
@@ -2775,7 +2780,7 @@ msgid "Unknown error encountered"
 msgstr "Napotkano nieznany błąd"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/nav/containers/Navbar.jsx:304
+#: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
 msgstr "Utwórz"
 
@@ -2784,13 +2789,11 @@ msgid "Create dashboard"
 msgstr "Utwórz panel"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:331
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:60
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
 msgstr "Tabela"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:306
 msgid "Database"
 msgstr "Baza danych"
 
@@ -2798,22 +2801,20 @@ msgstr "Baza danych"
 msgid "Creator"
 msgstr "Kreator"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:238
+#: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
 msgstr "Nie znaleziono wyników"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:239
+#: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
 msgstr "Spróbuj dostosować filtr, tak aby znaleźć to, czego szukasz."
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:258
+#: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
 msgstr "Wyświetlone przez"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:494
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:84
-#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:69
-#: frontend/src/metabase/tutorial/TutorialModal.jsx:34
+#: frontend/src/metabase/containers/EntitySearch.jsx:495
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
 msgstr "z"
 
@@ -2826,13 +2827,13 @@ msgid "Once you connect your own data, I can show you some automatic exploration
 msgstr "Po podłączeniu własnych danych, mogę pokazać kilka automatycznych poszukiwań o nazwie X-ray. Oto kilka przykładów z przykładowych danych."
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
-#: frontend/src/metabase/containers/Overworld.jsx:299
+#: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
 msgstr "Zacznij tu"
 
-#: frontend/src/metabase/containers/Overworld.jsx:294
-#: frontend/src/metabase/entities/collections.js:147
+#: frontend/src/metabase/containers/Overworld.jsx:296
+#: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
 msgstr "Nasze analizy"
@@ -2841,53 +2842,53 @@ msgstr "Nasze analizy"
 msgid "Browse all items"
 msgstr "Przeglądaj elementy"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:165
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
 msgstr "Zamienić lub zapisz jako nowe?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:173
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
 msgstr "Zastąp oryginalne zapytanie \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:178
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
 msgstr "Zapisz jako nowe pytanie"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:187
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
 msgstr "Najpierw zapisz swoje zapytanie"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:188
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
 msgstr "Zapisz pytanie"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:224
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
 msgstr "Jaka jest nazwa Twojej zakładki?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:232
-#: frontend/src/metabase/entities/collections.js:101
-#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:234
+#: frontend/src/metabase/entities/collections.js:102
+#: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/lib/core.js:50 frontend/src/metabase/lib/core.js:205
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:156
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:211
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:203
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:207
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:207
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:24
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:159
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:214
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:192
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:206
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:210
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
 msgstr "Opis"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:238
-#: frontend/src/metabase/entities/dashboards.js:153
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
+#: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
 msgstr "Jest to opcjonalne, ale jakże pomocne"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:245
-#: frontend/src/metabase/entities/dashboards.js:157
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
+#: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "Której kolekcja powinna to trafić?"
 
@@ -2899,7 +2900,7 @@ msgstr "zmodyfikowano"
 msgid "item"
 msgstr "element"
 
-#: frontend/src/metabase/containers/UndoListing.jsx:81
+#: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
 msgstr "Cofnij"
 
@@ -2923,15 +2924,15 @@ msgstr "Nie jesteśmy pewni, czy to zapytanie jest zgodne"
 msgid "Archive Dashboard"
 msgstr "Zarchiwizuj panel"
 
-#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:20
+#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Upewnij się, że dokonano wyboru dla każdej serii bo filtr nie będzie działać na tej zakładce."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:300
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
 msgstr "Ten panel jest pusty"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:301
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
 msgstr "Dodaj zapytanie, aby zaczęło być przydatne!"
 
@@ -2951,59 +2952,58 @@ msgstr "Wyłącz tryb pełnoekranowy"
 msgid "Enter fullscreen"
 msgstr "Włącz tryb pełnoekranowy"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:181
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:183
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Zapisywanie..."
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:216
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
 msgstr "Dodaj pytanie"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:219
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
 msgstr "Dodaj zapytanie do tego pulpitu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:248
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
 msgstr "Dodaj filtr"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:254
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:78
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Parametry"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:275
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
 msgstr "Dodaj pole tekstowe"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
 msgstr "Przenieś pulpit"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:302
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
 msgstr "Edytuj pulpit"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:306
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
 msgstr "Zmień układ pulpitu"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:369
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
 msgstr "Modyfikujesz pulpit"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:374
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
 msgstr "Wybierz pole, które ma być filtrowane dla każdej zakładki"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:28
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
 msgstr "Przenieś panel do..."
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:52
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
 msgstr "Panel przeniesiony do {0}"
 
@@ -3018,7 +3018,7 @@ msgstr "Jaki rodzaj filtra?"
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:179
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
 msgstr "Wyłącz"
 
@@ -3058,174 +3058,174 @@ msgstr "Odświeżenie za"
 msgid "Remove this question?"
 msgstr "Usunąć to pytanie?"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:71
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
 msgstr "Twój panel został zapisany"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:745
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:76
+#: frontend/src/metabase/components/CollectionLanding.jsx:744
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
 msgstr "Widzisz to"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:137
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
 msgstr "Zapisz to"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:170
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
 msgstr "Pokaż więcej informacji"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:140
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
 msgstr "Ta zakładka nie ma żadnych pól lub parametrów, które mogą być mapowane na ten typ parametru."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:142
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Wartości w tym polu nie pokrywają się z wartościami pozostałych wybranych pól."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:186
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
 msgstr "Brak prawidłowych pól"
 
-#: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
 msgstr "Imię i nazwisko musi mieć nie więcej niż 100 znaków"
 
-#: frontend/src/metabase/entities/collections.js:111
+#: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
 msgstr "Kolor jest wymagany"
 
-#: frontend/src/metabase/entities/dashboards.js:146
+#: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
 msgstr "Jaka jest nazwa tego panelu?"
 
-#: frontend/src/metabase/home/components/Activity.jsx:92
+#: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
 msgstr "zrobił(a) jakieś super niesamowite rzeczy, które trudno opisać"
 
-#: frontend/src/metabase/home/components/Activity.jsx:101
-#: frontend/src/metabase/home/components/Activity.jsx:116
+#: frontend/src/metabase/home/components/Activity.jsx:103
+#: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
 msgstr "utworzył(a_ alert o - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:126
-#: frontend/src/metabase/home/components/Activity.jsx:141
+#: frontend/src/metabase/home/components/Activity.jsx:128
+#: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
 msgstr "usunął(ęła) alert o - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:152
+#: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
 msgstr "zapisał(a) zapytanie  "
 
-#: frontend/src/metabase/home/components/Activity.jsx:165
+#: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
 msgstr "zapisano pytanie"
 
-#: frontend/src/metabase/home/components/Activity.jsx:169
+#: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
 msgstr "usuń pytanie"
 
-#: frontend/src/metabase/home/components/Activity.jsx:172
+#: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
 msgstr "Utworzono panel"
 
-#: frontend/src/metabase/home/components/Activity.jsx:175
+#: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
 msgstr "Skasowano panel"
 
-#: frontend/src/metabase/home/components/Activity.jsx:181
-#: frontend/src/metabase/home/components/Activity.jsx:196
+#: frontend/src/metabase/home/components/Activity.jsx:183
+#: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
 msgstr "dodano pytanie do panelu"
 
-#: frontend/src/metabase/home/components/Activity.jsx:206
-#: frontend/src/metabase/home/components/Activity.jsx:221
+#: frontend/src/metabase/home/components/Activity.jsx:208
+#: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
 msgstr "usunięto pytanie z panelu"
 
-#: frontend/src/metabase/home/components/Activity.jsx:231
-#: frontend/src/metabase/home/components/Activity.jsx:238
+#: frontend/src/metabase/home/components/Activity.jsx:233
+#: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
 msgstr "odebrano najnowsze dane z"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:621
-#: frontend/src/metabase/home/components/Activity.jsx:244
+#: frontend/src/metabase-lib/lib/Dimension.js:814
+#: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
 msgstr "Nieznany"
 
-#: frontend/src/metabase/home/components/Activity.jsx:251
+#: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
 msgstr "Witaj Świecie!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:252
+#: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
 msgstr "Metabase jest uruchomiona i działa."
 
-#: frontend/src/metabase/home/components/Activity.jsx:258
-#: frontend/src/metabase/home/components/Activity.jsx:288
+#: frontend/src/metabase/home/components/Activity.jsx:260
+#: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
 msgstr "dodano metrykę "
 
-#: frontend/src/metabase/home/components/Activity.jsx:272
-#: frontend/src/metabase/home/components/Activity.jsx:362
+#: frontend/src/metabase/home/components/Activity.jsx:274
+#: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
 msgstr " do "
 
-#: frontend/src/metabase/home/components/Activity.jsx:282
-#: frontend/src/metabase/home/components/Activity.jsx:322
-#: frontend/src/metabase/home/components/Activity.jsx:372
-#: frontend/src/metabase/home/components/Activity.jsx:413
+#: frontend/src/metabase/home/components/Activity.jsx:284
+#: frontend/src/metabase/home/components/Activity.jsx:324
+#: frontend/src/metabase/home/components/Activity.jsx:374
+#: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
 msgstr " tabela"
 
-#: frontend/src/metabase/home/components/Activity.jsx:298
-#: frontend/src/metabase/home/components/Activity.jsx:328
+#: frontend/src/metabase/home/components/Activity.jsx:300
+#: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
 msgstr "wprowadzono zmiany w metryce "
 
-#: frontend/src/metabase/home/components/Activity.jsx:312
-#: frontend/src/metabase/home/components/Activity.jsx:403
+#: frontend/src/metabase/home/components/Activity.jsx:314
+#: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
 msgstr " w "
 
-#: frontend/src/metabase/home/components/Activity.jsx:335
+#: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
 msgstr "usunięto metrykę "
 
-#: frontend/src/metabase/home/components/Activity.jsx:338
+#: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
 msgstr "utworzył(a) puls"
 
-#: frontend/src/metabase/home/components/Activity.jsx:341
+#: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
 msgstr "usunięto puls"
 
-#: frontend/src/metabase/home/components/Activity.jsx:347
-#: frontend/src/metabase/home/components/Activity.jsx:378
+#: frontend/src/metabase/home/components/Activity.jsx:349
+#: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
 msgstr "Dodano filtr"
 
-#: frontend/src/metabase/home/components/Activity.jsx:388
-#: frontend/src/metabase/home/components/Activity.jsx:419
+#: frontend/src/metabase/home/components/Activity.jsx:390
+#: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
 msgstr "wprowadził(a) zmiany w filtrze"
 
-#: frontend/src/metabase/home/components/Activity.jsx:426
+#: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
 msgstr "usunięto filtr {0}"
 
-#: frontend/src/metabase/home/components/Activity.jsx:429
+#: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
 msgstr "dołączyłeś!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:529
+#: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
 msgstr "Hmmm, wygląda na to, że nic się jeszcze nie wydarzyło."
 
-#: frontend/src/metabase/home/components/Activity.jsx:532
+#: frontend/src/metabase/home/components/Activity.jsx:534
 msgid "Save a question and get this baby going!"
 msgstr "Zapisz zapytanie i rozpocznij nową przygodę!"
 
@@ -3273,21 +3273,21 @@ msgstr "Ostatnio wyświetlane"
 msgid "You haven't looked at any dashboards or questions recently"
 msgstr "Ostatnio nie przeglądałeś(aś) żadnych pulpitów lub zapytań"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:99
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
 msgstr "{0} wybrane elementy"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:121
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:172
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
 msgstr "Przywróć"
 
-#: frontend/src/metabase/home/containers/HomepageApp.jsx:74
-#: frontend/src/metabase/nav/containers/Navbar.jsx:331
+#: frontend/src/metabase/home/containers/HomepageApp.jsx:77
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
 msgstr "Aktywność"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:28
+#: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
 msgstr "Wyniki dla \"{0}\""
 
@@ -3352,6 +3352,7 @@ msgstr "Adres URL obrazu awatara"
 msgid "Common"
 msgstr "Wspólne"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
@@ -3388,8 +3389,9 @@ msgstr "Długość"
 msgid "Longitude"
 msgstr "Szerokość"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:149
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
 msgstr "Numer"
@@ -3486,7 +3488,7 @@ msgstr "Wynik"
 
 #: frontend/src/metabase/lib/core.js:210
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:17
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
 msgstr "Tytuł"
 
@@ -3543,8 +3545,9 @@ msgid "Metabase will never retrieve this field. Use this for sensitive or irrele
 msgstr "Metabase nigdy nie będzie pobierać tego pola. Użyj tego dla informacji poufnych lub nieistotnych."
 
 #: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:614
-#: frontend/src/metabase/visualizations/lib/utils.js:126
+#: frontend/src/metabase/lib/query.js:300
+#: frontend/src/metabase/visualizations/lib/utils.js:130
+#: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -3559,7 +3562,7 @@ msgstr "LicznikŁączny"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
-#: frontend/src/metabase/visualizations/lib/utils.js:127
+#: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
 msgstr "Sum"
 
@@ -3568,7 +3571,7 @@ msgid "CumulativeSum"
 msgstr "SumaŁączna"
 
 #: frontend/src/metabase/lib/expressions/config.js:11
-#: frontend/src/metabase/visualizations/lib/utils.js:128
+#: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
 msgstr "Distinct"
 
@@ -3577,29 +3580,29 @@ msgid "StandardDeviation"
 msgstr "OdchyleniaStandardowe"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/visualizations/lib/utils.js:125
+#: frontend/src/metabase/visualizations/lib/utils.js:129
 msgid "Average"
 msgstr "Average"
 
 #: frontend/src/metabase/lib/expressions/config.js:14
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:25
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
 msgstr "Min"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
 msgstr "Max"
 
-#: frontend/src/metabase/lib/expressions/parser.js:384
+#: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
 msgstr "smutna, smutna panda, wykryła błędy składniowe"
 
-#: frontend/src/metabase/lib/formatting.js:707
+#: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} sekund"
@@ -3607,7 +3610,7 @@ msgstr[1] "{0} sekund"
 msgstr[2] "{0} sekund"
 msgstr[3] "{0} sekunda"
 
-#: frontend/src/metabase/lib/formatting.js:710
+#: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuta"
@@ -3648,222 +3651,224 @@ msgstr "Co masz na myśli?"
 msgid "What do you want to find out?"
 msgstr "Co byś się chciał dowiedzieć?"
 
-#: frontend/src/metabase/lib/query.js:612
-#: frontend/src/metabase/lib/schema_metadata.js:451
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:246
+#: frontend/src/metabase/lib/query.js:298
+#: frontend/src/metabase/lib/schema_metadata.js:458
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
 msgstr "Dane"
 
-#: frontend/src/metabase/lib/query.js:616
+#: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
 msgstr "Skumulowany licznik"
 
-#: frontend/src/metabase/lib/query.js:619
+#: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
 msgstr "Średnia z"
 
-#: frontend/src/metabase/lib/query.js:624
+#: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
 msgstr "Różne wartości z "
 
-#: frontend/src/metabase/lib/query.js:629
+#: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
 msgstr "Odchylenie standardowe z "
 
-#: frontend/src/metabase/lib/query.js:634
+#: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
 msgstr "Suma z "
 
-#: frontend/src/metabase/lib/query.js:639
+#: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
 msgstr "Skumulowana suma z "
 
-#: frontend/src/metabase/lib/query.js:644
+#: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
 msgstr "Maksimum z "
 
-#: frontend/src/metabase/lib/query.js:649
+#: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
 msgstr "Minimum z "
 
-#: frontend/src/metabase/lib/query.js:663
+#: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
 msgstr "Pogrupowane według "
 
-#: frontend/src/metabase/lib/query.js:677
+#: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
 msgstr "Filtrowane po "
 
-#: frontend/src/metabase/lib/query.js:706
+#: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
 msgstr "Uporządkowane po "
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
 msgstr "Prawda"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
 msgstr "Fałsz"
 
-#: frontend/src/metabase/lib/schema_metadata.js:305
+#: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
 msgstr "Wybierz pole długości geograficznej"
 
-#: frontend/src/metabase/lib/schema_metadata.js:306
+#: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
 msgstr "Podaj górną granicę szerokości geograficznej"
 
-#: frontend/src/metabase/lib/schema_metadata.js:307
+#: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
 msgstr "Podaj lewą granicę długości geograficznej"
 
-#: frontend/src/metabase/lib/schema_metadata.js:308
+#: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
 msgstr "Podaj dolną granicę szerokości geograficznej"
 
-#: frontend/src/metabase/lib/schema_metadata.js:309
+#: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
 msgstr "Podaj prawą granicę długości geograficznej"
 
-#: frontend/src/metabase/lib/schema_metadata.js:345
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase-lib/lib/Dimension.js:505
+#: frontend/src/metabase-lib/lib/Dimension.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:351
+#: frontend/src/metabase/lib/schema_metadata.js:371
 #: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:387
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
 msgstr "Jest"
 
-#: frontend/src/metabase/lib/schema_metadata.js:346
-#: frontend/src/metabase/lib/schema_metadata.js:366
-#: frontend/src/metabase/lib/schema_metadata.js:376
-#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/lib/schema_metadata.js:352
+#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:396
+#: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
 msgstr "Nie jest"
 
-#: frontend/src/metabase/lib/schema_metadata.js:347
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:369
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:353
+#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
 msgstr "Jest puste"
 
-#: frontend/src/metabase/lib/schema_metadata.js:348
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:370
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:402
+#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
 msgstr "Nie jest puste"
 
-#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
 msgstr "Równa się"
 
-#: frontend/src/metabase/lib/schema_metadata.js:355
+#: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
 msgstr "Nie równa się"
 
-#: frontend/src/metabase/lib/schema_metadata.js:356
+#: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
 msgstr "Większe od"
 
-#: frontend/src/metabase/lib/schema_metadata.js:357
+#: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
 msgstr "Mniejsze od"
 
-#: frontend/src/metabase/lib/schema_metadata.js:358
-#: frontend/src/metabase/lib/schema_metadata.js:384
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:285
+#: frontend/src/metabase/lib/schema_metadata.js:364
+#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Pomiędzy"
 
-#: frontend/src/metabase/lib/schema_metadata.js:359
+#: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
 msgstr "Większe lub równe"
 
-#: frontend/src/metabase/lib/schema_metadata.js:360
+#: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
 msgstr "Mniejsze lub równe"
 
-#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
 msgstr "Zawiera"
 
-#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
 msgstr "Nie zawiera"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
 msgstr "Zaczyna się od"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
 msgstr "Kończy się"
 
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:264
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Przed"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:271
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Po"
 
-#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
 msgstr "W"
 
-#: frontend/src/metabase/lib/schema_metadata.js:453
+#: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Tylko tabela z wierszami, bez dodatkowych operacji."
 
-#: frontend/src/metabase/lib/schema_metadata.js:459
+#: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
 msgstr "Ilość wierszy"
 
-#: frontend/src/metabase/lib/schema_metadata.js:461
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
 msgstr "Całkowita liczba wierszy."
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
 msgstr "Suma z "
 
-#: frontend/src/metabase/lib/schema_metadata.js:469
+#: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
 msgstr "Suma wszystkich wartości kolumny."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
 msgstr "Średnia z…"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
 msgstr "Średnia wszystkich wartości kolumny"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
 msgstr "Liczba różnych wartości..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Liczba unikatowych wartości w kolumnie ze wszystkich wierszy odpowiedzi."
 
-#: frontend/src/metabase/lib/schema_metadata.js:491
+#: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
 msgstr "Skumulowana suma..."
 
@@ -3871,7 +3876,7 @@ msgstr "Skumulowana suma..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Addytywna suma wszystkich wartości kolumny. \\\\nnp. całkowity przychód w czasie."
 
-#: frontend/src/metabase/lib/schema_metadata.js:499
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
 msgstr "Skumulowana liczba wierszy"
 
@@ -3879,105 +3884,105 @@ msgstr "Skumulowana liczba wierszy"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Addytywna liczba wierszy.\\\\nnp. łączna ilość transakcji w czasie."
 
-#: frontend/src/metabase/lib/schema_metadata.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
 msgstr "Odchylenie standardowe…"
 
-#: frontend/src/metabase/lib/schema_metadata.js:509
+#: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Numer, który pokazuje jak bardzo wartości danej kolumny różnią się między sobą."
 
-#: frontend/src/metabase/lib/schema_metadata.js:515
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
 msgstr "Minimum..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:517
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
 msgstr "Minimalna wartość dla kolumny"
 
-#: frontend/src/metabase/lib/schema_metadata.js:523
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
 msgstr "Maksimum..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:525
+#: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
 msgstr "Maksymalna wartość dla kolumny"
 
-#: frontend/src/metabase/lib/schema_metadata.js:533
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
 msgstr "Wydzielenie wymiarami"
 
-#: frontend/src/metabase/lib/settings.js:93
+#: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
 msgstr "mała litera"
 
-#: frontend/src/metabase/lib/settings.js:95
+#: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
 msgstr "wielka litera"
 
-#: frontend/src/metabase/lib/settings.js:97
+#: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "numer"
 
-#: frontend/src/metabase/lib/settings.js:99
+#: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
 msgstr "znak specjalny"
 
-#: frontend/src/metabase/lib/settings.js:105
+#: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
 msgstr "musi być"
 
-#: frontend/src/metabase/lib/settings.js:105
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:120
+#: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
 msgstr "znaków"
 
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
 msgstr "Musi być"
 
-#: frontend/src/metabase/lib/settings.js:122
+#: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
 msgstr "i zawiera"
 
-#: frontend/src/metabase/lib/utils.js:92
+#: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
 msgstr "zero"
 
-#: frontend/src/metabase/lib/utils.js:93
+#: frontend/src/metabase/lib/utils.js:86
 msgid "one"
 msgstr "jeden"
 
-#: frontend/src/metabase/lib/utils.js:94
+#: frontend/src/metabase/lib/utils.js:87
 msgid "two"
 msgstr "dwa"
 
-#: frontend/src/metabase/lib/utils.js:95
+#: frontend/src/metabase/lib/utils.js:88
 msgid "three"
 msgstr "trzy"
 
-#: frontend/src/metabase/lib/utils.js:96
+#: frontend/src/metabase/lib/utils.js:89
 msgid "four"
 msgstr "cztery"
 
-#: frontend/src/metabase/lib/utils.js:97
+#: frontend/src/metabase/lib/utils.js:90
 msgid "five"
 msgstr "pięć"
 
-#: frontend/src/metabase/lib/utils.js:98
+#: frontend/src/metabase/lib/utils.js:91
 msgid "six"
 msgstr "sześć"
 
-#: frontend/src/metabase/lib/utils.js:99
+#: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
 msgstr "siedem"
 
-#: frontend/src/metabase/lib/utils.js:100
+#: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
 msgstr "osiem"
 
-#: frontend/src/metabase/lib/utils.js:101
+#: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
 msgstr "dziewięć"
 
@@ -4051,6 +4056,7 @@ msgstr "Czas"
 msgid "Date range, relative date, time of day, etc."
 msgstr "Zakres dat, data względna, czas, itp."
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
@@ -4073,7 +4079,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Kategoria, Typ, Model, Ocena itd."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
-#: frontend/src/metabase/user/components/UserSettings.jsx:54
+#: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
 msgstr "Ustawienia konta"
 
@@ -4085,56 +4091,56 @@ msgstr "Zamknij panel administracyjny"
 msgid "Logs"
 msgstr "Logi"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:64
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
 msgstr "Pomoc"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:67
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
 msgstr "O Metabase"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:73
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
 msgstr "Wyloguj się"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:98
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
 msgstr "Dzięki za korzystanie"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
 msgstr "Pracujesz z wersją"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
 msgstr "Zbudowany na"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:124
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
 msgstr "jest znakiem towarowym"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:126
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
 msgstr "i jest tworzony w San Francisco, CA"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:194
+#: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
 msgstr "Metabase Admin"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:300
+#: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
 msgstr "Zadaj pytanie"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:309
+#: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
 msgstr "Nowy panel"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:315
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/nav/containers/Navbar.jsx:361
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
 msgstr "Nowy puls"
 
@@ -4142,16 +4148,16 @@ msgstr "Nowy puls"
 msgid "Reference"
 msgstr "Referencje"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:83
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
 msgstr "Które metryki?"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:110
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Definiowanie wspólnych metryk, upraszcza zadawanie pytań Tobie i Twojemu zespołowi"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:113
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
 msgstr "Jak utworzyć metryki"
 
@@ -4163,8 +4169,8 @@ msgstr "Wyświetlanie danych w czasie, jako mapę lub z tabelę przestawną by u
 msgid "Custom"
 msgstr "Własny"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:150
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:517
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
 msgstr "Nowe pytanie"
 
@@ -4172,22 +4178,22 @@ msgstr "Nowe pytanie"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Użyj tego prostego konstruktora zapytań by zobaczyć trendy, listy lub utworzyć własną metrykęwłasnych metryk."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:161
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Zapytanie natywne"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:162
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "W przypadku bardziej skomplikowanych zapytań można użyć własnej kwerendę w SQL lub natywnych zapytaniach."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:240
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
 msgstr "Wybierz wartość domyślną…"
 
-#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:149
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
 msgstr "Aktualizuj filtr"
 
@@ -4195,14 +4201,14 @@ msgstr "Aktualizuj filtr"
 #: frontend/src/metabase/lib/query_time.js:123
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:9
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Today"
 msgstr "Dziś"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
 msgstr "Wczoraj"
 
@@ -4214,7 +4220,7 @@ msgstr "Ostatnie 7 dni"
 msgid "Past 30 days"
 msgstr "Ostatnie 30 dni"
 
-#: frontend/src/metabase/lib/query_time.js:195
+#: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:29
 #: src/metabase/api/table.clj
@@ -4225,7 +4231,7 @@ msgstr[1] "Tygodnie"
 msgstr[2] "Tygodni"
 msgstr[3] "Tygodni"
 
-#: frontend/src/metabase/lib/query_time.js:197
+#: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:30
 #: src/metabase/api/table.clj
@@ -4236,7 +4242,7 @@ msgstr[1] "Miesięcy"
 msgstr[2] "Miesięcy"
 msgstr[3] "Miesięcy"
 
-#: frontend/src/metabase/lib/query_time.js:201
+#: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:31
 #: src/metabase/api/table.clj
@@ -4288,6 +4294,7 @@ msgstr "Wpisz wartość..."
 msgid "Enter a default value..."
 msgstr "Wpisz wartość domyślną.."
 
+#: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Wystąpił błąd"
@@ -4328,24 +4335,24 @@ msgstr "Opublikuj"
 msgid "Code"
 msgstr "Kod"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:70
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
 msgstr "Styl"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
 msgstr "Jakie parametry mogą być używane przez użytkowników tego programu do osadzania?"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:83
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
 msgstr "Ten element {0} nie ma jeszcze żadnych parametrów do skonfigurowania."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
 msgstr "Do edycji"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
 msgstr "Zakmniety"
 
@@ -4353,19 +4360,19 @@ msgstr "Zakmniety"
 msgid "Preview Locked Parameters"
 msgstr "Przegląd zablokowanych parametrów"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:115
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
 msgstr "Spróbuj przekazanie niektórych wartości do zablokowanych parametrów tutaj. Serwer będzie musiał podać rzeczywiste wartości w podpisanym tokenie podczas korzystania z tego dla rzeczywistego."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
 msgstr "Strefa zagrożenia"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
 msgstr "Spowoduje to wyłączenie osadzania dla {0}."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:128
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
 msgstr "Non pubblicare"
 
@@ -4406,64 +4413,64 @@ msgstr "Więcej {0}"
 msgid "examples on GitHub"
 msgstr "przykładów na Github"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:72
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
 msgstr "Włącz udostępnianie"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
 msgstr "Wyłączyć ten publiczny link?"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:77
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
 msgstr "Spowoduje to, że istniejące łącze przestanie działać. Można go ponownie włączyć, ale gdy zrobisz to będzie inny link."
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
 msgstr "Link publiczny"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:118
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
 msgstr "Udostępnij tę encję {0} osobom, które nie mają konta Metabase, korzystając z poniższego adresu URL:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:158
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
 msgstr "Publiczny embed"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:159
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
 msgstr "Osadź tę encję {0} w blogach lub stronach sieci Web, kopiując i wklejając ten urywek:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:176
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
 msgstr "Osadź ten element {0} w aplikacji"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:177
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
 msgstr "Integrując się z kodem serwera aplikacji, możesz zapewnić bezpieczne statystyki {0} ograniczone do określonego użytkownika, klienta, organizacji itp."
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
 msgstr "Usuń załącznik"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:95
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
 msgstr "Załącz plik z wynikami"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
 msgstr "To zapytanie zostanie dodane jako plik załącznika"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:128
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
 msgstr "To zapytanie nie zostanie uwzględnione w Pulsie"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:92
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
-msgstr "Ten impuls nie będzie już wysłany do {0} {1}."
+msgstr "Ten puls nie będzie już wysłany do {0} {1}."
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:94
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:376
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
 msgstr[0] "{0} adres"
@@ -4475,39 +4482,39 @@ msgstr[3] "{0} adresów"
 msgid "Slack channel {0} will no longer get this pulse {1}"
 msgstr "Kanał Slack {0} nie będzie już miał tego Pulsu {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:110
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
 msgstr "Kanał {0} nie będzie już otrzymywał tego Pulsu {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
 msgstr "Edytuj puls"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:131
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
 msgstr "Co to jest Puls?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:141
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
 msgstr "Mam to "
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
 msgstr "Gdzie to powinno być?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:173
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
 msgstr "Cofnięcie archiwizacji…"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
 msgstr "Od-archiwizowanie nie powiodło się"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
 msgstr "Niezarchiwizowany"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
 msgstr "Tworzenie pulsu"
 
@@ -4517,7 +4524,7 @@ msgstr "Załącznik"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:673
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
 msgstr "Uwaga"
 
@@ -4535,9 +4542,10 @@ msgstr "Wygląda na to puls jest coraz większy"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:120
 msgid "We recommend keeping pulses small and focused to help keep them digestible and useful to the whole team."
-msgstr "Zalecamy utrzymanie małych impulsów i skoncentrowanie się na tym, aby zapewnić ich strawność i użyteczność dla całego zespołu."
+msgstr "Zalecamy utrzymanie małych pulsów i skoncentrowanie się na tym, aby zapewnić ich strawność i użyteczność dla całego zespołu."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
+#: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
 msgstr "Wybierz swoje dane"
 
@@ -4553,47 +4561,47 @@ msgstr "Emaile"
 msgid "Slack messages"
 msgstr "Widomości Slack"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Wysłane"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:222
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} zostanie wysłane w"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:224
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Wiadomości"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Wyśij teraz wiadomość"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:241
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Wyślij teraz do {0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Wysyłanie..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:244
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Wysyłanie się niepowiodło"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Nie wysłano, ponieważ puls nie ma wyników."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:248
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Puls wysłany"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:287
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} musi zostać skonfigurowany przez administratora."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:302
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
 msgstr "Slack"
 
@@ -4642,21 +4650,21 @@ msgid "Before {0}"
 msgstr "Przed {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:295
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Jest pusty"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:301
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Nie jest pusty"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:213
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Zawsze"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:154
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
 msgstr "Zastosuj"
 
@@ -4722,7 +4730,7 @@ msgstr "Dystrybucja"
 msgid "View details"
 msgstr "Wyświetl szczegóły"
 
-#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:54
+#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
 msgstr "Wyświetl {0} {1}"
 
@@ -4746,7 +4754,7 @@ msgstr "Śr"
 msgid "Distincts"
 msgstr "Różne"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:32
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Pokaż {0}"
@@ -4754,16 +4762,16 @@ msgstr[1] "Pokaż {0}"
 msgstr[2] "Pokaż {0}"
 msgstr[3] "Pokaż {0}"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:225
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
 msgstr "Przybliż"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:19
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
 msgstr "Wyrażenia niestandardowe"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
 msgstr "Wspólne metryki"
 
@@ -4771,7 +4779,7 @@ msgstr "Wspólne metryki"
 msgid "Metabasics"
 msgstr "Metabasics"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
 msgstr "Nazwa (opcjonalne)"
 
@@ -4783,31 +4791,31 @@ msgstr "Wybierz agregację"
 msgid "Set up your own alert"
 msgstr "Skonfiguruj własny alert"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:140
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
 msgstr "Anulowanie subskrypcji..."
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:145
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
 msgstr "Nie można anulować subskrypcji"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:204
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
 msgstr "Anuluj subskrypcję"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:235
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
 msgstr "Brak stacji"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:263
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
 msgstr "Okay, anulowałeś subskrypcję"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:335
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
 msgstr "Otrzymujesz alerty {0}"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
 msgstr "{0} skonfigurowanie alertu"
 
@@ -4863,147 +4871,147 @@ msgstr "Edytuj swój alert"
 msgid "Edit alert"
 msgstr "Edytuj alert"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:374
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
 msgstr "Ten alert nie będzie już wysłany do {0}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:382
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
 msgstr "Kanał Slack {0} nie będzie już otrzymywać tego alertu."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:386
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
 msgstr "Kanał {0} nie będzie już otrzymywał tego alertu."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:403
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
 msgstr "Usuń"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:405
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
 msgstr "Zatrzymaj dostarczanie i Usuń ten alert. Nie ma cofnąć, więc należy być ostrożnym."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:413
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
 msgstr "Usunąć ten alert?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:497
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
 msgstr "Ostrzegaj mnie, gdy linia…"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:498
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
 msgstr "Ostrzegaj mnie, gdy pasek postępu…"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
 msgstr "Przekracza linię docelową"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
 msgstr "Osiągnie cel"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
 msgstr "Idzie poniżej linii docelowej"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
 msgstr "Idzie poniżej celu"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:512
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
 msgstr "Pierwszy raz go przecina, lub za każdym razem?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:513
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
 msgstr "Po raz pierwszy osiągnie cel, lub za każdym razem?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
 msgstr "Za pierwszym razem"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:516
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
 msgstr "Za każdym razem"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:619
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
 msgstr "Gdzie chcesz wysłać te alerty?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:630
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
 msgstr "Alerty e-mail do:"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:672
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
 msgstr "{0} alerty oparte na celu nie są jeszcze obsługiwane dla wykresów z więcej niż jednym wierszem, więc ten alert zostanie wysłany w każdym przypadku, gdy wykres ma {1}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
 msgstr "wyniki"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:679
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
 msgstr "Ten rodzaj alertu jest najbardziej przydatny w przypadku, gdy zapisane zapytanie nie zawiera żadnych wyników, ale użytkownik chce się o tym dowiedzieć."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:680
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
 msgstr "Rada"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
 msgstr "zazwyczaj"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:57
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
 msgstr "Wybierz segment lub tabelę"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
 msgstr "Wybierz bazę danych"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:88
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
 msgstr "Wybieranie.."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:128
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
 msgstr "Wybierz tabele"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:793
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
 msgstr "Brak tabel w tej bazie danych"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:830
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
 msgstr "Brakuje zapytania?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:834
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
 msgstr "Dowiedz się więcej o kwerendach zagnieżdżonych"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:868
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
 msgstr "Pola"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:946
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
 msgstr "Nie znaleziono segmentów."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:969
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
 msgstr "Znajdź segment"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:46
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
 msgstr "Pokaż mniej"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:56
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
 msgstr "Pokaż więcej"
 
@@ -5012,60 +5020,65 @@ msgid "Pick a field to sort by"
 msgstr "Wybierz pole do sortowania według"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
 msgstr "Sortuj"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
 msgstr "Limit wierszy"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:69
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
 msgstr "Nieznane pole"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
 msgstr "pole"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:114
+#: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
 msgstr "Pasuje"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
+#: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Dodawanie filtrów w celu zawężenia odpowiedzi"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:284
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
 msgstr "Dodaj grupowanie"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:322
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:102
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:113
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:152
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:194
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:59
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:68
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:75
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:225
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:231
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:237
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:70
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:75
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:64
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:89
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:131
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:176
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:302
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:308
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:314
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Dane"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:352
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
 msgstr "Filtrowane po"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:369
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
 msgstr "Wyświetl"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:386
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
 msgstr "Pogrupowane po"
 
@@ -5073,23 +5086,23 @@ msgstr "Pogrupowane po"
 msgid "None"
 msgstr "Żadne"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:345
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
 msgstr "To zapytanie jest napisane w {0}."
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:353
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
 msgstr "Ukryj Edytor"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:354
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
 msgstr "Ukryj kwerendę"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
 msgstr "Otwórz Edytor"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:360
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
 msgstr "Pokaż kwerendę"
 
@@ -5110,15 +5123,15 @@ msgstr "Pobierz te dane"
 msgid "Warning"
 msgstr "Ostrzeżenie"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:52
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
 msgstr "Twoja odpowiedź ma dużą liczbę wierszy, więc może to zająć trochę czasu, aby pobrać."
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:53
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
 msgstr "Maksymalny rozmiar pobierania to 1 000 000 wierszy."
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:232
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
 msgstr "Edycja pytań"
 
@@ -5134,17 +5147,17 @@ msgstr "Anuluj"
 msgid "Move question"
 msgstr "Przenieś zapytanie"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:283
+#: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
 msgstr "Która Kolekcja powinna to być?"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:313
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:110
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
+#: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
 msgstr "Zmienne"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:432
+#: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
 msgstr "Dowiedz się więcej o danych"
 
@@ -5188,11 +5201,11 @@ msgstr "{0} na to zapytanie"
 msgid "Convert this question to {0}"
 msgstr "Przekonwertuj to zapytanie na {0}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:122
+#: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
 msgstr "To zapytanie zajmie około {0}, aby odświeżyć"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:131
+#: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
 msgstr "Zaktualizowano {0}"
 
@@ -5212,11 +5225,11 @@ msgstr "Wyświetlanie pierwszego {0} {1}"
 msgid "Showing {0} {1}"
 msgstr "Wyświetlono {0} {1}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:281
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
 msgstr "Analizuję"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:294
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
 msgstr "Jeśli dasz mi jakieś dane to mogę wam pokazać coś fajnego. Uruchom zapytanie!"
 
@@ -5224,7 +5237,7 @@ msgstr "Jeśli dasz mi jakieś dane to mogę wam pokazać coś fajnego. Uruchom 
 msgid "How do I use this thing?"
 msgstr "Jak korzystać z tej rzeczy?"
 
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:28
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
 msgstr "Pobierz odpowiedz"
 
@@ -5252,39 +5265,39 @@ msgstr "Przepraszam. Coś poszło nie tak"
 msgid "Group time by"
 msgstr "Grupuj czas według"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:46
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
 msgstr "Twoje zapytanie trwało zbyt długo"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:47
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
 msgstr "Nie otrzymali odpowiedzi z powrotem z bazy danych w czasie, więc musieliśmy przestać. Możesz spróbować ponownie w minutę, lub jeśli problem będzie się powtarzał, możesz wysłać e-mail do administratora, aby poinformować o tym."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:55
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
 msgstr "Napotykamy problemy z serwerami"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:56
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
 msgstr "Spróbuj odświeżyć stronę po odczekaniu minuty lub dwóch. Jeśli problem będzie się powtarzał, zalecamy skontaktowanie się z administratorem."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:88
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
 msgstr "Wystąpił problem z Twoim zapytaniem"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:89
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
 msgstr "Przez większość czasu jest to spowodowane nieprawidłowym wyborem lub złą wartością wejściową. Dwukrotnie sprawdź dane wejściowe i ponów kwerendę."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:60
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
 msgstr "Może to być odpowiedź, której szukasz. Jeśli nie, spróbuj usunąć lub zmienić filtry, aby uczynić je mniej szczegółowymi."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
 msgstr "W przypadku niektórych wyników można również {0}."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:68
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
 msgstr "otrzymał(a) alert"
 
@@ -5292,11 +5305,11 @@ msgstr "otrzymał(a) alert"
 msgid "Back to last run"
 msgstr "Powrót do ostatniego uruchomienia"
 
-#: frontend/src/metabase/query_builder/components/VisualizationSettings.jsx:100
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
 msgstr "Wizualizacja"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:96
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
 msgstr "Brak zestawu opis."
 
@@ -5308,7 +5321,7 @@ msgstr "Użyj dla aktualnego zapytania"
 msgid "Potentially useful questions"
 msgstr "Potencjalnie przydatne zapytania"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:166
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
 msgstr "Grupuj według {0}"
 
@@ -5321,14 +5334,14 @@ msgstr "Suma wszystkich wartości {0}"
 msgid "All distinct values of {0}"
 msgstr "Wszystkie różne wartości z {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:187
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
 msgstr "Liczba elementów {0} zgrupowanych według {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5344,34 +5357,34 @@ msgstr "Odwołanie do danych"
 msgid "Learn more about your data structure to ask more useful questions"
 msgstr "Dowiedz się więcej o strukturze danych, aby zadać więcej przydatnych pytań"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:58
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:84
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
 msgstr "Nie można odnaleźć metadanych tabeli przed utworzeniem nowego zapytania"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:80
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
 msgstr "Zobacz {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:94
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
 msgstr "Definicja Metryki"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:118
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
 msgstr "Filtruj według {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:127
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
 msgstr "Liczba {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
 msgstr "Zobacz wszystkie {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:148
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
 msgstr "Definicja segmentu"
 
@@ -5383,7 +5396,7 @@ msgstr "Podczas ładowania tabeli wystąpił błąd"
 msgid "See the raw data for {0}"
 msgstr "Zobacz dane dla {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:180
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
 msgstr "Więcej"
 
@@ -5395,24 +5408,24 @@ msgstr "Nieprawidłowe wyrażenie"
 msgid "unknown error"
 msgstr "nieznany błąd"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:46
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
 msgstr "Pole formuły"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:57
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Pomyśl o tym jako o rodzaju jak pisanie formuły w programie arkusza kalkulacyjnego: można użyć liczby, pola w tabeli, symbole matematyczne jak +, i niektóre funkcje. Więc można wpisać coś w stylu podsumy kosztów."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
 msgstr "Dowiedz się więcej"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:66
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
 msgstr "Nadaj mu nazwę"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:72
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
 msgstr "Coś miłego i opisowego"
 
@@ -5464,7 +5477,8 @@ msgstr "prawda"
 msgid "false"
 msgstr "fałsz"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
 msgstr "Dodaj filtr"
 
@@ -5472,15 +5486,15 @@ msgstr "Dodaj filtr"
 msgid "Item"
 msgstr "Element"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:221
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
 msgstr "Poprzednie"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:252
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
 msgstr "Aktualne"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:278
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
@@ -5491,7 +5505,7 @@ msgid "Enter desired number"
 msgstr "Wprowadź żądaną liczbę"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:100
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
 msgstr "Pustę"
 
@@ -5515,35 +5529,35 @@ msgstr "Możesz wpisać wiele wartości oddzielonych przecinkiem"
 msgid "Enter desired text"
 msgstr "Wprowadź żądany tekst"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
 msgstr "Spróbuj"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
 msgstr "Do czego to?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
 msgstr "Zmienne w kwerendach natywnych umożliwiają dynamiczne zamienianie wartości w kwerendach za pomocą widżetów filtru lub adresu URL."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
 msgstr "element {0} tworzy zmienną w tym szablonie SQL o nazwie \"variable_name\". Zmienne mogą być podane typy w panelu bocznym, który zmienia ich zachowanie. Wszystkie typy zmiennych inne niż \"filtr pola\" automatycznie spowodują umieszczenie widżetu filtra na tej kwestii; z filtrami pól jest to opcjonalne. Po wypełnieniu tego widgetu filtru wartość ta zastępuje zmienną w szablonie SQL."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:121
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
 msgstr "Filtry pól"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:123
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Nadanie zmiennej \"filtr pola\" typ pozwala na łączenie kart SQL do panelu Widżety filtr lub użyć więcej typów widżetów filtr na zapytanie SQL. Zmienna filtru pola wstawia SQL podobny do generowanego przez konstruktora zapytań GUI podczas dodawania filtrów w istniejących kolumnach."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:126
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
 msgstr "Podczas dodawania zmiennej pola filtr należy zmapować ją do określonego pola. Następnie można wybrać wyświetlanie widżetu filtru na swoje zapytanie, ale nawet jeśli nie, można teraz mapować zmiennej filtr pola do filtru pulpitu nawigacyjnego podczas dodawania tego zapytania do pulpitu nawigacyjnego. Filtry pola powinny być używane wewnątrz klauzuli \"Where\"."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:130
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
 msgstr "Warunki opcjonalne"
 
@@ -5551,59 +5565,61 @@ msgstr "Warunki opcjonalne"
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
 msgstr "nawiasy wokół elementu {0} tworzą opcjonalną klauzulę w szablonie. Jeśli \"zmienna\" jest ustawiona, a następnie cała klauzula jest umieszczana w szablonie. Jeśli nie, to cała klauzula jest ignorowana."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:142
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
 msgstr "Aby użyć wielu klauzule opcjonalne można dołączyć co najmniej jeden nieopcjonalny klauzula WHERE następuje klauzule opcjonalne, począwszy od \"AND\"."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
 msgstr "Przeczytaj pełną dokumentację"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:127
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
 msgstr "Etykieta filtra"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:139
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
 msgstr "Typ zmiennej"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:143
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
 msgstr "Tekst"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:150
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:119
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
 msgstr "Data"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
 msgstr "Filtr pola"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:157
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
 msgstr "Pole do mapowania na"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
 msgstr "Typ widżetu Filtruj"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:201
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
 msgstr "Wymagane?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:211
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
 msgstr "Domyślna wartość widżetu filtr"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:46
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
 msgstr "Archiwizować to zapytanie?"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:57
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
-msgstr "To zapytanie zostanie usunięte z wszelkich pulpitów nawigacyjnych lub impulsów, używając go."
+msgstr "To zapytanie zostanie usunięte z wszelkich pulpitów nawigacyjnych lub pulsów, używając go."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:136
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
 msgstr "Pytanie"
 
@@ -5620,21 +5636,21 @@ msgstr "Edytujesz tą stronę"
 msgid "See this {0}"
 msgstr "Zobacz {0}"
 
-#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:120
+#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
 msgstr "Podzbiór z"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:68
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
 msgstr "Wybierz typ pola"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:57
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
 msgstr "Brak typu pola"
 
@@ -5643,16 +5659,16 @@ msgid "by"
 msgstr "przez"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
-#: frontend/src/metabase/reference/databases/FieldList.jsx:152
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
+#: frontend/src/metabase/reference/databases/FieldList.jsx:155
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
 msgstr "Typ pola"
 
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:72
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
 msgstr "Wybierz klucz obcy"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:53
+#: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
 msgstr "Wyświetlanie formuły {0}"
 
@@ -5669,12 +5685,12 @@ msgid "Nothing important yet"
 msgstr "Nic ważnego "
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:168
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:233
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:211
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:215
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:219
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:229
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:236
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:214
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
 msgstr "Nic interesującego"
 
@@ -5683,12 +5699,12 @@ msgid "Things to be aware of about this {0}"
 msgstr "Co należy wiedzieć o tym {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:178
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:243
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:221
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:225
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:229
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:239
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:246
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:224
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
 msgstr "Nic strasznego"
 
@@ -5750,15 +5766,15 @@ msgstr "Powody zmiany"
 msgid "Leave a note to explain what changes you made and why they were required"
 msgstr "Zostaw notatkę, aby wyjaśnić, jakie zmiany zostały wprowadzone i dlaczego były wymagane"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:166
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
 msgstr "Dlaczego ta baza danych jest interesująca"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:176
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
 msgstr "Co należy wiedzieć o tej bazy danych"
 
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:46
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
 msgstr "Bazy danych i tabele"
@@ -5766,42 +5782,42 @@ msgstr "Bazy danych i tabele"
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:41
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:170
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:173
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:34
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:184
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:187
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:30
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:188
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:187
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:191
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:190
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
 msgstr "Szczegóły"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
-#: frontend/src/metabase/reference/databases/TableList.jsx:111
+#: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
 msgstr "Tabele w {0}"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:222
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:200
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:218
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:203
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
 msgstr "Aktualna nazwa w bazie danych"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:231
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:227
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
 msgstr "Dlaczego to pole jest interesujące"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:241
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:237
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
 msgstr "Co należy wiedzieć o tym polu"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:253
-#: frontend/src/metabase/reference/databases/FieldList.jsx:155
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:249
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
+#: frontend/src/metabase/reference/databases/FieldList.jsx:158
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
 msgstr "Typ danych"
 
@@ -5810,13 +5826,13 @@ msgstr "Typ danych"
 msgid "Fields in this table will appear here as they're added"
 msgstr "Pola w tej tabeli pojawią się w tym miejscu, gdy są dodawane"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:134
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:135
+#: frontend/src/metabase/reference/databases/FieldList.jsx:137
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
 msgstr "Pola w {0}"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:149
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:150
+#: frontend/src/metabase/reference/databases/FieldList.jsx:152
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
 msgstr "Nazwa pola"
 
@@ -5840,7 +5856,10 @@ msgstr "Bazy danych pojawią się tutaj, gdy Twoi Administratorzy dodadzą jaką
 msgid "Connect a database"
 msgstr "Połącz z bazą danych"
 
+#. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
+#. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
+#: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
 msgstr "Liczba {0}"
 
@@ -5848,11 +5867,11 @@ msgstr "Liczba {0}"
 msgid "See raw data for {0}"
 msgstr "Zobacz dane dla {0}"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:209
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
 msgstr "Dlaczego ta tabela jest interesująca"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:219
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
 msgstr "Co należy wiedzieć o tej tabeli"
 
@@ -5864,16 +5883,16 @@ msgstr "Tabele w tej bazie danych pojawią się w tym miejscu, gdy są dodawane"
 msgid "Questions about this table will appear here as they're added"
 msgstr "Zaytania dotyczące tej tabeli pojawią się tutaj, jak są dodawane"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:71
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:75
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:74
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
 msgstr "Pytania o {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
 msgstr "Utworzone {0} przez {1}"
 
@@ -5885,151 +5904,152 @@ msgstr "Pola w tabeli"
 msgid "Questions about this table"
 msgstr "Zapytania dotyczące tej tabeli"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:157
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
 msgstr "Pomóż zespołowi rozpocząć pracę z twoimi danymi."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:159
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
 msgstr "Pokaż swojemu zespołowi, co najważniejsze, wybierając górny pulpit nawigacyjny, metryki i segmenty."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:165
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
 msgstr "Zacznij"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:173
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
 msgstr "Nasz najistotniejszy panel"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:188
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
 msgstr "Liczby, na które zwracamy uwagę"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:213
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
 msgstr "Metryki są ważnymi numerami, o których dba firma. Często stanowią one główny wskaźnik, w jaki sposób firma wykonuje."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:221
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
 msgstr "Zobacz wszystkie metryki"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:235
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
 msgstr "Segmenty i tabele"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
+#: frontend/src/metabase/home/containers/SearchApp.jsx:83
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
 msgstr "Tabele"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:262
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
 msgstr "Segmenty i tabele są blokami konstrukcyjnymi danych firmy. Tabele to zbiory informacji, podczas gdy segmenty są określonymi plasterkami o określonych znaczeniach, na przykład {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:267
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
 msgstr "Tabele są budulcem danych firmy."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:277
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
 msgstr "Zobacz wszystkie segmenty"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:293
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
 msgstr "Zobacz wszystkie tabele"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:301
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
 msgstr "Inne informacje o naszych danych"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
 msgstr "Dowiedz się więcej"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:307
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
 msgstr "Dobrym sposobem na poznanie danych jest spędzanie trochę czasu na poznawanie różnych tabel i innych informacji dostępnych dla Ciebie. Może to zająć trochę czasu, ale zaczniesz rozpoznawać nazwy i znaczenia w czasie."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:313
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
 msgstr "Poznaj nasze dane"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:321
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
 msgstr "Masz pytania?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:326
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
 msgstr "Kontakt {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:248
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
 msgstr "Pomóż odnaleźć się nowym użytkownikom Metabase."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:251
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
 msgstr "Przewodnik wprowadzenie podświetla pulpit nawigacyjny, metryki, segmenty i tabele, które mają największe znaczenie, i informuje użytkowników o ważnych rzeczach, które powinni znać przed kopaniem w danych."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:258
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
 msgstr "Czy istnieje ważny panel dla Twojego zespołu?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:260
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
 msgstr "Utwórz pulpit nawigacyjny teraz"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:266
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
 msgstr "Jaki jest Twój najważniejszy panel?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:285
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
 msgstr "Czy masz jakieś powszechnie odniesienia metryki?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:287
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
 msgstr "Dowiedz się, jak zdefiniować metrykę"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:300
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
 msgstr "Jakie są Twoje 3-5 najczęściej odniesienia metryki?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:344
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
 msgstr "Dodaj kolejną metrykę"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:357
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
 msgstr "Czy masz często odwołuje się segmenty lub tabele?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:359
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
 msgstr "Dowiedz się, jak utworzyć segment"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:372
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
 msgstr "Co to są 3-5 powszechnie odniesienia segmenty lub tabele, które byłyby przydatne dla tej grupy odbiorców?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:418
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
 msgstr "Dodawanie kolejnego segmentu lub tabeli"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:427
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
 msgstr "Czy jest coś, co użytkownicy powinni zrozumieć lub wiedzieć, zanim zaczną uzyskiwać dostęp do danych?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:433
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
 msgstr "Co powinien wiedzieć użytkownik tych danych przed rozpoczęciem dostępu do niego?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:437
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
 msgstr "Na przykład, oczekiwania dotyczące prywatności i użytkowania danych, Najczęstsze pułapki lub nieporozumienia, informacje o wydajności hurtowni danych, informacjach prawnych itp."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
 msgstr "Czy jest ktoś Twój użytkownik kulisy nawiązywać kontakt pod kątem współpracownik jeśli oni ' pomieszany około ten kierować?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:457
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
 msgstr "Kto powinien skontaktować się z działem pomocy, jeśli nie zna tych danych?"
 
@@ -6038,39 +6058,39 @@ msgstr "Kto powinien skontaktować się z działem pomocy, jeśli nie zna tych d
 msgid "Please enter a revision message"
 msgstr "Proszę wprowadzić komunikat poprawki"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:213
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
 msgstr "Dlaczego ta Metryka jest interesująca"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:223
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
 msgstr "Co należy wiedzieć o tej Metryce"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:233
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
 msgstr "Jak obliczana jest ta Metryka"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:235
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
 msgstr "Nic o tym, jak jest jeszcze obliczone"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:293
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
 msgstr "Inne pola, po których możesz grupować tę metrykę"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:294
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
 msgstr "Pola, po których możesz grupować tę metrykę"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:23
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Metryki są oficjalnymi numerami, o które dba twój zespół"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Metryki pojawią się tutaj, gdy Twoi Administratorzy utworzyli kilka"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
 msgstr "Dowiedz się, jak tworzyć metryki"
 
@@ -6082,9 +6102,9 @@ msgstr "Zapytania dotyczące tej metryki pojawią się tutaj, jak są dodawane"
 msgid "There are no revisions for this metric"
 msgstr "Nie ma żadnych wersji dla tej metryki"
 
-#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:88
-#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
-#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:88
+#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
+#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
+#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
 msgstr "Historia zmian dla {0}"
 
@@ -6092,27 +6112,27 @@ msgstr "Historia zmian dla {0}"
 msgid "X-ray this metric"
 msgstr "Prześwietl X-ray tą Metrykę"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:217
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
 msgstr "Dlaczego ten segment jest interesujący"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:227
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
 msgstr "Co należy wiedzieć o tym segmencie"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
 msgstr "Segmenty to interesujące podzbiory tabel"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Definiowanie wspólnych segmentów zespołu ułatwia jeszcze łatwiejsze zadawanie pytań"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
 msgstr "Segmenty pojawią się tutaj, gdy Twoi Administratorzy utworzyli kilka"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
 msgstr "Dowiedz się, jak tworzyć segmenty"
 
@@ -6140,7 +6160,7 @@ msgstr "Prześwietl X-ray ten segment"
 msgid "Login"
 msgstr "Zaloguj się"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:130
+#: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
 msgstr "Szukaj"
@@ -6157,99 +6177,99 @@ msgstr "Nowe zapytanie"
 msgid "Select the type of Database you use"
 msgstr "Wybierz typ używanej bazy danych"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:141
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
 msgstr "Dodaj swoje dane"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:145
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
 msgstr "Dodam własne dane później"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
 msgstr "Łączenie do {0}"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:165
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
 msgstr "Potrzebujesz informacji o bazie danych, takiej jak nazwa użytkownika i hasło. Jeśli nie masz tego już teraz, Metabase jest również dostarczana z przykładowym zestawem danych, który można rozpocząć."
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:196
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
 msgstr "Dodam moje dane później"
 
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:41
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
 msgstr "Sterowanie automatycznym skanowaniem"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:53
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
 msgstr "Preferencje danych użycia"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
 msgstr "Dzięki za pomoc w usprawnianiu nas"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:57
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
 msgstr "Nie będziemy zbierać żadnych zdarzeń użycia"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:76
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Aby pomóc w ulepszaniu Metabase, chcielibyśmy zebrać pewne dane dotyczące użycia w Google Analytics."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
 msgstr "Oto pełna lista wszystkiego, co śledzimy i dlaczego."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:98
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Zezwalaj na anonimowe zbieranie zdarzeń użycia Metabase"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} gromadzi wszelkie informacje na temat wyników danych lub pytań."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:106
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
 msgstr "nigdy"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
 msgstr "Cała kolekcja jest całkowicie anonimowa."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Kolekcja może być wyłączona w dowolnym momencie w ustawieniach administratora."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:45
+#: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
 msgstr "Jeśli czujesz że utknąłeś"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:52
+#: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
 msgstr "nasz przewodnik dla początkujących"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:53
+#: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
 msgstr "znajduje się zaledwie kilka kliknięć stąd."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:95
+#: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
 msgstr "Witamy w Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:96
+#: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Wygląda na to, że wszystko działa. Teraz niech cię poznać, połączyć się z danymi, i zacząć znaleźć kilka odpowiedzi!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:100
+#: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
 msgstr "Zacznijmy"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:145
+#: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
 msgstr "Wszystko ustawione!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:156
+#: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
 msgstr "Zabierz mnie do Metabase"
 
@@ -6266,7 +6286,7 @@ msgid "Create a password"
 msgstr "Stwórz hasło"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:116
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
 msgstr "Szzz..."
 
@@ -6425,7 +6445,7 @@ msgstr "Zapisz swoje zapytanie"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:237
 msgid "By the way, you can save your questions so you can refer to them later. Saved Questions can also be put into dashboards or Pulses."
-msgstr "Przy okazji, można zapisać swoje zapytania, aby można było odwołać się do nich później. Zapisane zapytania można również umieścić w panele lub impulsy."
+msgstr "Przy okazji, można zapisać swoje zapytania, aby można było odwołać się do nich później. Zapisane zapytania można również umieścić w panele lub pulsy."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:241
 msgid "Sounds good"
@@ -6459,11 +6479,11 @@ msgstr "Zaloguj się za pomocą e-mail Google"
 msgid "User Details"
 msgstr "Szczegóły użytkownika"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:275
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
 msgstr "Powróć do ustawień fabrycznych"
 
-#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:133
+#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
 msgstr "nieznana Mapa"
 
@@ -6475,24 +6495,24 @@ msgstr "Mapa siatki wymaga długości/szerokości geograficznej."
 msgid "more"
 msgstr "więcej"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:101
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
 msgstr "Które pola chcesz użyć dla osi X i Y?"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:103
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:60
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
 msgstr "Wybierz pola"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:204
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
 msgstr "Zapisz jako domyślny widok"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
 msgstr "Zaznacz prostokąt aby filtrować"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
 msgstr "Anuluj filtr"
 
@@ -6500,7 +6520,7 @@ msgstr "Anuluj filtr"
 msgid "Pin Map"
 msgstr "Przypinanie mapy"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:303
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
 msgstr "Nie ustawiono"
 
@@ -6508,31 +6528,31 @@ msgstr "Nie ustawiono"
 msgid "Rows {0}-{1} of {2}"
 msgstr "Wiersze {0}-{1} z {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:189
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
 msgstr "Dane obcięte do {0} wierszy."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:364
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
 msgstr "Nie można odnaleźć wizualizacji"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:371
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
 msgstr "Nie można wyświetlić tego wykresu z tymi danymi."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:469
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
 msgstr "Brak wyników!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:490
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
 msgstr "Wciąż czekam..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:493
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
 msgstr "Zazwyczaj trwa to średnio {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:499
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
 msgstr "(jest to trochę za dużo dla pulpitu)"
 
@@ -6548,11 +6568,11 @@ msgstr "Wybierz pole"
 msgid "error"
 msgstr "bład"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:126
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
 msgstr "Kliknij i przeciągnij, aby zmienić ich kolejność"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:139
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
 msgstr "Dodaj pola z poniższej listy"
 
@@ -6642,7 +6662,7 @@ msgid "Highlight the whole row"
 msgstr "Podświetl cały wiersz"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:98
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Kolory"
 
@@ -6707,20 +6727,20 @@ msgstr "Wizualizacja z tym identyfikatorem jest już zarejestrowana: "
 msgid "No visualization for {0}"
 msgstr "Brak wizualizacji dla {0}"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:75
+#: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
 msgstr "\"{0}\" jest polem niezagregowanym: Jeśli w punkcie na osi x znajduje się więcej niż jedna wartość, wartości zostaną zsumowane."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:91
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
 msgstr "Ten typ wykresu wymaga co najmniej 2 kolumny."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:96
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
 msgstr "Ten typ wykresu nie obsługuje więcej niż {0} serii danych."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:51
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:297
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
 msgstr "Cel"
 
@@ -6764,25 +6784,25 @@ msgstr "Edytuj ustawienia"
 msgid "xValues missing!"
 msgstr "brakuje wartości X!"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:114
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "Oś X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:140
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
 msgstr "Dodaj serię przełamania..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:153
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Oś Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:178
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
 msgstr "Dodaj kolejną serię..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:195
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
 msgstr "Rozmiar bąbelka"
 
@@ -6796,7 +6816,7 @@ msgid "Curve"
 msgstr "Krzywa"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:69
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
 msgstr "Krok"
 
@@ -6804,27 +6824,27 @@ msgstr "Krok"
 msgid "Show point markers on lines"
 msgstr "Pokaż znaczniki punktów w wierszach"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:235
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
 msgstr "Układanie"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:239
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
 msgstr "Nie układaj"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:240
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
 msgstr "Ułóż"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:241
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
 msgstr "Ułożone -100%"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:300
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
 msgstr "Pokaż cel"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:306
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
 msgstr "Wartość celu"
 
@@ -6844,126 +6864,126 @@ msgstr "Nic"
 msgid "Linear Interpolated"
 msgstr "Interpolacja liniowa"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:371
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
 msgstr "Skala osi X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
 msgstr "Seria czasu"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:391
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:409
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:381
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
 msgstr "Liniowa"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:410
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:383
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
 msgstr "Moc silnika"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:384
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
 msgstr "Log"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:396
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
 msgstr "Histogram"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:398
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
 msgstr "Porządkowa"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:404
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
 msgstr "Skala osi Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:417
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
 msgstr "Pokaż oś x linii i znaczników"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:423
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
 msgstr "Kompaktowy"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:424
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
 msgstr "Obróć o 45 stopni"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
 msgstr "Obróć o 90 stopni"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
 msgstr "Pokaż linię i znaczniki osi y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
 msgstr "Automatyczny zakres osi y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
 msgstr "W razie potrzeby użyj podzielonej osi y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
 msgstr "Pokaż etykietę na osi x"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:501
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
 msgstr "Etykieta osi X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:510
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
 msgstr "Pokaż etykietę na osi y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:516
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
 msgstr "Etykieta osi Y"
 
-#: frontend/src/metabase/visualizations/lib/utils.js:129
+#: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
 msgstr "Odchylenie standardowe"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:275
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:17
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:256
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
 msgstr "Obszar"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
 msgstr "wykres warstwowy"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:276
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:16
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:257
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
 msgstr "Słupek"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
 msgstr "wykres słupkowy"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
 msgstr "Które pola chcesz użyć?"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
 msgstr "Lejek"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:76
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:76
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Wykonaj pomiar"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
 msgstr "Typ lejka"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:88
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
 msgstr "Wykres słupkowy"
 
@@ -6971,141 +6991,141 @@ msgstr "Wykres słupkowy"
 msgid "line chart"
 msgstr "wykres liniowy"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:224
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Proszę wybrać kolumny długości i szerokości geograficznej w ustawieniach wykresu."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
 msgstr "Proszę wybrać mapę regionu."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Wybierz kolumny region i metryczne w ustawieniach wykresu."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:38
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:53
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
 msgstr "Rodzaj mapy"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:57
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:149
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
 msgstr "Mapa regionu"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
 msgstr "Przypinanie mapy"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
 msgstr "Typ przypięcia"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
 msgstr "Kafelki"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
 msgstr "Oznaczenia"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
 msgstr "Pole szerokości geograficznej"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
 msgstr "Pole długości geograficznej"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:142
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:168
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
 msgstr "Pole metryczne"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
 msgstr "Pole region"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
 msgstr "Promień"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:198
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
 msgstr "Rozmycie"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
 msgstr "Min. krycie"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
 msgstr "Max powiększenie"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:175
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
 msgstr "Nie znaleziono relacji."
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:213
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
 msgstr "przez {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:290
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
 msgstr "Obiekt {0} jest połączony z:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:47
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
 msgstr "Szczegóły obiektu"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
 msgstr "element"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
 msgstr "Razem"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Które kolumny chcesz użyć?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:44
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Wykres kołowy"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Wymiary"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:81
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Pokaż legendę"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:86
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Pokaż procenty w legendzie"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:92
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Minimalna wartość procentowa fragmentu"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:146
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
 msgstr "Osiągnięty cel"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:148
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
 msgstr "Przekroczono cel"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
 msgstr "Cel {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
 msgstr "Wizualizacja postępu wymaga numeru."
 
@@ -7113,9 +7133,9 @@ msgstr "Wizualizacja postępu wymaga numeru."
 msgid "Progress"
 msgstr "Postęp"
 
-#: frontend/src/metabase/entities/collections.js:108
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:176
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:57
+#: frontend/src/metabase/entities/collections.js:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Kolor"
 
@@ -7127,7 +7147,7 @@ msgstr "Wykres rzędowy"
 msgid "row chart"
 msgstr "wykres wierszowy"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:357
+#: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
 msgstr "Styl separatora"
 
@@ -7135,15 +7155,15 @@ msgstr "Styl separatora"
 msgid "Number of decimal places"
 msgstr "Liczba miejsc dziesiętnych"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:381
+#: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
 msgstr "Dodaj prefiks"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:385
+#: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
 msgstr "Dodaj sufiks"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:374
+#: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
 msgstr "Pomnóż przez liczbę"
 
@@ -7155,7 +7175,7 @@ msgstr "Wykres bąbelkowy"
 msgid "scatter plot"
 msgstr "wykres bąbelkowy"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:78
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
 msgstr "Przestawianie tabeli"
 
@@ -7164,7 +7184,8 @@ msgid "Visible fields"
 msgstr "Pola widoczne"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-msgid "Write here, and use Markdown if you''d like"
+#, fuzzy
+msgid "Write here, and use Markdown if you'd like"
 msgstr "Napisz tutaj, i jeśli chcesz użyj składni Markdown"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
@@ -7205,7 +7226,7 @@ msgstr "Prawa"
 msgid "Show background"
 msgstr "Pokaż tło"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:553
+#: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} kosz"
@@ -7213,7 +7234,7 @@ msgstr[1] "{0} kosze"
 msgstr[2] "{0} koszy"
 msgstr[3] "{0} koszy"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:559
+#: frontend/src/metabase-lib/lib/Dimension.js:731
 msgid "Auto binned"
 msgstr "Automatycznie sortowane"
 
@@ -7408,7 +7429,7 @@ msgstr "Ustaw adres email"
 
 #: src/metabase/api/setup.clj
 msgid "Add email credentials so you can more easily invite team members and get updates via Pulses."
-msgstr "Dodaj poświadczenia e-mail, dzięki czemu łatwiej możesz zaprosić członków zespołu i uzyskać aktualizacje za pośrednictwem impulsów."
+msgstr "Dodaj poświadczenia e-mail, dzięki czemu łatwiej możesz zaprosić członków zespołu i uzyskać aktualizacje za pośrednictwem pulsów."
 
 #: src/metabase/api/setup.clj
 msgid "Set Slack credentials"
@@ -7481,7 +7502,7 @@ msgstr "Automatyczne sortowanie"
 msgid "Don''t bin"
 msgstr "Nie sortuj"
 
-#: frontend/src/metabase/lib/query_time.js:193 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Dzień"
@@ -7490,7 +7511,7 @@ msgstr[2] "Dni"
 msgstr[3] "Dni"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
-#: frontend/src/metabase/lib/query_time.js:189 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minuta"
@@ -7498,7 +7519,7 @@ msgstr[1] "Minut"
 msgstr[2] "Minut"
 msgstr[3] "Minut"
 
-#: frontend/src/metabase/lib/query_time.js:191 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Godzina"
@@ -7506,7 +7527,7 @@ msgstr[1] "Godzin"
 msgstr[2] "Godzin"
 msgstr[3] "Godzin"
 
-#: frontend/src/metabase/lib/query_time.js:199 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
 msgstr[0] "Kwartał"
@@ -7575,7 +7596,7 @@ msgid "Bin every 20 degrees"
 msgstr "Sortuj co 20 stopni"
 
 #. returns `true` if successful -- see JavaDoc
-#: src/metabase/api/tiles.clj src/metabase/pulse/render.clj
+#: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
 msgstr "Nie odnaleziono odpowiedniego edytora zdjęć!"
 
@@ -7647,10 +7668,12 @@ msgstr "skumulowana suma"
 msgid "{0} and {1}"
 msgstr "{0} i {1}"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} z {1}"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
 msgstr "{0} na {1}"
@@ -7663,9 +7686,14 @@ msgstr "{0} w segmencie {1}"
 msgid "{0} segment"
 msgstr "{0} segment"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
-msgstr "metryka {0}"
+msgid_plural "{0} metrics"
+msgstr[0] "metryka {0}"
+msgstr[1] "metryk {0}"
+msgstr[2] "metryk {0}"
+msgstr[3] "metryk {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
@@ -8105,7 +8133,7 @@ msgstr "Baza wyszukiwania dla użytkowników. (będzie wyszukiwany rekurencyjnie
 
 #: src/metabase/integrations/ldap.clj
 msgid "User lookup filter, the placeholder '{login}' will be replaced by the user supplied login."
-msgstr "Filtru wyszukiwania użytkownika, symbol zastępczy \"{login}\" zostanie zastąpiony przez dostarczony login użytkownika."
+msgstr "User lookup filter, the placeholder '{login}' will be replaced by the user supplied login."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user's email. (usually ''mail'', ''email'' or ''userPrincipalName'')"
@@ -8246,6 +8274,7 @@ msgid "Cannot save Question: source query has circular references."
 msgstr "Nie można zapisać zapytania: kwerenda źródłowa ma odwołania cykliczne."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
+#: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
 msgstr "Karta {0} nie istnieje."
@@ -8647,7 +8676,7 @@ msgstr "Nierozpoznany typ kanału {0}"
 msgid "Error sending notification!"
 msgstr "Błąd podczas wysyłania powiadomienia!"
 
-#: src/metabase/pulse/color.clj
+#: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
 msgstr "Nie można znaleźć selektora kolorów JS w ' ' {0} ' '"
 
@@ -8954,43 +8983,43 @@ msgstr "Uprawnienia do danych"
 msgid "Collection permissions"
 msgstr "Uprawnienia do kolekcji"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:56
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
 msgstr "Zobacz wszystkie uprawnienia do kolekcji"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:25
+#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
 msgstr "Również zmienić kolekcje podrzędne"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:282
+#: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
 msgstr "Można edytować tej kolekcji i jej zawartość"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:289
+#: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
 msgstr "Można przeglądać elementy w tej kolekcji"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:749
+#: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
 msgstr "Dostęp do kolekcji"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:825
+#: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Ta grupa ma uprawnienia do wyświetlania co najmniej jeden podzbiór tej kolekcji."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:830
+#: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Ta grupa ma uprawnienia do edytowania co najmniej jeden podzbiór tej kolekcji."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
 msgstr "Wyświetl kolekcje podrzędne"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:211
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
 msgstr "Zapamiętaj mnie"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:95
+#: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
 msgstr "Prześwietl X-ray ten schemat"
 
@@ -9022,31 +9051,32 @@ msgstr "Zapisz pulpity, zapytania i kolekcje w \"{0}\""
 msgid "Access dashboards, questions, and collections in \"{0}\""
 msgstr "Dostęp do pulpitów, zapytań i kolekcji w \"{0}\""
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:221
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
 msgstr "Porównaj"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:229
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
 msgstr "Oddal"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:233
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
 msgstr "Połączone"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:293
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
 msgstr "Więcej X-rays"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:46
+#: frontend/src/metabase/home/containers/SearchApp.jsx:40
+#: src/metabase/pulse/render/body.clj
 msgid "No results"
 msgstr "Brak wyników"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:47
+#: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
 msgstr "Metabase nie może znaleźć żadnych wyników wyszukiwania."
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:111
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
 msgstr "Brak metryk"
 
@@ -9088,7 +9118,7 @@ msgstr "Nie można udzielić uprawnień: {0}"
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
 msgstr "Nie można odszyfrować zaszyfrowanego ciągu. Czy zmieniłeś lub zapomniałeś ustawić MB_ENCRYPTION_SECRET_KEY?"
 
-#: frontend/src/metabase/entities/collections.js:164
+#: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
 msgstr "Wszystkie kolekcje osobiste"
 
@@ -9253,18 +9283,18 @@ msgstr "N/A"
 msgid "Windows domain"
 msgstr "Domena systemu Windows"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:509
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:515
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:490
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:499
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
 msgstr "Etykiety"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:329
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
 msgstr "Dodawanie członków"
 
-#: frontend/src/metabase/entities/collections.js:115
+#: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
 msgstr "Kolekcja zapisana w"
 
@@ -9285,39 +9315,39 @@ msgid "Sharing"
 msgstr "Udostępnianie"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:234
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:270
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:299
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:305
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:313
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:321
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:218
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:251
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:280
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:286
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:294
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:302
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:80
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:85
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:91
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:97
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:50
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:56
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
 msgstr "Wyświetl"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:370
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:416
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:431
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:487
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:358
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:406
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:447
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
 msgstr "Osie"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:222
-#: frontend/src/metabase/admin/settings/selectors.js:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
+#: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
@@ -9351,21 +9381,21 @@ msgstr "RTG"
 msgid "Compare to the rest"
 msgstr "Porównaj z resztą"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:244
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Korzystanie z timezone wirtualnej maszyny Java (JVM)"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
 msgstr "Sugerujemy zostawić to, chyba że robisz ręczne mapowanie stref czasowych \n"
 "w wielu lub większości zapytań z tych danych."
 
-#: frontend/src/metabase/containers/Overworld.jsx:310
+#: frontend/src/metabase/containers/Overworld.jsx:312
 msgid "Your team's most important dashboards go here"
 msgstr "Tutaj trafiają najważniejsze pulpity Twojego zespołu"
 
-#: frontend/src/metabase/containers/Overworld.jsx:311
+#: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
 msgstr "Przypnij pulpit w {0} aby był dostępny z tego miejsca dla każdego"
 
@@ -9381,32 +9411,32 @@ msgstr "Użyj strefy czasowej JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Obecnie analizujemy tabele i pola aby pomóc ci w analizie twoich danych"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
 msgstr "Wskazówka:␣"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:258
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
 msgstr "Wybierz typ waluty"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:318
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
 msgstr "Typ Pola"
 
 #: frontend/src/metabase/admin/routes.jsx:109
-#: frontend/src/metabase/nav/containers/Navbar.jsx:224
+#: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
 msgstr "Kłopoty"
 
-#: frontend/src/metabase/admin/settings/selectors.js:96
+#: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
 msgstr "Włącz funkcję X-ray"
 
-#: frontend/src/metabase/admin/settings/selectors.js:323
+#: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
 msgstr "Opcje formatowania"
 
-#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:19
+#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
 msgstr "Szczegóły zadania"
 
@@ -9446,7 +9476,7 @@ msgstr "waluta"
 msgid "Pick a user or channel..."
 msgstr "Wybierze użytkownika lub kanał..."
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
+#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
 msgstr "Brak ustawień formatowania"
 
@@ -9554,33 +9584,33 @@ msgstr "HH:MM:SS.MS"
 msgid "Time style"
 msgstr "Styl czasu"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:299
+#: frontend/src/metabase/visualizations/lib/settings/column.js:300
 msgid "Unit of currency"
 msgstr "Jednostka waluty"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:319
+#: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
 msgstr "Styl etykiety waluty"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:337
+#: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
 msgstr "Gdzie wyświetlić jednostkę waluty"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:370
+#: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
 msgstr "Minimalna liczba miejsc dziesiętnych"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:271
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
 msgstr "Wykres typu skumulowany"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:314
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
 msgstr "Etykieta celu"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:322
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
-msgstr "Pokaż linię trędu"
+msgstr "Pokaż linię trendu"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:67
 msgid "Line style"
@@ -9607,7 +9637,7 @@ msgstr "Linia + Słupek"
 msgid "line and bar chart"
 msgstr "wykres słupkowo-liniowy"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:72
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
 msgstr "Wizualizacja wskaźnika wymaga numeru."
 
@@ -9615,75 +9645,75 @@ msgstr "Wizualizacja wskaźnika wymaga numeru."
 msgid "Gauge"
 msgstr "Wskaźnik"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
 msgstr "Zakres wskaźnika"
 
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
 msgstr "Pola do pokazania"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
 msgstr "ostatni {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:185
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
 msgstr "{0} było {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:52
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Grupuj według pola czasowego, aby zobaczyć, jak to się zmieniło w czasie"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
 msgstr "Zamienieć kolory dodatnie / ujemne?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
 msgstr "Kolumna przestawna"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:107
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
 msgstr "Kolumna komórki"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:123
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
 msgstr "Kolumna widoczna"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:143
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
 msgstr "Formatowanie warunkowe"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
 msgstr "Tytuł kolumny"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
 msgstr "Pokaż mini wykres słupkowy"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:183
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
 msgstr "Link"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:187
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
 msgstr "Link email"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
 msgstr "Obrak"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:195
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
 msgstr "Automatyczny"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:200
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
 msgstr "Zobacz jako link lub obraz"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
 msgstr "Tekst linku"
 
@@ -9948,7 +9978,7 @@ msgstr "Błąd wstępnego przetwarzania zapytania"
 msgid "No native form returned."
 msgstr "Nie zwrócono natywnego formularza."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
 msgstr "Nieprawidłowa odpowiedź ze sterownika bazy danych. Brak zapewnienia :status"
 
@@ -11314,7 +11344,7 @@ msgstr "Nieudana zmiana `query-caching-max-kb` na {0}."
 msgid "Values greater than {1} are not allowed."
 msgstr "Wartości większe niż {1} nie są dozwolone."
 
-#: src/metabase/query_processor/middleware/resolve_database.clj
+#: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
 msgstr "Baza danych {0} nie istnieje."
 
@@ -11363,7 +11393,7 @@ msgstr "Wyzwalacz"
 msgid "View triggers"
 msgstr "Zobacz wyzwalacz"
 
-#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:82
+#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
 msgstr "Informacje o harmonogramie"
 
@@ -11395,7 +11425,7 @@ msgstr "Ostateczny czas uruchomienia"
 msgid "May Fire Again?"
 msgstr "Uruchomić ponownie?"
 
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:75
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
 msgstr "Wyzwalacze dla {0}"
 
@@ -11407,19 +11437,19 @@ msgstr "Czynności"
 msgid "Jobs"
 msgstr "Zadania"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
 msgstr "Powielone {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:55
+#: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
 msgstr "Powiel ten element"
 
-#: frontend/src/metabase/components/EntityItem.jsx:61
+#: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
 msgstr "Zarchiwizuj ten element"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:330
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
 msgstr "Powiel pulpit"
 
@@ -11469,7 +11499,7 @@ msgstr "{0} {1} temu"
 msgid "{0} {1} from now"
 msgstr "{0} {1} od teraz"
 
-#: frontend/src/metabase/lib/query_time.js:187
+#: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
 msgstr[0] "Domyślny okres"
@@ -11477,7 +11507,7 @@ msgstr[1] "Domyślne okresy"
 msgstr[2] "Domyślne okresy"
 msgstr[3] "Domyślne okresy"
 
-#: frontend/src/metabase/lib/query_time.js:203
+#: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
 msgstr[0] "Minuta godziny"
@@ -11485,7 +11515,7 @@ msgstr[1] "Minuty godziny"
 msgstr[2] "Minuty godziny"
 msgstr[3] "Minuty godziny"
 
-#: frontend/src/metabase/lib/query_time.js:205
+#: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
 msgstr[0] "Godzina dnia"
@@ -11493,7 +11523,7 @@ msgstr[1] "Godziny dnia"
 msgstr[2] "Godziny dnia"
 msgstr[3] "Godziny dnia"
 
-#: frontend/src/metabase/lib/query_time.js:207
+#: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
 msgstr[0] "Dzień tygodnia"
@@ -11501,7 +11531,7 @@ msgstr[1] "Dni tygodnia"
 msgstr[2] "Dni tygodnia"
 msgstr[3] "Dni tygodnia"
 
-#: frontend/src/metabase/lib/query_time.js:209
+#: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
 msgstr[0] "Dzień miesiąca"
@@ -11509,7 +11539,7 @@ msgstr[1] "Dni miesiąca"
 msgstr[2] "Dni miesiąca"
 msgstr[3] "Dni miesiąca"
 
-#: frontend/src/metabase/lib/query_time.js:211
+#: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
 msgstr[0] "Dzień roku"
@@ -11517,7 +11547,7 @@ msgstr[1] "Dni roku"
 msgstr[2] "Dni roku"
 msgstr[3] "Dni roku"
 
-#: frontend/src/metabase/lib/query_time.js:213
+#: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
 msgstr[0] "Tydzień roku"
@@ -11525,7 +11555,7 @@ msgstr[1] "Tygodnie roku"
 msgstr[2] "Tygodni roku"
 msgstr[3] "Tygodni roku"
 
-#: frontend/src/metabase/lib/query_time.js:215
+#: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
 msgstr[0] "Miesiąc roku"
@@ -11533,7 +11563,7 @@ msgstr[1] "Miesiące roku"
 msgstr[2] "Miesięcy roku"
 msgstr[3] "Miesięcy roku"
 
-#: frontend/src/metabase/lib/query_time.js:217
+#: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "Kwartał roku"
@@ -11541,9 +11571,10 @@ msgstr[1] "Kwartały roku"
 msgstr[2] "Kwartałów roku"
 msgstr[3] "Kwartałów roku"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:79
+#: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} wybór"
@@ -11559,20 +11590,20 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "To"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:64
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
 msgstr "Niepoprawne"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:147
+#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
 msgstr "Dodaj czas"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:170
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
 msgstr "Nic do porównania dla poprzedniego {0}."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:517
+#: frontend/src/metabase-lib/lib/Dimension.js:678
 msgid "by {0}"
 msgstr "przez {0}"
 
@@ -11806,7 +11837,8 @@ msgstr "Wtyczka \"{0}\" zależy od wtyczki \"{1}\""
 
 #: src/metabase/plugins/dependencies.clj
 msgid "{0} dependency {1} satisfied? {2}"
-msgstr "{0} zależności {1} zadowolony? {2}"
+msgstr "{0} zależności {1} zadowolony? {2}\n"
+""
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugins with unsatisfied deps: {0}"
@@ -11866,35 +11898,35 @@ msgstr "Rejestrowanie sterownika lazy loading {0}"
 msgid "Error running query for Card {0}"
 msgstr "Błąd podczas uruchamiania zapytania o Kartę {0}"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
 msgstr "Ostatni tydzień"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This week"
 msgstr "Ten tydzień"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
 msgstr "Ostatni miesiąc"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This month"
 msgstr "Ten miesiąc"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
 msgstr "Ostatni kwartał"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
 msgstr "Ten kwartał"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
 msgstr "Ostatni rok"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This year"
 msgstr "Ten rok"
 
@@ -12141,7 +12173,7 @@ msgid "[[CreateDate]] by quarter of the year"
 msgstr "[[CreateDate]] według kwartału roku"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:200
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
 msgstr "Edytuj użytkownika"
 
@@ -12149,12 +12181,12 @@ msgstr "Edytuj użytkownika"
 msgid "New user"
 msgstr "Nowy użytkownik"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
 msgstr "Zresetuj hasło"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:209
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
 msgstr "Dezaktywuj użytkownika"
 
@@ -12166,40 +12198,40 @@ msgstr "Aktywuj ponownie {0}?"
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
 msgstr "Nie mogliśmy wysłać im zaproszenia e-mailowego, więc poinformuj ich, aby zalogowali się przy użyciu {0} i wygenerowanego hasła:"
 
-#: frontend/src/metabase/entities/collections.js:21
+#: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
 msgstr "kolekcja"
 
-#: frontend/src/metabase/entities/collections.js:22
+#: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
 msgstr "kolekcje"
 
-#: frontend/src/metabase/entities/dashboards.js:29
+#: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
 msgstr "pulpit"
 
-#: frontend/src/metabase/entities/dashboards.js:30
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
 msgstr "pulpity"
 
-#: frontend/src/metabase/entities/users.js:125
+#: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
 msgstr "Pierwsze imię jest wymagane"
 
-#: frontend/src/metabase/entities/users.js:126
-#: frontend/src/metabase/entities/users.js:133
+#: frontend/src/metabase/entities/users.js:38
+#: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
 msgstr "Musi mieć co najmniej 100 znaków"
 
-#: frontend/src/metabase/entities/users.js:132
+#: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
 msgstr "Nazwisko jest wymagane"
 
-#: frontend/src/metabase/entities/users.js:138
+#: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
 msgstr "email jest wymagany"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:90
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
 msgstr "Zarchiwizowane elementy pojawią się tutaj."
 
@@ -12207,11 +12239,11 @@ msgstr "Zarchiwizowane elementy pojawią się tutaj."
 msgid "No description"
 msgstr "Bez opisu"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:175
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
 msgstr "Suma wszystkich wartości"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:183
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
 msgstr "Zobacz wszystkie unikalne wartości"
 
@@ -12412,14 +12444,785 @@ msgstr "Dodawanie użytkownika {0} do grupy uprawnień All Users ..."
 msgid "Adding User {0} to Admin permissions group..."
 msgstr "Dodawanie użytkownika {0} do grupy uprawnień Admin  ..."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
 msgstr "Błąd zapytania"
 
-#: src/metabase/query_processor/async.clj
+#: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
 msgstr "Maksymalna liczba równoczesnych zapytań umożliwiających połączenie z bazą danych."
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
 msgstr "Przekroczono limit czasu po {0} milisekundach."
+
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
+msgid "Misfire Instruction"
+msgstr "Instrukcja niewypału"
+
+#: frontend/src/metabase/components/ArchiveModal.jsx:31
+msgid "Archive this?"
+msgstr "Zarchiwizować to?"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:244
+msgid "Learn about our data"
+msgstr "Dowiedz się o naszych danych"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
+msgid "Use DNS SRV when connecting"
+msgstr "Użyj  przy połączeniu DNS SRV"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
+msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
+"an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
+"leave this disabled."
+msgstr "Korzystanie z tej opcji wymaga, aby podany host był nazwą FQDN. Jeśli łączysz się z Atlas Cluster, może być konieczne włączenie tej opcji. Jeśli nie wiesz co to znaczy,\n"
+"pozostaw to wyłączone."
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
+msgid "Automatically run queries when doing simple filtering and summarizing"
+msgstr "Automatycznie uruchamiaj zapytania podczas prostego filtrowania i podsumowywania"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr "Po włączeniu tej opcji Metabasa automatycznie uruchamia zapytania, gdy użytkownicy wykonują proste eksploracje za pomocą przycisków Podsumuj i Filtruj podczas przeglądania tabeli lub wykresu. Możesz to wyłączyć, jeśli odpytywanie tej bazy danych jest powolne. To ustawienie nie wpływa na drążenie wszerz lub zapytania SQL."
+
+#: frontend/src/metabase/containers/Overworld.jsx:247
+msgid "Learn about this database"
+msgstr "Dowiedz się o tej bazie danych"
+
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+msgid "Archive this dashboard?"
+msgstr "Zarchiwizować ten pulpit?"
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:113
+msgid "All results"
+msgstr "Wszystkie wyniki"
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:180
+msgid "Our Analytics"
+msgstr "Nasze Analizy"
+
+#: frontend/src/metabase/lib/schema_metadata.js:500
+msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
+msgstr "Całkowita suma wszystkich wartości kolumny. \\ne.x. przychody ogółem w czasie."
+
+#: frontend/src/metabase/lib/schema_metadata.js:508
+msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
+msgstr "Całkowita liczba wierszy. \\ne.x. łączna liczba sprzedaży w czasie."
+
+#: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
+msgid "Filter"
+msgstr "Filtr"
+
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+msgid "record"
+msgid_plural "records"
+msgstr[0] "rekord"
+msgstr[1] "rekordy"
+msgstr[2] "rekordy"
+msgstr[3] "rekordy"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:346
+msgid "Browse Data"
+msgstr "Przeglądaj Dane"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:376
+msgid "Write SQL"
+msgstr "Napis SQL"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
+msgid "Simple question"
+msgstr "Proste pytanie"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
+msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
+msgstr "Wybierz niektóre dane, wyświetl je i łatwo filtruj, podsumowuj i wizualizuj."
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
+msgid "Custom question"
+msgstr "Niestandardowe zapytanie"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
+msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
+msgstr "Korzystaj z zaawansowanego edytora notatników, aby łączyć dane, tworzyć niestandardowe kolumny, wykonywać matematykę i wykonywać inne czynności."
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+msgid "Basic Metrics"
+msgstr "Podstawowe Metryki"
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+msgid "Custom…"
+msgstr "Własne..."
+
+#: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
+msgid "Add grouping"
+msgstr "Grupuj"
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
+msgid "Pick a limit"
+msgstr "Wybierz limit"
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
+msgid "Show maximum"
+msgstr "Pokaż maksimum"
+
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
+msgid "Get Preview"
+msgstr "Pokaż Podgląd"
+
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
+msgid "Back to previous results"
+msgstr "Cofnij do poprzednich wyników"
+
+#: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
+msgid "Sample values"
+msgstr "Przykładowe wartości"
+
+#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
+msgstr "Przeglądaj zawartość swoich baz danych, tabel i kolumn. Wybierz bazę danych, aby rozpocząć."
+
+#: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
+msgid "Visualize"
+msgstr "Wizualizuj"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
+msgid "Join data"
+msgstr "Połącz dane"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
+msgid "Custom column"
+msgstr "Własna kolumna"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
+msgid "Summarize"
+msgstr "Podsumuj"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
+msgid "Aggregate"
+msgstr "Agreguj"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
+msgid "Breakout"
+msgstr "Breakout"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
+msgid "Pick the metric you want to see"
+msgstr "Wybierz dane, które chcesz zobaczyć"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
+#: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
+msgid "Pick a column to group by"
+msgstr "Wybierz kolumnę grupowania"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
+msgid "Pick your starting data"
+msgstr "Wybierz początkowe dane"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select None"
+msgstr "Wybierz Brak"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select All"
+msgstr "Zaznacz wszystko"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
+msgid "Pick a table..."
+msgstr "Wybierz tabelę..."
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
+msgid "Enter a limit"
+msgstr "Wprowadź limit"
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
+msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
+msgstr "Nawiasy wokół {0} tworzą opcjonalną klauzulę w szablonie. Jeśli ustawiona jest \"variable\" (zmienna), cała klauzula jest umieszczana w szablonie. Jeśli nie, cała klauzula jest ignorowana."
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
+msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
+msgstr "Podczas korzystania z filtru pola nazwa kolumny nie powinna być uwzględniona w kodzie SQL. Zamiast tego zmienną należy odwzorować na pole w panelu bocznym."
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
+msgid "View the native query"
+msgstr "Wyświetl natywne zapytanie"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
+msgid "Native query for this question"
+msgstr "Natywne zapytanie dla tego pytania"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
+msgid "Convert this question to a native query"
+msgstr "Przekształć to pytanie w natywne zapytanie"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
+msgid "SQL for this question"
+msgstr "SQL dla tego zapytania"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
+msgid "Convert this question to SQL"
+msgstr "Konwertuj to zapytanie na SQL"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
+msgid "Get alerts"
+msgstr "Otrzymuj powiadomienia"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
+msgid "{0} breakout"
+msgid_plural "{0} breakouts"
+msgstr[0] "{0} breakout"
+msgstr[1] "{0} breakouts"
+msgstr[2] "{0} breakouts"
+msgstr[3] "{0} breakouts"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
+msgid "Hide filters"
+msgstr "Ukryj filtry"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
+msgid "Show filters"
+msgstr "Pokaż filtry"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
+msgid "Started from"
+msgstr "Zacznij od"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
+msgid "{0} row"
+msgid_plural "{0} rows"
+msgstr[0] "{0} wiersz"
+msgstr[1] "{0} wierszy"
+msgstr[2] "{0} wierszy"
+msgstr[3] "{0} wierszy"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
+msgid "Show all rows"
+msgstr "Pokaż wszystkie wiersze"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
+msgid "Show {0}"
+msgstr "Pokaż {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
+msgid "Showing first {0}"
+msgstr "Pokazuje pierwsze {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
+msgid "Showing {0}"
+msgstr "Pokazuje {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
+msgid "Summarized"
+msgstr "Streszczony"
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Hide editor"
+msgstr "Ukryj edytor"
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Show editor"
+msgstr "Pokaż edytor"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
+msgid "Pick the metric you'd like to see"
+msgstr "Wybierz dane, które chcesz zobaczyć"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
+msgid "{0} options"
+msgstr "{0} opcji"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
+msgid "Choose a visualization"
+msgstr "Wybierz wizualizację"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
+msgid "Filter by"
+msgstr "Fitruj po"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+msgid "Summarize by"
+msgstr "Sumuj po"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+msgid "Group by"
+msgstr "Grupuj po"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+msgid "Add a metric"
+msgstr "Dodaj metrykę"
+
+#: frontend/src/metabase/user/components/UserSettings.jsx:57
+msgid "Profile"
+msgstr "Profil"
+
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:548
+msgid "This is usually pretty fast but seems to be taking a while right now."
+msgstr "Zazwyczaj jest to dość szybkie, ale wydaje się, że zajmuje to teraz trochę czasu."
+
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
+msgid "Combo"
+msgstr "Combo"
+
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
+msgid "Row"
+msgstr "wiersz"
+
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
+msgid "Trend"
+msgstr "Trend"
+
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:129
+msgid "Boolean"
+msgstr "Boolean"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+msgid "Unknown Segment"
+msgstr "Nieznany Segment"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+msgid "Unknown Filter"
+msgstr "Nieznany Filtr"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
+msgid "Left outer join"
+msgstr "Left outer join"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
+msgid "Right outer join"
+msgstr " Right outer join"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
+msgid "Inner join"
+msgstr "Inner join"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
+msgid "Full outer join"
+msgstr "Full outer join"
+
+#: src/metabase/api/card.clj
+msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
+msgstr "Brak metadanych wyników karty przekazywanych do interfejsu API. Uruchamianie zapytania w celu pobrania poprawnych metadanych."
+
+#: src/metabase/api/session.clj
+msgid "Problem connecting to LDAP server, will fall back to local authentication"
+msgstr "Problem z połączeniem z serwerem LDAP, nastąpi powrót do lokalnego uwierzytelnienia"
+
+#: src/metabase/api/setup.clj
+msgid "Cannot create Database: cannot find driver {0}."
+msgstr "Nie można utworzyć bazy danych: nie można znaleźć sterownika {0}."
+
+#: src/metabase/api/tiles.clj
+msgid "Query failed"
+msgstr "Zapytanie nie powiodło się"
+
+#: src/metabase/async/util.clj
+msgid "Warning: {0} returned `nil`"
+msgstr "Ostrzeżenie: {0} zwrócił  `nil`"
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing result to output channel: already closed"
+msgstr "Nieoczekiwany błąd zapisu wyniku do kanału wyjściowego: już zamknięty"
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing exception to output channel: already closed"
+msgstr "Nieoczekiwany błąd zapisu wyjątku do kanału wyjściowego: już zamknięty"
+
+#: src/metabase/async/util.clj
+msgid "Request canceled, canceling future."
+msgstr "Żądanie anulowane, anulowanie w przyszłości."
+
+#: src/metabase/cmd/load_from_h2.clj
+msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
+msgstr "Metabaza może przesyłać dane tylko z H2 do Postgres lub MySQL / MariaDB."
+
+#: src/metabase/db.clj
+msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
+msgstr "OSTRZEŻENIE: Używanie Metabazy z bazą danych aplikacji H2 nie jest zalecane w przypadku wdrożeń produkcyjnych."
+
+#: src/metabase/db.clj
+msgid "Application database setup"
+msgstr "Konfiguracja bazy danych aplikacji"
+
+#: src/metabase/driver.clj
+msgid "Could not find {0} driver."
+msgstr "Nie można znaleźć sterownika {0}."
+
+#: src/metabase/driver.clj
+msgid "Abstract drivers cannot derive from concrete parent drivers."
+msgstr "Sterowniki abstrakcyjne nie mogą pochodzić od konkretnych sterowników nadrzędnych."
+
+#: src/metabase/driver/mysql.clj
+msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
+msgstr "Konieczne może być dodanie „trustServerCertificate = true” do dodatkowych opcji połączenia w celu połączenia za pomocą protokołu SSL."
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifer."
+msgstr "Nie wiadomo jak aliasować {0}, oczekiwano identyfikatora."
+
+#: src/metabase/driver/sql_jdbc/execute.clj
+msgid "Client closed connection, canceling query"
+msgstr "Połączenie zamknięte klienta, anulowanie zapytania"
+
+#: src/metabase/integrations/ldap.clj
+msgid "{0} is not a valid DN."
+msgstr "{0} nie jest prawidłową nazwą wyróżniającą."
+
+#: src/metabase/middleware/log.clj
+msgid "Error logging API request"
+msgstr "Błąd rejestrowania żądania interfejsu API"
+
+#: src/metabase/middleware/misc.clj
+msgid "Failed to set site-url"
+msgstr "Nie udało się ustawić adresu strony"
+
+#: src/metabase/models/database.clj
+msgid "Error destroying thread pool for DB."
+msgstr "Błąd podczas niszczenia puli wątków dla bazy danych."
+
+#: src/metabase/models/humanization.clj
+msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
+msgstr "Aktualizowanie nazwy wyświetlanej dla {0} ''{1}'': ''{2}'' -> ''{3}''\n"
+""
+
+#: src/metabase/models/humanization.clj
+msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
+msgstr "Nieprawidłowa strategia humanizacji \"{0}\". Prawidłowe strategie to: \"{1}\""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr "Zmiana strategii humanizacji nazw tabel i pól z \"{0}\" na \"{1}\""
+
+#: src/metabase/models/task_history.clj src/metabase/sync/util.clj
+msgid "Error saving task history"
+msgstr "Błąd podczas zapisywania historii zadań"
+
+#: src/metabase/plugins.clj
+msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
+msgstr "Spark-deps.jar nie jest już wymagany przez Metabase 0.32.0+. Możesz usunąć go z katalogu wtyczek."
+
+#: src/metabase/plugins/classloader.clj
+msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
+msgstr "Używanie NOWO TWORZONEGO modułu ładującego klasy jako modułu współdzielonego kontekstowego modułu ładującego: {0}"
+
+#: src/metabase/plugins/files.clj
+msgid "Failed to copy file"
+msgstr "Nie udało się skopiować pliku"
+
+#: src/metabase/public_settings.clj
+msgid "Invalid site URL: {0}"
+msgstr "Nieprawidłowy adres URL witryny: {0}"
+
+#: src/metabase/public_settings.clj
+msgid "site-url is invalid; returning nil for now. Will be reset on next request."
+msgstr "adres strony jest nieprawidłowy; powracając na razie zero. Zostanie zresetowany na następne żądanie."
+
+#: src/metabase/pulse/render/body.clj
+msgid "More results have been included as a file attachment"
+msgstr "Więcej wyników zostało dołączonych jako załącznik pliku"
+
+#: src/metabase/pulse/render/body.clj
+msgid "This question has been included as a file attachment"
+msgstr "To pytanie zostało dołączone jako załącznik pliku"
+
+#: src/metabase/pulse/render/body.clj
+msgid "We were unable to display this Pulse."
+msgstr "Nie byliśmy w stanie wyświetlić tego Pulsu."
+
+#: src/metabase/pulse/render/body.clj
+msgid "Please view this card in Metabase."
+msgstr "Zobacz tę kartę w Metabase."
+
+#: src/metabase/pulse/render/body.clj
+msgid "An error occurred while displaying this card."
+msgstr "Wystąpił błąd podczas wyświetlania tej karty."
+
+#: src/metabase/query_processor.clj
+msgid "Can only determine expected columns for MBQL queries."
+msgstr "Można określić tylko oczekiwane kolumny dla zapytań MBQL."
+
+#: src/metabase/query_processor.clj
+msgid "No columns returned."
+msgstr "Nie zwrócono żadnych kolumn."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr "Ostrzeżenie: nie można określić pól dla jawnego zapytania `source-query` , chyba że podasz także `source-metadata`."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
+msgstr "Nie można rozwiązać {0}: pole nie istnieje lub jego tabela należy do innej bazy danych."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
+msgstr "Nie można rozwiązać :field-literal inside :fk->  chyba, że wewnątrz łączy się z jawnym :alias."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot find Table ID for {0}"
+msgstr "Nie można znaleźć identyfikatora tabeli dla {0}"
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "No matching info found."
+msgstr "Nie znaleziono pasujących informacji."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Could not resolve {0}"
+msgstr "Nie można rozwiązać {0}"
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Invalid fk-> clause: nowhere to add corresponding join."
+msgstr "Niepoprawna klauzula fk->: nigdzie nie można dodać odpowiadającego sprzężenia."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "{0} driver does not support foreign keys."
+msgstr "Sterownik {0} nie obsługuje kluczy obcych."
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
+msgstr "Nie można wnioskować `:source-metadata` dla zapytania źródłowego z natywnym zapytaniem źródłowym bez metadanych źródłowych."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Query processor error: number of columns returned by driver does not match results."
+msgstr "Błąd procesora zapytań: liczba kolumn zwróconych przez sterownik nie zgadza się z wynikami."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Expected {0} columns, but first row of resuls has {1} columns."
+msgstr "Oczekiwano {0} kolumn, ale pierwszy wiersz rezulsów ma {1} kolumn."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "No expression named {0} found. Found: {1}"
+msgstr "Nie znaleziono wyrażenia o nazwie {0}. Znaleziono: {1}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Distinct values of {0}"
+msgstr "Unikalne wartości {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Average of {0}"
+msgstr "Średnia z {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0}"
+msgstr "Suma z {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "SD of {0}"
+msgstr "Standardowe odchylenie z {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Min of {0}"
+msgstr "Min z {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Max of {0}"
+msgstr "Max z {0}"
+
+#. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0} matching condition"
+msgstr "Suma {0} pasujących warunków"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Share of rows matching condition"
+msgstr "Udział wierszy spełniających warunek"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Count of rows matching condition"
+msgstr "Liczba wierszy spełniających warunek"
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Request already canceled, will not run synchronous QP code."
+msgstr "Żądanie już anulowane, nie uruchomi synchronicznego kodu QP."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unexpectedly got `nil` Query Processor response."
+msgstr "Nieoczekiwanie otrzymano odpowiedź `nil` z  procesora zapytań."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Got InterruptedException. Canceling query."
+msgstr "Otrzymano InterruptedException. Anulowanie zapytania."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
+msgstr "Nieobsługiwany wyjątek, oczekiwane oprogramowanie pośredniczące `catch-exceptions`."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Query timed out after %s"
+msgstr "Przekroczono limit czasu zapytania po %s"
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Creating new query thread pool for Database {0}"
+msgstr "Tworzenie nowej puli wątków zapytania dla bazy danych {0}"
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Destroying query thread pool for Database {0}"
+msgstr "Niszczenie puli wątków zapytań dla bazy danych {0}"
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Request canceled, canceling pending query"
+msgstr "Żądanie anulowane, anulowanie oczekującego zapytania"
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: query is missing source-metadata"
+msgstr "Nie można zaktualizować pola binned: w zapytaniu brakuje metadanych źródłowych"
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
+msgstr "Nie można zaktualizować binned pola: nie można znaleźć pasujących metadanych źródłowych dla pola \"{0}\""
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Using query processor cache backend: {0}"
+msgstr "Korzystanie z wewnętrznej pamięci podręcznej procesora zapytań: {0}"
+
+#: src/metabase/query_processor/middleware/expand_macros.clj
+msgid "Invalid metric: {0} reason: {1}"
+msgstr "Nieprawidłowe dane: powód {0}: {1}"
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unknown error"
+msgstr "Nieznany błąd"
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unexpected nil response from query processor."
+msgstr "Nieoczekiwana zero odpowiedź procesora zapytań."
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Query canceled"
+msgstr "Zapytanie anulowane"
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
+msgstr "Nie można rozpoznać sterownika dla zapytania: brakujący lub nieprawidłowy identyfikator `: database`."
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: Database {0} does not exist."
+msgstr "Nie można rozpoznać sterownika dla zapytania: Baza danych {0} nie istnieje."
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr "Nie można użyć: pola: wszystkie w sprzężeniu z zapytaniem źródłowym, chyba że ma :source-metadata."
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
+msgstr "Źle :joined-field clause: join with alias ''{0}'' nie istnieje. Znaleziono: {1}"
+
+#: src/metabase/query_processor/middleware/resolve_source_table.clj
+msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
+msgstr "Nieprawidłowy: tabela-źródłowa \"{0}\": do tej pory powinna zostać rozpoznana jako identyfikator tabeli."
+
+#: src/metabase/query_processor/store.clj
+msgid "Cannot store Tables or Fields before Database is stored."
+msgstr "Nie można przechowywać tabel ani pól przed zapisaniem bazy danych."
+
+#: src/metabase/query_processor/store.clj
+msgid "Attempting to fetch second Database. Queries can only reference one Database."
+msgstr "Próba pobrania drugiej bazy danych. Zapytania mogą odnosić się tylko do jednej bazy danych."
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
+msgstr "Nie udało się pobrać tabeli {0}: tabela nie istnieje lub należy do innej bazy danych."
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
+msgstr "Nie udało się pobrać pola {0}: pole nie istnieje lub należy do innej bazy danych."
+
+#: src/metabase/routes/index.clj
+msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
+msgstr "Nie udało się załadować szablonu {0}. Pamiętasz, jak zbudować nakładkę Metabase?"
+
+#: src/metabase/sample_data.clj
+msgid "Sample dataset DB file ''{0}'' cannot be found."
+msgstr "Nie można znaleźć przykładowego pliku bazy danych \"{0}\"."
+
+#: src/metabase/sample_data.clj
+msgid "Loading sample dataset..."
+msgstr "Ładowanie przykładowego zestawu danych ..."
+
+#: src/metabase/sample_data.clj
+msgid "Failed to load sample dataset"
+msgstr "Nie udało się załadować przykładowego zestawu danych"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Found new tables:"
+msgstr "Znaleziono nowe tabele:"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Marking tables as inactive:"
+msgstr "Oznaczanie tabel jako nieaktywne:"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Updating description for tables:"
+msgstr "Aktualizacja opisu tabel:"
+
+#: src/metabase/task.clj
+msgid "Rescheduling job {0}"
+msgstr "Zmiana harmonogramu zadania {0}"
+
+#: src/metabase/task.clj
+msgid "Error rescheduling job"
+msgstr "Błąd zmiany harmonogramu zadania"
+
+#: src/metabase/task/send_pulses.clj
+msgid "Starting Pulse Execution: {0}"
+msgstr "Rozpoczęcie wykonywania Pulsu: {0}"
+
+#: src/metabase/task/send_pulses.clj
+msgid "Finished Pulse Execution: {0}"
+msgstr "Zakończone wykonanie Pulsu: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Failed to schedule tasks for Database {0}"
+msgstr "Nie udało się zaplanować zadań dla bazy danych {0}"
+
+#: src/metabase/util/schema.clj
+msgid "All elements must be distinct."
+msgstr "Wszystkie elementy muszą być unikalne."
+
+#: 
+msgctxt "Modal for selecting columns in source data or when doing a join."
+msgid "Pick the columns you want to include"
+msgstr "Wybierz kolumny, które chcesz uwzględnić"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr "Gdy ta opcja jest włączona, Metabase automatycznie uruchamia zapytania, gdy użytkownicy wykonują proste eksploracje za pomocą przycisków Podsumuj i Filtruj podczas przeglądania tabeli lub wykresu. Możesz to wyłączyć, jeśli odpytywanie tej bazy danych jest powolne. To ustawienie nie wpływa na drążenie wszerz lub zapytania SQL."
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
+msgid "Change join type"
+msgstr "Zmień typ złączenia"
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifier."
+msgstr "Nie wiem jak aliasować {0}, oczekiwano identyfikatora."
+
+#: src/metabase/integrations/common.clj
+msgid "Error adding User {0} to Group {1}"
+msgstr "Błąd podczas dodawania użytkownika {0} do grupy {1}"
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr "Zmiana strategii humanizacji nazw tabel i pól z \"{0}\" na \"{1}\""
+
+#: src/metabase/query_processor.clj
+msgid "Infinite loop detected: recursively preprocessed query {0} times."
+msgstr "Wykryto nieskończoną pętlę: zapytanie rekursywnie wstępnie przetworzone {0} razy."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr "Ostrzeżenie: nie można określić pól dla jawnego zapytania „”, chyba że podasz także „metadane źródłowe”."
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Error determining expected columns for query"
+msgstr "Błąd podczas określania oczekiwanych kolumn dla zapytania"
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
+msgstr "Nieobsługiwany wyjątek, oczekiwane oprogramowanie pośredniczące `catch-exceptions`  do obsługi."
+

--- a/locales/pt.po
+++ b/locales/pt.po
@@ -28,18 +28,19 @@ msgstr "Explorar esses dados"
 msgid "Select a database type"
 msgstr "Selecione um tipo de banco de dados"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:75
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:401
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:71
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:182
+#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:410
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:74
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:203
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:180
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:197
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:193
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:171
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:180
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:164
 msgid "Save"
 msgstr "Salvar"
@@ -59,7 +60,7 @@ msgid "This is a lightweight process that checks for\n"
 msgstr "Este é um processo rápido que procura atualizações no esquema deste banco de dados. Na maior parte dos casos, tudo bem você deixar isso configurado para sincronizar de hora em hora."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:184
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
 msgid "Scan"
 msgstr "Escanear"
 
@@ -75,128 +76,130 @@ msgid "Metabase can scan the values present in each\n"
 msgstr "Metabase pode varrer os valores presentes em cada \n"
 "campo neste banco de dados para ativar filtros checkbox em painéis e perguntas. Isso pode ser um processo que consome muitos recursos, especialmente se você tiver um banco de dados grande."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:159
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Quando o Metabase deve verificar e armazenar automaticamente os valores dos campos?"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:164
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
 msgstr "Regularmente, seguindo um cronograma"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:195
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
 msgstr "Somente quando um novo elemento de filtro é adicionado"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:199
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
 msgstr "Quando um usuário adicionar um novo filtro a um dashboard ou a uma questão SQL, Metabase irá examinar o(s) campo(s) mapeado(s) para tal filtro, para mostrar a lista de valores selecionáveis "
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:210
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
 msgid "Never, I'll do this manually if I need to"
 msgstr "Nunca, eu farei isto manualmente se precisar"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:222
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:222
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:426
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
 msgid "Saving..."
 msgstr "Salvando..."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:39
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
 msgid "Server error encountered"
 msgstr "Um erro foi encontrado no servidor"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:58
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
 msgstr "Excluir este banco de dados?"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
 msgstr "Todas as questões, métricas e segmentos que dependem desse banco de dados será perdido"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:67
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
 msgstr "Esta ação não pode ser desfeita."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
 msgstr "Se tiver a certeza, por favor digite:"
 
 #. O comando para remover é DELETE, se traduzir este comando, o Metabase não irá habilitar a remoção de itens.
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:53
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
 msgstr "DELETE"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:71
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
 msgstr "nesta caixa:"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:82
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:50
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:93
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:58
-#: frontend/src/metabase/admin/permissions/selectors.js:160
-#: frontend/src/metabase/admin/permissions/selectors.js:170
-#: frontend/src/metabase/admin/permissions/selectors.js:185
-#: frontend/src/metabase/admin/permissions/selectors.js:224
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:355
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:181
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:247
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:61
+#: frontend/src/metabase/admin/permissions/selectors.js:163
+#: frontend/src/metabase/admin/permissions/selectors.js:173
+#: frontend/src/metabase/admin/permissions/selectors.js:188
+#: frontend/src/metabase/admin/permissions/selectors.js:227
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:202
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:268
+#: frontend/src/metabase/components/ArchiveModal.jsx:35
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
-#: frontend/src/metabase/components/form/StandardForm.jsx:61
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:196
+#: frontend/src/metabase/components/form/StandardForm.jsx:62
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:198
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:289
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:162
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:153
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:38
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:189
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:24
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:48
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:41
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:92
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:259
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:88
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:121
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:132
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
 msgstr "Excluir"
 
 #. Existem alguns campos traduzidos como Bancos de dados e outros como base de dados. Para seguir o padrão, ajustei para Banco de dados
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:128
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:74
-#: frontend/src/metabase/admin/permissions/selectors.js:320
-#: frontend/src/metabase/admin/permissions/selectors.js:327
-#: frontend/src/metabase/admin/permissions/selectors.js:423
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
+#: frontend/src/metabase/admin/permissions/selectors.js:323
+#: frontend/src/metabase/admin/permissions/selectors.js:330
+#: frontend/src/metabase/admin/permissions/selectors.js:426
 #: frontend/src/metabase/admin/routes.jsx:53
-#: frontend/src/metabase/nav/containers/Navbar.jsx:214
+#: frontend/src/metabase/nav/containers/Navbar.jsx:243
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
 msgstr "Bancos de Dados"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:129
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
 msgstr "Adicionar banco de dados"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
 msgstr "Conexão"
@@ -205,107 +208,107 @@ msgstr "Conexão"
 msgid "Scheduling"
 msgstr "Agendamento"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:78
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:84
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:26
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:221
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
 msgstr "Salvar alterações"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:185
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:38
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:38
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
 msgstr "Ações"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:193
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
 msgstr "Sincronize o esquema do banco de dados agora"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:194
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:206
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:109
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
 msgstr "Iniciando..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:195
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
 msgstr "Não foi possível sincronizar"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
 msgstr "Sincronização iniciada!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:205
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
 msgstr "Verificar novamente os valores do campo agora"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:207
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
 msgstr "A verificação não pôde ser iniciada"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
 msgstr "Verificação começou!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:215
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:401
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
 msgstr "Zona Perigosa"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:221
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
 msgstr "Descartar valores de campo salvos"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
 msgstr "Remover este banco de dados"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:73
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
 msgstr "Adicionar banco de dados"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:85
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:36
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:36
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:122
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:32
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:399
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:446
 #: frontend/src/metabase/containers/EntitySearch.jsx:26
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:218
-#: frontend/src/metabase/entities/collections.js:93
-#: frontend/src/metabase/entities/dashboards.js:145
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:461
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:81
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:220
+#: frontend/src/metabase/entities/collections.js:94
+#: frontend/src/metabase/entities/dashboards.js:142
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
 msgstr "Nome"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:86
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
 msgstr "Engine"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:115
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
 msgstr "Removendo..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:145
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
 msgstr "Carregando..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:161
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
 msgstr "Recuperar o conjunto de dados de exemplo"
 
@@ -322,9 +325,9 @@ msgid "Successfully saved!"
 msgstr "Salvo com sucesso!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:177
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:197
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
 msgstr "Editar"
@@ -333,87 +336,91 @@ msgstr "Editar"
 msgid "Revision History"
 msgstr "Histórico de Revisão"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
 msgstr "Remover este {0}?"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
 msgstr "Perguntas gravadas e outras coisas que dependem disso {0} continuarão em execução, mas este {1} não pode mais ser selecionado no editor de consultas"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
 msgstr "Se tiver certeza de que deseja remover este {0}, escreva uma explicação do porquê o que está sendo removido:"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
 msgstr "Isso será mostrado no resumo da atividade e em um email que ele será enviado para qualquer pessoa da sua equipe que tenha criado algo que eles usem isso {0}."
 
 #. I guess this translation is not accurate. In what context does it occur?
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
 msgstr "Retirar"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
 msgstr "Retirando ..."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
 msgstr "Falhou"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
 msgstr "Sucesso"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:91
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
+#: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Pré-visualizar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
 msgstr "Não há descrição da coluna"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:135
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
 msgstr "Selecione uma visibilidade de campo"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:210
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
 msgstr "Sem tipo especial"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:211
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:148
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
 msgstr "Outro"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:231
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Selecione um tipo especial"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:277
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
 msgstr "Selecione uma referência"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:77
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:89
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:106
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:122
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
 msgstr "Colunas"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Coluna"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:121
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:306
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
 msgstr "Visibilidade"
 
@@ -421,53 +428,53 @@ msgstr "Visibilidade"
 msgid "Type"
 msgstr "Tipo"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
 msgstr "Banco de dados atual:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
 msgstr "Mostrar esquema original"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:45
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
 msgstr "Tipo de Dado"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
 msgstr "Informação adicional"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
 msgstr "Encontre um esquema"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:51
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "{0} esquema"
 msgstr[1] "{0} esquemas"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
 msgstr "Por que esconder isso?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
 msgstr "Dados técnicos"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
 msgstr "Irrelevante"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
 msgid "Queryable"
 msgstr "Consultável"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:91
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
 msgstr "Oculto"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
 msgstr "Não há descrição da tabela"
 
@@ -475,65 +482,67 @@ msgstr "Não há descrição da tabela"
 msgid "Metadata Strength"
 msgstr "Força dos metadados"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} Tabela Consultável"
 msgstr[1] "{0} Tabelas Consultáveis"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:96
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} Tabela Escondida"
 msgstr[1] "{0} Tabelas Escondidas"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
 msgstr "Encontre uma tabela"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
 msgstr "Esquemas"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:24
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:137
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:68
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:56
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:190
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
 msgstr "Métricas"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
 msgstr "Adicione uma métrica"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:37
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Definição"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Crie métricas para adicionar ao menu Visualizar no editor de consultas"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:24
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:930
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:952
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:56
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segmentos"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
 msgstr "Adicionar um segmento"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Criar segmentos para adicionar ao menu Filtro no editor de consultas"
 
@@ -561,53 +570,53 @@ msgstr "editado em "
 msgid "made some changes"
 msgstr "fez algumas alterações"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
-#: frontend/src/metabase/home/components/Activity.jsx:80
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:332
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/home/components/Activity.jsx:82
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
 msgstr "Você"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
 msgstr "Modelo de dados"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
 msgstr " História"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:48
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
 msgstr "Histórico de revisão para"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:239
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
 msgstr "{0} - configuração"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
 msgstr "Onde este campo aparecerá no Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:329
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Filtrando neste campo"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Quando esse campo é usado em um filtro, quais valores ele deve aceitar?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:453
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Ainda não há descrição para este campo"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:379
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
 msgstr "Valor original"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:380
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
 msgid "Mapped value"
 msgstr "Valor atribuído"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:423
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
 msgstr "Insira um valor"
 
@@ -624,7 +633,7 @@ msgid "Custom mapping"
 msgstr "Mapeamento personalizado"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:155
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
 msgid "Unrecognized mapping type"
 msgstr "Tipo de mapeamento não reconhecido"
 
@@ -632,23 +641,23 @@ msgstr "Tipo de mapeamento não reconhecido"
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "O campo atual não é uma chave estrangeira ou os metadados principais estão ausentes idioma estrangeiro na tabela de destino"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:187
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
 msgstr "O campo selecionado não é uma chave estrangeira"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:347
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
 msgstr "Valores exibidos"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:348
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Escolha se você deseja mostrar o valor original do banco de dados ou mostrar informações associadas ou personalizadas."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:268
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
 msgstr "Escolha um campo"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:289
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
 msgstr "Selecione uma coluna para mostrar"
 
@@ -656,16 +665,16 @@ msgstr "Selecione uma coluna para mostrar"
 msgid "Tip:"
 msgstr "Conselho:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Você pode querer atualizar o nome do campo para ter certeza de que ainda tem significado dependendo das opções de alocação."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:364
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:102
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
 msgstr "Valores de campo no cache"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:365
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "o Metabase pode digitalizar os valores nesse campo para habilitar Filtros da caixa de seleção em painéis e perguntas."
 
@@ -674,167 +683,168 @@ msgid "Re-scan this field"
 msgstr "Reexaminar este campo"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
 msgstr "Descartar valores de campo em cache"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:118
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
 msgstr "Erro ao descartar valores"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard triggered!"
 msgstr "Limpeza iniciada!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:105
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Selecione qualquer tabela para ver seu esquema e adicionar ou editar metadados."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:37
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:34
-#: frontend/src/metabase/entities/collections.js:96
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "Nome é obrigatório"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:40
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
 msgstr "Descrição é obrigatória"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:44
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:41
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
 msgstr "Mensagem da revisão é obrigatória"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:50
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
 msgstr "A agregação é obrigatória"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
 msgstr "Edite sua métrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
 msgstr "Crie sua métrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:115
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Faça alterações na sua métrica e deixe uma nota explicativa."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Você pode criar métricas e salvá-las como um campo calculado nessa tabela. As métricas salvas incluem o tipo de agregação, o campo agregado e opcionalmente, qualquer filtro que você adicionar. Por exemplo, você pode usar esse para definir a forma oficial de calcular o \"Preço Médio\" para una Tabela Pedidos."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
 msgstr "Resultado: "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
 msgstr "Nomeie sua métrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
 msgstr "Dê um nome à sua métrica para ajudar outras pessoas a encontrarem."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:162
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
 msgstr "Algo descritivo, mas não muito longo"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
 msgstr "Descreva sua métrica"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Dê uma descrição à sua métrica para ajudar os outros a entender o que é tente"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Este é um bom lugar para ser mais específico sobre as regras de métrica menos óbvio"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:179
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
 msgstr "Razão para alterações"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:177
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Deixe uma nota para explicar que alterações você fez e por que elas foram necessário."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Isso aparecerá no histórico de revisão dessa métrica para ajudar todos para lembrar por que a mudança foi feita"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
 msgstr "Pelo menos um filtro é necessário"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
 msgstr "Edite seu segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
 msgstr "Crie seu segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:121
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Faça alterações no seu segmento e deixe uma nota explicativa."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Selecione e adicione filtros para criar um novo segmento para a tabela {0}"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
 msgstr "Nomeie seu segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:162
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
 msgstr "Dê um nome ao seu segmento para ajudar outras pessoas a encontrá-lo."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:170
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
 msgstr "Descreva seu segmento"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Dê ao seu segmento uma descrição para ajudar os outros a entender o que é tente"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:175
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Este é um bom lugar para ser mais específico sobre as regras de segmentação menos óbvia"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:185
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Isso aparecerá no histórico de revisão deste segmento para ajudar todos para lembrar por que a mudança foi feita"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:266
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:87
-#: frontend/src/metabase/nav/containers/Navbar.jsx:199
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:269
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:91
+#: frontend/src/metabase/nav/containers/Navbar.jsx:228
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
 msgstr "Configuração"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:103
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "o Metabase pode ler os valores nesta tabela para ativar filtros caixas de seleção em painéis e perguntas."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:108
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
 msgstr "Releia esta tabela"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:253
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
 msgstr "Adicionar"
 
@@ -843,20 +853,22 @@ msgstr "Adicionar"
 msgid "Not a valid formatted email address"
 msgstr "Formato do e-mail incorreto"
 
+#: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:100
 msgid "First name"
 msgstr "Nome"
 
+#: frontend/src/metabase/entities/users.js:42
 #: frontend/src/metabase/setup/components/UserStep.jsx:203
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:117
 msgid "Last name"
 msgstr "Sobrenome"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:77
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:158
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:161
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:470
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:481
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
@@ -870,34 +882,35 @@ msgstr "Grupos de Permissões"
 msgid "Make this user an admin"
 msgstr "Converta este usuário para administrador"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:32
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
 msgstr "Todos os usuários pertencem ao grupo \"{0}\" e não podem ser excluídos dele. Estabelecer permissões para esse grupo é uma ótima maneira de garantir que você sabe o que os novos usuários do Metabase podem ver"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:41
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
 msgstr "Este é um grupo especial cujos membros podem ver tudo na instância do Metabase, e quem pode acessar e fazer alterações na configuração em Painel de Administração, incluindo a alteração de permissões! Então, adicione pessoas para neste grupo com cuidado."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:45
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
 msgstr "Para garantir que você não fique sem acesso ao Metabase, você deve sempre ter ao menos um usuário neste grupo."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
 msgstr "Membros"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:124
-#: frontend/src/metabase/admin/settings/selectors.js:113
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
+#: frontend/src/metabase/admin/settings/selectors.js:110
+#: frontend/src/metabase/entities/users.js:50
 #: frontend/src/metabase/lib/core.js:55
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
 msgstr "E-mail"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:203
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
 msgstr "Um grupo vale apenas o que seus membros valem."
 
@@ -908,8 +921,8 @@ msgid "Admin"
 msgstr "Administrador"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:237
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:290
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
 msgstr "e"
 
@@ -939,13 +952,13 @@ msgstr "Tem certeza? Todos os membros deste grupo perderão as configurações 
 "Isso não pode ser desfeito."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
 msgstr "Sim"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
 msgstr "Não"
 
@@ -964,10 +977,11 @@ msgstr "Excluir grupo"
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:107
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:327
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:395
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:265
+#: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
 msgstr "Feito"
 
@@ -977,9 +991,9 @@ msgstr "Nome do Grupo"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:131
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:88
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
 msgstr "Grupos"
 
@@ -1008,9 +1022,9 @@ msgid "Deactivate"
 msgstr "Desativar"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:93
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
-#: frontend/src/metabase/nav/containers/Navbar.jsx:204
+#: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
 msgstr "Pessoas"
 
@@ -1050,7 +1064,6 @@ msgid "We've re-sent {0}'s invite"
 msgstr "Enviamos novamente um convite para: {0}"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
-#: frontend/src/metabase/tutorial/Tutorial.jsx:253
 msgid "Okay"
 msgstr "Okay"
 
@@ -1082,13 +1095,13 @@ msgstr "Eles poderão logar novamente, e serão colocados de volta nos grupos qu
 msgid "Reset {0}'s password?"
 msgstr "Redefinir a senha de {0}?"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:77
+#: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
 msgstr "Redefinir"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:44
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
 msgstr "Tem certeza de que quer fazer isso?"
 
@@ -1104,76 +1117,78 @@ msgstr "Aqui está uma senha temporária que você pode usar para fazer login e 
 msgid "We've sent them an email with instructions for creating a new password."
 msgstr "Nós lhe enviamos um email com instruções para criar uma nova senha."
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:101
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
 msgstr "Ativo"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:127
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
 msgstr "Desativado"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:115
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
 msgstr "Adicione alguém"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
 msgstr "Último acesso"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:153
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
 msgstr "Acesso via Google"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:158
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
 msgstr "Acesso via LDAP"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:170
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
 msgstr "Reativar esta conta"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:193
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
 msgstr "Nunca"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:27
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
 msgstr[0] "{0} tabela"
 msgstr[1] "{0} tabelas"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:45
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
 msgstr " será "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:48
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
 msgstr "dado acesso a"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:53
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
 msgstr " e "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:56
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
 msgstr "negado acesso a"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:70
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
 msgstr " não poderá mais "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:71
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
 msgstr " agora será capaz de "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:79
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
 msgstr " consultas nativas para "
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
-#: frontend/src/metabase/nav/containers/Navbar.jsx:219
+#: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
 msgstr "Permissões"
 
@@ -1198,15 +1213,15 @@ msgstr "Nenhuma alteração será feita nas permissões."
 msgid "You've made changes to permissions."
 msgstr "Você fez alterações nas permissões."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:52
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
 msgstr "Permissões para esta coleção"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
 msgstr "Tem alterações não salvas"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:54
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
 msgstr "Você quer sair desta página e descartar suas alterações?"
 
@@ -1226,120 +1241,120 @@ msgstr "Todos os usuários do Metabase pertencem ao grupo \"Todos os usuários\"
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
 msgstr "O Metabot é o bot Slack do Metabase. Você pode escolher o que ele tem acesso aqui"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:119
+#: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
 msgstr "O grupo \"{0}\" pode ter acesso a um conjunto diferente de {1} que este grupo, o que pode dar a este grupo acesso adicional a alguns {2}."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:124
+#: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
 msgstr "O grupo \"{0}\" tem um nível de acesso maior que este, o que anulará esta configuração. Você deveria limitar ou revogar o acceso do grupo '{1}' a este elemento."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
 msgstr "Limite"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
 msgstr "Revogar"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:156
+#: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
 msgstr "acesso apesar que o grupo \"{0}\" tem maior acceso?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:258
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
 msgstr "Limite de acesso"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:223
-#: frontend/src/metabase/admin/permissions/selectors.js:266
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:226
+#: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
 msgstr "Revogar acesso"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:168
+#: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
 msgstr "Alterar o acesso a este banco de dados para limitado?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:169
+#: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
 msgstr "Alterar"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:182
+#: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
 msgstr "Permitir a gravação de consultas diretas"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:183
+#: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
 msgstr "Isso também alterará o acesso a dados desse grupo para sem restrições neste banco de dados."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:184
+#: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
 msgstr "Permitir"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:221
+#: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
 msgstr "Revoga o acesso a todas as tabelas?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:222
+#: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
 msgstr "Isso também revogará o acesso desse grupo a consultas não formatadas para este banco de dados."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:251
+#: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
 msgstr "Conceder acesso sem restrições"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:252
+#: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
 msgstr "Acesso sem restrições"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:259
+#: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
 msgstr "Acesso limitado"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:267
+#: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
 msgstr "Sem acesso"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:273
+#: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
 msgstr "Escrever consultas diretas"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:274
+#: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
 msgstr "Você pode escrever consultas diretas"
 
 #. Isso foi tradução automática? Sugestão: "Cuide da coleção"
-#: frontend/src/metabase/admin/permissions/selectors.js:281
+#: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
 msgstr "Curar a coleção"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:288
+#: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
 msgstr "Ver coleção"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:331
-#: frontend/src/metabase/admin/permissions/selectors.js:427
-#: frontend/src/metabase/admin/permissions/selectors.js:524
+#: frontend/src/metabase/admin/permissions/selectors.js:334
+#: frontend/src/metabase/admin/permissions/selectors.js:430
+#: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
 msgstr "Acesso aos dados"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:492
-#: frontend/src/metabase/admin/permissions/selectors.js:649
-#: frontend/src/metabase/admin/permissions/selectors.js:654
+#: frontend/src/metabase/admin/permissions/selectors.js:495
+#: frontend/src/metabase/admin/permissions/selectors.js:652
+#: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
 msgstr "Veja as tabelas"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:590
+#: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
 msgstr "Consultas SQL"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:660
+#: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
 msgstr "Veja esquemas"
 
 #: frontend/src/metabase/admin/routes.jsx:59
-#: frontend/src/metabase/nav/containers/Navbar.jsx:209
+#: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
 msgstr "Modelo de dados"
 
@@ -1348,30 +1363,30 @@ msgstr "Modelo de dados"
 msgid "Sign in with Google"
 msgstr "Entre com o Google"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:13
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
 msgstr "Permite que usuários com contas existentes do Metabase façam login com uma conta do Google que corresponde ao seu endereço de e-mail além do seu nome de usuário e senha do Metabase."
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:17
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
 msgstr "Configurar"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
-#: frontend/src/metabase/admin/settings/selectors.js:207
+#: frontend/src/metabase/admin/settings/selectors.js:204
 msgid "LDAP"
 msgstr "LDAP"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:25
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
 msgstr "Permitir que usuários do seu diretório LDAP efetuem login no Metabase com suas credenciais LDAP e permite o mapeamento automático de grupos LDAP nos grupos do Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
-#: frontend/src/metabase/admin/settings/selectors.js:160
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
 msgstr "Esse não é um endereço de e-mail válido"
 
@@ -1409,7 +1424,7 @@ msgstr "Limpar"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:202
+#: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
 msgstr "Autenticação"
 
@@ -1473,21 +1488,21 @@ msgstr "Crie um usuário do Slack Bot para o MetaBot"
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Quando estiver lá, dê um nome e clique em {0}. Então, copie e cole a API do Token do Bot no campo abaixo. Assim que você tiver terminado, crie um canal \"metabase_files\" no Slack. O Metabase precisa disso para fazer upload de gráficos."
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:90
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
 msgstr "Você está executando o Metabase {0}, que é o mais recente e o melhor!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:99
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0} está disponivel. Você está executando {1}"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:112
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
 msgstr "Atualizar"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:116
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
 msgstr "O que mudou:"
 
@@ -1500,80 +1515,80 @@ msgstr "Adicione um mapa"
 msgid "URL"
 msgstr "URL"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:199
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
 msgstr "Remover mapa personalizado"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:327
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:40
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:181
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
 msgstr "Excluir"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:226
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:187
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:241
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:246
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
 msgstr "Selecione..."
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:241
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
 msgstr "Valores da amostra:"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
 msgstr "Adicione um novo mapa"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
 msgstr "Editar mapa"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:280
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
 msgstr "Como você quer chamar este mapa?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
 msgstr "e.x. Reino Unido, Brasil, Marte"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:292
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
 msgstr "URL para o arquivo GeoJSON que você deseja usar"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:298
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
 msgstr "Como https://my-mb-server.com/maps/my-map.json"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:33
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
 msgstr "Carregar"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:315
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
 msgstr "Qual propriedade especifica o identificador da região?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:324
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
 msgstr "Qual propriedade especifica o nome da região?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:345
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
 msgstr "Carregue um arquivo GeoJSON para visualizar"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
 msgstr "Salvar mapa"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
 msgstr "Adicionar mapa"
 
@@ -1585,11 +1600,11 @@ msgstr "Usando incorporado"
 msgid "By enabling embedding you're agreeing to the embedding license located at"
 msgstr "Ao ativar a incorporação, você aceita a licença de incorporação localizada em"
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:19
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
 msgstr "Em linguagem simples, quando você insere tabelas ou painéis do Metabase em seu próprio aplicativo, esse aplicativo não está sujeito à licença AGPL que cobre o resto do Metabase, desde que você mantenha o logotipo do Metabase e o \"Powered by Metabase\" visível nessas inserções. No entanto, você deve ler o texto da licença, já que essa é a licença real que você concorda ao ativar esta função."
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:32
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
 msgstr "Ativar"
 
@@ -1613,25 +1628,25 @@ msgstr "Compre um token"
 msgid "Enter a token"
 msgstr "Digite um token"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:134
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
 msgstr "Editar atribuições"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:140
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
 msgstr "Trabalhos de grupo"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:147
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
 msgstr "Crie uma tarefa"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
 msgstr "Atribuições permitem que o Metabase adicione e remova automaticamente usuários de grupos de acordo com as informações de associação fornecidas pelo servidor de diretório. A associação ao grupo de administração pode ser conceder através de atribuições, mas não será automaticamente excluído como uma medida à prova de falhas."
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
 msgstr "Nome distinto"
 
@@ -1643,43 +1658,43 @@ msgstr "Link público"
 msgid "Revoke Link"
 msgstr "Revogar link"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:121
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
 msgstr "Desativar este link?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:122
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
 msgstr "Eles não funcionarão mais e não poderão ser restaurados, mas você poderá criar novos links de acesso."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
 msgstr "Lista de Painéis Públicos"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:152
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
 msgstr "Nenhum painel foi compartilhado publicamente ainda."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:160
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
 msgstr "Lista de cartões públicos"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:163
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
 msgstr "Nenhuma pergunta foi compartilhada publicamente ainda."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:172
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
 msgstr "Lista de Painéis incorporados"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
 msgstr "Nenhum painel foi incorporado ainda."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:183
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
 msgstr "Lista de cartões incorporados"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:184
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
 msgstr "Nenhuma pergunta foi incorporada ainda."
 
@@ -1700,18 +1715,17 @@ msgid "Generate Key"
 msgstr "Gerar chave"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:78
-#: frontend/src/metabase/admin/settings/selectors.js:87
+#: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
 msgstr "Habilitado"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:83
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:103
+#: frontend/src/metabase/admin/settings/selectors.js:82
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Desativado"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:116
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
 msgstr "A diretiva de configuração {0} é desconhecida"
 
@@ -1719,7 +1733,7 @@ msgstr "A diretiva de configuração {0} é desconhecida"
 msgid "Setup"
 msgstr "Configurar"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
 msgstr "Geral"
@@ -1748,11 +1762,11 @@ msgstr "Padrão do banco de dados"
 msgid "Select a timezone"
 msgstr "Selecione um fuso horário"
 
-#: frontend/src/metabase/admin/settings/selectors.js:55
+#: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Nem todos os bancos de dados suportam fusos horários, nesses casos a configuração não terá efeito."
 
-#: frontend/src/metabase/admin/settings/selectors.js:60
+#: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
 msgstr "Idioma"
 
@@ -1760,202 +1774,202 @@ msgstr "Idioma"
 msgid "Select a language"
 msgstr "Selecione um idioma"
 
-#: frontend/src/metabase/admin/settings/selectors.js:70
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
 msgstr "Acompanhamento anônimo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:75
+#: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
 msgstr "Nomes de tabelas e campos amigáveis"
 
-#: frontend/src/metabase/admin/settings/selectors.js:81
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Apenas substitui sublinhados e hífens por espaços"
 
-#: frontend/src/metabase/admin/settings/selectors.js:91
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
 msgstr "Ativar consultas aninhadas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:102
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
 msgstr "Atualizações"
 
-#: frontend/src/metabase/admin/settings/selectors.js:107
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
 msgstr "Verificar atualizações"
 
-#: frontend/src/metabase/admin/settings/selectors.js:118
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
 msgstr "Servidor SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:126
+#: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
 msgstr "Porta SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:130
-#: frontend/src/metabase/admin/settings/selectors.js:230
+#: frontend/src/metabase/admin/settings/selectors.js:127
+#: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
 msgstr "Esse não é um número de porta válido"
 
-#: frontend/src/metabase/admin/settings/selectors.js:134
+#: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
 msgstr "Segurança SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:142
+#: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
 msgstr "Usuário SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
 msgstr "Senha SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
 msgstr "E-mail do remetente"
 
-#: frontend/src/metabase/admin/settings/selectors.js:170
+#: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
 msgstr "Slack API Token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:172
+#: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
 msgstr "Digite o token que você recebeu do Slack"
 
-#: frontend/src/metabase/admin/settings/selectors.js:189
+#: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
 msgstr "Início de sessão única"
 
-#: frontend/src/metabase/admin/settings/selectors.js:213
+#: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
 msgstr "Autenticação LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:219
+#: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
 msgstr "Servidor LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:227
+#: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
 msgstr "Porta LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:234
+#: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
 msgstr "Segurança LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
 msgstr "Nome de usuário ou DN"
 
-#: frontend/src/metabase/admin/settings/selectors.js:247
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:188
-#: frontend/src/metabase/user/components/UserSettings.jsx:72
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:191
+#: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
 msgstr "Senha"
 
-#: frontend/src/metabase/admin/settings/selectors.js:252
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "User search base"
 msgstr "Base de pesquisa do usuário"
 
-#: frontend/src/metabase/admin/settings/selectors.js:258
+#: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
 msgstr "Filtro do usuário"
 
-#: frontend/src/metabase/admin/settings/selectors.js:264
+#: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
 msgstr "Verifique os parênteses"
 
-#: frontend/src/metabase/admin/settings/selectors.js:270
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
 msgstr "Atributo do e-mail"
 
-#: frontend/src/metabase/admin/settings/selectors.js:275
+#: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
 msgstr "Atributo do nome"
 
-#: frontend/src/metabase/admin/settings/selectors.js:280
+#: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
 msgstr "Atributo do sobrenome"
 
-#: frontend/src/metabase/admin/settings/selectors.js:285
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
 msgstr "Sincronizar membros do grupo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:291
+#: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
 msgstr "Base de pesquisa de grupo"
 
-#: frontend/src/metabase/admin/settings/selectors.js:300
+#: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
 msgstr "Mapas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
 msgstr "URL do servidor da camada de mapa"
 
-#: frontend/src/metabase/admin/settings/selectors.js:306
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "O Metabase usa o OpenStreetMaps por padrão."
 
-#: frontend/src/metabase/admin/settings/selectors.js:311
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
 msgstr "Mapas personalizados"
 
-#: frontend/src/metabase/admin/settings/selectors.js:312
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Adicione seus próprios arquivos GeoJSON para permitir diferentes visualizações de mapas da região"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
 msgstr "Compartilhamento público"
 
-#: frontend/src/metabase/admin/settings/selectors.js:336
+#: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
 msgstr "Ativar o compartilhamento público"
 
-#: frontend/src/metabase/admin/settings/selectors.js:341
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
 msgstr "Painéis compartilhados"
 
-#: frontend/src/metabase/admin/settings/selectors.js:347
+#: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
 msgstr "Perguntas compartilhadas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:354
+#: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
 msgstr "Incorporar em outras aplicações"
 
-#: frontend/src/metabase/admin/settings/selectors.js:381
+#: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Habilitar incorporação do Metabase em outros aplicativos"
 
-#: frontend/src/metabase/admin/settings/selectors.js:391
+#: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
 msgstr "Chave secreta de incorporação"
 
-#: frontend/src/metabase/admin/settings/selectors.js:397
+#: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
 msgstr "Painéis embutidos"
 
-#: frontend/src/metabase/admin/settings/selectors.js:403
+#: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
 msgstr "Perguntas incorporadas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:410
+#: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
 msgstr "Cache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:415
+#: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
 msgstr "Ativar cache"
 
-#: frontend/src/metabase/admin/settings/selectors.js:420
+#: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
 msgstr "Duração mínima da consulta"
 
-#: frontend/src/metabase/admin/settings/selectors.js:427
+#: frontend/src/metabase/admin/settings/selectors.js:424
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Cache do Time-to-Live Multiplier (TTL)"
 
-#: frontend/src/metabase/admin/settings/selectors.js:434
+#: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
 msgstr "Tamanho máximo de entrada de cache"
 
@@ -1971,11 +1985,11 @@ msgstr "Seu alerta foi atualizado."
 msgid "The alert was successfully deleted."
 msgstr "O alerta foi removido corretamente."
 
-#: frontend/src/metabase/auth/auth.js:33
+#: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
 msgstr "Por favor, insira um endereço de e-mail com um formato válido."
 
-#: frontend/src/metabase/auth/auth.js:116
+#: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
@@ -2017,91 +2031,88 @@ msgstr "Enviar e-mail de redefinição de senha"
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Consulte o seu e-mail para obter instruções sobre como redefinir sua senha"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:128
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
 msgstr "Entre no Metabase"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:138
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
 msgstr "OU"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:157
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
 msgstr "Nome de usuário ou endereço de e-mail"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:217
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
 msgstr "Entrar"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:230
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
 msgstr "Parece que esqueci minha senha"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
 msgstr "solicitar envio de e-mail de redefinição de senha"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:120
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
 msgstr "Oops, esse é um link expirado"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:122
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
 msgstr "Por razões de segurança, links de redefinição de senha expiram depois de um tempo. \n"
 "Se você ainda precisar redefinir sua senha, você pode {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:147
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
 msgstr "Nova senha"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:149
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
 msgstr "Para manter seus dados seguros, senhas {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:163
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
 msgstr "Crie uma nova senha"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:170
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:141
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
 msgstr "Você deve cumprir as instruções acima"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:184
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:150
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
 msgstr "Confirme a nova senha"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:191
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:159
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
 msgstr "Tem que combinar com o que você acabou de colocar"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:216
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
 msgstr "Sua senha foi redefinida."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:222
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:227
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
 msgstr "Entre com sua nova senha"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:182
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:251
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Falhou"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:183
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:129
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:225
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:252
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
 msgstr "Salvo"
 
@@ -2109,24 +2120,22 @@ msgstr "Salvo"
 msgid "Ok"
 msgstr "Ok"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:38
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
 msgstr "Arquivar esta coleção?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:43
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Os painéis, coleções e notificações nesta coleção também serão arquivados."
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
-#: frontend/src/metabase/components/CollectionLanding.jsx:624
+#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: frontend/src/metabase/components/CollectionLanding.jsx:620
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:47
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:195
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:200
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:40
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:53
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
 msgstr "Arquivo"
@@ -2135,28 +2144,27 @@ msgstr "Arquivo"
 msgid "This {0} has been archived"
 msgstr "Este {0} foi arquivado"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:715
+#: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
 msgstr "Veja o arquivo"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:43
+#: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
 msgstr "Desarquivar este {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:70
-#: frontend/src/metabase/components/BrowseApp.jsx:132
-#: frontend/src/metabase/components/BrowseApp.jsx:225
+#: frontend/src/metabase/components/BrowseApp.jsx:39
+#: frontend/src/metabase/components/BrowseApp.jsx:102
+#: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
 msgstr "Nossos dados"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:169
+#: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
 msgstr "Aplique raio-X nesta tabela"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:183
-#: frontend/src/metabase/containers/Overworld.jsx:246
+#: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
 msgstr "Aprenda mais sobre essa tabela"
 
@@ -2174,31 +2182,31 @@ msgstr "Salvo!"
 msgid "Saving failed."
 msgstr "Não foi possível salvar"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
 msgstr "Dom"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
 msgstr "Seg"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
 msgstr "Ter"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
 msgstr "Qua"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
 msgstr "Qui"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
 msgstr "Sex"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
 msgstr "Sáb"
 
@@ -2243,61 +2251,61 @@ msgstr "Notificações te permitem enviar os dados atualizados para seu time seg
 msgid "Questions are a saved look at your data."
 msgstr "Perguntas são visões salvas de seus dados."
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:287
+#: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
 msgstr "Fixados"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:341
+#: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
 msgstr "Arraste algo aqui para fixar no topo da página."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:737
-#: frontend/src/metabase/components/CollectionLanding.jsx:353
-#: frontend/src/metabase/home/containers/SearchApp.jsx:35
-#: frontend/src/metabase/home/containers/SearchApp.jsx:92
+#: frontend/src/metabase/admin/permissions/selectors.js:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:352
+#: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
 msgstr "Coleções"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:432
-#: frontend/src/metabase/components/CollectionLanding.jsx:455
+#: frontend/src/metabase/components/CollectionLanding.jsx:431
+#: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
 msgstr "Arraste aqui para desafixar"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:490
+#: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
 msgstr[0] "{0} item selecionado"
 msgstr[1] "{0} itens selecionados"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:522
+#: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
 msgstr "Mover {0} itens?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:523
+#: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
 msgstr "Mover \"{0}\"?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:631
+#: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
 msgstr "Mover"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:692
+#: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
 msgstr "Editar coleção"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:700
+#: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
 msgstr "Arquivar esta coleção?"
 
-#: frontend/src/metabase/components/CollectionList.jsx:64
-#: frontend/src/metabase/entities/collections.js:155
+#: frontend/src/metabase/components/CollectionList.jsx:67
+#: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
 msgstr "Minha coleção pessoal"
 
-#: frontend/src/metabase/components/CollectionList.jsx:106
+#: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
 msgstr "Coleção nova"
 
@@ -2305,11 +2313,11 @@ msgstr "Coleção nova"
 msgid "Copied!"
 msgstr "Copiado!"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:216
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Usa um túnel SSH para conexões com o banco de dados"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
@@ -2317,75 +2325,76 @@ msgstr "Algumas instalações de banco de dados só podem ser acessadas conectan
 "Esta opção também fornece uma camada adicional de segurança quando não você tem uma VPN. \n"
 "Isso geralmente é mais lento que uma conexão direta."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:271
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Este é um grande banco de dados, então deixe-me escolher quando o Metabase sincronizar e digitalizar"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:273
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Por padrão, o Metabase executa uma sincronização leve de hora em hora, e uma análise diária intensiva dos valores do campo.\n"
 "Se você tem um banco de dados grande, recomendamos ativá-lo e verificar quando e com que frequência as varreduras de valores de campo ocorrem."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:289
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} para gerar um ID e uma chave secreta do cliente para seu projeto."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:291
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:353
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
 msgstr "Clique aqui"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Escolhe \"Outro\" como tipo de aplicação. Nomeie-o como quiser"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:316
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
 msgstr "{0} para obter um código de autenticação"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:328
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
 msgstr "com permissões do Google Drive"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:348
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Para usar o Metabase com esses dados, você deve ativar o acesso à API em Google Developers Console."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:351
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} para ir ao console, se você ainda não fez isso."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
 msgstr "Como você gostaria de chamar esse banco de dados?"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:427
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:237
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:188
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:74
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:194
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:79
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
 msgstr "Próximo"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:52
+#: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
 msgstr "Remova este {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:43
+#: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
 msgstr "Fixar este item"
 
-#: frontend/src/metabase/components/EntityItem.jsx:49
+#: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
 msgstr "Mover este item"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
 msgstr "Editar esta questão"
 
@@ -2398,6 +2407,7 @@ msgstr "Tipo de ação"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
 msgstr "Veja o histórico de revisões"
 
@@ -2413,8 +2423,7 @@ msgstr "Ação de arquivamento"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:329
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:342
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
 msgstr "Adicionar ao Painel"
 
@@ -2438,13 +2447,12 @@ msgstr "Outro tipo de ação"
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:449
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:454
 msgid "Get alerts about this"
 msgstr "Receber alertas sobre isso"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
 msgstr "Veja o SQL"
 
@@ -2464,45 +2472,45 @@ msgstr "Aqui está a mensagem de erro completa"
 msgid "Hi, Metabot here."
 msgstr "Oi, eu sou o metabot"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:95
+#: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
 msgstr "Baseado no schema"
 
 #. Alterei pois, é da tela principal e ficava como "Uma olhada no seu XXXX tabela"
 #. alterando para "Uma olhada em XXXX tabela"
-#: frontend/src/metabase/components/ExplorePane.jsx:174
+#: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
 msgstr "Uma olhada em"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:234
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
 msgstr "Pesquise na lista"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:238
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
 msgstr "Pesquise por {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
 msgstr "ou insira um ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
 msgstr "Insira um ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
 msgstr "Digite um número"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:248
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
 msgstr "Digite um texto"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:355
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
 msgstr "Nenhuma correspondência {0} foi encontrada."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:363
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Incluindo cada opção no seu filtro provavelmente não vai fazer muito..."
 
@@ -2518,17 +2526,17 @@ msgstr "Encontramos um erro. Você pode tentar atualizar a página, ou voltar."
 #: frontend/src/metabase/components/HeaderBar.jsx:45
 #: frontend/src/metabase/components/ListItem.jsx:37
 #: frontend/src/metabase/reference/components/Detail.jsx:47
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:158
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:213
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:191
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:205
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:209
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:209
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:161
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:216
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:194
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:208
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
 msgstr "Ainda sem descrição"
 
 #: frontend/src/metabase/components/Header.jsx:112
-#: frontend/src/metabase/entities/containers/EntityForm.jsx:43
+#: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
 msgstr "Novo {0}"
 
@@ -2536,54 +2544,53 @@ msgstr "Novo {0}"
 msgid "Asked by {0}"
 msgstr "Perguntado por {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:13
+#: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
 msgstr "Hoje "
 
-#: frontend/src/metabase/components/HistoryModal.jsx:15
+#: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
 msgstr "Ontem "
 
-#: frontend/src/metabase/components/HistoryModal.jsx:68
+#: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
 msgstr "Primeira revisão."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:70
+#: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
 msgstr "Revertido para uma revisão anterior e {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:82
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:289
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:379
-#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
+#: frontend/src/metabase/components/HistoryModal.jsx:42
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
+#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
 msgstr "Histórico de revisão"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:90
+#: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
 msgstr "Quando"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:91
+#: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
 msgstr "Quem"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:92
+#: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
 msgstr "Que"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:113
+#: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
 msgstr "Reverter"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:114
+#: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
 msgstr "Revertendo..."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:115
+#: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
 msgstr "Reverter falhou"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:116
+#: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
 msgstr "Revertido"
 
@@ -2592,26 +2599,24 @@ msgid "Everything"
 msgstr "Tudo"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
-#: frontend/src/metabase/home/containers/SearchApp.jsx:69
 msgid "Dashboards"
 msgstr "Painéis"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
-#: frontend/src/metabase/home/containers/SearchApp.jsx:115
 msgid "Questions"
 msgstr "Perguntas"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:321
+#: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
 msgstr "Notificações"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:103
+#: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
 msgstr "Voltar"
 
-#: frontend/src/metabase/components/ListSearchField.jsx:18
+#: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
 msgstr "Encontrar..."
 
@@ -2648,14 +2653,14 @@ msgid "Temporary Password"
 msgstr "Senha Temporária"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
 msgstr "Esconder"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:412
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
 msgstr "Mostrar"
 
@@ -2720,7 +2725,7 @@ msgstr "15 (ponto médio)"
 msgid "Calendar Day"
 msgstr "Dia do calendário"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:210
+#: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
 msgstr "o seu fuso horário no Metabase"
 
@@ -2749,11 +2754,11 @@ msgid "A component used to make a selection"
 msgstr "Um componente usado para fazer uma seleção"
 
 #: frontend/src/metabase/components/Select.info.js:20
-#: frontend/src/metabase/components/Select.info.js:28
+#: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
 msgstr "Selecionado"
 
-#: frontend/src/metabase/components/Select.jsx:297
+#: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
 msgstr "Nada para selecionar"
 
@@ -2766,7 +2771,7 @@ msgid "Unknown error encountered"
 msgstr "Erro desconhecido encontrado"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/nav/containers/Navbar.jsx:304
+#: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
 msgstr "Criar"
 
@@ -2775,13 +2780,11 @@ msgid "Create dashboard"
 msgstr "Criar um painel"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:331
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:60
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
 msgstr "Tabela"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:306
 msgid "Database"
 msgstr "Banco de dados"
 
@@ -2789,22 +2792,20 @@ msgstr "Banco de dados"
 msgid "Creator"
 msgstr "Criador"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:238
+#: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
 msgstr "Não foram encontrados resultados"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:239
+#: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
 msgstr "Tente ajustar seu filtro para encontrar o que você está procurando."
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:258
+#: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
 msgstr "Veja por"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:494
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:84
-#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:69
-#: frontend/src/metabase/tutorial/TutorialModal.jsx:34
+#: frontend/src/metabase/containers/EntitySearch.jsx:495
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
 msgstr "de"
 
@@ -2817,13 +2818,13 @@ msgid "Once you connect your own data, I can show you some automatic exploration
 msgstr "Assim que você conectar seus próprios dados, eu posso mostrar algumas explorações automáticas, chamadas raios-X. Aqui estão alguns exemplos com dados de exemplo."
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
-#: frontend/src/metabase/containers/Overworld.jsx:299
+#: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
 msgstr "Comece aqui"
 
-#: frontend/src/metabase/containers/Overworld.jsx:294
-#: frontend/src/metabase/entities/collections.js:147
+#: frontend/src/metabase/containers/Overworld.jsx:296
+#: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
 msgstr "Nossas análises"
@@ -2832,53 +2833,53 @@ msgstr "Nossas análises"
 msgid "Browse all items"
 msgstr "Exibir todos os itens"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:165
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
 msgstr "Substituir ou salvar como novo?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:173
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
 msgstr "Substituir a pergunta original, \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:178
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
 msgstr "Salvar como uma nova pergunta"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:187
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
 msgstr "Primeiro, salve sua pergunta"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:188
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
 msgstr "Salvar a pergunta"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:224
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
 msgstr "Qual é o nome do seu cartão?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:232
-#: frontend/src/metabase/entities/collections.js:101
-#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:234
+#: frontend/src/metabase/entities/collections.js:102
+#: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/lib/core.js:50 frontend/src/metabase/lib/core.js:205
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:156
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:211
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:203
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:207
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:207
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:24
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:159
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:214
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:192
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:206
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:210
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
 msgstr "Descrição"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:238
-#: frontend/src/metabase/entities/dashboards.js:153
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
+#: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
 msgstr "É opcional, mas tão útil"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:245
-#: frontend/src/metabase/entities/dashboards.js:157
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
+#: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "Em que coleção isso deveria ir?"
 
@@ -2890,7 +2891,7 @@ msgstr "modificado"
 msgid "item"
 msgstr "item"
 
-#: frontend/src/metabase/containers/UndoListing.jsx:81
+#: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
 msgstr "Desfazer"
 
@@ -2914,15 +2915,15 @@ msgstr "Não temos certeza se essa pergunta é compatível"
 msgid "Archive Dashboard"
 msgstr "Arquivar Painel"
 
-#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:20
+#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Certifique-se de fazer uma seleção para cada série ou o filtro não funcionará neste cartão."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:300
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
 msgstr "Este painel parece estar vazio."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:301
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
 msgstr "Adicione uma pergunta para torná-lo útil!"
 
@@ -2942,59 +2943,58 @@ msgstr "Desativar tela cheia"
 msgid "Enter fullscreen"
 msgstr "Ativar tela cheia"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:181
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:183
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Salvando..."
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:216
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
 msgstr "Adicione uma pergunta"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:219
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
 msgstr "Adicione uma pergunta a este painel"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:248
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
 msgstr "Adicionar filtro"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:254
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:78
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Parâmetros"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:275
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
 msgstr "Adicionar uma caixa de texto"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
 msgstr "Mover painel"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:302
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
 msgstr "Editar painel"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:306
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
 msgstr "Editar layout do Painel"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:369
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
 msgstr "Você está editando um painel"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:374
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
 msgstr "Selecione o campo que deve ser filtrado para cada cartão"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:28
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
 msgstr "Mover painel para..."
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:52
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
 msgstr "Painel movido para {0}"
 
@@ -3009,7 +3009,7 @@ msgstr "Que tipo de filtro?"
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:179
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
 msgstr "Desligado"
 
@@ -3049,174 +3049,174 @@ msgstr "Atualizando em"
 msgid "Remove this question?"
 msgstr "Remover esta pergunta?"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:71
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
 msgstr "Seu painel foi salvo."
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:745
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:76
+#: frontend/src/metabase/components/CollectionLanding.jsx:744
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
 msgstr "Veja"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:137
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
 msgstr "Salvar isto"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:170
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
 msgstr "Moste mais sobre isso"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:140
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
 msgstr "Este cartão ainda não tem campos ou parâmetros que podem ser mapeados para este tipo de parâmetro."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:142
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Os valores nesse campo não sobrepõe os valores de outros campos que você escolheu."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:186
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
 msgstr "Não há campos válidos"
 
-#: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
 msgstr "O nome deve ter 100 caracteres ou menos"
 
-#: frontend/src/metabase/entities/collections.js:111
+#: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
 msgstr "Cor é obrigatório"
 
-#: frontend/src/metabase/entities/dashboards.js:146
+#: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
 msgstr "Qual é o nome do seu painel?"
 
-#: frontend/src/metabase/home/components/Activity.jsx:92
+#: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
 msgstr "eu fiz algumas coisas incríveis que são difíceis de descrever"
 
-#: frontend/src/metabase/home/components/Activity.jsx:101
-#: frontend/src/metabase/home/components/Activity.jsx:116
+#: frontend/src/metabase/home/components/Activity.jsx:103
+#: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
 msgstr "criou um alerta sobre - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:126
-#: frontend/src/metabase/home/components/Activity.jsx:141
+#: frontend/src/metabase/home/components/Activity.jsx:128
+#: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
 msgstr "removeu um alerta sobre - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:152
+#: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
 msgstr "salvou uma pergunta sobre "
 
-#: frontend/src/metabase/home/components/Activity.jsx:165
+#: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
 msgstr "salvou uma pergunta"
 
-#: frontend/src/metabase/home/components/Activity.jsx:169
+#: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
 msgstr "removeu uma questão"
 
-#: frontend/src/metabase/home/components/Activity.jsx:172
+#: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
 msgstr "criou um painel"
 
-#: frontend/src/metabase/home/components/Activity.jsx:175
+#: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
 msgstr "removeu um painel"
 
-#: frontend/src/metabase/home/components/Activity.jsx:181
-#: frontend/src/metabase/home/components/Activity.jsx:196
+#: frontend/src/metabase/home/components/Activity.jsx:183
+#: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
 msgstr "adicionou uma pergunta ao painel - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:206
-#: frontend/src/metabase/home/components/Activity.jsx:221
+#: frontend/src/metabase/home/components/Activity.jsx:208
+#: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
 msgstr "removeu uma pergunta do painel - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:231
-#: frontend/src/metabase/home/components/Activity.jsx:238
+#: frontend/src/metabase/home/components/Activity.jsx:233
+#: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
 msgstr "recebeu os dados mais recentes de"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:621
-#: frontend/src/metabase/home/components/Activity.jsx:244
+#: frontend/src/metabase-lib/lib/Dimension.js:814
+#: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: frontend/src/metabase/home/components/Activity.jsx:251
+#: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
 msgstr "Olá mundo!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:252
+#: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
 msgstr "O Metabase está funcionando."
 
-#: frontend/src/metabase/home/components/Activity.jsx:258
-#: frontend/src/metabase/home/components/Activity.jsx:288
+#: frontend/src/metabase/home/components/Activity.jsx:260
+#: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
 msgstr "adicionou a métrica "
 
-#: frontend/src/metabase/home/components/Activity.jsx:272
-#: frontend/src/metabase/home/components/Activity.jsx:362
+#: frontend/src/metabase/home/components/Activity.jsx:274
+#: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
 msgstr " a "
 
-#: frontend/src/metabase/home/components/Activity.jsx:282
-#: frontend/src/metabase/home/components/Activity.jsx:322
-#: frontend/src/metabase/home/components/Activity.jsx:372
-#: frontend/src/metabase/home/components/Activity.jsx:413
+#: frontend/src/metabase/home/components/Activity.jsx:284
+#: frontend/src/metabase/home/components/Activity.jsx:324
+#: frontend/src/metabase/home/components/Activity.jsx:374
+#: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
 msgstr " tabela"
 
-#: frontend/src/metabase/home/components/Activity.jsx:298
-#: frontend/src/metabase/home/components/Activity.jsx:328
+#: frontend/src/metabase/home/components/Activity.jsx:300
+#: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
 msgstr "fez alterações na métrica "
 
-#: frontend/src/metabase/home/components/Activity.jsx:312
-#: frontend/src/metabase/home/components/Activity.jsx:403
+#: frontend/src/metabase/home/components/Activity.jsx:314
+#: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
 msgstr " no "
 
-#: frontend/src/metabase/home/components/Activity.jsx:335
+#: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
 msgstr "removeu a métrica "
 
-#: frontend/src/metabase/home/components/Activity.jsx:338
+#: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
 msgstr "criou uma notificação"
 
-#: frontend/src/metabase/home/components/Activity.jsx:341
+#: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
 msgstr "removeu uma notificação"
 
-#: frontend/src/metabase/home/components/Activity.jsx:347
-#: frontend/src/metabase/home/components/Activity.jsx:378
+#: frontend/src/metabase/home/components/Activity.jsx:349
+#: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
 msgstr "adicionou o filtro"
 
-#: frontend/src/metabase/home/components/Activity.jsx:388
-#: frontend/src/metabase/home/components/Activity.jsx:419
+#: frontend/src/metabase/home/components/Activity.jsx:390
+#: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
 msgstr "fez alterações no filtro"
 
-#: frontend/src/metabase/home/components/Activity.jsx:426
+#: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
 msgstr "filtro removido {0}"
 
-#: frontend/src/metabase/home/components/Activity.jsx:429
+#: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
 msgstr "juntou-se!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:529
+#: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
 msgstr "Hmmm, parece que nada aconteceu ainda."
 
-#: frontend/src/metabase/home/components/Activity.jsx:532
+#: frontend/src/metabase/home/components/Activity.jsx:534
 msgid "Save a question and get this baby going!"
 msgstr "Salve uma pergunta e faça esse trabalho!"
 
@@ -3264,21 +3264,21 @@ msgstr "Visualizado recentemente"
 msgid "You haven't looked at any dashboards or questions recently"
 msgstr "Você não olhou nenhum painel ou pergunta recentemente"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:99
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
 msgstr "{0} itens selecionados"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:121
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:172
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
 msgstr "Desarquivar"
 
-#: frontend/src/metabase/home/containers/HomepageApp.jsx:74
-#: frontend/src/metabase/nav/containers/Navbar.jsx:331
+#: frontend/src/metabase/home/containers/HomepageApp.jsx:77
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
 msgstr "Atividade"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:28
+#: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
 msgstr "Resultados para \"{0}\""
 
@@ -3343,6 +3343,7 @@ msgstr "URL do avatar"
 msgid "Common"
 msgstr "Comum"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
@@ -3379,8 +3380,9 @@ msgstr "Latitude"
 msgid "Longitude"
 msgstr "Longitude"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:149
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
 msgstr "Número"
@@ -3478,7 +3480,7 @@ msgstr "Pontuação"
 
 #: frontend/src/metabase/lib/core.js:210
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:17
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
 msgstr "Título"
 
@@ -3535,8 +3537,9 @@ msgid "Metabase will never retrieve this field. Use this for sensitive or irrele
 msgstr "O Metabase nunca recuperará este campo. Use-o para informações confidenciais ou irrelevante"
 
 #: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:614
-#: frontend/src/metabase/visualizations/lib/utils.js:126
+#: frontend/src/metabase/lib/query.js:300
+#: frontend/src/metabase/visualizations/lib/utils.js:130
+#: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -3551,7 +3554,7 @@ msgstr "Contagem cumulativa"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
-#: frontend/src/metabase/visualizations/lib/utils.js:127
+#: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
 msgstr "Soma"
 
@@ -3560,7 +3563,7 @@ msgid "CumulativeSum"
 msgstr "Soma cumulativa"
 
 #: frontend/src/metabase/lib/expressions/config.js:11
-#: frontend/src/metabase/visualizations/lib/utils.js:128
+#: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
 msgstr "Diferente"
 
@@ -3569,35 +3572,35 @@ msgid "StandardDeviation"
 msgstr "Desvio padrão"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/visualizations/lib/utils.js:125
+#: frontend/src/metabase/visualizations/lib/utils.js:129
 msgid "Average"
 msgstr "Média"
 
 #: frontend/src/metabase/lib/expressions/config.js:14
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:25
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
 msgstr "Mínimo"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
 msgstr "Máximo"
 
-#: frontend/src/metabase/lib/expressions/parser.js:384
+#: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
 msgstr "Panda triste triste, erros lexicais detectados"
 
-#: frontend/src/metabase/lib/formatting.js:707
+#: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} segundo"
 msgstr[1] "{0} segundos"
 
-#: frontend/src/metabase/lib/formatting.js:710
+#: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} minuto"
@@ -3637,224 +3640,226 @@ msgstr "Que tem em mente?"
 msgid "What do you want to find out?"
 msgstr "O que você quer saber?"
 
-#: frontend/src/metabase/lib/query.js:612
-#: frontend/src/metabase/lib/schema_metadata.js:451
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:246
+#: frontend/src/metabase/lib/query.js:298
+#: frontend/src/metabase/lib/schema_metadata.js:458
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
 msgstr "Dados brutos"
 
-#: frontend/src/metabase/lib/query.js:616
+#: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
 msgstr "Contagem cumulativa"
 
-#: frontend/src/metabase/lib/query.js:619
+#: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
 msgstr "Média de "
 
-#: frontend/src/metabase/lib/query.js:624
+#: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
 msgstr "Valores que não sejam "
 
-#: frontend/src/metabase/lib/query.js:629
+#: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
 msgstr "Desvio padrão de "
 
-#: frontend/src/metabase/lib/query.js:634
+#: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
 msgstr "Soma de "
 
-#: frontend/src/metabase/lib/query.js:639
+#: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
 msgstr "Soma cumulativa de "
 
-#: frontend/src/metabase/lib/query.js:644
+#: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
 msgstr "Máximo de "
 
-#: frontend/src/metabase/lib/query.js:649
+#: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
 msgstr "Mínimo de "
 
-#: frontend/src/metabase/lib/query.js:663
+#: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
 msgstr "Agrupado por "
 
-#: frontend/src/metabase/lib/query.js:677
+#: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
 msgstr "Filtrado por "
 
-#: frontend/src/metabase/lib/query.js:706
+#: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
 msgstr "Ordenado por "
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
 msgstr "Verdadeiro"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
 msgstr "Falso"
 
-#: frontend/src/metabase/lib/schema_metadata.js:305
+#: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
 msgstr "Selecione o campo longitude"
 
-#: frontend/src/metabase/lib/schema_metadata.js:306
+#: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
 msgstr "Latitude Superior"
 
-#: frontend/src/metabase/lib/schema_metadata.js:307
+#: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
 msgstr "Longitude Esquerdo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:308
+#: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
 msgstr "Latitude Inferior"
 
-#: frontend/src/metabase/lib/schema_metadata.js:309
+#: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
 msgstr "Longitude certo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:345
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase-lib/lib/Dimension.js:505
+#: frontend/src/metabase-lib/lib/Dimension.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:351
+#: frontend/src/metabase/lib/schema_metadata.js:371
 #: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:387
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
 msgstr "É"
 
-#: frontend/src/metabase/lib/schema_metadata.js:346
-#: frontend/src/metabase/lib/schema_metadata.js:366
-#: frontend/src/metabase/lib/schema_metadata.js:376
-#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/lib/schema_metadata.js:352
+#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:396
+#: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
 msgstr "Não é"
 
-#: frontend/src/metabase/lib/schema_metadata.js:347
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:369
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:353
+#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
 msgstr "Vazio"
 
-#: frontend/src/metabase/lib/schema_metadata.js:348
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:370
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:402
+#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
 msgstr "Não vazio"
 
-#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
 msgstr "Igual à"
 
-#: frontend/src/metabase/lib/schema_metadata.js:355
+#: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
 msgstr "Diferente"
 
-#: frontend/src/metabase/lib/schema_metadata.js:356
+#: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
 msgstr "Maior do que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:357
+#: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
 msgstr "Menos que"
 
-#: frontend/src/metabase/lib/schema_metadata.js:358
-#: frontend/src/metabase/lib/schema_metadata.js:384
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:285
+#: frontend/src/metabase/lib/schema_metadata.js:364
+#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Entre"
 
-#: frontend/src/metabase/lib/schema_metadata.js:359
+#: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
 msgstr "Maior que ou igual a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:360
+#: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
 msgstr "Menor ou igual a"
 
-#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
 msgstr "Contém"
 
-#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
 msgstr "Não contém"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
 msgstr "Comece com"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
 msgstr "Termina em"
 
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:264
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Antes"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:271
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Depois"
 
-#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
 msgstr "Dentro"
 
-#: frontend/src/metabase/lib/schema_metadata.js:453
+#: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Apenas uma tabela com as linhas na resposta, sem operações adicionais."
 
-#: frontend/src/metabase/lib/schema_metadata.js:459
+#: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
 msgstr "Número de linhas"
 
-#: frontend/src/metabase/lib/schema_metadata.js:461
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
 msgstr "Número total de linhas na resposta."
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
 msgstr "Soma de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:469
+#: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
 msgstr "Soma de todos os valores de uma coluna."
 
 #. Acho que a agregação de "Medium of.... " está ficando errada, pois traduz em 
 #. "Média de... de" mas vou deixar a tradução assim por enquanto
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
 msgstr "Média de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
 msgstr "Média de todos os valores em uma coluna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
 msgstr "Número de valores diferentes de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Número de valores exclusivos de uma coluna entre todas as linhas na resposta"
 
-#: frontend/src/metabase/lib/schema_metadata.js:491
+#: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
 msgstr "Soma acumulada de ..."
 
@@ -3863,7 +3868,7 @@ msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over t
 msgstr "Soma aditiva de todos os valores em uma coluna. \n"
 " por exemplo, receita total ao longo do tempo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:499
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
 msgstr "Contagem cumulativa de linhas"
 
@@ -3872,105 +3877,105 @@ msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over
 msgstr "Contagem aditiva do número de linhas. \n"
 " por exemplo, número total de vendas ao longo do tempo"
 
-#: frontend/src/metabase/lib/schema_metadata.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
 msgstr "Desvio padrão de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:509
+#: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Número que expressa o quanto os valores de uma coluna variam entre todos os linhas na resposta."
 
-#: frontend/src/metabase/lib/schema_metadata.js:515
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
 msgstr "Mínimo de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:517
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
 msgstr "Valor Mínimo de uma Coluna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:523
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
 msgstr "Máximo de ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:525
+#: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
 msgstr "Valor máximo de uma coluna"
 
-#: frontend/src/metabase/lib/schema_metadata.js:533
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
 msgstr "Divida por dimensão"
 
-#: frontend/src/metabase/lib/settings.js:93
+#: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
 msgstr "letra minúscula"
 
-#: frontend/src/metabase/lib/settings.js:95
+#: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
 msgstr "letra maiúscula"
 
-#: frontend/src/metabase/lib/settings.js:97
+#: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "número"
 
-#: frontend/src/metabase/lib/settings.js:99
+#: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
 msgstr "caractere especial"
 
-#: frontend/src/metabase/lib/settings.js:105
+#: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
 msgstr "deve ser"
 
-#: frontend/src/metabase/lib/settings.js:105
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:120
+#: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
 msgstr "quantidade de caractere"
 
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
 msgstr "Deve ser"
 
-#: frontend/src/metabase/lib/settings.js:122
+#: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
 msgstr "e incluir"
 
-#: frontend/src/metabase/lib/utils.js:92
+#: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
 msgstr "zero"
 
-#: frontend/src/metabase/lib/utils.js:93
+#: frontend/src/metabase/lib/utils.js:86
 msgid "one"
 msgstr "um"
 
-#: frontend/src/metabase/lib/utils.js:94
+#: frontend/src/metabase/lib/utils.js:87
 msgid "two"
 msgstr "dois"
 
-#: frontend/src/metabase/lib/utils.js:95
+#: frontend/src/metabase/lib/utils.js:88
 msgid "three"
 msgstr "três"
 
-#: frontend/src/metabase/lib/utils.js:96
+#: frontend/src/metabase/lib/utils.js:89
 msgid "four"
 msgstr "quatro"
 
-#: frontend/src/metabase/lib/utils.js:97
+#: frontend/src/metabase/lib/utils.js:90
 msgid "five"
 msgstr "cinco"
 
-#: frontend/src/metabase/lib/utils.js:98
+#: frontend/src/metabase/lib/utils.js:91
 msgid "six"
 msgstr "seis"
 
-#: frontend/src/metabase/lib/utils.js:99
+#: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
 msgstr "sete"
 
-#: frontend/src/metabase/lib/utils.js:100
+#: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
 msgstr "oito"
 
-#: frontend/src/metabase/lib/utils.js:101
+#: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
 msgstr "nove"
 
@@ -4044,6 +4049,7 @@ msgstr "Tempo"
 msgid "Date range, relative date, time of day, etc."
 msgstr "Intervalo de datas, data relativa, hora do dia, etc."
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
@@ -4066,7 +4072,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Categoria, Tipo, Modelo, Classificação, etc."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
-#: frontend/src/metabase/user/components/UserSettings.jsx:54
+#: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
 msgstr "Configuração da conta"
 
@@ -4078,56 +4084,56 @@ msgstr "Sair do admin"
 msgid "Logs"
 msgstr "Logs"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:64
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
 msgstr "Ajuda"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:67
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
 msgstr "Sobre o Metabase"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:73
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
 msgstr "Sair"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:98
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
 msgstr "Obrigado por usar"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
 msgstr "Você está na versão"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
 msgstr "Construído em"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:124
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
 msgstr "é uma marca registrada da"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:126
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
 msgstr "e é construído com amor em São Francisco, CA"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:194
+#: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
 msgstr "Administrador do Metabase"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:300
+#: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
 msgstr "Fazer uma pergunta"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:309
+#: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
 msgstr "Novo painel"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:315
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/nav/containers/Navbar.jsx:361
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
 msgstr "Nova notificação"
 
@@ -4135,16 +4141,16 @@ msgstr "Nova notificação"
 msgid "Reference"
 msgstr "Referência"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:83
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
 msgstr "Qual métrica?"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:110
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Definir métricas comuns para sua equipe facilita ainda mais fazer perguntas"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:113
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
 msgstr "Como criar métricas"
 
@@ -4156,8 +4162,8 @@ msgstr "Verifique os dados ao longo do tempo, como um mapa, ou gire-os para ajud
 msgid "Custom"
 msgstr "Personalizado"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:150
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:517
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
 msgstr "Nova pergunta"
 
@@ -4165,22 +4171,22 @@ msgstr "Nova pergunta"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Use o gerador de perguntas para ver tendências, listas de coisas ou para criar suas próprias métricas."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:161
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Consulta nativa"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:162
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Para perguntas mais complicadas, você pode escrever sua própria consulta SQL ou nativo"
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:240
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
 msgstr "Selecione um valor padrão..."
 
-#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:149
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
 msgstr "Atualizar filtro"
 
@@ -4188,14 +4194,14 @@ msgstr "Atualizar filtro"
 #: frontend/src/metabase/lib/query_time.js:123
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:9
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Today"
 msgstr "Hoje"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
 msgstr "Ontem"
 
@@ -4207,7 +4213,7 @@ msgstr "Últimos 7 dias"
 msgid "Past 30 days"
 msgstr "Últimos 30 dias"
 
-#: frontend/src/metabase/lib/query_time.js:195
+#: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:29
 #: src/metabase/api/table.clj
@@ -4216,7 +4222,7 @@ msgid_plural "Weeks"
 msgstr[0] "Semana"
 msgstr[1] "Semanas"
 
-#: frontend/src/metabase/lib/query_time.js:197
+#: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:30
 #: src/metabase/api/table.clj
@@ -4225,7 +4231,7 @@ msgid_plural "Months"
 msgstr[0] "Mês"
 msgstr[1] "Meses"
 
-#: frontend/src/metabase/lib/query_time.js:201
+#: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:31
 #: src/metabase/api/table.clj
@@ -4275,6 +4281,7 @@ msgstr "Digite um valor..."
 msgid "Enter a default value..."
 msgstr "Digite um valor padrão..."
 
+#: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Ocorreu um erro"
@@ -4315,24 +4322,24 @@ msgstr "Publicar"
 msgid "Code"
 msgstr "Código"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:70
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
 msgstr "Estilo"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
 msgstr "Quais parâmetros os usuários desta incorporação podem usar?"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:83
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
 msgstr "Este {0} ainda não tem parâmetros para configurar."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
 msgstr "Editável"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
 msgstr "Bloqueado"
 
@@ -4340,19 +4347,19 @@ msgstr "Bloqueado"
 msgid "Preview Locked Parameters"
 msgstr "Visualização de parâmetros bloqueados"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:115
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
 msgstr "Tente passar alguns valores para seus parâmetros bloqueados aqui. Seu servidor terá que fornecer os valores reais no token assinado ao usar este de uma maneira real."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
 msgstr "Área perigosa"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
 msgstr "Isso desativará a incorporação para este {0}."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:128
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
 msgstr "Despublicar"
 
@@ -4392,64 +4399,64 @@ msgstr "Mais {0}"
 msgid "examples on GitHub"
 msgstr "exemplos no GitHub"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:72
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
 msgstr "Ativar compartilhamento"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
 msgstr "Desativar este link público?"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:77
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
 msgstr "Isso fará com que o link existente pare de funcionar. Você pode voltar para habilitá-lo, mas quando você fizer isso será um link diferente."
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
 msgstr "Link público"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:118
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
 msgstr "Compartilhe isto {0} com pessoas que não tenham uma conta Metabase usando a seguinte URL:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:158
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
 msgstr "Incorporar publicamente"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:159
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
 msgstr "Incorporar este {0} em posts ou páginas da web ao copiar e colar este fragmento:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:176
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
 msgstr "Incorporar este {0} em um aplicativo"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:177
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
 msgstr "Ao integrar-se com seu servidor de aplicativos, você pode fornecer um {0} seguro limitado a um usuário, cliente, organização, etc. específicos"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
 msgstr "Remover o anexo"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:95
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
 msgstr "Anexar arquivo com resultados"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
 msgstr "Esta questão será adicionada como um anexo"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:128
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
 msgstr "Esta questão não será incluída em sua notificação"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:92
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
 msgstr "Esta notificação não será mais enviada por e-mail para {0} {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:94
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:376
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
 msgstr[0] "{0} endereço"
@@ -4459,39 +4466,39 @@ msgstr[1] "{0} endereços"
 msgid "Slack channel {0} will no longer get this pulse {1}"
 msgstr "O canal Slack {0} não receberá mais essa notificação {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:110
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
 msgstr "O canal {0} não receberá mais essa notificação {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
 msgstr "Editar uma notificação"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:131
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
 msgstr "O que é uma notificação?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:141
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
 msgstr "Entendi"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
 msgstr "Para onde esses dados devem ir?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:173
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
 msgstr "Desarquivando..."
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
 msgstr "Falha ao desarquivar"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
 msgstr "Desarquivado"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
 msgstr "Crie um notificação"
 
@@ -4501,7 +4508,7 @@ msgstr "Anexo"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:673
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
 msgstr "Atenção"
 
@@ -4522,6 +4529,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Recomendamos manter as notificações pequenas e simples para mantê-las fáceis e úteis para toda a equipe."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
+#: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
 msgstr "Escolha seus dados"
 
@@ -4537,47 +4545,47 @@ msgstr "E-mails"
 msgid "Slack messages"
 msgstr "Mensagens Slack"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Enviado"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:222
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} será enviado para"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:224
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Mensagens"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Enviar e-mail agora"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:241
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Envie para {0} agora"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Enviando..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:244
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Envio falhou"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Não foi enviado porque a notificação não tem resultados."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:248
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Notificação enviada"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:287
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} deve ser configurado por um administrador."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:302
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
 msgstr "Slack"
 
@@ -4626,21 +4634,21 @@ msgid "Before {0}"
 msgstr "Antes de {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:295
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Vazio"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:301
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Não vazio"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:213
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Todo o tempo"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:154
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
 msgstr "Aplicar"
 
@@ -4706,7 +4714,7 @@ msgstr "Distribuição"
 msgid "View details"
 msgstr "Ver detalhes"
 
-#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:54
+#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
 msgstr "Veja {1} de {0}"
 
@@ -4730,23 +4738,23 @@ msgstr "Média"
 msgid "Distincts"
 msgstr "Distintos"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:32
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Veja este {0}"
 msgstr[1] "Veja estes {0}"
 
 #. não seria ampliar aqui?
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:225
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
 msgstr "Aumentar Zoom"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:19
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
 msgstr "Expressão personalizada"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
 msgstr "Métricas Comuns"
 
@@ -4754,7 +4762,7 @@ msgstr "Métricas Comuns"
 msgid "Metabasics"
 msgstr "Metabase"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
 msgstr "Nome (opcional)"
 
@@ -4766,31 +4774,31 @@ msgstr "Escolha uma agregação"
 msgid "Set up your own alert"
 msgstr "Configure seu próprio alerta"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:140
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
 msgstr "Cancelando inscrição..."
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:145
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
 msgstr "Falha ao cancelar a inscrição"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:204
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
 msgstr "Retirar-se"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:235
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
 msgstr "Sem canal"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:263
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
 msgstr "Ok, sua inscrição foi cancelada"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:335
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
 msgstr "Você está recebendo alertas de {0}"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
 msgstr "{0} configurou um alerta"
 
@@ -4846,147 +4854,147 @@ msgstr "Edite seu alerta"
 msgid "Edit alert"
 msgstr "Editar alerta"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:374
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
 msgstr "Este alerta não será mais enviado por email para {0}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:382
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
 msgstr "O canal Slack {0} não receberá mais este alerta."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:386
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
 msgstr "O canal {0} não receberá mais este alerta."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:403
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
 msgstr "Remover este alerta"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:405
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
 msgstr "Pare de enviar e remova este alerta. Não pode ser desfeito, então tenha tenha cuidado"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:413
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
 msgstr "Remover este alerta?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:497
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
 msgstr "Deixe-me saber quando a linha..."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:498
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
 msgstr "Deixe-me saber quando a barra de progresso..."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
 msgstr "Vai acima da linha da meta"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
 msgstr "Alcançar a meta"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
 msgstr "Vai abaixo da linha de meta"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
 msgstr "Vai abaixo da meta"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:512
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
 msgstr "A primeira vez que você cruza ou a cada vez?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:513
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
 msgstr "A primeira vez que você alcança a meta ou a cada vez?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
 msgstr "A primeira vez"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:516
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
 msgstr "Toda vez"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:619
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
 msgstr "Para onde você deseja enviar esses alertas?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:630
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
 msgstr "Envie e-mails de alerta para:"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:672
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
 msgstr "{0} Alertas baseados em metas ainda não são compatíveis com gráficos com mais de uma linha, portanto, esse alerta será enviado desde que o gráfico tenha {1}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
 msgstr "resultados"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:679
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
 msgstr "{0} Este tipo de alerta é mais útil quando sua pergunta {1} não lança nenhum resultado, mas você quer saber quando isso acontece."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:680
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
 msgstr "Dica:"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
 msgstr "geralmente"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:57
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
 msgstr "Escolha um segmento ou tabela"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
 msgstr "Selecione um banco de dados"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:88
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
 msgstr "Selecione..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:128
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
 msgstr "Selecione uma tabela"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:793
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
 msgstr "Nenhuma tabela foi encontrada neste banco de dados."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:830
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
 msgstr "Uma pergunta está faltando?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:834
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
 msgstr "Saiba mais sobre consultas aninhadas"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:868
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
 msgstr "Campos"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:946
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
 msgstr "Nenhum segmento foi encontrado"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:969
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
 msgstr "Encontre um segmento"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:46
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
 msgstr "Ver menos"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:56
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
 msgstr "Ver mais"
 
@@ -4995,60 +5003,65 @@ msgid "Pick a field to sort by"
 msgstr "Escolha um campo para ordenar por"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
 msgstr "Ordenar"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
 msgstr "Limite de linha"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:69
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
 msgstr "Campo Desconhecido"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
 msgstr "campo"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:114
+#: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
 msgstr "Combinações"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
+#: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Adicione filtros para limitar sua resposta"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:284
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
 msgstr "Adicione um grupo"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:322
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:102
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:113
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:152
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:194
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:59
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:68
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:75
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:225
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:231
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:237
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:70
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:75
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:64
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:89
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:131
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:176
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:302
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:308
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:314
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Dados"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:352
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
 msgstr "Filtrado por"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:369
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
 msgstr "Ver"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:386
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
 msgstr "Agrupado por"
 
@@ -5056,23 +5069,23 @@ msgstr "Agrupado por"
 msgid "None"
 msgstr "Nenhum"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:345
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
 msgstr "Esta questão está escrita em {0}."
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:353
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
 msgstr "Ocultar editor"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:354
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
 msgstr "Esconder consulta"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
 msgstr "Abrir editor"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:360
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
 msgstr "Mostrar consulta"
 
@@ -5093,15 +5106,15 @@ msgstr "Baixe esta informação"
 msgid "Warning"
 msgstr "Aviso"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:52
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
 msgstr "Sua resposta tem muitas linhas, então pode demorar um pouco para baixar."
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:53
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
 msgstr "O tamanho máximo para baixar é de 1 milhão de linhas."
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:232
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
 msgstr "Editar pergunta"
 
@@ -5117,17 +5130,17 @@ msgstr "CANCELAR"
 msgid "Move question"
 msgstr "Mover pergunta"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:283
+#: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
 msgstr "Em que coleção deveria ser?"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:313
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:110
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
+#: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
 msgstr "Variáveis"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:432
+#: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
 msgstr "Conheça seus dados"
 
@@ -5171,11 +5184,11 @@ msgstr "{0} desta questão"
 msgid "Convert this question to {0}"
 msgstr "Converta esta questão para {0}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:122
+#: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
 msgstr "Esta questão será atualizada em aproximadamente {0}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:131
+#: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
 msgstr "Atualizado {0} atrás"
 
@@ -5193,11 +5206,11 @@ msgstr "Mostrando primeiro {0} {1}"
 msgid "Showing {0} {1}"
 msgstr "Mostrando {0} {1}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:281
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
 msgstr "Fazendo ciência"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:294
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
 msgstr "Se você me der alguma informação, eu posso te mostrar uma coisa ótima. Execute uma consulta!"
 
@@ -5205,7 +5218,7 @@ msgstr "Se você me der alguma informação, eu posso te mostrar uma coisa ótim
 msgid "How do I use this thing?"
 msgstr "Como eu uso essa coisa?"
 
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:28
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
 msgstr "Obter uma resposta"
 
@@ -5233,39 +5246,39 @@ msgstr "Sinto muito. Algo deu errado."
 msgid "Group time by"
 msgstr "Horário do grupo por"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:46
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
 msgstr "Sua pergunta demorou muito"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:47
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
 msgstr "Nós não recebemos uma resposta do seu banco de dados a tempo, então tivemos que Você pode tentar novamente em um minuto, ou se o problema persistir, Você pode enviar um email para um administrador para notificá-lo."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:55
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
 msgstr "Estamos com problemas com o servidor"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:56
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
 msgstr "Tente atualizar a página depois de esperar um ou dois minutos. Se o problema persistir, recomendamos que você entre em contato com um administrador."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:88
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
 msgstr "Houve um problema com sua pergunta"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:89
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
 msgstr "Na maioria das vezes isso é causado por uma seleção inválida ou por um Valor incorreto de entrada. Verifique suas entradas e tente novamente."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:60
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
 msgstr "Esta pode ser a resposta que você está procurando. Caso contrário, tente Remova ou altere seus filtros para torná-los menos específicos."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
 msgstr "Você também pode {0} quando há alguns resultados."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:68
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
 msgstr "receber um alerta"
 
@@ -5273,11 +5286,11 @@ msgstr "receber um alerta"
 msgid "Back to last run"
 msgstr "Retornar para a última execução"
 
-#: frontend/src/metabase/query_builder/components/VisualizationSettings.jsx:100
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
 msgstr "Display"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:96
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
 msgstr "Sem descrição"
 
@@ -5289,7 +5302,7 @@ msgstr "Use para a pergunta atual"
 msgid "Potentially useful questions"
 msgstr "Perguntas potencialmente úteis"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:166
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
 msgstr "Agrupar por {0}"
 
@@ -5302,14 +5315,14 @@ msgstr "Soma de todos os valores de {0}"
 msgid "All distinct values of {0}"
 msgstr "Todos os valores diferentes de {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:187
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
 msgstr "Número de {0} agrupados por {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5325,34 +5338,34 @@ msgstr "Referência de dados"
 msgid "Learn more about your data structure to ask more useful questions"
 msgstr "Saiba mais sobre sua estrutura de dados para fazer perguntas mais úteis"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:58
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:84
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
 msgstr "Os metadados na tabela não foram encontrados antes de criar um novo questão"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:80
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
 msgstr "Veja {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:94
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
 msgstr "Definição de Métrica"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:118
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
 msgstr "Filtrar por {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:127
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
 msgstr "Número de {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
 msgstr "Ver todos {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:148
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
 msgstr "Definição de Segmento"
 
@@ -5364,7 +5377,7 @@ msgstr "Ocorreu um erro ao carregar a tabela"
 msgid "See the raw data for {0}"
 msgstr "Veja os dados brutos de {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:180
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
 msgstr "Mais"
 
@@ -5376,24 +5389,24 @@ msgstr "Expressão inválida"
 msgid "unknown error"
 msgstr "erro desconhecido"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:46
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
 msgstr "Campo fórmula"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:57
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Pense nisso como algo como escrever uma fórmula em um programa de planilhas: você pode usar números, campos nesta tabela, símbolos matemáticos como +, e algumas funções. Então você poderia escrever algo como Subtotal &minus; Custo."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
 msgstr "Saiba mais"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:66
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
 msgstr "Dê um nome a ele"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:72
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
 msgstr "Algo legal e descritivo"
 
@@ -5445,7 +5458,8 @@ msgstr "verdadeiro"
 msgid "false"
 msgstr "falso"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
 msgstr "Adicionar filtro"
 
@@ -5453,15 +5467,15 @@ msgstr "Adicionar filtro"
 msgid "Item"
 msgstr "Element"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:221
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
 msgstr "Anterior"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:252
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
 msgstr "Atual"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:278
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
@@ -5472,7 +5486,7 @@ msgid "Enter desired number"
 msgstr "Digite o número desejado"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:100
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
 msgstr "Vazio"
 
@@ -5496,35 +5510,35 @@ msgstr "Você pode inserir vários valores separados por vírgulas"
 msgid "Enter desired text"
 msgstr "Digite o texto desejado"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
 msgstr "Experimente"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
 msgstr "Para que serve isto?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
 msgstr "Variáveis ​​em consultas nativas permitem que você substitua dinamicamente os valores em suas consultas usando elementos de filtro ou através do URL"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
 msgstr "{0} cria uma variável neste modelo SQL chamado \"nome_da_variável\". Você pode atribuir tipos às variáveis ​​no painel lateral, o que muda seu comportamento. Todos os tipos de variáveis que não sejam \"Filtro de Campo\" farão com que o filtro seja colocado nesta questão; com filtros de campo, isso é opcional. Quando este filtro isso é preenchido, esse valor substitui a variável no modelo SQL."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:121
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
 msgstr "Filtros de campo"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:123
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Dar a uma variavel o tipo \"Filtro de campo\" te permite vincular as placas SQL com os elementos de filtro nos painéis, ou usar mais tipos de elementos de filtro na sua pergunta SQL. Uma variável de Filtro de Campo insere SQL semelhante ao editor de consultas GUI quando os filtros são adicionados às colunas existentes."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:126
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
 msgstr "Ao adicionar uma variável de Filtro de Campo, você deve atribuí-la a um campo específico. Em seguida, você pode optar por mostrar um elemento de filtro na sua pergunta, mas mesmo se você não fizer isso, você pode agora atribuir a sua variável de Filtro de Campo para um Filtro de Painel ao adicionar esta pergunta ao painel. Filtros de Campo devem ser usados ​​dentro de uma cláusula \"WHERE\"."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:130
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
 msgstr "Cláusulas opcionais"
 
@@ -5532,59 +5546,61 @@ msgstr "Cláusulas opcionais"
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
 msgstr "os parênteses em torno de um {0} criam uma cláusula opcional no modelo. Se a \"variável\" está posta, então a cláusula inteira é posta no  modelo. Caso contrário, a cláusula inteira será ignorada."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:142
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
 msgstr "Para usar várias cláusulas opcionais, você pode incluir pelo menos uma cláusula WHERE não opcional seguida de cláusulas opcionais que começam com \"AND\"."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
 msgstr "Leia a documentação completa"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:127
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
 msgstr "Filtro de Etiqueta"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:139
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
 msgstr "Tipo de Variável"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:143
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
 msgstr "Texto"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:150
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:119
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
 msgstr "Data"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
 msgstr "Filtro de campo"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:157
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
 msgstr "Campo para mapear para"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
 msgstr "Tipo de filtro"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:201
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
 msgstr "Obrigatório?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:211
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
 msgstr "Valor padrão do filtro"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:46
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
 msgstr "Arquivar esta pergunta?"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:57
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Esta questão será removida de qualquer painel ou notificação que a utilize."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:136
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
 msgstr "Pergunta"
 
@@ -5601,21 +5617,21 @@ msgstr "Você está editando esta página"
 msgid "See this {0}"
 msgstr "Veja isto {0}"
 
-#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:120
+#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
 msgstr "Um subconjunto de"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:68
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
 msgstr "Selecione um tipo de campo"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:57
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
 msgstr "Sem tipo de campo"
 
@@ -5624,16 +5640,16 @@ msgid "by"
 msgstr "por"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
-#: frontend/src/metabase/reference/databases/FieldList.jsx:152
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
+#: frontend/src/metabase/reference/databases/FieldList.jsx:155
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
 msgstr "Tipo do campo"
 
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:72
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
 msgstr "Selecione uma chave estrangeira"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:53
+#: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
 msgstr "Veja a fórmula para {0}"
 
@@ -5650,12 +5666,12 @@ msgid "Nothing important yet"
 msgstr "Nada importante ainda"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:168
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:233
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:211
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:215
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:219
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:229
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:236
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:214
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
 msgstr "Nada de interessante ainda"
 
@@ -5664,12 +5680,12 @@ msgid "Things to be aware of about this {0}"
 msgstr "Coisas para ter em mente sobre isso {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:178
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:243
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:221
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:225
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:229
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:239
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:246
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:224
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
 msgstr "Nada para estar ciente ainda"
 
@@ -5731,15 +5747,15 @@ msgstr "Razão da mudança"
 msgid "Leave a note to explain what changes you made and why they were required"
 msgstr "Deixe uma nota para explicar que mudanças você fez e por que elas foram obrigatório"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:166
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
 msgstr "Por que esse banco de dados é interessante"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:176
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
 msgstr "Coisas para manter em mente sobre este banco de dados"
 
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:46
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
 msgstr "Bancos de dados e tabelas"
@@ -5747,42 +5763,42 @@ msgstr "Bancos de dados e tabelas"
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:41
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:170
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:173
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:34
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:184
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:187
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:30
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:188
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:187
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:191
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:190
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
 msgstr "Detalhes"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
-#: frontend/src/metabase/reference/databases/TableList.jsx:111
+#: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
 msgstr "Tabelas em {0}"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:222
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:200
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:218
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:203
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
 msgstr "Nome real no banco de dados"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:231
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:227
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
 msgstr "Por que esse campo é interessante"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:241
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:237
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
 msgstr "Coisas a ter em mente sobre este campo"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:253
-#: frontend/src/metabase/reference/databases/FieldList.jsx:155
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:249
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
+#: frontend/src/metabase/reference/databases/FieldList.jsx:158
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
 msgstr "Tipo de dados"
 
@@ -5791,13 +5807,13 @@ msgstr "Tipo de dados"
 msgid "Fields in this table will appear here as they're added"
 msgstr "Os campos nesta tabela aparecerão aqui à medida que forem adicionados"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:134
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:135
+#: frontend/src/metabase/reference/databases/FieldList.jsx:137
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
 msgstr "Campos em {0}"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:149
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:150
+#: frontend/src/metabase/reference/databases/FieldList.jsx:152
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
 msgstr "Nome do campo"
 
@@ -5821,7 +5837,10 @@ msgstr "Os bancos de dados aparecerão aqui quando os administradores tiverem ad
 msgid "Connect a database"
 msgstr "Conecte um banco de dados"
 
+#. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
+#. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
+#: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
 msgstr "Número de {0}"
 
@@ -5829,11 +5848,11 @@ msgstr "Número de {0}"
 msgid "See raw data for {0}"
 msgstr "Ver dados brutos de {0}"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:209
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
 msgstr "Por que esta tabela é interessante"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:219
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
 msgstr "Coisas para manter em mente sobre esta tabela"
 
@@ -5845,16 +5864,16 @@ msgstr "As tabelas neste banco de dados aparecerão aqui quando forem adicionada
 msgid "Questions about this table will appear here as they're added"
 msgstr "Perguntas sobre esta tabela aparecerão aqui quando forem adicionadas"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:71
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:75
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:74
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
 msgstr "Perguntas sobre {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
 msgstr "Criado {0} por {1}"
 
@@ -5866,151 +5885,152 @@ msgstr "Campos nesta tabela"
 msgid "Questions about this table"
 msgstr "Perguntas sobre esta tabela"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:157
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
 msgstr "Ajude sua equipe a começar com seus dados."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:159
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
 msgstr "Mostre à sua equipe o que é mais importante ao escolher seu melhor painel, suas métricas e seus principais segmentos."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:165
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
 msgstr "Começar"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:173
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
 msgstr "Nosso painel mais importante"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:188
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
 msgstr "Números aos quais prestamos atenção"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:213
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
 msgstr "As métricas são números importantes que são importantes para sua empresa. Frequentemente eles representam um indicador central de como o negócio está funcionando."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:221
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
 msgstr "Veja todas as métricas"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:235
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
 msgstr "Segmentos e Tabelas"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
+#: frontend/src/metabase/home/containers/SearchApp.jsx:83
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
 msgstr "Tabelas"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:262
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
 msgstr "Segmentos e tabelas são os componentes básicos dos seus dados companhia Tabelas são coleções de informações sem formatação enquanto os segmentos são partes limitadas com significados específicos, como {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:267
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
 msgstr "Tabelas são os componentes básicos dos dados da sua empresa."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:277
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
 msgstr "Veja todos os segmentos"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:293
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
 msgstr "Veja todas as tabelas"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:301
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
 msgstr "Outras coisas que você deve saber sobre nossos dados"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
 msgstr "Descubra mais"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:307
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
 msgstr "Uma boa maneira de conhecer seus dados é dedicar um pouco de tempo para Explore as diferentes tabelas e outras informações disponíveis. Você pode levar um pouco, mas você começará a reconhecer nomes e significados ao longo do tempo."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:313
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
 msgstr "Explore nossos dados"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:321
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
 msgstr "Você tem alguma pergunta?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:326
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
 msgstr "Fale com {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:248
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
 msgstr "Ajude os novos usuários do Metabase a encontrar o caminho."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:251
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
 msgstr "O guia de introdução destaca o painel, as métricas, o segmentos e tabelas mais importantes, e informa os usuários sobre coisas importantes que você deve saber antes de investigar os dados."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:258
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
 msgstr "Existe um painel importante para sua equipe?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:260
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
 msgstr "Crie um painel agora"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:266
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
 msgstr "Qual é o seu painel mais importante?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:285
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
 msgstr "Você tem alguma métrica comumente referenciada?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:287
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
 msgstr "Aprenda a definir uma métrica"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:300
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
 msgstr "Quais são as 3-5 métricas mais referenciadas?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:344
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
 msgstr "Adicione outra métrica"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:357
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
 msgstr "Você tem um segmento ou tabela comumente referenciado?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:359
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
 msgstr "Aprenda a criar um segmento"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:372
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
 msgstr "Quais são os 3-5 segmentos ou tabelas comumente referenciados que seriam útil para esse público?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:418
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
 msgstr "Adicione outro segmento ou tabela"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:427
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
 msgstr "Existe alguma coisa que seus usuários devem entender ou saber antes de começar para acessar os dados?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:433
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
 msgstr "O que um usuário deve saber sobre esses dados antes de começarem a acessar eles?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:437
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
 msgstr "Por exemplo, expectativas sobre privacidade e uso de dados, perigos comuns ou mal-entendidos, informações sobre o desempenho do data warehouse, avisos legais, etc."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
 msgstr "Existe alguém com quem seus usuários podem entrar em contato se precisarem de ajuda se Você está confuso sobre este guia?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:457
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
 msgstr "Com quem os usuários devem entrar em contato para obter ajuda se estiverem confuso sobre esta informação?"
 
@@ -6019,39 +6039,39 @@ msgstr "Com quem os usuários devem entrar em contato para obter ajuda se estive
 msgid "Please enter a revision message"
 msgstr "Por favor, adicione uma mensagem de revisão"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:213
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
 msgstr "Por que essa métrica é interessante"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:223
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
 msgstr "Coisas a ter em conta acerca desta métrica"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:233
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
 msgstr "Como essa métrica é calculada"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:235
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
 msgstr "Nada sobre como foi calculado ainda"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:293
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
 msgstr "Outros campos pelos quais você pode agrupar essa métrica"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:294
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
 msgstr "Campos pelos quais você pode agrupar essa métrica"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:23
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "As métricas são os números oficiais com os quais sua equipe se preocupa"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
 msgstr "As métricas aparecerão aqui quando seus administradores tiverem criado alguns"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
 msgstr "Aprenda como criar métricas"
 
@@ -6063,9 +6083,9 @@ msgstr "Perguntas sobre essa métrica aparecerão aqui quando forem adicionadas"
 msgid "There are no revisions for this metric"
 msgstr "Não há comentários para esta métrica"
 
-#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:88
-#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
-#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:88
+#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
+#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
+#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
 msgstr "Histórico de revisão de {0}"
 
@@ -6073,27 +6093,27 @@ msgstr "Histórico de revisão de {0}"
 msgid "X-ray this metric"
 msgstr "Aplique raios-X a esta métrica"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:217
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
 msgstr "Por que esse segmento é interessante"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:227
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
 msgstr "Coisas a ter em mente sobre este segmento"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
 msgstr "Segmentos são subconjuntos interessantes de tabelas"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Definir segmentos comuns para sua equipe facilita ainda mais fazer perguntas"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
 msgstr "Os segmentos aparecerão aqui quando os administradores tiverem criado alguns"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
 msgstr "Aprenda a criar segmentos"
 
@@ -6121,7 +6141,7 @@ msgstr "Aplique raios-X a este segmento"
 msgid "Login"
 msgstr "Iniciar sessão"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:130
+#: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
 msgstr "Pesquisar"
@@ -6138,99 +6158,99 @@ msgstr "Nova pergunta"
 msgid "Select the type of Database you use"
 msgstr "Selecione o tipo de banco de dados que você usa"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:141
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
 msgstr "Adicione seus dados"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:145
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
 msgstr "Eu adicionarei meus próprios dados mais tarde"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
 msgstr "Conectando com {0}"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:165
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
 msgstr "Você precisará de informações sobre seu banco de dados, como seu nome de usuário e a senha. Se você não tem isso agora, o Metabase também vem com um conjunto de dados de amostra com os quais você pode começar."
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:196
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
 msgstr "Eu adicionarei meus dados mais tarde"
 
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:41
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
 msgstr "Controle automático de digitalização"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:53
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
 msgstr "Preferências de uso de dados"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
 msgstr "Obrigado por nos ajudar a melhorar"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:57
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
 msgstr "Nós não coletaremos nenhum evento de uso"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:76
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Para nos ajudar a melhorar o Metabase, gostaríamos de coletar certas informações sobre o uso através do Google Analytics."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
 msgstr "Aqui está uma lista completa de tudo que acompanhamos e por quê."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:98
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Permitir que o Metabase colete eventos de uso anonimamente"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} coleta informações sobre seus dados ou resultados de perguntas."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:106
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
 msgstr "nunca"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
 msgstr "Toda a informação obtida é completamente anônima."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "A coleção pode ser desativada a qualquer momento na seção de configuração"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:45
+#: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
 msgstr "Se você se sentir sobrecarregado"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:52
+#: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
 msgstr "nosso guia inicial"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:53
+#: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
 msgstr "É um único clique."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:95
+#: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
 msgstr "Bem vindo ao Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:96
+#: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Parece que tudo está funcionando. Agora vamos conhecê-lo, conecte-se com o seu dados e comece a encontrar algumas respostas!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:100
+#: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
 msgstr "Vamos começar"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:145
+#: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
 msgstr "Estás pronto!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:156
+#: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
 msgstr "Leve-me para o Metabase"
 
@@ -6247,7 +6267,7 @@ msgid "Create a password"
 msgstr "Crie uma senha"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:116
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
 msgstr "Shhh..."
 
@@ -6299,7 +6319,7 @@ msgstr "O Metabot está se sentindo bem com o que está acontecendo…"
 msgid "We’ll show you some interesting explorations of your data in\n"
 "just a few minutes."
 msgstr "Vamos mostrar algumas explorações de seus dados em \n"
-"alguns minuros."
+"alguns minutos."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:72
 msgid "This seems to be taking a while. In the meantime, you can check out one of these example explorations to see what Metabase can do for you."
@@ -6441,11 +6461,11 @@ msgstr "Faça login com o endereço de e-mail do Google"
 msgid "User Details"
 msgstr "Detalhes do usuário"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:275
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
 msgstr "Redefinir para o padrão"
 
-#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:133
+#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
 msgstr "mapa desconhecido"
 
@@ -6457,24 +6477,24 @@ msgstr "O mapa da grade requer longitude / latitude agrupada."
 msgid "more"
 msgstr "mais"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:101
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
 msgstr "Quais campos você deseja usar para os eixos X e Y?"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:103
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:60
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
 msgstr "Escolha campos"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:204
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
 msgstr "Salvar como visualização padrão"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
 msgstr "Desenhar caixa para filtrar"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
 msgstr "Cancelar filtro"
 
@@ -6482,7 +6502,7 @@ msgstr "Cancelar filtro"
 msgid "Pin Map"
 msgstr "Fixar mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:303
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
 msgstr "Desmarcar"
 
@@ -6490,31 +6510,31 @@ msgstr "Desmarcar"
 msgid "Rows {0}-{1} of {2}"
 msgstr "Linhas {0}-{1} de {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:189
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
 msgstr "Dados truncados para {0} linhas."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:364
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
 msgstr "A visualização não pôde ser encontrada"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:371
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
 msgstr "Não foi possível mostrar este gráfico com essas informações."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:469
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
 msgstr "Nenhum resultado!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:490
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
 msgstr "Ainda esperando..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:493
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
 msgstr "Isso geralmente leva cerca de {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:499
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Isso é um pouco demorado para um painel)"
 
@@ -6530,11 +6550,11 @@ msgstr "Selecione um campo"
 msgid "error"
 msgstr "erro"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:126
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
 msgstr "Clique e arraste para mudar a ordenação"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:139
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
 msgstr "Adicionar campos da lista abaixo"
 
@@ -6625,7 +6645,7 @@ msgid "Highlight the whole row"
 msgstr "Realçar"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:98
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Cores"
 
@@ -6690,20 +6710,20 @@ msgstr "A visualização com este identificador já está registrada: "
 msgid "No visualization for {0}"
 msgstr "Nenhuma exibição para {0}"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:75
+#: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
 msgstr "\"{0}\" é um campo não agregado: se ele têm mais de um valor em um único ponto no  eixo X, os valores serão somados."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:91
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
 msgstr "Este tipo de gráfico requer pelo menos 2 colunas."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:96
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
 msgstr "Este tipo de gráfico não suporta mais de {0} séries de dados."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:51
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:297
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
 msgstr "Meta"
 
@@ -6743,25 +6763,25 @@ msgstr "Editar configuração"
 msgid "xValues missing!"
 msgstr "xValores ausentes!"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:114
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "Eixo X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:140
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
 msgstr "Adicione um detalhamento da série..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:153
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Eixo Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:178
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
 msgstr "Adicione outra série..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:195
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
 msgstr "Tamanho da bolha"
 
@@ -6775,7 +6795,7 @@ msgid "Curve"
 msgstr "Curva"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:69
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
 msgstr "Passo"
 
@@ -6783,27 +6803,27 @@ msgstr "Passo"
 msgid "Show point markers on lines"
 msgstr "Mostrar marcadores de ponto em linhas"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:235
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
 msgstr "Empilhado"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:239
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
 msgstr "Não empilhados"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:240
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
 msgstr "Pilha"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:241
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
 msgstr "Empilhamento - 100%"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:300
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
 msgstr "Mostrar meta"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:306
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
 msgstr "Valor da meta"
 
@@ -6823,126 +6843,126 @@ msgstr "Nada"
 msgid "Linear Interpolated"
 msgstr "Linha interpolada"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:371
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
 msgstr "Escala do Eixo X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
 msgstr "Séries cronológica"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:391
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:409
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:381
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
 msgstr "Linear"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:410
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:383
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
 msgstr "Expoente"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:384
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
 msgstr "Logarítmico"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:396
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
 msgstr "Histograma"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:398
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
 msgstr "Ordinal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:404
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
 msgstr "Escala do Eixo Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:417
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
 msgstr "Mostrar marcas de linha e eixo X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:423
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
 msgstr "Compacto"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:424
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
 msgstr "Rodar 45°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
 msgstr "Rodar 90°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
 msgstr "Mostrar linha e marcas do eixo Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
 msgstr "Eixo Y automático"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
 msgstr "Use um eixo Y dividido quando necessário"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
 msgstr "Mostrar rótulo no eixo X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:501
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
 msgstr "Etiqueta do eixo X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:510
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
 msgstr "Mostrar rótulo no eixo Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:516
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
 msgstr "Etiqueta do eixo Y"
 
-#: frontend/src/metabase/visualizations/lib/utils.js:129
+#: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
 msgstr "Desvio padrão"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:275
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:17
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:256
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
 msgstr "Área"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
 msgstr "gráfico de área"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:276
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:16
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:257
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
 msgstr "Barra"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
 msgstr "gráfico de barras"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
 msgstr "Quais campos você deseja usar?"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
 msgstr "Funil"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:76
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:76
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Medida"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
 msgstr "Tipo de Funil"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:88
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
 msgstr "Gráfico de barras"
 
@@ -6950,141 +6970,141 @@ msgstr "Gráfico de barras"
 msgid "line chart"
 msgstr "gráfico de linhas"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:224
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Selecione as colunas de longitude e latitude na configuração do gráfico"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
 msgstr "Por favor, selecione um mapa da região."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Selecione as colunas e métricas da região nas configurações do gráfico."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:38
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:53
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
 msgstr "Tipo de mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:57
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:149
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
 msgstr "Mapa da região"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
 msgstr "Fixar mapa"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
 msgstr "Tipo de pino"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
 msgstr "Azulejos"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
 msgstr "Marcadores"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
 msgstr "Campo de latitude"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
 msgstr "Campo de longitude"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:142
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:168
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
 msgstr "Campo métrico"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
 msgstr "Campo de região"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
 msgstr "Rádio"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:198
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
 msgstr "Borrão"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
 msgstr "Opacidade mínima"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
 msgstr "Zoom máximo"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:175
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
 msgstr "Nenhum relacionamento foi encontrado."
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:213
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
 msgstr "via {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:290
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
 msgstr "Este {0} está conectado a:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:47
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
 msgstr "Detalhe do Objeto"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
 msgstr "objeto"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
 msgstr "Total"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Quais colunas você deseja usar?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:44
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Pizza"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Dimensão"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:81
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Mostrar legenda"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:86
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Mostrar percentagens na legenda"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:92
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Percentagem mínima de porção"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:146
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
 msgstr "Meta atingida"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:148
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
 msgstr "Meta excedida"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
 msgstr "Meta {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
 msgstr "A exibição de progresso requer um número."
 
@@ -7092,9 +7112,9 @@ msgstr "A exibição de progresso requer um número."
 msgid "Progress"
 msgstr "Progresso"
 
-#: frontend/src/metabase/entities/collections.js:108
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:176
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:57
+#: frontend/src/metabase/entities/collections.js:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Cor"
 
@@ -7106,7 +7126,7 @@ msgstr "Gráfico de linhas"
 msgid "row chart"
 msgstr "gráfico de linha"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:357
+#: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
 msgstr "Estilo separador"
 
@@ -7114,15 +7134,15 @@ msgstr "Estilo separador"
 msgid "Number of decimal places"
 msgstr "Número de decimais"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:381
+#: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
 msgstr "Adicione um prefixo"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:385
+#: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
 msgstr "Adicione um sufixo"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:374
+#: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
 msgstr "Multiplique por um número"
 
@@ -7134,7 +7154,7 @@ msgstr "Dispersão"
 msgid "scatter plot"
 msgstr "gráfico de dispersão"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:78
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
 msgstr "Converter em tabela dinâmica"
 
@@ -7143,7 +7163,7 @@ msgid "Visible fields"
 msgstr "Campos visíveis"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-msgid "Write here, and use Markdown if you''d like"
+msgid "Write here, and use Markdown if you'd like"
 msgstr "Escreva aqui, e use Markdown se você quiser"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
@@ -7184,13 +7204,13 @@ msgstr "Direita"
 msgid "Show background"
 msgstr "Mostrar fundo"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:553
+#: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} agrupamento"
 msgstr[1] "{0} agrupamentos"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:559
+#: frontend/src/metabase-lib/lib/Dimension.js:731
 msgid "Auto binned"
 msgstr "Auto agrupado"
 
@@ -7461,26 +7481,26 @@ msgstr "Agrupamento automático"
 msgid "Don''t bin"
 msgstr "Não Agrupar"
 
-#: frontend/src/metabase/lib/query_time.js:193 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Dia"
 msgstr[1] "Dias"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
-#: frontend/src/metabase/lib/query_time.js:189 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Minuto"
 msgstr[1] "Minutos"
 
-#: frontend/src/metabase/lib/query_time.js:191 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Hora"
 msgstr[1] "Horas"
 
-#: frontend/src/metabase/lib/query_time.js:199 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
 msgstr[0] "Trimestre"
@@ -7547,7 +7567,7 @@ msgid "Bin every 20 degrees"
 msgstr "Agrupe a cada 20 graus"
 
 #. returns `true` if successful -- see JavaDoc
-#: src/metabase/api/tiles.clj src/metabase/pulse/render.clj
+#: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
 msgstr "Escritor de imagens apropriado não foi encontrado!"
 
@@ -7619,10 +7639,12 @@ msgstr "incremento"
 msgid "{0} and {1}"
 msgstr "{0} e {1}"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} de {1}"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
 msgstr "{0} por {1}"
@@ -7635,9 +7657,12 @@ msgstr "{0] no segmento {1}"
 msgid "{0} segment"
 msgstr "{0} segmento"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
-msgstr "{0} métrica"
+msgid_plural "{0} metrics"
+msgstr[0] "{0} métrica"
+msgstr[1] "{0} métricas"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
@@ -8219,6 +8244,7 @@ msgid "Cannot save Question: source query has circular references."
 msgstr "Não foi possível salvar a Pergunta: a consulta original têm uma referência circular."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
+#: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
 msgstr "Cartão {0} não existe."
@@ -8621,7 +8647,7 @@ msgstr "O tipo de canal {0} é desconhecido"
 msgid "Error sending notification!"
 msgstr "Erro ao enviar notificação!"
 
-#: src/metabase/pulse/color.clj
+#: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
 msgstr "Não foi possível encontrar o seletor de cores JS em \"{0}\""
 
@@ -8928,43 +8954,43 @@ msgstr "Permissão de dados"
 msgid "Collection permissions"
 msgstr "Permissão de coleções"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:56
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
 msgstr "Ver todas as permissões de coleções"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:25
+#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
 msgstr "Mude também as sub-coleções"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:282
+#: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
 msgstr "Pode editar essa coleção e seu conteúdo"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:289
+#: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
 msgstr "Pode ver os itens dessa coleção"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:749
+#: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
 msgstr "Acesso à coleção"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:825
+#: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Este grupo tem permissão para ver ao menos uma sub-coleção desta coleção."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:830
+#: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Este grupo tem permissão para editar ao menos uma sub-coleção desta coleção."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
 msgstr "Ver sub-coleções"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:211
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
 msgstr "Lembre me"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:95
+#: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
 msgstr "Raio-X desse esquema"
 
@@ -8996,31 +9022,32 @@ msgstr "Salvar painéis, questões e coleções em \"{0}\""
 msgid "Access dashboards, questions, and collections in \"{0}\""
 msgstr "Acessar painéis, questões e coleções em \"{0}\""
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:221
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
 msgstr "Comparar"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:229
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
 msgstr "Diminuir Zoom"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:233
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
 msgstr "Relacionado"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:293
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
 msgstr "Mais Raios-X"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:46
+#: frontend/src/metabase/home/containers/SearchApp.jsx:40
+#: src/metabase/pulse/render/body.clj
 msgid "No results"
 msgstr "Sem resultados"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:47
+#: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
 msgstr "Metabase não pode localizar nenhum resultado da sua pesquisa."
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:111
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
 msgstr "Sem métricas"
 
@@ -9062,7 +9089,7 @@ msgstr "Falha ao garantir permissões: {0}"
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
 msgstr "Não foi possivel decriptar o texto. Você mudou ou esqueceu de dar um valor para MB_ENCRYPTION_SECRET_KEY?"
 
-#: frontend/src/metabase/entities/collections.js:164
+#: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
 msgstr "Todas coleções pessoais"
 
@@ -9226,18 +9253,18 @@ msgstr "N/D"
 msgid "Windows domain"
 msgstr "Domínio Windows"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:509
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:515
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:490
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:499
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
 msgstr "Rótulos"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:329
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
 msgstr "Adicionar membros"
 
-#: frontend/src/metabase/entities/collections.js:115
+#: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
 msgstr "Coleção que está salva"
 
@@ -9258,39 +9285,39 @@ msgid "Sharing"
 msgstr "Compartilhamento"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:234
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:270
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:299
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:305
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:313
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:321
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:218
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:251
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:280
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:286
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:294
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:302
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:80
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:85
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:91
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:97
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:50
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:56
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
 msgstr "Exibição"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:370
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:416
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:431
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:487
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:358
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:406
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:447
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
 msgstr "Eixos"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:222
-#: frontend/src/metabase/admin/settings/selectors.js:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
+#: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
@@ -9326,20 +9353,20 @@ msgstr "Raio-X"
 msgid "Compare to the rest"
 msgstr "Comparar ao restante"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:244
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Usar o fuso horário da Maquina Virtual Java (JVM)"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
 msgstr "Nós sugerimos que você deixe desativado exceto quando você estiver fazendo conversões de fuso horário em várias ou na maioria de suas consultas com esses dados."
 
-#: frontend/src/metabase/containers/Overworld.jsx:310
+#: frontend/src/metabase/containers/Overworld.jsx:312
 msgid "Your team's most important dashboards go here"
 msgstr "Os painéis mais importantes do seu time vão aqui"
 
-#: frontend/src/metabase/containers/Overworld.jsx:311
+#: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
 msgstr "Fixe painéis em {0} para eles aparecerem neste espaço para todos"
 
@@ -9355,32 +9382,32 @@ msgstr "Use o fuso horário da JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Nós estamos atualmente analisando as tabelas e campos para ajudar-lhe a explorar seus dados."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
 msgstr "Dica: "
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:258
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
 msgstr "Selecione um tipo de moeda"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:318
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
 msgstr "Tipo de Campo"
 
 #: frontend/src/metabase/admin/routes.jsx:109
-#: frontend/src/metabase/nav/containers/Navbar.jsx:224
+#: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
 msgstr "Solução de Problemas"
 
-#: frontend/src/metabase/admin/settings/selectors.js:96
+#: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
 msgstr "Habilitar funções Raio-X"
 
-#: frontend/src/metabase/admin/settings/selectors.js:323
+#: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
 msgstr "Opções de Formatação"
 
-#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:19
+#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
 msgstr "Detalhes da Tarefa"
 
@@ -9420,7 +9447,7 @@ msgstr "Moeda"
 msgid "Pick a user or channel..."
 msgstr "Selecione um usuário ou canal..."
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
+#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
 msgstr "Sem definições de formatação"
 
@@ -9528,31 +9555,31 @@ msgstr "HH:MM:SS.MS"
 msgid "Time style"
 msgstr "Formato de hora"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:299
+#: frontend/src/metabase/visualizations/lib/settings/column.js:300
 msgid "Unit of currency"
 msgstr "Unidade de moeda"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:319
+#: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
 msgstr "Formato do rótulo da moeda"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:337
+#: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
 msgstr "Onde mostrar a unidade da moeda"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:370
+#: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
 msgstr "Número mínimo de casas decimais"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:271
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
 msgstr "Tipo de gráfico empilhado"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:314
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
 msgstr "Rótulo do Objetivo"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:322
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
 msgstr "Mostrar linha de tendência"
 
@@ -9581,7 +9608,7 @@ msgstr "Linha + Coluna"
 msgid "line and bar chart"
 msgstr "gráfico de linha e coluna"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:72
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
 msgstr "A visualização de indicador requer um número."
 
@@ -9589,75 +9616,75 @@ msgstr "A visualização de indicador requer um número."
 msgid "Gauge"
 msgstr "Indicador"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
 msgstr "Intervalo do indicador"
 
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
 msgstr "Campo a ser mostrado"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
 msgstr "último {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:185
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
 msgstr "{0} era {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:52
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Agrupe por um campo contendo data/tempo para ver como foi a alteração ao longo do tempo"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
 msgstr "Alternar cores positivas / negativas?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
 msgstr "Coluna eixo"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:107
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
 msgstr "Coluna da célula"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:123
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
 msgstr "Colunas visíveis"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:143
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
 msgstr "Formatação Condicional"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
 msgstr "Título da coluna"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
 msgstr "Mostrar um gráfico de mini barras"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:183
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
 msgstr "Link"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:187
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
 msgstr "Link de Email"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
 msgstr "Imagem"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:195
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
 msgstr "Automático"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:200
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
 msgstr "Visualizar como link ou imagem"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
 msgstr "Texto do link"
 
@@ -9921,7 +9948,7 @@ msgstr "Erro ao pré processar a consulta"
 msgid "No native form returned."
 msgstr "Nenhum formulário nativo retornado"
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
 msgstr "Resposta inválida do driver de banco de dados. Nenhum status foi dado."
 
@@ -11288,7 +11315,7 @@ msgstr "Falha ao configurar {0} para `query-caching-max-kb`."
 msgid "Values greater than {1} are not allowed."
 msgstr "Valores maiores que {1} não são permitidos."
 
-#: src/metabase/query_processor/middleware/resolve_database.clj
+#: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
 msgstr "Banco de dados {0} não existe."
 
@@ -11337,7 +11364,7 @@ msgstr "Gatilhos"
 msgid "View triggers"
 msgstr "Gatilhos de Exibição"
 
-#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:82
+#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
 msgstr "Informações do Agendador"
 
@@ -11369,7 +11396,7 @@ msgstr "Hora da Execução Final"
 msgid "May Fire Again?"
 msgstr "Pode Executar Novamente?"
 
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:75
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
 msgstr "Gatilhos para {0}"
 
@@ -11381,19 +11408,19 @@ msgstr "Tarefas"
 msgid "Jobs"
 msgstr "Trabalhos"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
 msgstr "Duplicados {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:55
+#: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
 msgstr "Duplicar este item"
 
-#: frontend/src/metabase/components/EntityItem.jsx:61
+#: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
 msgstr "Arquivar este item"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:330
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
 msgstr "Duplicar painel"
 
@@ -11443,63 +11470,64 @@ msgstr "{0} {1} atrás"
 msgid "{0} {1} from now"
 msgstr "{0} {1} a partir de agora"
 
-#: frontend/src/metabase/lib/query_time.js:187
+#: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
 msgstr[0] "Período padrão"
 msgstr[1] "Períodos padrão"
 
-#: frontend/src/metabase/lib/query_time.js:203
+#: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
 msgstr[0] "Minuto da hora"
 msgstr[1] "Minutos da hora"
 
-#: frontend/src/metabase/lib/query_time.js:205
+#: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
 msgstr[0] "Hora do dia"
 msgstr[1] "Horas do dia"
 
-#: frontend/src/metabase/lib/query_time.js:207
+#: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
 msgstr[0] "Dia da semana"
 msgstr[1] "Dias da semana"
 
-#: frontend/src/metabase/lib/query_time.js:209
+#: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
 msgstr[0] "Dia do mês"
 msgstr[1] "Dias do mês"
 
-#: frontend/src/metabase/lib/query_time.js:211
+#: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
 msgstr[0] "Dia do ano"
 msgstr[1] "Dias do ano"
 
-#: frontend/src/metabase/lib/query_time.js:213
+#: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
 msgstr[0] "Semana do ano"
 msgstr[1] "Semanas do ano"
 
-#: frontend/src/metabase/lib/query_time.js:215
+#: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
 msgstr[0] "Mês do ano"
 msgstr[1] "Meses do ano"
 
-#: frontend/src/metabase/lib/query_time.js:217
+#: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "Trimestre do ano"
 msgstr[1] "Trimestres do ano"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:79
+#: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} seleção"
@@ -11513,20 +11541,20 @@ msgstr "[T]T"
 msgid "This"
 msgstr "Isto"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:64
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
 msgstr "Inválido"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:147
+#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
 msgstr "Adicionar um horário"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:170
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
 msgstr "Nada a comparar para o anterior"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:517
+#: frontend/src/metabase-lib/lib/Dimension.js:678
 msgid "by {0}"
 msgstr "por {0}"
 
@@ -11820,35 +11848,35 @@ msgstr "Registrando Metabase driver {0}..."
 msgid "Error running query for Card {0}"
 msgstr "Erro rodando consulta para o Cartão {0}"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
 msgstr "Última semana"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This week"
 msgstr "Esta semana"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
 msgstr "Último mês"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This month"
 msgstr "Este mês"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
 msgstr "Último trimestre"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
 msgstr "Este trimestre"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
 msgstr "Último ano"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This year"
 msgstr "Este ano"
 
@@ -12095,7 +12123,7 @@ msgid "[[CreateDate]] by quarter of the year"
 msgstr "[[CreateDate]] por trimestre do ano"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:200
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
 msgstr "Editar Usuário"
 
@@ -12103,12 +12131,12 @@ msgstr "Editar Usuário"
 msgid "New user"
 msgstr "Novo Usuário"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
 msgstr "Resetar senha"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:209
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
 msgstr "Desativar usuário"
 
@@ -12120,40 +12148,40 @@ msgstr "Reativar {0}?"
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
 msgstr "Não foi possível enviá-los um convite por e-mail. Portanto, informe os para fazer login usando {0} e essa senha que geramos para eles:"
 
-#: frontend/src/metabase/entities/collections.js:21
+#: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
 msgstr "coleção"
 
-#: frontend/src/metabase/entities/collections.js:22
+#: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
 msgstr "coleções"
 
-#: frontend/src/metabase/entities/dashboards.js:29
+#: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
 msgstr "painel"
 
-#: frontend/src/metabase/entities/dashboards.js:30
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
 msgstr "painéis"
 
-#: frontend/src/metabase/entities/users.js:125
+#: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
 msgstr "Primeiro nome é necessário"
 
-#: frontend/src/metabase/entities/users.js:126
-#: frontend/src/metabase/entities/users.js:133
+#: frontend/src/metabase/entities/users.js:38
+#: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
 msgstr "Deve ter 100 caracteres ou menos"
 
-#: frontend/src/metabase/entities/users.js:132
+#: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
 msgstr "Último nome é necessário"
 
-#: frontend/src/metabase/entities/users.js:138
+#: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
 msgstr "Email é necessário"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:90
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
 msgstr "Os itens que você arquivar aparecerão aqui."
 
@@ -12161,11 +12189,11 @@ msgstr "Os itens que você arquivar aparecerão aqui."
 msgid "No description"
 msgstr "Sem descrição"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:175
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
 msgstr "Soma de todos os valores"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:183
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
 msgstr "Ver todos os valores distintos"
 
@@ -12365,15 +12393,778 @@ msgstr "Adicionando Usuário {0} para o grupo de permissões \"Todos os usuário
 msgid "Adding User {0} to Admin permissions group..."
 msgstr "Adicionando Usuário {0} ao grupo de Administradores"
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
 msgstr "Falha na consulta"
 
-#: src/metabase/query_processor/async.clj
+#: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
 msgstr "Número máximo de consultas simultâneas para permitir por banco de dados conectados"
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
 msgstr "Tempo esgotado após {0} milissegundos "
+
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
+msgid "Misfire Instruction"
+msgstr "Falha de instrução"
+
+#: frontend/src/metabase/components/ArchiveModal.jsx:31
+msgid "Archive this?"
+msgstr "Arquivar?"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:244
+msgid "Learn about our data"
+msgstr "Aprenda sobre seus dados"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
+msgid "Use DNS SRV when connecting"
+msgstr "Use DNS SRV quando conectado"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
+msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
+"an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
+"leave this disabled."
+msgstr "Utilizar essa opção requer que o host seja um FQDN. Caso esteja conectando-se a um cluster Atlas, você talvez precise habilitar essa opção. Se não souber o que isso significa, deixe-a desativada."
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
+msgid "Automatically run queries when doing simple filtering and summarizing"
+msgstr "Execute queries automaticamente ao filtrar ou sumarizar"
+
+#. Em dúvida sobre qual seria o termo mais adequado para "drill-through"
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr "Com essa opção ativa, o Metabase irá automaticamente rodar consultas quando os usuários fizerem simples explorações com os botões Sumarizar e Filtrar ao explorar uma tabela ou gráfico. Você pode desativar essa opção caso as consultas estejam lentas. Essa configuração não afeta as sondagens ou as consultas SQL."
+
+#: frontend/src/metabase/containers/Overworld.jsx:247
+msgid "Learn about this database"
+msgstr "Aprenda sobre essa base de dados"
+
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+msgid "Archive this dashboard?"
+msgstr "Arquivar este dashboard?"
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:113
+msgid "All results"
+msgstr "Todos resultados"
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:180
+msgid "Our Analytics"
+msgstr "Nossas análises"
+
+#: frontend/src/metabase/lib/schema_metadata.js:500
+msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
+msgstr "Soma acumulada de todos valores da coluna.\\ne.x. faturamento total no tempo."
+
+#: frontend/src/metabase/lib/schema_metadata.js:508
+msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
+msgstr "Contagem acumulada de linhas.\\ne.x. quantidade total de vendas no tempo."
+
+#: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
+msgid "Filter"
+msgstr "Filtrar"
+
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+msgid "record"
+msgid_plural "records"
+msgstr[0] "registro"
+msgstr[1] "registros"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:346
+msgid "Browse Data"
+msgstr "Navegue pelos dados"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:376
+msgid "Write SQL"
+msgstr "Escrever em SQL"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
+msgid "Simple question"
+msgstr "Pergunta simples"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
+msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
+msgstr "Escolha alguns dados, explore-os e facilmente filtre, sumarize e visualize-os"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
+msgid "Custom question"
+msgstr "Pergunta customizada"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
+msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
+msgstr "Use o editor de texto avançado para juntar dados, criar colunas customizadas, efetuar cálculos e muito mais."
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+msgid "Basic Metrics"
+msgstr "Métricas Básicas"
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+msgid "Custom…"
+msgstr "Customizado..."
+
+#: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
+msgid "Add grouping"
+msgstr "Adicionar agrupamento"
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
+msgid "Pick a limit"
+msgstr "Escolha um limite"
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
+msgid "Show maximum"
+msgstr "Mostrar máximo"
+
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
+msgid "Get Preview"
+msgstr "Pré-visualizar"
+
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
+msgid "Back to previous results"
+msgstr "Voltar para resultados anteriores"
+
+#: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
+msgid "Sample values"
+msgstr "Amostrar valores"
+
+#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
+msgstr "Navegue pelo conteúdo de seus bancos de dados, tabelas e colunas. Escolha um banco para iniciar."
+
+#: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
+msgid "Visualize"
+msgstr "Visualizar"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
+msgid "Join data"
+msgstr "Unir dados (join)"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
+msgid "Custom column"
+msgstr "Coluna customizada"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
+msgid "Summarize"
+msgstr "Sumarize"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
+msgid "Aggregate"
+msgstr "Agregue"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
+msgid "Breakout"
+msgstr "Saída"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
+msgid "Pick the metric you want to see"
+msgstr "Escolha a métrica que deseja ver"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
+#: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
+msgid "Pick a column to group by"
+msgstr "Selecione uma coluna para agrupar"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
+msgid "Pick your starting data"
+msgstr "Selecione seu dado inicial"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select None"
+msgstr "Selecionar Nenhum"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select All"
+msgstr "Selecionar Todos"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
+msgid "Pick a table..."
+msgstr "Escolha uma tabela"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
+msgid "Enter a limit"
+msgstr "Insira um limite"
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
+msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
+msgstr "Chaves em volta de um {0} cria uma cláusula opcional no template. Se \"variable\" estiver configurada, então a cláusula inteira será inserida no template. Caso contrário, a cláusula inteira será ignorada."
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
+msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
+msgstr "Ao usar um Filtro de Campo, o nome da coluna não será incluído no SQL. Ao invés disso, a variável será mapeada para um campo no painel latera."
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
+msgid "View the native query"
+msgstr "Visualizar consulta nativa"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
+msgid "Native query for this question"
+msgstr "Consulta nativa desta pergunta"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
+msgid "Convert this question to a native query"
+msgstr "Converta esta pergunta para uma query nativa"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
+msgid "SQL for this question"
+msgstr "SQL desta pergunta"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
+msgid "Convert this question to SQL"
+msgstr "Converta esta pergunta para SQL"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
+msgid "Get alerts"
+msgstr "Receber Alertas"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
+msgid "{0} breakout"
+msgid_plural "{0} breakouts"
+msgstr[0] "saída"
+msgstr[1] "saídas"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
+msgid "Hide filters"
+msgstr "Esconder filtros"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
+msgid "Show filters"
+msgstr "Mostrar filtros"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
+msgid "Started from"
+msgstr "Começado em"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
+msgid "{0} row"
+msgid_plural "{0} rows"
+msgstr[0] "{0} linha"
+msgstr[1] "{0} linhas"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
+msgid "Show all rows"
+msgstr "Ver todas as linhas"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
+msgid "Show {0}"
+msgstr "Mostrar {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
+msgid "Showing first {0}"
+msgstr "Mostrar primeiro {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
+msgid "Showing {0}"
+msgstr "Mostrando {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
+msgid "Summarized"
+msgstr "Resumido"
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Hide editor"
+msgstr "Esconder editor"
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Show editor"
+msgstr "Mostrar editor"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
+msgid "Pick the metric you'd like to see"
+msgstr "Selecione a métrica que você gostaria de ver"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
+msgid "{0} options"
+msgstr "{0} opções"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
+msgid "Choose a visualization"
+msgstr "Escolha uma visualização"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
+msgid "Filter by"
+msgstr "Filtrado por"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+msgid "Summarize by"
+msgstr "Resumido por"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+msgid "Group by"
+msgstr "Agrupado por"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+msgid "Add a metric"
+msgstr "Adicione uma métrica"
+
+#: frontend/src/metabase/user/components/UserSettings.jsx:57
+msgid "Profile"
+msgstr "Perfil"
+
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:548
+msgid "This is usually pretty fast but seems to be taking a while right now."
+msgstr "Isso normalmente é bem rápido mas parece estar demorando um pouco agora"
+
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
+msgid "Combo"
+msgstr "Combo"
+
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
+msgid "Row"
+msgstr "Linha"
+
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
+msgid "Trend"
+msgstr "Tendência"
+
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:129
+msgid "Boolean"
+msgstr "Booleano"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+msgid "Unknown Segment"
+msgstr "Segmento desconhecido"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+msgid "Unknown Filter"
+msgstr "Filtro desconhecido"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
+msgid "Left outer join"
+msgstr "Junção externa à esquerda"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
+msgid "Right outer join"
+msgstr "Junção externa à direita"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
+msgid "Inner join"
+msgstr "Junção Interna"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
+msgid "Full outer join"
+msgstr "Junção externa total"
+
+#: src/metabase/api/card.clj
+msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
+msgstr "Metadados dos cards de resultados passados para a API estão FALTANDO. Rodando consultas para obter os metadados corretos."
+
+#: src/metabase/api/session.clj
+msgid "Problem connecting to LDAP server, will fall back to local authentication"
+msgstr "Problema ao se conectar com o servidor LDAP, voltando à autenticação local"
+
+#: src/metabase/api/setup.clj
+msgid "Cannot create Database: cannot find driver {0}."
+msgstr "Não foi possível criar banco de dados: não foi possível achar driver {0}."
+
+#: src/metabase/api/tiles.clj
+msgid "Query failed"
+msgstr "Consulta falhou"
+
+#: src/metabase/async/util.clj
+msgid "Warning: {0} returned `nil`"
+msgstr "Aviso: {0} retornou 'nada'"
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing result to output channel: already closed"
+msgstr "Erro inesperado ao escrever o resultado para o canal de saída: já estava fechado"
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing exception to output channel: already closed"
+msgstr "Erro inesperado ao escrever a exceção para o canal de saída: já estava fechado"
+
+#: src/metabase/async/util.clj
+msgid "Request canceled, canceling future."
+msgstr "Requisição cancelada, cancelando posteriores."
+
+#: src/metabase/cmd/load_from_h2.clj
+msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
+msgstr "O Metabase só pode transferir dados do H2 para Postgres ou MySQL/MariaDB."
+
+#: src/metabase/db.clj
+msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
+msgstr "AVISO: Usar o Metabase com o banco de dados H2 não é indicado para ambientes de produção."
+
+#: src/metabase/db.clj
+msgid "Application database setup"
+msgstr "Configuração do banco de dados da aplicação"
+
+#: src/metabase/driver.clj
+msgid "Could not find {0} driver."
+msgstr "Não foi possível encontrar o driver {0}."
+
+#: src/metabase/driver.clj
+msgid "Abstract drivers cannot derive from concrete parent drivers."
+msgstr "Divers abstratos não podem derivar de diver 'Pai' concreto"
+
+#: src/metabase/driver/mysql.clj
+msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
+msgstr "Você pode ter que adicionar 'trustServerCertificate=true' nas opções de conexão adicionais para possibilitar conectar com SSL."
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifer."
+msgstr "Não sabemos como apelidar {0}, um identificador era esperado."
+
+#: src/metabase/driver/sql_jdbc/execute.clj
+msgid "Client closed connection, canceling query"
+msgstr "Conexão com cliente fechada, cancelando a consulta"
+
+#: src/metabase/integrations/ldap.clj
+msgid "{0} is not a valid DN."
+msgstr "{0} não é uma entrada de Nome Distinto válida."
+
+#: src/metabase/middleware/log.clj
+msgid "Error logging API request"
+msgstr "Erro ao gravar registro de requisição API"
+
+#: src/metabase/middleware/misc.clj
+msgid "Failed to set site-url"
+msgstr "Falha ao alterar a url do Metabase"
+
+#: src/metabase/models/database.clj
+msgid "Error destroying thread pool for DB."
+msgstr "Erro ao destruir as requisições para o BD."
+
+#: src/metabase/models/humanization.clj
+msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
+msgstr "Atualizando o nome de exibição para {0} ''{1}'': ''{2}'' -> ''{3}''"
+
+#: src/metabase/models/humanization.clj
+msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
+msgstr "Estratégia de humanização inválida ''{0}''. As estratégias válidas são: {1}"
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr "Alterando a estratégia de humanização das Tabelas e Nomes de Campos de: ''{0}'' para ''{1}''"
+
+#: src/metabase/models/task_history.clj src/metabase/sync/util.clj
+msgid "Error saving task history"
+msgstr "Erro salvando a história das tarefas"
+
+#: src/metabase/plugins.clj
+msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
+msgstr "spark-deps.jar não é mais necessário desde o Metabase 0.32.0+. Você pode removê-lo do diretório de plugins."
+
+#: src/metabase/plugins/classloader.clj
+msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
+msgstr "Usando o classloader NEWLY CREATED como classloader de contexto compartilhado: {0}"
+
+#: src/metabase/plugins/files.clj
+msgid "Failed to copy file"
+msgstr "Falha ao copiar arquivo"
+
+#: src/metabase/public_settings.clj
+msgid "Invalid site URL: {0}"
+msgstr "URL do site inválido: {0}"
+
+#: src/metabase/public_settings.clj
+msgid "site-url is invalid; returning nil for now. Will be reset on next request."
+msgstr "site-url é inválido; retornaremos nada por enquanto. Valor será resetado na próxima requisição."
+
+#: src/metabase/pulse/render/body.clj
+msgid "More results have been included as a file attachment"
+msgstr "Mais resultados foram incluídos como arquivo anexo"
+
+#: src/metabase/pulse/render/body.clj
+msgid "This question has been included as a file attachment"
+msgstr "Essa questão foi incluída como um arquivo anexo "
+
+#: src/metabase/pulse/render/body.clj
+msgid "We were unable to display this Pulse."
+msgstr "Não foi possível visualizar essa Notificação."
+
+#: src/metabase/pulse/render/body.clj
+msgid "Please view this card in Metabase."
+msgstr "Por favor visualize esse cartão no Metabase."
+
+#: src/metabase/pulse/render/body.clj
+msgid "An error occurred while displaying this card."
+msgstr "Um erro ocorreu ao tentar visualizar esse cartão."
+
+#: src/metabase/query_processor.clj
+msgid "Can only determine expected columns for MBQL queries."
+msgstr "Só é possivel determinar colunas esperadas para consultas MBQL."
+
+#: src/metabase/query_processor.clj
+msgid "No columns returned."
+msgstr "Nenhuma coluna retornada."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr "Alerta: não foi possível determinar campos para uma consulta de código fonte explícita a não ser que você inclua os metadados da fonte."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
+msgstr "Não foi possível incluir {0}: Campo não existe, ou a Tabela pertence à um banco de dados diferente."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
+msgstr "Não foi possível incluir :campo-literal dentro de :chave-estrangeira-> a não ser que seja feita uma junção externa: apelido."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot find Table ID for {0}"
+msgstr "Não posso encontrar o ID da Tabela para {0}"
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "No matching info found."
+msgstr "Nenhuma informação correspondente encontrada."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Could not resolve {0}"
+msgstr "Não foi possível adicionar {0}"
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Invalid fk-> clause: nowhere to add corresponding join."
+msgstr "Chave estrangeira inválisa-> cláusula: nenhum lugar para adicionar a junção correspondente."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "{0} driver does not support foreign keys."
+msgstr "O driver {0} não suporta chaves estrangeiras."
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
+msgstr "Não foi possível inferir `:metadados:fonte` para consulta com código fonte nativo sem os metadados da fonte."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Query processor error: number of columns returned by driver does not match results."
+msgstr "Erro do processador de consulta: número de colunas retornado pelo driver não corresponde aos resultados."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Expected {0} columns, but first row of resuls has {1} columns."
+msgstr "Esperava {0} colunas, mas a primeira linha têm {1} colunas."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "No expression named {0} found. Found: {1}"
+msgstr "Nenhuma expressão chamada {0} foi encontrada. Achamos: {1}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Distinct values of {0}"
+msgstr "Valores distintos de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Average of {0}"
+msgstr "Média de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0}"
+msgstr "Soma de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "SD of {0}"
+msgstr "Desvio Padrão de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Min of {0}"
+msgstr "Mínimo de {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Max of {0}"
+msgstr "Máximo de {0}"
+
+#. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0} matching condition"
+msgstr "Soma de {0} correspondentes à condição"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Share of rows matching condition"
+msgstr "Parcela de linhas correspondentes à condição"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Count of rows matching condition"
+msgstr "Quantidade de linhas correspondentes à condição"
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Request already canceled, will not run synchronous QP code."
+msgstr "Requisição já cancelada, não iremos executar código de processamento de consultas síncrono."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unexpectedly got `nil` Query Processor response."
+msgstr "Inesperadamente recebemos 'nada' como resposta do Processador de Consultas."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Got InterruptedException. Canceling query."
+msgstr "Recebemos InterruptedException. Cancelando consulta."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
+msgstr "Exceção não tratada, esperávamos que o middleware 'catch-exceptions` ia processá-la."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Query timed out after %s"
+msgstr "Consulta com tempo esgotado após %s"
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Creating new query thread pool for Database {0}"
+msgstr "Criando novo pool de threads para consulta ao Banco de Dados {0}"
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Destroying query thread pool for Database {0}"
+msgstr "Removendo pool de threads para consulta ao Banco de Dados {0}"
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Request canceled, canceling pending query"
+msgstr "Requisição cancelada, cancelando consultas pendentes"
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: query is missing source-metadata"
+msgstr "Não foi possível atualizar o campo armazenado: está faltando metadados de origem na consulta "
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
+msgstr "Não foi possível atualizar o campo armazenado: não encontrei metadados de origem correspondentes ao Campo \"{0}\""
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Using query processor cache backend: {0}"
+msgstr "Usando o backend do processador de consultas: {0}"
+
+#: src/metabase/query_processor/middleware/expand_macros.clj
+msgid "Invalid metric: {0} reason: {1}"
+msgstr "Métrica inválida: {0} motivo: {1}"
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unknown error"
+msgstr "Erro desconhecido"
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unexpected nil response from query processor."
+msgstr "Resposta inesperadamente nula do processador de consultas"
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Query canceled"
+msgstr "Consulta cancelada"
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
+msgstr "Não foi possível selecionar o driver para a consulta: Identificação de  `:database` inválida ou ausente."
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: Database {0} does not exist."
+msgstr "Não foi possível selecionar o driver para a consulta: Banco de Dados {0} não existe."
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr "Não é possível usar :campos :todos em junção a não ser que os mesmos tenham :metadados-fonte"
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
+msgstr "Cláusula :joined-field com problema: apelido de junção ''{0}'' não existe. Achamos: {1}"
+
+#: src/metabase/query_processor/middleware/resolve_source_table.clj
+msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
+msgstr ":tabela-fonte Inválida ''{0}'': já deveríamos ter identificado o ID da tabela."
+
+#: src/metabase/query_processor/store.clj
+msgid "Cannot store Tables or Fields before Database is stored."
+msgstr "Não é possível armazenar Campos ou Tabelas antes de armazenar o Banco de Dados."
+
+#: src/metabase/query_processor/store.clj
+msgid "Attempting to fetch second Database. Queries can only reference one Database."
+msgstr "Tentando buscar segundo Banco de Dados. Consultas podem somente referenciar um Banco de Dados."
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
+msgstr "Falha ao buscar Tabela {0}: Tabela não existe, ou pertence a um Banco de Dados diferente."
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
+msgstr "Falha ao buscar Campo{0}: Campo não existe, ou pertence a um Banco de Dados diferente."
+
+#: src/metabase/routes/index.clj
+msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
+msgstr "Falha ao carregar o modelo \"{0}\". Você se lembrou de compilar o frontend do Metabase?"
+
+#: src/metabase/sample_data.clj
+msgid "Sample dataset DB file ''{0}'' cannot be found."
+msgstr "O conjunto de dados arquivo DB \"{0}\" não foi encontrado"
+
+#: src/metabase/sample_data.clj
+msgid "Loading sample dataset..."
+msgstr "Carregando o conjunto de dados da amostra"
+
+#: src/metabase/sample_data.clj
+msgid "Failed to load sample dataset"
+msgstr "Falhou ao carregar o conjunto de dados da amostra"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Found new tables:"
+msgstr "Achamos novas tabelas:"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Marking tables as inactive:"
+msgstr "Marcando tabelas como inativas:"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Updating description for tables:"
+msgstr "Atualizando descrições para as tabelas:"
+
+#: src/metabase/task.clj
+msgid "Rescheduling job {0}"
+msgstr "Reagendando a rotina {0}"
+
+#: src/metabase/task.clj
+msgid "Error rescheduling job"
+msgstr "Erro ao reagendar rotina"
+
+#: src/metabase/task/send_pulses.clj
+msgid "Starting Pulse Execution: {0}"
+msgstr "Inicializando a execução das notificações: {0}"
+
+#: src/metabase/task/send_pulses.clj
+msgid "Finished Pulse Execution: {0}"
+msgstr "Execução das notificações concluídas: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Failed to schedule tasks for Database {0}"
+msgstr "Falha ao agendar tarefas para o Banco de Dados {0}"
+
+#: src/metabase/util/schema.clj
+msgid "All elements must be distinct."
+msgstr "Todos os elementos devem ser distintos."
+
+#: 
+msgctxt "Modal for selecting columns in source data or when doing a join."
+msgid "Pick the columns you want to include"
+msgstr "Selecione as colunas que quer incluir"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr "Quando ativado, essa opção faz com que o Metabase realize consultas quando usuários fazem explorações de dados simples com os botões de Resumir e Filtrar. Você pode desabilitar se as consultas ao banco estão lentas. Isso não afeta as consultas SQL ou drill-throughs."
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
+msgid "Change join type"
+msgstr "Mudar tipo de junção"
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifier."
+msgstr "Não sabemos como apelidar {0}, um identificador era esperado."
+
+#: src/metabase/integrations/common.clj
+msgid "Error adding User {0} to Group {1}"
+msgstr "Erro ao adicionar Usuário {0} ao Grupo {1}"
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr "Alterando a estratégia de humanização das Tabelas e Nomes de Campos de: ''{0}'' para ''{1}''"
+
+#: src/metabase/query_processor.clj
+msgid "Infinite loop detected: recursively preprocessed query {0} times."
+msgstr "Loop infinito detectado: consulta foi reprocessada recursivamente {0} vezes."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr "Alerta: não foi possível determinar campos para uma consulta de código fonte explícita a não ser que você inclua os metadados da fonte."
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Error determining expected columns for query"
+msgstr "Erro ao determinar colunas esperadas da consulta"
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
+msgstr "Exceção não tratada, esperávamos que o middleware 'catch-exceptions` ia processá-la."
 

--- a/locales/ru.po
+++ b/locales/ru.po
@@ -28,18 +28,19 @@ msgstr "Исследовать данные"
 msgid "Select a database type"
 msgstr "Выберите тип базы данных"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:75
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:401
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:71
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:182
+#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:410
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:74
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:203
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:180
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:197
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:193
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:171
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:180
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:164
 msgid "Save"
 msgstr "Сохранить"
@@ -59,7 +60,7 @@ msgid "This is a lightweight process that checks for\n"
 msgstr "Это лёгкий процесс проверяющий обновления структуры этой базы данных. В большинстве случаев Вам будет достаточно оставить ежечасное обновление"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:184
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
 msgid "Scan"
 msgstr "Сканирование"
 
@@ -74,126 +75,128 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase может просканировать значения каждого поля базы данных и сделать доступными checkbox-фильтры на панелях индикаторов и в вопросах. Процесс достаточно ресурсозатратный, особенно, если речь идет об очень большой базе данных."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:159
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Когда Metabase должен автоматически сканировать и кэшировать значения?"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:164
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
 msgstr "Регулярно, по расписанию"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:195
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
 msgstr "Только при добавлении виджета фильтра"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:199
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
 msgstr "Когда пользователь добавляет новый фильтр к дэшборду или SQL запрос, Метабэйз сканирует поля связанные с этим фильтром для отображения опций"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:210
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
 msgid "Never, I'll do this manually if I need to"
 msgstr "Нет, я сделаю это когда нужно"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:222
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:222
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:426
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
 msgid "Saving..."
 msgstr "Сохранение..."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:39
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
 msgid "Server error encountered"
 msgstr "Ошибка на сервере"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:58
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
 msgstr "Удалить эту базу данных?"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
 msgstr "Все сохранённые вопросы, метрики и сегменты, которые зависят от этой базы данных, будут потеряны."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:67
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
 msgstr "Это действие необратимо."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
 msgstr "Если вы уверены, напишите"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:53
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
 msgstr "УДАЛИТЬ"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:71
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
 msgstr "в этом поле:"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:82
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:50
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:93
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:58
-#: frontend/src/metabase/admin/permissions/selectors.js:160
-#: frontend/src/metabase/admin/permissions/selectors.js:170
-#: frontend/src/metabase/admin/permissions/selectors.js:185
-#: frontend/src/metabase/admin/permissions/selectors.js:224
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:355
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:181
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:247
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:61
+#: frontend/src/metabase/admin/permissions/selectors.js:163
+#: frontend/src/metabase/admin/permissions/selectors.js:173
+#: frontend/src/metabase/admin/permissions/selectors.js:188
+#: frontend/src/metabase/admin/permissions/selectors.js:227
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:202
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:268
+#: frontend/src/metabase/components/ArchiveModal.jsx:35
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
-#: frontend/src/metabase/components/form/StandardForm.jsx:61
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:196
+#: frontend/src/metabase/components/form/StandardForm.jsx:62
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:198
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:289
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:162
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:153
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:38
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:189
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:24
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:48
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:41
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:92
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:259
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Отмена"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:88
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:121
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:132
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
 msgstr "Удалить"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:128
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:74
-#: frontend/src/metabase/admin/permissions/selectors.js:320
-#: frontend/src/metabase/admin/permissions/selectors.js:327
-#: frontend/src/metabase/admin/permissions/selectors.js:423
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
+#: frontend/src/metabase/admin/permissions/selectors.js:323
+#: frontend/src/metabase/admin/permissions/selectors.js:330
+#: frontend/src/metabase/admin/permissions/selectors.js:426
 #: frontend/src/metabase/admin/routes.jsx:53
-#: frontend/src/metabase/nav/containers/Navbar.jsx:214
+#: frontend/src/metabase/nav/containers/Navbar.jsx:243
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
 msgstr "Базы данных"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:129
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
 msgstr "Добавить базу данных"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
 msgstr "Подключение"
@@ -202,107 +205,107 @@ msgstr "Подключение"
 msgid "Scheduling"
 msgstr "Расписание"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:78
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:84
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:26
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:221
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
 msgstr "Сохранить изменения"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:185
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:38
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:38
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
 msgstr "Действия"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:193
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
 msgstr "Произвести синхронизацию схемы"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:194
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:206
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:109
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
 msgstr "Начинаю..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:195
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
 msgstr "Ошибка синхронизации"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
 msgstr "Синхронизация началась!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:205
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
 msgstr "Пересканировать значения полей"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:207
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
 msgstr "Невозможно начать сканирование"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
 msgstr "Сканирование запланировано!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:215
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:401
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
 msgstr "Опасная зона"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:221
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
 msgstr "Сбросить сохраненные значения полей"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
 msgstr "Удалить эту базу данных"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:73
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
 msgstr "Добавить базу данных"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:85
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:36
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:36
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:122
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:32
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:399
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:446
 #: frontend/src/metabase/containers/EntitySearch.jsx:26
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:218
-#: frontend/src/metabase/entities/collections.js:93
-#: frontend/src/metabase/entities/dashboards.js:145
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:461
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:81
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:220
+#: frontend/src/metabase/entities/collections.js:94
+#: frontend/src/metabase/entities/dashboards.js:142
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
 msgstr "Имя"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:86
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
 msgstr "Тип"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:115
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
 msgstr "Удаление..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:145
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
 msgstr "Загрузка..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:161
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
 msgstr "Вернуть данные примеров"
 
@@ -319,9 +322,9 @@ msgid "Successfully saved!"
 msgstr "Сохранено!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:177
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:197
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
 msgstr "Изменить"
@@ -330,86 +333,90 @@ msgstr "Изменить"
 msgid "Revision History"
 msgstr "Журнал изменений"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
 msgstr "Убрать {0}?"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
 msgstr "Сохранённые вопросы и другие составляющие, зависящие от {0}, продолжат работать, но {1} уже нельзя будет выбрать в мастере запросов."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
 msgstr "Если вы уверены, что хотите убрать {0}, пожалуйста, напишите краткое обьяснение к вашим действиям:"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
 msgstr "Это будет отражено в списке действий и в сообщениях, которые будут отправлены любому из состава вашей команды, кто создал что-либо, используещее {0}."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
 msgstr "Убрать"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
 msgstr "Удаление..."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
 msgstr "Завершено с ошибкой"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
 msgstr "Успешно завершено"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:91
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
+#: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Предварительный просмотр"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
 msgstr "Еще нет описания стоблца"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:135
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
 msgstr "Выберите видимость поля"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:210
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
 msgstr "Без специального типа"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:211
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:148
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
 msgstr "Другое"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:231
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Выбрать специальный тип"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:277
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
 msgstr "Выбрать цель"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:77
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:89
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:106
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:122
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
 msgstr "Столбцы"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Столбец"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:121
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:306
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
 msgstr "Видимость"
 
@@ -417,27 +424,27 @@ msgstr "Видимость"
 msgid "Type"
 msgstr "Тип"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
 msgstr "Текущая база данных:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
 msgstr "Показать оригинальную схему"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:45
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
 msgstr "Тип данных"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
 msgstr "Дополнительная информация"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
 msgstr "Найти схему"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:51
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "{0} схема"
@@ -445,27 +452,27 @@ msgstr[1] "{0} схем"
 msgstr[2] "{0} схем"
 msgstr[3] "{0} схемы"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
 msgstr "Зачем скрывать?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
 msgstr "Технические данные"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
 msgstr "Не важно/Хлам"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
 msgid "Queryable"
 msgstr "Доступно в запросах"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:91
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
 msgstr "Скрыто"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
 msgstr "Еще нет описания таблицы"
 
@@ -473,7 +480,7 @@ msgstr "Еще нет описания таблицы"
 msgid "Metadata Strength"
 msgstr "Сложность метаданных"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} доступных для запроса таблиц"
@@ -481,7 +488,7 @@ msgstr[1] "{0} доступных для запроса таблиц"
 msgstr[2] "{0} доступных для запроса таблиц"
 msgstr[3] "{0} доступных для запроса таблиц"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:96
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} скрытая таблица"
@@ -489,53 +496,55 @@ msgstr[1] "{0} скрытых таблиц"
 msgstr[2] "{0} скрытых таблиц"
 msgstr[3] "{0} скрытые таблицы"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
 msgstr "Найти таблицу"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
 msgstr "Схемы"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:24
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:137
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:68
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:56
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:190
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
 msgstr "Метрики"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
 msgstr "Добавить Метрику"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:37
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Определение"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Создать метрики для добавления в мастер запросов"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:24
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:930
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:952
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:56
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Сегменты"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
 msgstr "Добавить Сегмент"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Создать сегменты для добавления в фильтры мастера запросов"
 
@@ -563,53 +572,53 @@ msgstr "изменено "
 msgid "made some changes"
 msgstr "сделаны некоторые изменения"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
-#: frontend/src/metabase/home/components/Activity.jsx:80
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:332
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/home/components/Activity.jsx:82
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
 msgstr "Вы"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
 msgstr "Модель данных"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
 msgstr " История"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:48
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
 msgstr "История изменений за"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:239
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
 msgstr "{0} – установки поля"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
 msgstr "Где это поле будет отображено в системе"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:329
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Фильтрация этого поля"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Если это поле используется как фильтр, какой вид информации должны использовать пользователи для фильтрации?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:453
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Для этого поля пока нет описания"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:379
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
 msgstr "Оригинальное значение"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:380
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
 msgid "Mapped value"
 msgstr "Связанное значение"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:423
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
 msgstr "Введите значение"
 
@@ -626,7 +635,7 @@ msgid "Custom mapping"
 msgstr "Своя связь"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:155
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
 msgid "Unrecognized mapping type"
 msgstr "Неопознанный вид связи"
 
@@ -634,23 +643,23 @@ msgstr "Неопознанный вид связи"
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Данное поле не является внешним ключем либо метаданные другой таблицы, содержащей внешний ключ, отсутствуют"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:187
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
 msgstr "Выбранное поле не является внешнем ключём"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:347
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
 msgstr "Показать значения"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:348
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Выберите, что отобразить в поле: исходное значение из базы данных, ассоциированную или иную настраиваемую информацию."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:268
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
 msgstr "Выберите поле"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:289
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
 msgstr "Пожалуйста, выберете столбец для отображения."
 
@@ -658,16 +667,16 @@ msgstr "Пожалуйста, выберете столбец для отобр�
 msgid "Tip:"
 msgstr "Подсказка:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Возможно, вы захотите обновить наименование поля, чтобы убедиться, что оно соответствует выбранному варианту переназначения связи."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:364
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:102
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
 msgstr "Кэшированные значения полей"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:365
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase может сканировать значения данного поля и включить возможность использования checkbox-фильтров на панели индикаторов и в вопросах."
 
@@ -676,167 +685,168 @@ msgid "Re-scan this field"
 msgstr "Пересканировать это поле"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
 msgstr "Сбросить кэшированные значения полей"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:118
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
 msgstr "Не удалось сбросить значения"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard triggered!"
 msgstr "Сброс значений начался!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:105
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Выбрать базу данных что бы увидеть её схему или изменить мета данные."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:37
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:34
-#: frontend/src/metabase/entities/collections.js:96
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "Имя обязательно"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:40
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
 msgstr "Описание обязательно"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:44
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:41
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
 msgstr "Описание внесенных изменений обязательно"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:50
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
 msgstr "Агрегация обязательна"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
 msgstr "Изменить Вашу Метрику"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
 msgstr "Создать Вашу Метрику"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:115
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Внесите изменения в метрику и оставьте к ним пояснение."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Вы можете создать сохраненные метрики, чтобы использовать их в данной таблице. Сохраненные метрики включают тип агрегации, агрегированное поле и, при необходимости, любой фильтр. Например, вы можете использовать их, чтобы создать что-то вроде единственного официального способа вычисления \"Средней цены\" для таблицы \"Заказы\"."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
 msgstr "Результаты: "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
 msgstr "Имя вашей Метрики"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
 msgstr "Задайте имя для вашей метрики, чтобы другие пользователи смогли ее найти."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:162
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
 msgstr "Что-нибудь описательное, но не слишком длинное"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
 msgstr "Опишите вашу Метрику"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Укажите описание вашей метрики, чтобы помочь другим понять о чем она."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Это идеальное место, чтобы быть более конкретным в отношении менее очевидных правил вычисления метрики"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:179
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
 msgstr "Причина изменений"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:177
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Оставьте описание внесенных вами изменений и почему они были необходимы."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Данное сообщение появится в истории изменений метрики и поможет всем восстановить ход событий"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
 msgstr "Необходим как минимум один фильтр"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
 msgstr "Изменить ваш Сегмент"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
 msgstr "Создать ваш Сегмент"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:121
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Внесите изменения в ваш сегмент и оставьте к ним пояснение."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Выберите и добавьте фильтры для создания вашего нового сегмента к таблице {0}"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
 msgstr "Задайте имя для вашего Сегмента"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:162
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
 msgstr "Задайте имя для вашего сегмента, чтобы другие смогли его найти."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:170
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
 msgstr "Опишите ваш Сегмент"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Укажите описание вашей метрики, чтобы помочь другим понять о чем она. "
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:175
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Это идеальное место, чтобы быть более конкретным в отношении менее очевидных правил определения сегмента"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:185
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Данное сообщение появится в истории изменений сегмента и поможет всем восстановить ход событий"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:266
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:87
-#: frontend/src/metabase/nav/containers/Navbar.jsx:199
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:269
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:91
+#: frontend/src/metabase/nav/containers/Navbar.jsx:228
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
 msgstr "Настройки"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:103
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase может сканировать значения в этом таблицы для того, чтобы построить выпадающие списки для фильтров дашбордов и запросов."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:108
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
 msgstr "Пересканировать эту таблицу"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:253
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
 msgstr "Добавить"
 
@@ -845,11 +855,13 @@ msgstr "Добавить"
 msgid "Not a valid formatted email address"
 msgstr "Email указан неверно"
 
+#: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:100
 msgid "First name"
 msgstr "Имя"
 
+#: frontend/src/metabase/entities/users.js:42
 #: frontend/src/metabase/setup/components/UserStep.jsx:203
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:117
 msgid "Last name"
@@ -857,9 +869,9 @@ msgstr "Фамилия"
 
 #. Строка "Email" есть ниже.
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:77
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:158
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:161
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:470
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:481
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
@@ -875,35 +887,36 @@ msgstr "Группы Разрешений"
 msgid "Make this user an admin"
 msgstr "Определить администратором"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:32
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
 msgstr "Все пользователи входят в группу {0} и не могут быть из нее исключены. Установите разрешения для данной группы - так вы будете уверены в том, что смогут увидеть новые пользователи Metabase."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:41
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
 msgstr "Это специальная группа, члены которой смогут видеть все, что связано с данным экземпляром Metabase, иметь доступ и редактировать настройки в Панели администратора, включая полномочия! Поэтому включайте пользователей в данную группу соблюдая меры предосторожности."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:45
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
 msgstr "В данной группе должен оставаться хотя бы один пользователь, иначе доступ к Metabase будет блокирован."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
 msgstr "Участники"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:124
-#: frontend/src/metabase/admin/settings/selectors.js:113
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
+#: frontend/src/metabase/admin/settings/selectors.js:110
+#: frontend/src/metabase/entities/users.js:50
 #: frontend/src/metabase/lib/core.js:55
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
 msgstr "Email"
 
 #. Нужен контекст, чтобы правильно перевести.
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:203
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
 msgstr "Группа также хороша, как и ее члены."
 
@@ -914,8 +927,8 @@ msgid "Admin"
 msgstr "Администратор"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:237
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:290
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
 msgstr "и"
 
@@ -946,13 +959,13 @@ msgid "Are you sure? All members of this group will lose any permissions setting
 msgstr "Вы уверены? Все участники этой группы потеряют все полномочия основанные на этой группе. Данное действие не может быть отменено."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
 msgstr "Да"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
 msgstr "Нет"
 
@@ -971,10 +984,11 @@ msgstr "Удалить группу"
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:107
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:327
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:395
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:265
+#: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
 msgstr "Готово"
 
@@ -984,9 +998,9 @@ msgstr "Имя группы"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:131
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:88
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
 msgstr "Группы"
 
@@ -1015,9 +1029,9 @@ msgid "Deactivate"
 msgstr "Деактивировать"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:93
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
-#: frontend/src/metabase/nav/containers/Navbar.jsx:204
+#: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
 msgstr "Люди"
 
@@ -1058,7 +1072,6 @@ msgid "We've re-sent {0}'s invite"
 msgstr "Мы переотправили приглашение {0}"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
-#: frontend/src/metabase/tutorial/Tutorial.jsx:253
 msgid "Okay"
 msgstr "Хорошо"
 
@@ -1090,13 +1103,13 @@ msgstr "Они смогут зайти снова, и им будут возвр
 msgid "Reset {0}'s password?"
 msgstr "Сбросить пароль для {0}?"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:77
+#: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
 msgstr "Сбросить"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:44
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
 msgstr "Вы уверены что хотите выполнить это действие?"
 
@@ -1112,41 +1125,41 @@ msgstr "Это временный пароль, с которым они смо�
 msgid "We've sent them an email with instructions for creating a new password."
 msgstr "Мы отправили электронное письмо с инструкцией по установке нового пароля."
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:101
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
 msgstr "Активный"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:127
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
 msgstr "Неактивный"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:115
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
 msgstr "Добавить кого-нибудь"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
 msgstr "Последний вход"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:153
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
 msgstr "Вход с помощью Google"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:158
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
 msgstr "Вход с помощью LDAP"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:170
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
 msgstr "Повторно активировать эту учетную запись"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:193
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
 msgstr "Никогда"
 
 #. This looks awful on Russian, fix "tables" word alignment so it would be "таблица {0}" and so on
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:27
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
@@ -1155,36 +1168,38 @@ msgstr[1] "{0} таблицы"
 msgstr[2] "{0} таблиц"
 msgstr[3] "{0} таблиц"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:45
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
 msgstr " будут "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:48
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
 msgstr "предоставлен доступ к"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:53
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
 msgstr " и "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:56
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
 msgstr "доступ запрещен для"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:70
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
 msgstr " никогда не смогут "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:71
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
 msgstr " теперь смогут "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:79
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
 msgstr " прямые запросы к "
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
-#: frontend/src/metabase/nav/containers/Navbar.jsx:219
+#: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
 msgstr "Привилегии"
 
@@ -1209,15 +1224,15 @@ msgstr "Никаких изменений доступа выполнено не
 msgid "You've made changes to permissions."
 msgstr "Вы внесли изменения в настройки доступа."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:52
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
 msgstr "Разрешения для этой коллекции"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
 msgstr "У вас есть несохраненные изменения"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:54
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
 msgstr "Вы действительно хотите покинуть эту страницу и отменить изменения?"
 
@@ -1237,119 +1252,119 @@ msgstr "Каждый пользователь Metabase относится к г�
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
 msgstr "MetaBot это Slack бот Metabase. Здесь вы можете выбрать к чему он будет иметь доступ."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:119
+#: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
 msgstr "Группа \"{0}\" имеет доступ к иным {1}, чем данная группа, что позволит ей получить доступ к {2}."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:124
+#: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
 msgstr "Группа \"{0}\" имеет больший уровень доступа, чем этот, что переопределит данный параметр. Вам следует ограничить или отозвать доступ группы \"{1}\" к данному элементу."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
 msgstr "Ограничение"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
 msgstr "Отозвать"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:156
+#: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
 msgstr "доступ, даже если \"{0}\" имеет больший доступ?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:258
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
 msgstr "Ограничить доступ"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:223
-#: frontend/src/metabase/admin/permissions/selectors.js:266
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:226
+#: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
 msgstr "Отозвать доступ"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:168
+#: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
 msgstr "Ограничить доступ к этой базе данных?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:169
+#: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
 msgstr "Изменить"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:182
+#: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
 msgstr "Разрешить написание прямых запросов?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:183
+#: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
 msgstr "Это также предоставит данной группе Неограниченный доступ к базе данных."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:184
+#: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
 msgstr "Разрешить"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:221
+#: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
 msgstr "Отозвать доступ ко всем таблицам?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:222
+#: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
 msgstr "Это также отзовет доступ группы к прямым запросам к базе данных."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:251
+#: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
 msgstr "Предоставить неограниченный доступ"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:252
+#: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
 msgstr "Неограниченный доступ"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:259
+#: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
 msgstr "Ограниченный доступ"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:267
+#: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
 msgstr "Нет доступа"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:273
+#: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
 msgstr "Написание прямых запросов"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:274
+#: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
 msgstr "Может писать прямые запросы"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:281
+#: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
 msgstr "Управлять коллекцией"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:288
+#: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
 msgstr "Посмотреть коллекцию"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:331
-#: frontend/src/metabase/admin/permissions/selectors.js:427
-#: frontend/src/metabase/admin/permissions/selectors.js:524
+#: frontend/src/metabase/admin/permissions/selectors.js:334
+#: frontend/src/metabase/admin/permissions/selectors.js:430
+#: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
 msgstr "Доступ к данным"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:492
-#: frontend/src/metabase/admin/permissions/selectors.js:649
-#: frontend/src/metabase/admin/permissions/selectors.js:654
+#: frontend/src/metabase/admin/permissions/selectors.js:495
+#: frontend/src/metabase/admin/permissions/selectors.js:652
+#: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
 msgstr "Посмотреть таблицы"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:590
+#: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
 msgstr "SQL запросы"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:660
+#: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
 msgstr "Посмотреть схемы"
 
 #: frontend/src/metabase/admin/routes.jsx:59
-#: frontend/src/metabase/nav/containers/Navbar.jsx:209
+#: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
 msgstr "Модель данных"
 
@@ -1358,30 +1373,30 @@ msgstr "Модель данных"
 msgid "Sign in with Google"
 msgstr "Войти с помощью Google"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:13
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
 msgstr "Разрешить пользователям с существующими Metabase аккаунтами входить с помощью Google аккаунтов при совпадении email адресов в дополнение к их Metabase логину и паролю."
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:17
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
 msgstr "Настроить"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
-#: frontend/src/metabase/admin/settings/selectors.js:207
+#: frontend/src/metabase/admin/settings/selectors.js:204
 msgid "LDAP"
 msgstr "LDAP"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:25
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
 msgstr "Позволяет пользователям в каталоге LDAP входить в Metabase с учетными данными LDAP, а также автоматически связывает группы LDAP с группами Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
-#: frontend/src/metabase/admin/settings/selectors.js:160
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
 msgstr "Это не валидный email адрес"
 
@@ -1419,7 +1434,7 @@ msgstr "Очистить"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:202
+#: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
 msgstr "Аутентификация"
 
@@ -1483,21 +1498,21 @@ msgstr "Создать Slack Bot пользователя для MetaBot"
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Пока вы здесь, дайте имя и нажмите {0}. Затем скопируйте и вставьте Bot API токен в поле ниже. После этого, создайте канал \"metabase_files\" в Slack. Это требуется Metabase для загрузки графиков."
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:90
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
 msgstr "Вы последнюю версию запустили Metanase {0}, которая великолепна!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:99
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0} доступна. Вы используете {1}"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:112
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
 msgstr "Обновить"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:116
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
 msgstr "Что изменено:"
 
@@ -1510,80 +1525,80 @@ msgstr "Добавить карту"
 msgid "URL"
 msgstr "Ссылка"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:199
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
 msgstr "Удалить текущую карту"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:327
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:40
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:181
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
 msgstr "Удалить"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:226
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:187
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:241
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:246
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
 msgstr "Выбрать..."
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:241
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
 msgstr "Примеры значений:"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
 msgstr "Добавить новую карту"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
 msgstr "Изменить карту"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:280
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
 msgstr "Как вы хотите назвать эту карту?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
 msgstr "например, Великобритания, Бразилия, Марс"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:292
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
 msgstr "URL к файлу GeoJSON, который нужно использовать"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:298
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
 msgstr "Например, https://my-mb-server.com/maps/my-map.json"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:33
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
 msgstr "Обновить"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
 msgstr "Загрузить"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:315
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
 msgstr "Какой признак определяет идентификатор региона?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:324
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
 msgstr "Какой признак определяет отображаемое наименование региона?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:345
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
 msgstr "Загрузите файл GeoJSON для предварительного просмотра"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
 msgstr "Сохранить карту"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
 msgstr "Добавить карту"
 
@@ -1595,11 +1610,11 @@ msgstr "Использовать встраивание"
 msgid "By enabling embedding you're agreeing to the embedding license located at"
 msgstr "Разрешая встраивание, вы соглашаетесь с лицензией по встраиванию расположенной"
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:19
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
 msgstr "Говоря по-русски, когда вы встраиваете графики и панели индикаторов Metabase в ваше приложение, такое приложение не должно отвечать требованиям Affero General Public License, которое охватывает остальную часть Metabase, при условии, что на встраиваемых элементах останутся логотип Metabase и надпись \"Powered by Metabase\". Однако, в любом случае, вам следует ознакомиться с лицензией по ссылке выше, действующую редакцию которой вы принимаете, включая данную настройку."
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:32
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
 msgstr "Включить"
 
@@ -1623,25 +1638,25 @@ msgstr "Купить токен"
 msgid "Enter a token"
 msgstr "Ввести токен"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:134
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
 msgstr "Изменить сопоставления"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:140
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
 msgstr "Групповое сопоставление"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:147
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
 msgstr "Создать сопоставление"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
 msgstr "Сопоставление позволяет Metabase автоматически добавлять и исключать пользователей из групп на основании информации из каталога сервера. Доступ к группе Администраторов может быть предоставлен на основании сопоставления, но не будет снят автоматически как мера предосторожности."
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
 msgstr "Отличительное наименование"
 
@@ -1653,43 +1668,43 @@ msgstr "Публичная ссылка"
 msgid "Revoke Link"
 msgstr "Удалить ссылку"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:121
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
 msgstr "Отключить эту ссылку?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:122
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
 msgstr "Они больше не работают и не могут быть восстановлены, но вы можете создать новые ссылки."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
 msgstr "Перечень открытых Панелей индикаторов"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:152
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
 msgstr "Ни к одной из панели индикаторов общий доступ еще не предоставлен."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:160
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
 msgstr "Перечень общих Карточек"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:163
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
 msgstr "Ни к одному вопросу общий доступ еще не предоставлен."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:172
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
 msgstr "Перечень встроенных Панелей индикаторов"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
 msgstr "Ни одна панель индикаторов еще не встроена."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:183
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
 msgstr "Список встраиваемых карточек"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:184
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
 msgstr "Ни один вопрос еще не встроен."
 
@@ -1710,18 +1725,17 @@ msgid "Generate Key"
 msgstr "Сгенерировать ключ"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:78
-#: frontend/src/metabase/admin/settings/selectors.js:87
+#: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
 msgstr "Включено"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:83
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:103
+#: frontend/src/metabase/admin/settings/selectors.js:82
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Отключено"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:116
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
 msgstr "Неизвестная настройка {0}"
 
@@ -1729,7 +1743,7 @@ msgstr "Неизвестная настройка {0}"
 msgid "Setup"
 msgstr "Настроить"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
 msgstr "Общее"
@@ -1758,11 +1772,11 @@ msgstr "По-умолчанию для базы данных"
 msgid "Select a timezone"
 msgstr "Выбрать часовой пояс"
 
-#: frontend/src/metabase/admin/settings/selectors.js:55
+#: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Не все базы данных поддерживают часовые пояса, поэтому данная настройка может не сработать."
 
-#: frontend/src/metabase/admin/settings/selectors.js:60
+#: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
 msgstr "Язык"
 
@@ -1770,202 +1784,202 @@ msgstr "Язык"
 msgid "Select a language"
 msgstr "Выбрать язык"
 
-#: frontend/src/metabase/admin/settings/selectors.js:70
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
 msgstr "Анонимное отслеживание"
 
-#: frontend/src/metabase/admin/settings/selectors.js:75
+#: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
 msgstr "Понятные имена таблиц и полей"
 
-#: frontend/src/metabase/admin/settings/selectors.js:81
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Только замените знаки нижнего подчеркивания и точки пробелами"
 
-#: frontend/src/metabase/admin/settings/selectors.js:91
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
 msgstr "Включить вложенные запросы"
 
-#: frontend/src/metabase/admin/settings/selectors.js:102
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
 msgstr "Обновления"
 
-#: frontend/src/metabase/admin/settings/selectors.js:107
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
 msgstr "Проверить обновления"
 
-#: frontend/src/metabase/admin/settings/selectors.js:118
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
 msgstr "SMTP хост"
 
-#: frontend/src/metabase/admin/settings/selectors.js:126
+#: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
 msgstr "SMTP порт"
 
-#: frontend/src/metabase/admin/settings/selectors.js:130
-#: frontend/src/metabase/admin/settings/selectors.js:230
+#: frontend/src/metabase/admin/settings/selectors.js:127
+#: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
 msgstr "Некорректный номер порта"
 
-#: frontend/src/metabase/admin/settings/selectors.js:134
+#: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
 msgstr "Безопасность SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:142
+#: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
 msgstr "SMTP пользователь"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
 msgstr "SMTP пароль"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
 msgstr "От кого"
 
-#: frontend/src/metabase/admin/settings/selectors.js:170
+#: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
 msgstr "Slack API Token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:172
+#: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
 msgstr "Введите токен полученный от Slack"
 
-#: frontend/src/metabase/admin/settings/selectors.js:189
+#: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
 msgstr "Единый вход"
 
-#: frontend/src/metabase/admin/settings/selectors.js:213
+#: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
 msgstr "Аутентификация LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:219
+#: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
 msgstr "LDAP хост"
 
-#: frontend/src/metabase/admin/settings/selectors.js:227
+#: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
 msgstr "LDAP порт"
 
-#: frontend/src/metabase/admin/settings/selectors.js:234
+#: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
 msgstr "Безопасность LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
 msgstr "Пользователь или DN"
 
-#: frontend/src/metabase/admin/settings/selectors.js:247
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:188
-#: frontend/src/metabase/user/components/UserSettings.jsx:72
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:191
+#: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
 msgstr "Пароль"
 
-#: frontend/src/metabase/admin/settings/selectors.js:252
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "User search base"
 msgstr "База для поиска пользователя"
 
-#: frontend/src/metabase/admin/settings/selectors.js:258
+#: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
 msgstr "Пользовательский фильтр"
 
-#: frontend/src/metabase/admin/settings/selectors.js:264
+#: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
 msgstr "Проверьте круглые скобки"
 
-#: frontend/src/metabase/admin/settings/selectors.js:270
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
 msgstr "Email аттрибут"
 
-#: frontend/src/metabase/admin/settings/selectors.js:275
+#: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
 msgstr "Атрибут имени"
 
-#: frontend/src/metabase/admin/settings/selectors.js:280
+#: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
 msgstr "Атрибут фамилии"
 
-#: frontend/src/metabase/admin/settings/selectors.js:285
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
 msgstr "Синхронизировать членство в группе"
 
-#: frontend/src/metabase/admin/settings/selectors.js:291
+#: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
 msgstr "База для поиска группы"
 
-#: frontend/src/metabase/admin/settings/selectors.js:300
+#: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
 msgstr "Карты"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
 msgstr "URL сервера загрузки плиток карты"
 
-#: frontend/src/metabase/admin/settings/selectors.js:306
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "По умолчанию, Metabase использует OpenStreetMaps."
 
-#: frontend/src/metabase/admin/settings/selectors.js:311
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
 msgstr "Пользовательская карта"
 
-#: frontend/src/metabase/admin/settings/selectors.js:312
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Добавьте собственные GeoJSON файлы для возможности визуализации различных регионов на картах"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
 msgstr "Общий доступ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:336
+#: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
 msgstr "Включить общий доступ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:341
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
 msgstr "Публичные дашборды"
 
-#: frontend/src/metabase/admin/settings/selectors.js:347
+#: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
 msgstr "Публичные запросы"
 
-#: frontend/src/metabase/admin/settings/selectors.js:354
+#: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
 msgstr "Встраивание в других Приложениях"
 
-#: frontend/src/metabase/admin/settings/selectors.js:381
+#: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Включить встраивание Metabase в других Приложениях"
 
-#: frontend/src/metabase/admin/settings/selectors.js:391
+#: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
 msgstr "Секретный ключ для встраивания"
 
-#: frontend/src/metabase/admin/settings/selectors.js:397
+#: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
 msgstr "Встраиваемые дашборды"
 
-#: frontend/src/metabase/admin/settings/selectors.js:403
+#: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
 msgstr "Встраиваемые запросы"
 
-#: frontend/src/metabase/admin/settings/selectors.js:410
+#: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
 msgstr "Кэширование"
 
-#: frontend/src/metabase/admin/settings/selectors.js:415
+#: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
 msgstr "Включить кэширование"
 
-#: frontend/src/metabase/admin/settings/selectors.js:420
+#: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
 msgstr "Минимальное время запроса"
 
-#: frontend/src/metabase/admin/settings/selectors.js:427
+#: frontend/src/metabase/admin/settings/selectors.js:424
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Множитель Cache Time-To-Live (TTL)"
 
-#: frontend/src/metabase/admin/settings/selectors.js:434
+#: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
 msgstr "Максимальный размер записи кэша"
 
@@ -1981,11 +1995,11 @@ msgstr "Предупреждение было сохранено."
 msgid "The alert was successfully deleted."
 msgstr "Предупреждение успешно удалено."
 
-#: frontend/src/metabase/auth/auth.js:33
+#: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
 msgstr "Введите корректный email"
 
-#: frontend/src/metabase/auth/auth.js:116
+#: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
@@ -2027,91 +2041,88 @@ msgstr "Послать емаил для сброса пароля"
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Послать емаил с инструкцией как сбросить пароль."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:128
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
 msgstr "Войти в Metabase"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:138
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
 msgstr "ИЛИ"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:157
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
 msgstr "Имя пользователя или email"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:217
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
 msgstr "Войти"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:230
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
 msgstr "Похоже что я забыл свой пароль"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
 msgstr "запросить новое письмо с запросом на сброс пароля"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:120
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
 msgstr "Уууупс, кажется эта ссылку устарела."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:122
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
 msgstr "По соображениям безопасности, ссылки на сброс пароля через некоторое время истекают.\n"
 "Если вам все еще нужно сбросить пароль, вы можете {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:147
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
 msgstr "Новый пароль"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:149
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
 msgstr "Ради безопасности, пароли {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:163
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
 msgstr "Создать новый пароль"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:170
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:141
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
 msgstr "Удостоверьтесь что пароль соответствует рекомендации безопасности выше"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:184
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:150
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
 msgstr "Подтвердите новый пароль"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:191
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:159
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
 msgstr "Удостоверьтесь что он соответствует тому который вы уже ввели"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:216
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
 msgstr "Ваш пароль был сброшен."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:222
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:227
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
 msgstr "Зайди с вашим новым паролем"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:182
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:251
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Сохранение не удалось"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:183
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:129
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:225
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:252
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
 msgstr "Сохранено"
 
@@ -2119,24 +2130,22 @@ msgstr "Сохранено"
 msgid "Ok"
 msgstr "Ок"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:38
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
 msgstr "Переместить коллекцию в архив?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:43
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Дашборды, коллекции и пульсы в этой коллекции так же будут премещены в архив."
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
-#: frontend/src/metabase/components/CollectionLanding.jsx:624
+#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: frontend/src/metabase/components/CollectionLanding.jsx:620
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:47
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:195
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:200
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:40
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:53
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
 msgstr "Архив"
@@ -2145,28 +2154,27 @@ msgstr "Архив"
 msgid "This {0} has been archived"
 msgstr "Этот {0} перемещен в архив."
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:715
+#: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
 msgstr "Посмотреть архив"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:43
+#: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
 msgstr "Востоновить этот {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:70
-#: frontend/src/metabase/components/BrowseApp.jsx:132
-#: frontend/src/metabase/components/BrowseApp.jsx:225
+#: frontend/src/metabase/components/BrowseApp.jsx:39
+#: frontend/src/metabase/components/BrowseApp.jsx:102
+#: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
 msgstr "Наши данные"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:169
+#: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
 msgstr "Просканировать эту таблицу"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:183
-#: frontend/src/metabase/containers/Overworld.jsx:246
+#: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
 msgstr "Узнать больше об этой таблице"
 
@@ -2184,31 +2192,31 @@ msgstr "Сохранено!"
 msgid "Saving failed."
 msgstr "Не получилось сохранить."
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
 msgstr "Вс"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
 msgstr "По"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
 msgstr "Вт"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
 msgstr "Ср"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
 msgstr "Чт"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
 msgstr "Пт"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
 msgstr "Сб"
 
@@ -2253,27 +2261,26 @@ msgstr "Пульсы позволяют вам отправлять послед
 msgid "Questions are a saved look at your data."
 msgstr "Запросы - это сохраненный взгляд на ваши данные."
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:287
+#: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
 msgstr "Прикрепленные"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:341
+#: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
 msgstr "Переместите что-то для того чтобы закрепить наверху"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:737
-#: frontend/src/metabase/components/CollectionLanding.jsx:353
-#: frontend/src/metabase/home/containers/SearchApp.jsx:35
-#: frontend/src/metabase/home/containers/SearchApp.jsx:92
+#: frontend/src/metabase/admin/permissions/selectors.js:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:352
+#: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
 msgstr "Коллекции"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:432
-#: frontend/src/metabase/components/CollectionLanding.jsx:455
+#: frontend/src/metabase/components/CollectionLanding.jsx:431
+#: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
 msgstr "Переместите чтобы открепить"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:490
+#: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
 msgstr[0] "{0} элемент выбран"
@@ -2281,35 +2288,36 @@ msgstr[1] "{0} элемента выбрано"
 msgstr[2] "{0} элементов выбрано"
 msgstr[3] "{0} элементов выбрано"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:522
+#: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
 msgstr "Переместить {0} элементов?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:523
+#: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
 msgstr "Переместить \"{0}\"?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:631
+#: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
 msgstr "Переместить"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:692
+#: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
 msgstr "Изменить эту коллекцию"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:700
+#: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
 msgstr "Переместить коллекцию в архив"
 
-#: frontend/src/metabase/components/CollectionList.jsx:64
-#: frontend/src/metabase/entities/collections.js:155
+#: frontend/src/metabase/components/CollectionList.jsx:67
+#: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
 msgstr "Моя личная коллекция"
 
-#: frontend/src/metabase/components/CollectionList.jsx:106
+#: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
 msgstr "Новая коллекция"
 
@@ -2317,11 +2325,11 @@ msgstr "Новая коллекция"
 msgid "Copied!"
 msgstr "Скопировано!"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:216
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Использать SSH-туннель для связи с базой данных"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
@@ -2329,75 +2337,76 @@ msgstr "Некоторые инсталляции баз данных могут
 "Эта опция так же предоставляет дополнительный уровень безопасности, когда недоступен VPN. \n"
 "Использование может снизить скорость в сравнении с прямым соединением."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:271
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Это большая база данных, так что дайте я выберу когда Мэтабэйз синхронизирует и сканирует"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:273
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "По-умолчанию, Metabase выполняет поверхностное сканирование каждый час и полное сканирование значений полей каждые сутки.\n"
 "Если у вас большая база данных, мы рекомендуем настроить подходящее расписание для сканирования значений полей."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:289
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} для генерации Client ID и Client Secret для вашего проекта."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:291
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:353
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
 msgstr "Нажмите здесь"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Выберите \"Прочее\" как тип приложения. Назовите его на ваш вкус."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:316
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
 msgstr "{0} для получения кода аутентификации"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:328
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
 msgstr "с разрешениями Google Drive"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:348
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Вам необходимо разрешить доступ по API в Google Developers Console, чтобы использовать эти данные в Metabase."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:351
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} перейдите в консоль, если вы этого еще не сделали"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
 msgstr "Как бы вы хотели обращаться к этой базе данных?"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:427
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:237
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:188
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:74
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:194
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:79
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
 msgstr "Дальше"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:52
+#: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
 msgstr "Удалить этот {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:43
+#: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
 msgstr "Закрепить этот элемент"
 
-#: frontend/src/metabase/components/EntityItem.jsx:49
+#: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
 msgstr "Переместить этот элемент"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
 msgstr "Изменить этот запрос"
 
@@ -2410,6 +2419,7 @@ msgstr "Тип действия"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
 msgstr "Просмотреть исторю"
 
@@ -2425,8 +2435,7 @@ msgstr "Заархивировать действие"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:329
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:342
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
 msgstr "Добавить к дашборду"
 
@@ -2450,13 +2459,12 @@ msgstr "Иной вид действия"
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:449
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:454
 msgid "Get alerts about this"
 msgstr "Получать сигналы об этом"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
 msgstr "Посмотреть SQL"
 
@@ -2476,43 +2484,43 @@ msgstr "Полный текст сообщения об ошибке"
 msgid "Hi, Metabot here."
 msgstr "Привет, Metabot здесь."
 
-#: frontend/src/metabase/components/ExplorePane.jsx:95
+#: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
 msgstr "Основано на схеме"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:174
+#: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
 msgstr "Взгляните на"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:234
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
 msgstr "Поиск в списке"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:238
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
 msgstr "Искать по {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
 msgstr " или введитеь ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
 msgstr "Введите ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
 msgstr "Ведите номер"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:248
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
 msgstr "Введите текст"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:355
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
 msgstr "Не найдено сходст в {0}."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:363
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Предположу, что выбор всех значений фильтра делу не поможет…"
 
@@ -2528,17 +2536,17 @@ msgstr "Мы столкнулись с ошибкой. Попробуйте об
 #: frontend/src/metabase/components/HeaderBar.jsx:45
 #: frontend/src/metabase/components/ListItem.jsx:37
 #: frontend/src/metabase/reference/components/Detail.jsx:47
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:158
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:213
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:191
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:205
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:209
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:209
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:161
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:216
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:194
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:208
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
 msgstr "Описание не заполнено"
 
 #: frontend/src/metabase/components/Header.jsx:112
-#: frontend/src/metabase/entities/containers/EntityForm.jsx:43
+#: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
 msgstr "Новый {0}"
 
@@ -2546,54 +2554,53 @@ msgstr "Новый {0}"
 msgid "Asked by {0}"
 msgstr "Задан {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:13
+#: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
 msgstr "Сегодня, "
 
-#: frontend/src/metabase/components/HistoryModal.jsx:15
+#: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
 msgstr "Вчера, "
 
-#: frontend/src/metabase/components/HistoryModal.jsx:68
+#: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
 msgstr "Первая ревизия"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:70
+#: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
 msgstr "Возвращен к более ранней редакции и {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:82
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:289
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:379
-#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
+#: frontend/src/metabase/components/HistoryModal.jsx:42
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
+#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
 msgstr "История ревизий"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:90
+#: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
 msgstr "Когда"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:91
+#: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
 msgstr "Кто"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:92
+#: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
 msgstr "Что"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:113
+#: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
 msgstr "Возвратить"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:114
+#: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
 msgstr "Возврат…"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:115
+#: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
 msgstr "Возврат не удался"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:116
+#: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
 msgstr "Возвращен"
 
@@ -2602,26 +2609,24 @@ msgid "Everything"
 msgstr "Все"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
-#: frontend/src/metabase/home/containers/SearchApp.jsx:69
 msgid "Dashboards"
 msgstr "Дашборды"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
-#: frontend/src/metabase/home/containers/SearchApp.jsx:115
 msgid "Questions"
 msgstr "Запросы"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:321
+#: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
 msgstr "Пульсы"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:103
+#: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
 msgstr "Назад"
 
-#: frontend/src/metabase/components/ListSearchField.jsx:18
+#: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
 msgstr "Найти..."
 
@@ -2658,14 +2663,14 @@ msgid "Temporary Password"
 msgstr "Временный пароль"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
 msgstr "Скрыть"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:412
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
 msgstr "Показать"
 
@@ -2730,7 +2735,7 @@ msgstr "15-ое (середина)"
 msgid "Calendar Day"
 msgstr "День календаря"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:210
+#: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
 msgstr "часовой пояс вашего Metabase"
 
@@ -2759,11 +2764,11 @@ msgid "A component used to make a selection"
 msgstr "Компонент использован для возможности выбора"
 
 #: frontend/src/metabase/components/Select.info.js:20
-#: frontend/src/metabase/components/Select.info.js:28
+#: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
 msgstr "Выбрано"
 
-#: frontend/src/metabase/components/Select.jsx:297
+#: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
 msgstr "Ничего не выбрано"
 
@@ -2776,7 +2781,7 @@ msgid "Unknown error encountered"
 msgstr "Возникла неизвестная ошибка"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/nav/containers/Navbar.jsx:304
+#: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
 msgstr "Создать"
 
@@ -2785,13 +2790,11 @@ msgid "Create dashboard"
 msgstr "Создать дашборд"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:331
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:60
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
 msgstr "Таблица"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:306
 msgid "Database"
 msgstr "База данных"
 
@@ -2799,22 +2802,20 @@ msgstr "База данных"
 msgid "Creator"
 msgstr "Создатель"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:238
+#: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
 msgstr "Ничего не найдено"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:239
+#: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
 msgstr "Попробуйте установить фильтр для того чтобы найти то, что искали."
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:258
+#: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
 msgstr "Просмотрено"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:494
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:84
-#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:69
-#: frontend/src/metabase/tutorial/TutorialModal.jsx:34
+#: frontend/src/metabase/containers/EntitySearch.jsx:495
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
 msgstr "из"
 
@@ -2827,13 +2828,13 @@ msgid "Once you connect your own data, I can show you some automatic exploration
 msgstr "Как только вы подключите собственные данные я смогу показать некоторые автоматические изыскания, названные X-ray. Вот несколько примеров на данных, которые есть у меня."
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
-#: frontend/src/metabase/containers/Overworld.jsx:299
+#: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
 msgstr "Начните здесь"
 
-#: frontend/src/metabase/containers/Overworld.jsx:294
-#: frontend/src/metabase/entities/collections.js:147
+#: frontend/src/metabase/containers/Overworld.jsx:296
+#: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
 msgstr "Наша статистика"
@@ -2842,53 +2843,53 @@ msgstr "Наша статистика"
 msgid "Browse all items"
 msgstr "Просмотреть все элементы"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:165
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
 msgstr "Заменить или сохранить как новый?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:173
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
 msgstr "Заменить исходный вопрос, \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:178
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
 msgstr "Сохранить как новый запрос"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:187
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
 msgstr "Для начала, сохраните ваш запрос"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:188
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
 msgstr "Сохранить запрос"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:224
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
 msgstr "Как называется ваша карточка?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:232
-#: frontend/src/metabase/entities/collections.js:101
-#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:234
+#: frontend/src/metabase/entities/collections.js:102
+#: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/lib/core.js:50 frontend/src/metabase/lib/core.js:205
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:156
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:211
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:203
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:207
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:207
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:24
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:159
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:214
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:192
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:206
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:210
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
 msgstr "Описание"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:238
-#: frontend/src/metabase/entities/dashboards.js:153
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
+#: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
 msgstr "Это не обязательно, но может быть полезным"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:245
-#: frontend/src/metabase/entities/dashboards.js:157
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
+#: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "В какую коллекцию следует это включить?"
 
@@ -2900,7 +2901,7 @@ msgstr "изменено"
 msgid "item"
 msgstr "элемент"
 
-#: frontend/src/metabase/containers/UndoListing.jsx:81
+#: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
 msgstr "Отмена"
 
@@ -2924,15 +2925,15 @@ msgstr "Мы не уверены, сочетается ли данный воп�
 msgid "Archive Dashboard"
 msgstr "Архивировать Панель индикаторов"
 
-#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:20
+#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Убедитесь что сделан выбор для каждой из серий, иначе фильтр не будет работать на этой карточке."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:300
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
 msgstr "Панель индикаторов кажется пустоватой."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:301
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
 msgstr "Добавьте вопрос и сделайте ее полезной!"
 
@@ -2952,59 +2953,58 @@ msgstr "Выход из полноэкранного режима"
 msgid "Enter fullscreen"
 msgstr "Полноэкранный режим"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:181
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:183
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Сохранение..."
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:216
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
 msgstr "Добавить запрос"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:219
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
 msgstr "Добавить запрос на этот дашборд"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:248
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
 msgstr "Добавить фильтр"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:254
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:78
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Параметры"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:275
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
 msgstr "Добавить текстовое поле"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
 msgstr "Переместить дашборд"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:302
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
 msgstr "Изменить дашборд"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:306
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
 msgstr "Изменить внешний вид дашборда"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:369
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
 msgstr "Вы редактируете дашборд"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:374
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
 msgstr "Выберите поле, которое должно быть фильтром в каждой из карт"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:28
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
 msgstr "Переместить дашборд..."
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:52
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
 msgstr "Дашборд перемещен в {0}"
 
@@ -3019,7 +3019,7 @@ msgstr "Какой тип фильтра?"
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:179
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
 msgstr "Выключить"
 
@@ -3059,174 +3059,174 @@ msgstr "Обновление через"
 msgid "Remove this question?"
 msgstr "Удалить этот запрос?"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:71
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
 msgstr "Ваш дашборд был сохранен"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:745
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:76
+#: frontend/src/metabase/components/CollectionLanding.jsx:744
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
 msgstr "Просмотреть"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:137
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
 msgstr "Сохранить"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:170
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
 msgstr "Показать больше об этом"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:140
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
 msgstr "Карточка не содержит полей или параметров которые могут быть сопоставлены с этим типом параметра."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:142
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Значение этого поля не покрывают значения никаких полей, которые вы выбрали."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:186
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
 msgstr "Нет корректных полей"
 
-#: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
 msgstr "Имя не должно превышать 100 символов"
 
-#: frontend/src/metabase/entities/collections.js:111
+#: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
 msgstr "Цвет обязателен"
 
-#: frontend/src/metabase/entities/dashboards.js:146
+#: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
 msgstr "Как называется ваш дашборд?"
 
-#: frontend/src/metabase/home/components/Activity.jsx:92
+#: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
 msgstr "сделал супер-пупер финт, который сложно описать словами"
 
-#: frontend/src/metabase/home/components/Activity.jsx:101
-#: frontend/src/metabase/home/components/Activity.jsx:116
+#: frontend/src/metabase/home/components/Activity.jsx:103
+#: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
 msgstr "создал оповещение о - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:126
-#: frontend/src/metabase/home/components/Activity.jsx:141
+#: frontend/src/metabase/home/components/Activity.jsx:128
+#: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
 msgstr "удалил оповещение о - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:152
+#: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
 msgstr "сохранить вопрос о "
 
-#: frontend/src/metabase/home/components/Activity.jsx:165
+#: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
 msgstr "сохранил запрос"
 
-#: frontend/src/metabase/home/components/Activity.jsx:169
+#: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
 msgstr "удалил запрос"
 
-#: frontend/src/metabase/home/components/Activity.jsx:172
+#: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
 msgstr "создал панель индикаторов"
 
-#: frontend/src/metabase/home/components/Activity.jsx:175
+#: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
 msgstr "удалил панель индикаторов"
 
-#: frontend/src/metabase/home/components/Activity.jsx:181
-#: frontend/src/metabase/home/components/Activity.jsx:196
+#: frontend/src/metabase/home/components/Activity.jsx:183
+#: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
-msgstr "доавил вопрос на панель индикаторов - "
+msgstr "добавил вопрос на панель индикаторов - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:206
-#: frontend/src/metabase/home/components/Activity.jsx:221
+#: frontend/src/metabase/home/components/Activity.jsx:208
+#: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
 msgstr "удалил вопрос с панели индикаторов - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:231
-#: frontend/src/metabase/home/components/Activity.jsx:238
+#: frontend/src/metabase/home/components/Activity.jsx:233
+#: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
 msgstr "последние данные получены"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:621
-#: frontend/src/metabase/home/components/Activity.jsx:244
+#: frontend/src/metabase-lib/lib/Dimension.js:814
+#: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: frontend/src/metabase/home/components/Activity.jsx:251
+#: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
 msgstr "Привет Мир!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:252
+#: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
 msgstr "Metabase запущен и работает."
 
-#: frontend/src/metabase/home/components/Activity.jsx:258
-#: frontend/src/metabase/home/components/Activity.jsx:288
+#: frontend/src/metabase/home/components/Activity.jsx:260
+#: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
 msgstr "добавил метрику "
 
-#: frontend/src/metabase/home/components/Activity.jsx:272
-#: frontend/src/metabase/home/components/Activity.jsx:362
+#: frontend/src/metabase/home/components/Activity.jsx:274
+#: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
 msgstr " к "
 
-#: frontend/src/metabase/home/components/Activity.jsx:282
-#: frontend/src/metabase/home/components/Activity.jsx:322
-#: frontend/src/metabase/home/components/Activity.jsx:372
-#: frontend/src/metabase/home/components/Activity.jsx:413
+#: frontend/src/metabase/home/components/Activity.jsx:284
+#: frontend/src/metabase/home/components/Activity.jsx:324
+#: frontend/src/metabase/home/components/Activity.jsx:374
+#: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
 msgstr " таблица"
 
-#: frontend/src/metabase/home/components/Activity.jsx:298
-#: frontend/src/metabase/home/components/Activity.jsx:328
+#: frontend/src/metabase/home/components/Activity.jsx:300
+#: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
 msgstr "изменил метрику "
 
-#: frontend/src/metabase/home/components/Activity.jsx:312
-#: frontend/src/metabase/home/components/Activity.jsx:403
+#: frontend/src/metabase/home/components/Activity.jsx:314
+#: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
 msgstr " в "
 
-#: frontend/src/metabase/home/components/Activity.jsx:335
+#: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
 msgstr "удалил метрику "
 
-#: frontend/src/metabase/home/components/Activity.jsx:338
+#: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
 msgstr "создал пульс"
 
-#: frontend/src/metabase/home/components/Activity.jsx:341
+#: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
 msgstr "удалил пульс"
 
-#: frontend/src/metabase/home/components/Activity.jsx:347
-#: frontend/src/metabase/home/components/Activity.jsx:378
+#: frontend/src/metabase/home/components/Activity.jsx:349
+#: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
 msgstr "добавио фильтр"
 
-#: frontend/src/metabase/home/components/Activity.jsx:388
-#: frontend/src/metabase/home/components/Activity.jsx:419
+#: frontend/src/metabase/home/components/Activity.jsx:390
+#: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
 msgstr "изменил фильтр"
 
-#: frontend/src/metabase/home/components/Activity.jsx:426
+#: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
 msgstr "удалил фильтр {0}"
 
-#: frontend/src/metabase/home/components/Activity.jsx:429
+#: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
 msgstr "присоединился!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:529
+#: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
 msgstr "Хммм, похоже ничего не произошло."
 
-#: frontend/src/metabase/home/components/Activity.jsx:532
+#: frontend/src/metabase/home/components/Activity.jsx:534
 msgid "Save a question and get this baby going!"
 msgstr "Сохраните вопрос и заставьте эту детку идти!"
 
@@ -3274,21 +3274,21 @@ msgstr "Недавно просмотренно"
 msgid "You haven't looked at any dashboards or questions recently"
 msgstr "В последнее время, вы не смотрели ни на один дэшборд"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:99
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
 msgstr "{0} элементов выбрано"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:121
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:172
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
 msgstr "Разархивировать"
 
-#: frontend/src/metabase/home/containers/HomepageApp.jsx:74
-#: frontend/src/metabase/nav/containers/Navbar.jsx:331
+#: frontend/src/metabase/home/containers/HomepageApp.jsx:77
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
 msgstr "Активность"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:28
+#: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
 msgstr "Результаты для \"{0}\""
 
@@ -3353,6 +3353,7 @@ msgstr "Ссылка на аватар"
 msgid "Common"
 msgstr "Общее"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
@@ -3389,8 +3390,9 @@ msgstr "Широта"
 msgid "Longitude"
 msgstr "Долгота"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:149
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
 msgstr "Число"
@@ -3488,7 +3490,7 @@ msgstr "Результат"
 
 #: frontend/src/metabase/lib/core.js:210
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:17
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
 msgstr "Заголовок"
 
@@ -3545,8 +3547,9 @@ msgid "Metabase will never retrieve this field. Use this for sensitive or irrele
 msgstr "Metabase никогда не получит это поле. Используйте для чувствительной нерелевантной информации."
 
 #: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:614
-#: frontend/src/metabase/visualizations/lib/utils.js:126
+#: frontend/src/metabase/lib/query.js:300
+#: frontend/src/metabase/visualizations/lib/utils.js:130
+#: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -3561,7 +3564,7 @@ msgstr "Накопительное количество"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
-#: frontend/src/metabase/visualizations/lib/utils.js:127
+#: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
 msgstr "Сумма"
 
@@ -3571,7 +3574,7 @@ msgstr "Накопительная сумма"
 
 #. Во множественном числе исходя из применяемости в Metabase.
 #: frontend/src/metabase/lib/expressions/config.js:11
-#: frontend/src/metabase/visualizations/lib/utils.js:128
+#: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
 msgstr "Уникальные"
 
@@ -3580,29 +3583,29 @@ msgid "StandardDeviation"
 msgstr "Стандартное отклонение"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/visualizations/lib/utils.js:125
+#: frontend/src/metabase/visualizations/lib/utils.js:129
 msgid "Average"
 msgstr "Среднее"
 
 #: frontend/src/metabase/lib/expressions/config.js:14
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:25
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
 msgstr "Минимальное"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
 msgstr "Максимальное"
 
-#: frontend/src/metabase/lib/expressions/parser.js:384
+#: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
 msgstr "грустная грустная панда, обнаружены лексические ошибки"
 
-#: frontend/src/metabase/lib/formatting.js:707
+#: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} секунда"
@@ -3610,7 +3613,7 @@ msgstr[1] "{0} секунд"
 msgstr[2] "{0} секунд"
 msgstr[3] "{0} секунды"
 
-#: frontend/src/metabase/lib/formatting.js:710
+#: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} минута"
@@ -3651,222 +3654,224 @@ msgstr "О чем вы думаете?"
 msgid "What do you want to find out?"
 msgstr "Что вас интересует?"
 
-#: frontend/src/metabase/lib/query.js:612
-#: frontend/src/metabase/lib/schema_metadata.js:451
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:246
+#: frontend/src/metabase/lib/query.js:298
+#: frontend/src/metabase/lib/schema_metadata.js:458
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
 msgstr "Исходные данные"
 
-#: frontend/src/metabase/lib/query.js:616
+#: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
 msgstr "Накопительное количество"
 
-#: frontend/src/metabase/lib/query.js:619
+#: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
 msgstr "Среднее "
 
-#: frontend/src/metabase/lib/query.js:624
+#: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
 msgstr "Уникальные значения "
 
-#: frontend/src/metabase/lib/query.js:629
+#: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
 msgstr "Стандартное отклонение "
 
-#: frontend/src/metabase/lib/query.js:634
+#: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
 msgstr "Сумма "
 
-#: frontend/src/metabase/lib/query.js:639
+#: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
 msgstr "Накопительная сумма "
 
-#: frontend/src/metabase/lib/query.js:644
+#: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
 msgstr "Максимум "
 
-#: frontend/src/metabase/lib/query.js:649
+#: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
 msgstr "Минимум "
 
-#: frontend/src/metabase/lib/query.js:663
+#: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
 msgstr "Сгруппировано по "
 
-#: frontend/src/metabase/lib/query.js:677
+#: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
 msgstr "Отфильтровано по "
 
-#: frontend/src/metabase/lib/query.js:706
+#: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
 msgstr "Сортировано по "
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
 msgstr "Истина"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
 msgstr "Ложь"
 
-#: frontend/src/metabase/lib/schema_metadata.js:305
+#: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
 msgstr "Выберите поле с долготой"
 
-#: frontend/src/metabase/lib/schema_metadata.js:306
+#: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
 msgstr "Введите верхнюю широту"
 
-#: frontend/src/metabase/lib/schema_metadata.js:307
+#: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
 msgstr "Введите левую долготу"
 
-#: frontend/src/metabase/lib/schema_metadata.js:308
+#: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
 msgstr "Введите нижнюю широту"
 
-#: frontend/src/metabase/lib/schema_metadata.js:309
+#: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
 msgstr "Введите правую долготу"
 
-#: frontend/src/metabase/lib/schema_metadata.js:345
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase-lib/lib/Dimension.js:505
+#: frontend/src/metabase-lib/lib/Dimension.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:351
+#: frontend/src/metabase/lib/schema_metadata.js:371
 #: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:387
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
 msgstr "-"
 
-#: frontend/src/metabase/lib/schema_metadata.js:346
-#: frontend/src/metabase/lib/schema_metadata.js:366
-#: frontend/src/metabase/lib/schema_metadata.js:376
-#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/lib/schema_metadata.js:352
+#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:396
+#: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
 msgstr "Не"
 
-#: frontend/src/metabase/lib/schema_metadata.js:347
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:369
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:353
+#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
 msgstr "Пусто"
 
-#: frontend/src/metabase/lib/schema_metadata.js:348
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:370
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:402
+#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
 msgstr "Не пусто"
 
-#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
 msgstr "Равно"
 
-#: frontend/src/metabase/lib/schema_metadata.js:355
+#: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
 msgstr "Не равно"
 
-#: frontend/src/metabase/lib/schema_metadata.js:356
+#: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
 msgstr "Больше чем"
 
-#: frontend/src/metabase/lib/schema_metadata.js:357
+#: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
 msgstr "Меньше чем"
 
-#: frontend/src/metabase/lib/schema_metadata.js:358
-#: frontend/src/metabase/lib/schema_metadata.js:384
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:285
+#: frontend/src/metabase/lib/schema_metadata.js:364
+#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Между"
 
-#: frontend/src/metabase/lib/schema_metadata.js:359
+#: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
 msgstr "Больше или равно"
 
-#: frontend/src/metabase/lib/schema_metadata.js:360
+#: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
 msgstr "Меньше или равно"
 
-#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
 msgstr "Содержит"
 
-#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
 msgstr "Не содержит"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
 msgstr "Начинается с"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
 msgstr "Заканчивается"
 
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:264
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "До"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:271
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "После"
 
-#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
 msgstr "Внутри"
 
-#: frontend/src/metabase/lib/schema_metadata.js:453
+#: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Просто таблица со строками результатов, без дополнительных операций."
 
-#: frontend/src/metabase/lib/schema_metadata.js:459
+#: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
 msgstr "Количество записей"
 
-#: frontend/src/metabase/lib/schema_metadata.js:461
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
 msgstr "Общее количество записей в ответе"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
 msgstr "Количество ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:469
+#: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
 msgstr "Количество всех значений колонки."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
 msgstr "Среднее ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
 msgstr "Среднее всех значений колонки."
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
 msgstr "Уникальные значения..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Количество уникальных значений столбца среди всех записей в ответе."
 
-#: frontend/src/metabase/lib/schema_metadata.js:491
+#: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
 msgstr "Сумма нарастащим итогом…"
 
@@ -3875,7 +3880,7 @@ msgstr "Сумма нарастащим итогом…"
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Совокупное сумма всех значений столбца.\\\\ne.x. всего доход за временной интервал."
 
-#: frontend/src/metabase/lib/schema_metadata.js:499
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
 msgstr "Нарастающий итог"
 
@@ -3883,106 +3888,106 @@ msgstr "Нарастающий итог"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Совокупное количество записей.\\\\ne.x. всего продаж за временной интервал."
 
-#: frontend/src/metabase/lib/schema_metadata.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
 msgstr "Стандартное отклонение…"
 
 #. Кривая формулировка получилась, нужно уточнение.
-#: frontend/src/metabase/lib/schema_metadata.js:509
+#: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Число, отражающее насколько значения столбца отклоняются от всех записей ответа."
 
-#: frontend/src/metabase/lib/schema_metadata.js:515
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
 msgstr "Минимум ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:517
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
 msgstr "Минимальное значение столбца"
 
-#: frontend/src/metabase/lib/schema_metadata.js:523
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
 msgstr "Максимум ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:525
+#: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
 msgstr "Максимальное значение колонки"
 
-#: frontend/src/metabase/lib/schema_metadata.js:533
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
 msgstr "Разбить по измерению"
 
-#: frontend/src/metabase/lib/settings.js:93
+#: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
 msgstr "буква в нижнем регистре"
 
-#: frontend/src/metabase/lib/settings.js:95
+#: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
 msgstr "буква в верхнем регистре"
 
-#: frontend/src/metabase/lib/settings.js:97
+#: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "число"
 
-#: frontend/src/metabase/lib/settings.js:99
+#: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
 msgstr "специальный символ"
 
-#: frontend/src/metabase/lib/settings.js:105
+#: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
 msgstr "должен содержать не менее"
 
-#: frontend/src/metabase/lib/settings.js:105
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:120
+#: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
 msgstr "символов"
 
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
 msgstr "Должен содержать не менее"
 
-#: frontend/src/metabase/lib/settings.js:122
+#: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
 msgstr "и содержать как минимум"
 
-#: frontend/src/metabase/lib/utils.js:92
+#: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
 msgstr "ноль"
 
-#: frontend/src/metabase/lib/utils.js:93
+#: frontend/src/metabase/lib/utils.js:86
 msgid "one"
 msgstr "один"
 
-#: frontend/src/metabase/lib/utils.js:94
+#: frontend/src/metabase/lib/utils.js:87
 msgid "two"
 msgstr "два"
 
-#: frontend/src/metabase/lib/utils.js:95
+#: frontend/src/metabase/lib/utils.js:88
 msgid "three"
 msgstr "три"
 
-#: frontend/src/metabase/lib/utils.js:96
+#: frontend/src/metabase/lib/utils.js:89
 msgid "four"
 msgstr "четыре"
 
-#: frontend/src/metabase/lib/utils.js:97
+#: frontend/src/metabase/lib/utils.js:90
 msgid "five"
 msgstr "пять"
 
-#: frontend/src/metabase/lib/utils.js:98
+#: frontend/src/metabase/lib/utils.js:91
 msgid "six"
 msgstr "шесть"
 
-#: frontend/src/metabase/lib/utils.js:99
+#: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
 msgstr "семь"
 
-#: frontend/src/metabase/lib/utils.js:100
+#: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
 msgstr "восемь"
 
-#: frontend/src/metabase/lib/utils.js:101
+#: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
 msgstr "девять"
 
@@ -4056,6 +4061,7 @@ msgstr "Время"
 msgid "Date range, relative date, time of day, etc."
 msgstr "Временной интервал, относительная дата, время дня, прочее."
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
@@ -4078,7 +4084,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Категория, Тип, Модель, Рейтинг, прочее."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
-#: frontend/src/metabase/user/components/UserSettings.jsx:54
+#: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
 msgstr "Настройки учетной записи"
 
@@ -4090,56 +4096,56 @@ msgstr "Выйти из администрирования"
 msgid "Logs"
 msgstr "Логи"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:64
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
 msgstr "Помощь"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:67
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
 msgstr "О Metabase"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:73
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
 msgstr "Выход"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:98
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
 msgstr "Спасибо за использование"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
 msgstr "Ваша версия"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
 msgstr "Построено"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:124
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
 msgstr "Торговый знак"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:126
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
 msgstr "и было создано с заботой в Сан Франциско, Калифорния"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:194
+#: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
 msgstr "Управление Metabase"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:300
+#: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
 msgstr "Задать вопрос"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:309
+#: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
 msgstr "Новый дашборд"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:315
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/nav/containers/Navbar.jsx:361
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
 msgstr "Новый пульс"
 
@@ -4147,16 +4153,16 @@ msgstr "Новый пульс"
 msgid "Reference"
 msgstr "Справочник"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:83
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
 msgstr "Какая метрика?"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:110
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Определение произвольных метрик для вашей команды позволит упростить поиск ответов на запросы."
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:113
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
 msgstr "Как создать метрики"
 
@@ -4168,8 +4174,8 @@ msgstr "Смотрите данные по времени, как карту, с
 msgid "Custom"
 msgstr "Произвольный"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:150
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:517
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
 msgstr "Новый запрос"
 
@@ -4177,22 +4183,22 @@ msgstr "Новый запрос"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Используйте простой построитель запросов для просмотра трендов, списка вещей, или создания собственных метрик."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:161
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Прямой запрос"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:162
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Для более сложных запросов, вы можете написать собственный SQL или прямой запрос."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:240
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
 msgstr "Выберите значение по-умолчанию..."
 
-#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:149
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
 msgstr "Обновить фильтр"
 
@@ -4200,14 +4206,14 @@ msgstr "Обновить фильтр"
 #: frontend/src/metabase/lib/query_time.js:123
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:9
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Today"
 msgstr "Сегодня"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
 msgstr "Вчера"
 
@@ -4219,7 +4225,7 @@ msgstr "Прошлые 7 дней"
 msgid "Past 30 days"
 msgstr "Прошлые 30 дней"
 
-#: frontend/src/metabase/lib/query_time.js:195
+#: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:29
 #: src/metabase/api/table.clj
@@ -4230,7 +4236,7 @@ msgstr[1] "Недель"
 msgstr[2] "Недель"
 msgstr[3] "Недель"
 
-#: frontend/src/metabase/lib/query_time.js:197
+#: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:30
 #: src/metabase/api/table.clj
@@ -4241,7 +4247,7 @@ msgstr[1] "Месяцев"
 msgstr[2] "Месяцев"
 msgstr[3] "Месяцев"
 
-#: frontend/src/metabase/lib/query_time.js:201
+#: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:31
 #: src/metabase/api/table.clj
@@ -4293,6 +4299,7 @@ msgstr "Введите значение..."
 msgid "Enter a default value..."
 msgstr "Введите значение по-умолчания..."
 
+#: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Возникла ошибка"
@@ -4333,24 +4340,24 @@ msgstr "Опубликовать"
 msgid "Code"
 msgstr "Код"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:70
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
 msgstr "Стиль"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
 msgstr "Какие параметры могут использоваться для встраивания?"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:83
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
 msgstr "{0} не содержит настраиваемых параметров."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
 msgstr "Редактируемо"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
 msgstr "Заблокировано"
 
@@ -4358,19 +4365,19 @@ msgstr "Заблокировано"
 msgid "Preview Locked Parameters"
 msgstr "Предпросмотр заблокированных параметров"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:115
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
 msgstr "Попробуйте добавить значения для заблокированных параметров. В дальнейшем ваш сервер будет предоставлять актуальные значения в подписанном токене."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
 msgstr "Опасная зона"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
 msgstr "Это отключит встраивание для {0}."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:128
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
 msgstr "Снять с публикации"
 
@@ -4410,64 +4417,64 @@ msgstr "Больше {0}"
 msgid "examples on GitHub"
 msgstr "примеры на GitHub"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:72
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
 msgstr "Включить общий доступ"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
 msgstr "Отключить эту публичную ссылку?"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:77
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
 msgstr "Это отлючит работоспособность существующей ссылки. Вы можете повторно включить её, но при этом будет создана новая ссылка."
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
 msgstr "Публичная ссылка"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:118
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
 msgstr "Поделиться {0} с людьми, которыми не имеют учетных записей в Metabase используя ссылку ниже:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:158
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
 msgstr "Встроить в режиме общего доступа"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:159
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
 msgstr "Встройте {0} в сообщения блога или веб-страницы, скопировав и вставив следующий сниппет:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:176
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
 msgstr "Встроить {0} в приложение"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:177
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
 msgstr "Вы можете интегрировать в серверную часть кода вашего приложения безопасную статистику {0}, ограниченную конкретным пользователем, покупателем, организацией и т.п."
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
 msgstr "Удалить приложение"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:95
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
 msgstr "Прикрепить файл с результатами"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
 msgstr "Этот запрос будет добавлен в виде загружаемого файла"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:128
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
 msgstr "Этот запрос не может быть включен в пульс"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:92
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
 msgstr "Этот пульс больше не будет отправляться на email {0} {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:94
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:376
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
 msgstr[0] "{0} адрес"
@@ -4479,39 +4486,39 @@ msgstr[3] "{0} адреса"
 msgid "Slack channel {0} will no longer get this pulse {1}"
 msgstr "Канал Slack {0} больше не будет получать пульс {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:110
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
 msgstr "Канал {0} больше не будет получать пульс {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
 msgstr "Изменить пульс"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:131
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
 msgstr "Что такое пульс?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:141
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
 msgstr "Понятно"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
 msgstr "Где должны быть эти данные?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:173
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
 msgstr "Разархивирование..."
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
 msgstr "Разархивирование не удалось"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
 msgstr "Разархивировано"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
 msgstr "Создать пульс"
 
@@ -4521,7 +4528,7 @@ msgstr "Приложение"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:673
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
 msgstr "Внимание"
 
@@ -4542,6 +4549,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Мы рекомендуем держать пульсы небольшими и целенаправленными, что бы приносить пользу всей команде."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
+#: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
 msgstr "Выберите данные"
 
@@ -4557,47 +4565,47 @@ msgstr "Электронные адреса"
 msgid "Slack messages"
 msgstr "Сообщения Slack"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Отправлено"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:222
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} будет отправлено на"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:224
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Сообщения"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Отправить Email прямо сейчас"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:241
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Отправить {0} прямо сейчас"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Отправка..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:244
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Отправка не удалась"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Не отправлено, потому что пульс не содержит результатов."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:248
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Пульс отправлен"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:287
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} должно быть настроено администратором."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:302
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
 msgstr "Slack"
 
@@ -4646,21 +4654,21 @@ msgid "Before {0}"
 msgstr "До {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:295
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Пусто"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:301
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Не пусто"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:213
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Все время"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:154
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
 msgstr "Применить"
 
@@ -4726,7 +4734,7 @@ msgstr "Распространение"
 msgid "View details"
 msgstr "Просмотреть детали"
 
-#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:54
+#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
 msgstr "Просмотреть {0} {1}"
 
@@ -4750,7 +4758,7 @@ msgstr "Среднее"
 msgid "Distincts"
 msgstr "Уникальные"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:32
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Показать {0}"
@@ -4758,16 +4766,16 @@ msgstr[1] "Показать {0}"
 msgstr[2] "Показать {0}"
 msgstr[3] "Показать {0}"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:225
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
 msgstr "Приблизить"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:19
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
 msgstr "Произвольное выражение"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
 msgstr "Общие Метрики"
 
@@ -4775,7 +4783,7 @@ msgstr "Общие Метрики"
 msgid "Metabasics"
 msgstr "Metabasics"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
 msgstr "Имя (не обязательно)"
 
@@ -4787,31 +4795,31 @@ msgstr "Выберите агрегацию"
 msgid "Set up your own alert"
 msgstr "Настройке собственное предупреждение"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:140
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
 msgstr "Отписка..."
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:145
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
 msgstr "Ошибка при отписке"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:204
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
 msgstr "Отписаться"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:235
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
 msgstr "Нет канала"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:263
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
 msgstr "Отлично, вы отписались"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:335
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
 msgstr "Вами получено {0} предупреждений"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
 msgstr "{0} установил оповещение"
 
@@ -4867,147 +4875,147 @@ msgstr "Изменить ваше предупреждение"
 msgid "Edit alert"
 msgstr "Изменить предупреждение"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:374
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
 msgstr "Это предупреждение больше не будет отправляться на {0}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:382
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
 msgstr "Канал Slack {0} больше не будет получать данное предупреждение."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:386
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
 msgstr "Канал {0} больше не будет получать данное предупреждение."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:403
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
 msgstr "Удалить это предупреждение"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:405
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
 msgstr "Остановить доставку и удалить это предупреждение. Действие не может быть отменено, будьте внимательны."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:413
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
 msgstr "Удалить это предупреждение?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:497
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
 msgstr "Предупредить меня когда линия..."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:498
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
 msgstr "Предупредить меня когда прогресс..."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
 msgstr "Превысит линию цели"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
 msgstr "Достигнет цели"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
 msgstr "Опустится ниже линии цели"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
 msgstr "Опустится ниже цели"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:512
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
 msgstr "При первом пересечении, или каждый раз?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:513
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
 msgstr "При первом достижении цели, или каждый раз?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
 msgstr "Первый раз"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:516
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
 msgstr "Каждый раз"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:619
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
 msgstr "Куда вы хотите отправлять данные предупреждения?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:630
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
 msgstr "Отправлять предупреждения на:"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:672
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
 msgstr "{0} Уведомления основанные на целях ещё не поддерживаются для графиков с более чем одной кривой. Следовательно это уведомление будет послано как только значение графика достигнет {1}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
 msgstr "результаты"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:679
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
 msgstr "{0} Это уведомление особенно полезно когда ваш сохранённый вопрос не {1} возвращает никаких результатов, но вы хотите знать когда это произойдёт."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:680
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
 msgstr "Подсказка"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
 msgstr "обычно"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:57
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
 msgstr "Прикрепите сегмент или таблицу"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
 msgstr "Выберите базу данных"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:88
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
 msgstr "Выбрать..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:128
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
 msgstr "Выберите таблицу"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:793
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
 msgstr "В этой базе данных не найдено ни одной таблицы."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:830
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
 msgstr "Запрос пропущен?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:834
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
 msgstr "Узнать больше о вложенных запросах"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:868
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
 msgstr "Поля"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:946
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
 msgstr "Сегменты не найдены."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:969
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
 msgstr "Найти сегмент"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:46
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
 msgstr "Меньше"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:56
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
 msgstr "Больше"
 
@@ -5016,60 +5024,65 @@ msgid "Pick a field to sort by"
 msgstr "Выберите поле для сортировки"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
 msgstr "Сортировка"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
 msgstr "Количество строк"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:69
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
 msgstr "Неизвестное поле"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
 msgstr "поле"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:114
+#: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
 msgstr "Совпадения"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
+#: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Добавьте фильтры чтобы сократить результаты запроса"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:284
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
 msgstr "Добавить группировку"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:322
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:102
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:113
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:152
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:194
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:59
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:68
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:75
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:225
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:231
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:237
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:70
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:75
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:64
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:89
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:131
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:176
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:302
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:308
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:314
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Данные"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:352
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
 msgstr "Отфильтровано по"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:369
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
 msgstr "Просмотр"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:386
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
 msgstr "Сгруппировано по"
 
@@ -5077,23 +5090,23 @@ msgstr "Сгруппировано по"
 msgid "None"
 msgstr "Ничего"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:345
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
 msgstr "Этот запрос написан в {0}."
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:353
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
 msgstr "Скрыть Редактор"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:354
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
 msgstr "Скрыть Запрос"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
 msgstr "Открыть Редактор"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:360
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
 msgstr "Показать Запрос"
 
@@ -5114,15 +5127,15 @@ msgstr "Скачать эти данные"
 msgid "Warning"
 msgstr "Предупреждение"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:52
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
 msgstr "Ваш результат содержит большое количество строк и займет какое-то время на загрузку."
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:53
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
 msgstr "Максимальный размер скачания 1 миллион строк."
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:232
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
 msgstr "Изменить запрос"
 
@@ -5138,17 +5151,17 @@ msgstr "ОТМЕНА"
 msgid "Move question"
 msgstr "Переместить запрос"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:283
+#: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
 msgstr "Какая коллекция должна быть здесь?"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:313
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:110
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
+#: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
 msgstr "Переменные"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:432
+#: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
 msgstr "Изучить свои данные"
 
@@ -5192,11 +5205,11 @@ msgstr "{0} для этого запроса"
 msgid "Convert this question to {0}"
 msgstr "Преобразовать этот запрос в {0}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:122
+#: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
 msgstr "Обновление запроса займёт {0}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:131
+#: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
 msgstr "Обновлено {0}"
 
@@ -5216,11 +5229,11 @@ msgstr "Просмотр первых {0} {1}"
 msgid "Showing {0} {1}"
 msgstr "Просмотр {0} {1}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:281
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
 msgstr "Научные изыскания"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:294
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
 msgstr "Если вы дадите мне данные я смогу показать что-то крутое. Запустите запрос!"
 
@@ -5228,7 +5241,7 @@ msgstr "Если вы дадите мне данные я смогу показ�
 msgid "How do I use this thing?"
 msgstr "Как я могу использовать эту вещь?"
 
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:28
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
 msgstr "Получить ответ"
 
@@ -5256,40 +5269,40 @@ msgstr "Просим прощения. Что-то пошло не так."
 msgid "Group time by"
 msgstr "Группировать время по"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:46
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
 msgstr "Ваш запрос занимает слишком много времени"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:47
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
 msgstr "Мы не получили ответ от Вашей базы данных вовремя, так что нам пришлось остановиться. Вы можете попробовать ещё раз через пару минут, или если проблема сохраняется оповестить администратора по электронной почте"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:55
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
 msgstr "У нас сложности с сервером"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:56
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
 msgstr "Попробуйте обновить страницу, подождав одну-две минуты. Если проблема повториться, рекомендуем обратиться к администратору."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:88
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
 msgstr "С вашим запросов возникла проблема"
 
 #. What does it mean "invalid selection"? Selection of what? Or is it an SQL "select" operator?
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:89
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
 msgstr "В большинстве случае это связано с ошибкой выбора или введенного значения. Перепроверьте данные и повторите запрос."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:60
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
 msgstr "Возможно, мы нашли то, что вы искали. Если нет, попробуйте отменить или изменить фильтры, сделав их менее строгими."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
 msgstr "Мы также можете {0} по получении результата."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:68
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
 msgstr "получить предупреждение"
 
@@ -5297,11 +5310,11 @@ msgstr "получить предупреждение"
 msgid "Back to last run"
 msgstr "Вернуться к последнему запуску"
 
-#: frontend/src/metabase/query_builder/components/VisualizationSettings.jsx:100
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
 msgstr "Визуализация"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:96
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
 msgstr "Описание не задано."
 
@@ -5313,7 +5326,7 @@ msgstr "Использовать текущий запрос."
 msgid "Potentially useful questions"
 msgstr "Потенциально полезные запросы."
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:166
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
 msgstr "Группировка по {0}"
 
@@ -5326,14 +5339,14 @@ msgstr "Сумма всех значений {0}"
 msgid "All distinct values of {0}"
 msgstr "Уникальные значения {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:187
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
 msgstr "Число {0} сгруппированных по {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5349,34 +5362,34 @@ msgstr "Ссылка на данные"
 msgid "Learn more about your data structure to ask more useful questions"
 msgstr "Узнайте больше о структуре ваших данных чтобы задавать полезные запросы"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:58
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:84
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
 msgstr "Не удалось найти метаданные таблицы до создания нового вопроса"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:80
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
 msgstr "Посмотреть {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:94
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
 msgstr "Определение метрики"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:118
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
 msgstr "Отфильтровано по {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:127
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
 msgstr "Число {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
 msgstr "Смотреть все {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:148
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
 msgstr "Определение сегмента"
 
@@ -5388,7 +5401,7 @@ msgstr "При загрузке таблицы произошла ошибка"
 msgid "See the raw data for {0}"
 msgstr "Посмотреть исходные данные для {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:180
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
 msgstr "Больше"
 
@@ -5400,24 +5413,24 @@ msgstr "Некорректное выражение"
 msgid "unknown error"
 msgstr "неизвестная ошибка"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:46
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
 msgstr "Формула поля"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:57
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Подумайте об этом как о том, как написать формулу в программе для работы с электронными таблицами: вы можете использовать числа, поля таблицы, математические символы, такие как +, и некоторые функции. Таким образом, вы можете ввести что-то вроде Итого - Стоимость."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
 msgstr "Узнать больше"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:66
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
 msgstr "Дать имя"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:72
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
 msgstr "Что-нибудь замечательное и понятное"
 
@@ -5469,7 +5482,8 @@ msgstr "истина"
 msgid "false"
 msgstr "ложь"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
 msgstr "Добавить фильтр"
 
@@ -5477,15 +5491,15 @@ msgstr "Добавить фильтр"
 msgid "Item"
 msgstr "Элемент"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:221
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
 msgstr "Предыдущий"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:252
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
 msgstr "Текущий"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:278
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
@@ -5496,7 +5510,7 @@ msgid "Enter desired number"
 msgstr "Введите желаемый номер"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:100
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
 msgstr "Пусто"
 
@@ -5520,35 +5534,35 @@ msgstr "Вы можете ввести множество значений, ра
 msgid "Enter desired text"
 msgstr "Введите желаемый текст"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
 msgstr "Попробовать"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
 msgstr "Для чего это?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
 msgstr "Переменные в исходных запросах позволяют динамически заменять значения в ваших запросах используя виджеты фильтров или через внешнюю ссылку."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
 msgstr "{0} создает переменную в этом шаблоне SQL с именем \"variable_name\". Переменные могут быть заданы типами на боковой панели, что изменяет их поведение. Все переменные, отличные от \"фильтр по полю\", автоматически вызывают фильтрацию фильтра по этому вопросу; с фильтрами по полям, это необязательно. Когда этот виджет фильтра заполняется, это значение заменяет переменную в шаблоне SQL."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:121
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
 msgstr "Фильтры поля"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:123
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Присвоение переменной типа \"фильтр полей\" позволяет связать карточки SQL с виджетами фильтра панели мониторинга или использовать дополнительные типы виджетов фильтра в запросе SQL. Переменная фильтра поля вставляет SQL, подобный тому, который генерируется построителем запросов GUI при добавлении фильтров на существующие столбцы."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:126
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
 msgstr "При добавлении переменной фильтра полей необходимо сопоставить ее с определенным полем. Затем можно выбрать отображение виджета фильтра для вопроса, но даже если это не так, теперь можно сопоставить переменную фильтра поля с фильтром панели мониторинга при добавлении этого вопроса на панель мониторинга. Фильтры полей должны использоваться внутри предложения \"WHERE\"."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:130
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
 msgstr "Необязательные условия"
 
@@ -5556,59 +5570,61 @@ msgstr "Необязательные условия"
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
 msgstr "скобки вокруг {0} создают опциональное условие в шаблоне. Если \"переменная\" установлена, тогда фильтр включается в шаблон, а если нет - всё условие игнорируется."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:142
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
 msgstr "Для использования множества необязательных условий, вы можете включить по крайней мере одно обязательное условие WHERE, дополнив его необязательными через \"AND\"."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
 msgstr "Ознакомиться с полной документацией"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:127
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
 msgstr "Заголовок фильтра"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:139
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
 msgstr "Тип переменной"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:143
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
 msgstr "Текст"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:150
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:119
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
 msgstr "Дата"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
 msgstr "Фильтр поля"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:157
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
 msgstr "Связующие поля"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
 msgstr "Тип фильтра виджета"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:201
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
 msgstr "Обязательно?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:211
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
 msgstr "Значение по-умолчанию для фильтра виджета"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:46
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
 msgstr "Переместить этот запрос в архив?"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:57
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Этот запрос будет удален со всех дашбордов или пульсов, где он был добавлен."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:136
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
 msgstr "Запрос"
 
@@ -5625,21 +5641,21 @@ msgstr "Вы редактируете эту страницу"
 msgid "See this {0}"
 msgstr "Посмотреть {0}"
 
-#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:120
+#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
 msgstr "Множество"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:68
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
 msgstr "Выберите тип поля"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:57
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
 msgstr "Нет типа поля"
 
@@ -5649,16 +5665,16 @@ msgid "by"
 msgstr "по"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
-#: frontend/src/metabase/reference/databases/FieldList.jsx:152
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
+#: frontend/src/metabase/reference/databases/FieldList.jsx:155
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
 msgstr "Тип поля"
 
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:72
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
 msgstr "Выберите внешний ключ"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:53
+#: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
 msgstr "Просмотреть формулу {0}"
 
@@ -5675,12 +5691,12 @@ msgid "Nothing important yet"
 msgstr "Пока ничего важного"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:168
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:233
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:211
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:215
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:219
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:229
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:236
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:214
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
 msgstr "Пока ничего интересного"
 
@@ -5689,12 +5705,12 @@ msgid "Things to be aware of about this {0}"
 msgstr "Что нужно знать о {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:178
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:243
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:221
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:225
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:229
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:239
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:246
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:224
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
 msgstr "Пока ничего не известно"
 
@@ -5757,15 +5773,15 @@ msgstr "Причины изменения"
 msgid "Leave a note to explain what changes you made and why they were required"
 msgstr "Оставьте описание, чтобы объяснить какие изменения Вы сделали и почему они необходимы"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:166
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
 msgstr "Почему эта база данных может быть интересна"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:176
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
 msgstr "Что нужно знать об этой базе данных"
 
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:46
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
 msgstr "Базы данных и таблицы"
@@ -5773,42 +5789,42 @@ msgstr "Базы данных и таблицы"
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:41
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:170
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:173
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:34
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:184
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:187
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:30
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:188
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:187
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:191
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:190
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
 msgstr "Детали"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
-#: frontend/src/metabase/reference/databases/TableList.jsx:111
+#: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
 msgstr "Таблицы в {0}"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:222
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:200
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:218
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:203
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
 msgstr "Имя в базе данных"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:231
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:227
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
 msgstr "Почему это поле может быть интересно"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:241
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:237
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
 msgstr "Что нужно знать об этом поле"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:253
-#: frontend/src/metabase/reference/databases/FieldList.jsx:155
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:249
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
+#: frontend/src/metabase/reference/databases/FieldList.jsx:158
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
 msgstr "Тип данных"
 
@@ -5817,13 +5833,13 @@ msgstr "Тип данных"
 msgid "Fields in this table will appear here as they're added"
 msgstr "Поля в этой таблицу появятся после их добавления"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:134
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:135
+#: frontend/src/metabase/reference/databases/FieldList.jsx:137
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
 msgstr "Поля в {0}"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:149
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:150
+#: frontend/src/metabase/reference/databases/FieldList.jsx:152
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
 msgstr "Имя поля"
 
@@ -5847,7 +5863,10 @@ msgstr "Базы данных появится здесь после добав�
 msgid "Connect a database"
 msgstr "Подключить базу данных"
 
+#. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
+#. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
+#: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
 msgstr "Количество {0}"
 
@@ -5855,11 +5874,11 @@ msgstr "Количество {0}"
 msgid "See raw data for {0}"
 msgstr "Посмотреть исходные данные для {0}"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:209
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
 msgstr "Почему эта таблица может быть интересна"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:219
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
 msgstr "Что нужно знать об этой таблице"
 
@@ -5871,16 +5890,16 @@ msgstr "Таблицы в этой базе данных появятся пос
 msgid "Questions about this table will appear here as they're added"
 msgstr "Запросы об этой таблице появятся после добавления"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:71
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:75
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:74
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
 msgstr "Запросы о {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
 msgstr "Создано {0} пользователем {1}"
 
@@ -5892,151 +5911,152 @@ msgstr "Поля в этой таблице"
 msgid "Questions about this table"
 msgstr "Запросы об этой таблице"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:157
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
 msgstr "Помогите вашей команде с вашими данными."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:159
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
 msgstr "Покажите вашей команде наиболее важное выбрав дашборд, метрики и сегменты."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:165
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
 msgstr "Начнем"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:173
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
 msgstr "Наш самый важный дашборд"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:188
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
 msgstr "Числа, требующие внимания"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:213
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
 msgstr "Метрики - это важные для компании измеримые показатели. Они часто представляют собой основные показатели того, как работает бизнес."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:221
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
 msgstr "Посмотреть все метрики"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:235
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
 msgstr "Сегменты и таблицы"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
+#: frontend/src/metabase/home/containers/SearchApp.jsx:83
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
 msgstr "Таблицы"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:262
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
 msgstr "Сегменты и таблицы являются составными блоками данных вашей компании. Таблицы представляют собой коллекции необработанной информации, а сегменты - это конкретные срезы со специфическими значениями, например {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:267
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
 msgstr "Таблицы являются составными блоками данных вашей компании."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:277
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
 msgstr "Посмотреть все сегменты"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:293
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
 msgstr "Посмотреть все таблицы"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:301
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
 msgstr "Другие вещи, которые нужно знать о наших данных"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
 msgstr "Найти больше"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:307
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
 msgstr "Хороший способ познакомиться с вашими данными - потратить немного времени на изучение разных таблиц и другой информации, доступной вам. Это может занять некоторое время, но вы со временем вы станете узнавать их названия и значения."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:313
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
 msgstr "Исследовать данные"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:321
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
 msgstr "Остались вопросы?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:326
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
 msgstr "Свяжитесь с {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:248
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
 msgstr "Помогите новым пользователям Metabase найти свой путь."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:251
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
 msgstr "В руководстве Getting Started основное внимание уделяется панели, метрикам, сегментам и таблицам, которые информируют ваших пользователей о важных вещах, которые они должны знать, прежде чем вникать в данные."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:258
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
 msgstr "Этот дашборд важен для вашей команды?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:260
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
 msgstr "Создать дашборд прямо сейчас"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:266
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
 msgstr "Какой дашборд наиболее важен?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:285
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
 msgstr "Есть ли у вас какие-либо часто упоминаемые метрики?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:287
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
 msgstr "Узнайте как определить метрику"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:300
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
 msgstr "Каковы ваши 3-5 наиболее часто упоминаемых метрики?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:344
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
 msgstr "Добавить другую метрику"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:357
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
 msgstr "Есть ли у вас какие-либо часто упоминаемые сегменты или таблицы?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:359
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
 msgstr "Узнайте как создать сегмент"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:372
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
 msgstr "Какие 3-5 часто упоминаемых сегментов или таблиц, которые были бы полезны для этой аудитории?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:418
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
 msgstr "Добавить другой сегмент или таблицу"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:427
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
 msgstr "Есть ли что-нибудь, что ваши пользователи должны понимать или знать, прежде чем они получат доступ к данным?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:433
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
 msgstr "Что должен знать пользователь об этих данных перед тем, как к ним обращаться?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:437
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
 msgstr "Например, ожидания относительно конфиденциальности и использования данных, типичные ошибки или недопонимания, информация о производительности хранилища данных, юридические уведомления и т.д."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
 msgstr "Могут ли пользователи к вам обращаться при возникновении вопросов?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:457
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
 msgstr "С кем должны связывать пользователи для помощи при возникновении вопросов по данным?"
 
@@ -6045,39 +6065,39 @@ msgstr "С кем должны связывать пользователи дл�
 msgid "Please enter a revision message"
 msgstr "Пожалуйста, добавьте сообщение ревизии"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:213
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
 msgstr "Почему эта Метрика может быть интересной"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:223
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
 msgstr "Что нужно знать об этой метрике"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:233
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
 msgstr "Как рассчитывается эта метрика"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:235
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
 msgstr "Пока ничего не рассчитано"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:293
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
 msgstr "Другие поля, по которым вы можете группировать эту метрику"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:294
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
 msgstr "Метрика может быть сгруппирована по следующим полям"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:23
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Метрики это официальные цифры, о которых заботится ваша команда"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Метрики будут появляться здесь как только ваши админы их сделают"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
 msgstr "Узнайте как создать метрики"
 
@@ -6089,9 +6109,9 @@ msgstr "Запросы об этой метрике появятся после 
 msgid "There are no revisions for this metric"
 msgstr "Данная метрика не содержит ревизий"
 
-#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:88
-#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
-#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:88
+#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
+#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
+#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
 msgstr "История ревизий {0}"
 
@@ -6099,27 +6119,27 @@ msgstr "История ревизий {0}"
 msgid "X-ray this metric"
 msgstr "Просканировать эту метрику"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:217
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
 msgstr "Почему этот сегмент интересен"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:227
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
 msgstr "Что нужно знать об этом сегменте"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
 msgstr "Сегменты это интересные срезы по таблицам"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Определение общих сегментов для вашей команды упрощает создание запросов"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
 msgstr "Сегменты появятся здесь после того как администраторы их создадут"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
 msgstr "Узнайте как создавать сегменты"
 
@@ -6147,7 +6167,7 @@ msgstr "Просканировать этот сегмент"
 msgid "Login"
 msgstr "Логин"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:130
+#: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
 msgstr "Поиск"
@@ -6164,99 +6184,99 @@ msgstr "Новый запрос"
 msgid "Select the type of Database you use"
 msgstr "Выберите тип базы данных"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:141
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
 msgstr "Добавьте свои данные"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:145
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
 msgstr "Я добавлю данные позже"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
 msgstr "Подключение к {0}"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:165
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
 msgstr "Вам необходимо некоторая информация о вашей базе данных, такая как имя пользователя и пароль. Если у вас нее ее прямо сейчас - Metabase поставляется с набором тестовых данных, с которым вы можете начать."
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:196
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
 msgstr "Я добавлю мои данные позже"
 
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:41
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
 msgstr "Контроль за автоматическим сканированием"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:53
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
 msgstr "Настройки использования данных"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
 msgstr "Спасибо за помощь в улучшении"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:57
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
 msgstr "Мы не хотим собирать никакие события использования"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:76
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Для улучшения Metabase, мы бы хотели собирать некоторые данные по использованию через Google Analytics."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
 msgstr "Вот полный список всего что мы отслеживаем и почему."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:98
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Разрешить Metabase собирать анонимные данные о использовании"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} собирает что либо о ваших данных или результатах вопросов."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:106
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
 msgstr "никогда"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
 msgstr "Все коллекции полностью анонимны."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Коллекция может быть отключена в любой момент в настройках администратора."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:45
+#: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
 msgstr "Если вы застряли"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:52
+#: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
 msgstr "наше руководство по началу работы"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:53
+#: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
 msgstr "всего в одном клике от вас."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:95
+#: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
 msgstr "Добро пожаловать в Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:96
+#: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Похоже, все работает. Теперь давайте познакомимся поближе: настройте подключение к данным и пойдем искать ответы!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:100
+#: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
 msgstr "Начнем"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:145
+#: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
 msgstr "Все настроено!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:156
+#: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
 msgstr "Покажите мне Metabase"
 
@@ -6273,7 +6293,7 @@ msgid "Create a password"
 msgstr "Создайте пароль"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:116
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
 msgstr "Тссс..."
 
@@ -6466,11 +6486,11 @@ msgstr "Войти с помощью аккаунта Google"
 msgid "User Details"
 msgstr "Детали пользователя"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:275
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
 msgstr "Сбросить по-умолчанию"
 
-#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:133
+#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
 msgstr "неизвестная карта"
 
@@ -6482,24 +6502,24 @@ msgstr "Карта нуждается в соответствующих град
 msgid "more"
 msgstr "больше"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:101
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
 msgstr "Какие поля вы хотите использовать для осей X и Y?"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:103
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:60
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
 msgstr "Выберите поля"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:204
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
 msgstr "Сохранить как вид по-умолчанию"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
 msgstr "Нарисуйте \"коробку\" для фильтрации"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
 msgstr "Отменить фильтр"
 
@@ -6507,7 +6527,7 @@ msgstr "Отменить фильтр"
 msgid "Pin Map"
 msgstr "Закрепить карту"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:303
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
 msgstr "Снять выбор"
 
@@ -6515,31 +6535,31 @@ msgstr "Снять выбор"
 msgid "Rows {0}-{1} of {2}"
 msgstr "Записи {0}-{1} из {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:189
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
 msgstr "Данные сокращены до {0} строк."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:364
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
 msgstr "Невозможно найти визуализацию"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:371
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
 msgstr "Невозможно отобразить график с текущими данным."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:469
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
 msgstr "Нет результатов!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:490
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
 msgstr "Ожидание..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:493
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
 msgstr "Это в среднем занимает {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:499
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Это несколько длинновато для дашборда)"
 
@@ -6555,11 +6575,11 @@ msgstr "Выберите поле"
 msgid "error"
 msgstr "ошибка"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:126
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
 msgstr "Нажмите и перетащите для изменения их порядка"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:139
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
 msgstr "Добавить поля к списке ниже"
 
@@ -6649,7 +6669,7 @@ msgid "Highlight the whole row"
 msgstr "Подсветить всю строку"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:98
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Цвета"
 
@@ -6714,20 +6734,20 @@ msgstr "Визуализация с этим идентификатором уж
 msgid "No visualization for {0}"
 msgstr "Нет визуализации для {0}"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:75
+#: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
 msgstr "\"{0}\" - не агрегированое поле: если в точке оси x имеется более двух значений - они будут просуммированы."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:91
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
 msgstr "Данный тип графика требует как минимум 2 столбца."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:96
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
 msgstr "Данный тип графика не поддерживает больше чем {0} наборов данных."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:51
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:297
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
 msgstr "Цель"
 
@@ -6772,25 +6792,25 @@ msgstr "Изменить настройки"
 msgid "xValues missing!"
 msgstr "X-значения отсутствуют!"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:114
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "Ось абсцисс"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:140
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
 msgstr "Добавить разрыв серии..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:153
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Ось ординат"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:178
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
 msgstr "Добавить другую серию..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:195
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
 msgstr "Размер пузырька"
 
@@ -6804,7 +6824,7 @@ msgid "Curve"
 msgstr "Кривая"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:69
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
 msgstr "Шаг"
 
@@ -6812,27 +6832,27 @@ msgstr "Шаг"
 msgid "Show point markers on lines"
 msgstr "Показать отметки точек на линиях"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:235
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
 msgstr "Объединение"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:239
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
 msgstr "Не объединять"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:240
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
 msgstr "Объединить"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:241
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
 msgstr "Объединить - 100%"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:300
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
 msgstr "Показать цель"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:306
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
 msgstr "Значение цели"
 
@@ -6852,126 +6872,126 @@ msgstr "Ничего"
 msgid "Linear Interpolated"
 msgstr "Линейная интерполяция"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:371
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
 msgstr "Шкала оси абсцисс"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
 msgstr "Временная шкала"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:391
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:409
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:381
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
 msgstr "Линейный"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:410
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:383
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
 msgstr "В степени"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:384
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
 msgstr "Лог"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:396
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
 msgstr "Гистограмма"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:398
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
 msgstr "Порядковый"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:404
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
 msgstr "Масштаб Y оси"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:417
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
 msgstr "Показать строку и метки по оси x"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:423
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
 msgstr "Компактно"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:424
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
 msgstr "Перевернуть на 45°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
 msgstr "Перевернуть на 90°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
 msgstr "Показать строку и метки по оси y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
 msgstr "Авто диапазон оси ординат"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
 msgstr "Использовать разрывы школы ординат когда это необходимо"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
 msgstr "Показать метку на X оси"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:501
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
 msgstr "Метка X оси"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:510
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
 msgstr "Показать метку на Y оси"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:516
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
 msgstr "Метка Y оси"
 
-#: frontend/src/metabase/visualizations/lib/utils.js:129
+#: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
 msgstr "Стандартное отклонение"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:275
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:17
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:256
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
 msgstr "Область"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
 msgstr "область графика"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:276
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:16
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:257
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
 msgstr "Гистограмма"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
 msgstr "гистограмма"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
 msgstr "Какое поле вы хотите использовать?"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
 msgstr "Воронка"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:76
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:76
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Измерение"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
 msgstr "Тип воронки"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:88
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
 msgstr "Гистограмма"
 
@@ -6979,141 +6999,141 @@ msgstr "Гистограмма"
 msgid "line chart"
 msgstr "График"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:224
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Пожалуйста выберите колонки, содержащие широту и долготу для настройки графика."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
 msgstr "Пожалуйста выберите карту региона."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Пожалуйста выберите область и столбцы показателей в настройках графика."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:38
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Карта"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:53
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
 msgstr "Тип карты"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:57
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:149
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
 msgstr "Карта региона"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
 msgstr "Закрепить карту"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
 msgstr "Тип значка"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
 msgstr "Плитка"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
 msgstr "Маркеры"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
 msgstr "Поле широты"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
 msgstr "Поле долготы"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:142
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:168
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
 msgstr "Поле измерения"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
 msgstr "Поле региона"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
 msgstr "Радиус"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:198
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
 msgstr "Размытие"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
 msgstr "Минимальная прозрачность"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
 msgstr "Максимальное приближение"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:175
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
 msgstr "Связи не найдены."
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:213
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
 msgstr "через {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:290
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
 msgstr "{0} связано с:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:47
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
 msgstr "Детали объекта"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
 msgstr "объект"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
 msgstr "Всего"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Какие колонки вы хотите использовать?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:44
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Пирог"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Измерение"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:81
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Показать легенду"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:86
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Показать процентовку в легенде"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:92
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Минимальный процентаж среза"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:146
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
 msgstr "Цель достигнута"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:148
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
 msgstr "Цель достигнута"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
 msgstr "Цель {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
 msgstr "Визуализация прогресс требуется число."
 
@@ -7121,9 +7141,9 @@ msgstr "Визуализация прогресс требуется число.
 msgid "Progress"
 msgstr "Прогресс"
 
-#: frontend/src/metabase/entities/collections.js:108
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:176
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:57
+#: frontend/src/metabase/entities/collections.js:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Цвет"
 
@@ -7135,7 +7155,7 @@ msgstr "Линейная диаграмма"
 msgid "row chart"
 msgstr "линейная диаграмма"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:357
+#: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
 msgstr "Стиль разделителя"
 
@@ -7143,15 +7163,15 @@ msgstr "Стиль разделителя"
 msgid "Number of decimal places"
 msgstr "Количество десятичных знаков"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:381
+#: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
 msgstr "Добавить префикс"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:385
+#: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
 msgstr "Добавить суффикс"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:374
+#: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
 msgstr "Умножить на число"
 
@@ -7163,7 +7183,7 @@ msgstr "Разброс"
 msgid "scatter plot"
 msgstr "точечная диаграмма"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:78
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
 msgstr "Свод таблицы"
 
@@ -7172,7 +7192,8 @@ msgid "Visible fields"
 msgstr "Видимые поля"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-msgid "Write here, and use Markdown if you''d like"
+#, fuzzy
+msgid "Write here, and use Markdown if you'd like"
 msgstr "Напишите здесь, и используется если хотите Markdown"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
@@ -7213,7 +7234,7 @@ msgstr "Право"
 msgid "Show background"
 msgstr "Показать фон"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:553
+#: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "контейнер"
@@ -7221,7 +7242,7 @@ msgstr[1] "контейнеров"
 msgstr[2] "контейнеры"
 msgstr[3] "контейнер"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:559
+#: frontend/src/metabase-lib/lib/Dimension.js:731
 msgid "Auto binned"
 msgstr "Авт. скомпоновано"
 
@@ -7424,7 +7445,7 @@ msgstr "Установить параметры Slack"
 
 #: src/metabase/api/setup.clj
 msgid "Does your team use Slack? If so, you can send automated updates via pulses and ask questions with MetaBot."
-msgstr "Использует ли ваша команда Slack? Если так, то вы можете отправлять автоматические обновления через пульсы и задавать вопросы с помощью MetaBot."
+msgstr "Ваша команда использует Slack? Если так, то вы можете отправлять автоматические обновления через пульсы и задавать вопросы с помощью MetaBot."
 
 #: src/metabase/api/setup.clj
 msgid "Invite team members"
@@ -7489,7 +7510,7 @@ msgstr "Авто компоновка"
 msgid "Don''t bin"
 msgstr "Не компоновать"
 
-#: frontend/src/metabase/lib/query_time.js:193 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "День"
@@ -7498,7 +7519,7 @@ msgstr[2] "дней"
 msgstr[3] "дней"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
-#: frontend/src/metabase/lib/query_time.js:189 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Минута"
@@ -7506,7 +7527,7 @@ msgstr[1] "Минут"
 msgstr[2] "Минут"
 msgstr[3] "Минут"
 
-#: frontend/src/metabase/lib/query_time.js:191 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Час"
@@ -7514,7 +7535,7 @@ msgstr[1] "Часов"
 msgstr[2] "Часов"
 msgstr[3] "Часов"
 
-#: frontend/src/metabase/lib/query_time.js:199 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
 msgstr[0] "Квартал"
@@ -7583,7 +7604,7 @@ msgid "Bin every 20 degrees"
 msgstr "Конт. каждые 20 градусов"
 
 #. returns `true` if successful -- see JavaDoc
-#: src/metabase/api/tiles.clj src/metabase/pulse/render.clj
+#: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
 msgstr "Не найден подходящий обработчик изображений!"
 
@@ -7655,10 +7676,12 @@ msgstr "накопительная сумма"
 msgid "{0} and {1}"
 msgstr "{0} и {1}"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} из {1}"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
 msgstr "{0} по {1}"
@@ -7671,9 +7694,14 @@ msgstr "{0} в {1} сегменте"
 msgid "{0} segment"
 msgstr "{0} сегмент"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
-msgstr "{0} метрика"
+msgid_plural "{0} metrics"
+msgstr[0] "{0} метрика"
+msgstr[1] "{0} метрик"
+msgstr[2] "{0} метрик"
+msgstr[3] "{0} метрики"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
@@ -8254,6 +8282,7 @@ msgid "Cannot save Question: source query has circular references."
 msgstr "Невозможно сохранить запрос: найдены циклические ссылки."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
+#: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
 msgstr "Карточка {0} не существует."
@@ -8655,7 +8684,7 @@ msgstr "Нераспознанный тип канала {0}"
 msgid "Error sending notification!"
 msgstr "Ошибка отправки уведомления!"
 
-#: src/metabase/pulse/color.clj
+#: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
 msgstr "Невозможно найти селектор JS ''{0}''"
 
@@ -8967,43 +8996,43 @@ msgstr "Доступ к данным"
 msgid "Collection permissions"
 msgstr "Разрешения для коллекций"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:56
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
 msgstr "Посмотреть разрешения для всех коллекций"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:25
+#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
 msgstr "Так же изменить под-коллекции"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:282
+#: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
 msgstr "Может редактировать коллекцию и содержимое"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:289
+#: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
 msgstr "Может смотреть содержимое этой коллекции"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:749
+#: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
 msgstr "Доступ к коллекции"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:825
+#: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "У этой группы есть разрешение на просмотре как минимум одного подмножества этой коллекции."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:830
+#: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "У этой группы есть разрешение на редактирование как минимум одного подмножества этой коллекции."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
 msgstr "Просмотр под-коллекций"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:211
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
 msgstr "Запомнить меня"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:95
+#: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
 msgstr "Просканировать эту схему"
 
@@ -9035,31 +9064,32 @@ msgstr "Сохранять дашборды, вопросы и коллекци�
 msgid "Access dashboards, questions, and collections in \"{0}\""
 msgstr "Получать доступ к дашбордам, вопросам и коллекциям в \"{0}\""
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:221
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
 msgstr "Сравнить"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:229
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
 msgstr "На уровень выше"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:233
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
 msgstr "Связанные"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:293
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
 msgstr "Больше рентгенов"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:46
+#: frontend/src/metabase/home/containers/SearchApp.jsx:40
+#: src/metabase/pulse/render/body.clj
 msgid "No results"
 msgstr "Нет результатов"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:47
+#: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
 msgstr "Metabase не смог ничего найти по этому запросу."
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:111
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
 msgstr "Нет метрик"
 
@@ -9101,7 +9131,7 @@ msgstr "Ошибка назначения полномочий: {0}"
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
 msgstr "Невозможно расшифровать зашифрованную строку. Вы изменили или забыли установить MB_ENCRYPTION_SECRET_KEY?"
 
-#: frontend/src/metabase/entities/collections.js:164
+#: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
 msgstr "Все личные коллекции"
 
@@ -9265,18 +9295,18 @@ msgstr "Н/Д"
 msgid "Windows domain"
 msgstr "Домен Windows"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:509
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:515
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:490
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:499
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
 msgstr "Заголовки"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:329
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
 msgstr "Добавить участников"
 
-#: frontend/src/metabase/entities/collections.js:115
+#: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
 msgstr "Коллекция сохранена в"
 
@@ -9297,39 +9327,39 @@ msgid "Sharing"
 msgstr "Поделиться"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:234
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:270
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:299
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:305
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:313
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:321
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:218
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:251
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:280
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:286
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:294
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:302
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:80
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:85
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:91
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:97
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:50
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:56
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
 msgstr "Отображение"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:370
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:416
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:431
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:487
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:358
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:406
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:447
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
 msgstr "Оси"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:222
-#: frontend/src/metabase/admin/settings/selectors.js:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
+#: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
@@ -9363,20 +9393,20 @@ msgstr "Рентген"
 msgid "Compare to the rest"
 msgstr "Cравнить с остальным"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:244
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Использовать часовой пояс виртуальной Java машины (JVM)"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
 msgstr "Мы рекомендуем оставить это выключенным, только если вы не обрабатываете часовой пояс вручную в большинстве своих запросов с этими данными."
 
-#: frontend/src/metabase/containers/Overworld.jsx:310
+#: frontend/src/metabase/containers/Overworld.jsx:312
 msgid "Your team's most important dashboards go here"
 msgstr "Важнейшие дашборды вашей команды будут здесь"
 
-#: frontend/src/metabase/containers/Overworld.jsx:311
+#: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
 msgstr "Закрепить дашборды в {0} чтобы они появились в этом пространстве для всех."
 
@@ -9392,32 +9422,32 @@ msgstr "Использовать часовой пояс JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Сейчас мы анализируем таблицы и поля чтобы помочь вам изучать свои данные"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
 msgstr "Подсказка: "
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:258
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
 msgstr "Выберите тип валюты"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:318
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
 msgstr "Тип поля"
 
 #: frontend/src/metabase/admin/routes.jsx:109
-#: frontend/src/metabase/nav/containers/Navbar.jsx:224
+#: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
 msgstr "Разрешение проблем"
 
-#: frontend/src/metabase/admin/settings/selectors.js:96
+#: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
 msgstr "Включить функции \"Рентгена\""
 
-#: frontend/src/metabase/admin/settings/selectors.js:323
+#: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
 msgstr "Опции форматирования"
 
-#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:19
+#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
 msgstr "Детали задачи"
 
@@ -9457,7 +9487,7 @@ msgstr "Валюта"
 msgid "Pick a user or channel..."
 msgstr "Выберите пользователя или канал..."
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
+#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
 msgstr "Опции форматирования не определены"
 
@@ -9565,31 +9595,31 @@ msgstr "ЧЧ:ММ:СС:МС"
 msgid "Time style"
 msgstr "Формат времени"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:299
+#: frontend/src/metabase/visualizations/lib/settings/column.js:300
 msgid "Unit of currency"
 msgstr "Единица валюты"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:319
+#: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
 msgstr "Стиль заголовка валюты"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:337
+#: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
 msgstr "Где отображать единицу валюты"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:370
+#: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
 msgstr "Минимальное количество знаков после запятой"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:271
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
 msgstr "Тип диаграммы с накоплением"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:314
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
 msgstr "Название цели"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:322
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
 msgstr "Показать линию тренда"
 
@@ -9618,7 +9648,7 @@ msgstr "Линия + Столбец"
 msgid "line and bar chart"
 msgstr "линейные и Столбчатые диаграммы"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:72
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
 msgstr "Для визуализации прибора требуется число."
 
@@ -9626,75 +9656,75 @@ msgstr "Для визуализации прибора требуется чис
 msgid "Gauge"
 msgstr "Прибор"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
 msgstr "Диапазоны прибора"
 
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
 msgstr "Поле для отображения"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
 msgstr "Последняя {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:185
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
 msgstr "{0} был {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:52
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Группа по полю времени, чтобы увидеть, как это изменилось с течением времени"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
 msgstr "Переключить позитивные / негативные цвета?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
 msgstr "Колонка таблицы"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:107
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
 msgstr "Ячейка столбца"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:123
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
 msgstr "Видимые столбцы"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:143
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
 msgstr "Условное форматирование"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
 msgstr "Заголовок столбца"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
 msgstr "Показать мини-гистограмму"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:183
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
 msgstr "Ссылка"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:187
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
 msgstr "Email ссылка"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
 msgstr "Изображение"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:195
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
 msgstr "Автоматически"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:200
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
 msgstr "Показать как ссылку или как изображение"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
 msgstr "Текст ссылки"
 
@@ -9958,7 +9988,7 @@ msgstr "Ошибка предварительной обработки запр�
 msgid "No native form returned."
 msgstr "Не возвращена нативная форма."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
 msgstr "Неверный ответ драйвера базы данных. Нет: предоставления статуса."
 
@@ -11324,7 +11354,7 @@ msgstr "Не удалось установить для `query-caching-max-kb` �
 msgid "Values greater than {1} are not allowed."
 msgstr "Значения, превышающие {1}, не допускаются."
 
-#: src/metabase/query_processor/middleware/resolve_database.clj
+#: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
 msgstr "База данных {0} не существует."
 
@@ -11373,7 +11403,7 @@ msgstr "Триггер"
 msgid "View triggers"
 msgstr "Просмотр триггеров"
 
-#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:82
+#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
 msgstr "Информация о планировщике"
 
@@ -11405,7 +11435,7 @@ msgstr "Окончательное время запуска"
 msgid "May Fire Again?"
 msgstr "Возможен повторный запуск?"
 
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:75
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
 msgstr "Триггеры для {0}"
 
@@ -11417,19 +11447,19 @@ msgstr "Задачи"
 msgid "Jobs"
 msgstr "Работа"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
 msgstr "Дубликат {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:55
+#: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
 msgstr "Дублировать этот элемент"
 
-#: frontend/src/metabase/components/EntityItem.jsx:61
+#: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
 msgstr "Архивировать этот элемент"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:330
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
 msgstr "Дублировать Панель Управления"
 
@@ -11479,7 +11509,7 @@ msgstr "{0} {1} назад"
 msgid "{0} {1} from now"
 msgstr "{0} {1} назад"
 
-#: frontend/src/metabase/lib/query_time.js:187
+#: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
 msgstr[0] "Период по умолчанию"
@@ -11487,7 +11517,7 @@ msgstr[1] "Периоды по умолчанию"
 msgstr[2] "Периоды по умолчанию"
 msgstr[3] "Периоды по умолчанию"
 
-#: frontend/src/metabase/lib/query_time.js:203
+#: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
 msgstr[0] "Минута часа"
@@ -11495,7 +11525,7 @@ msgstr[1] "минуты часа"
 msgstr[2] "минуты часа"
 msgstr[3] "минуты часа"
 
-#: frontend/src/metabase/lib/query_time.js:205
+#: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
 msgstr[0] "Час дня"
@@ -11503,7 +11533,7 @@ msgstr[1] "Час дня"
 msgstr[2] "Час дня"
 msgstr[3] "Час дня"
 
-#: frontend/src/metabase/lib/query_time.js:207
+#: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
 msgstr[0] "День недели"
@@ -11511,7 +11541,7 @@ msgstr[1] "Дни недели"
 msgstr[2] "Дни недели"
 msgstr[3] "Дни недели"
 
-#: frontend/src/metabase/lib/query_time.js:209
+#: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
 msgstr[0] "День месяца"
@@ -11519,7 +11549,7 @@ msgstr[1] "Дни месяца"
 msgstr[2] "Дни месяца"
 msgstr[3] "Дни месяца"
 
-#: frontend/src/metabase/lib/query_time.js:211
+#: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
 msgstr[0] "День года"
@@ -11527,7 +11557,7 @@ msgstr[1] "Дни года"
 msgstr[2] "Дни года"
 msgstr[3] "Дни года"
 
-#: frontend/src/metabase/lib/query_time.js:213
+#: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
 msgstr[0] "Неделя года"
@@ -11535,7 +11565,7 @@ msgstr[1] "Недели  года"
 msgstr[2] "Недели  года"
 msgstr[3] "Недели  года"
 
-#: frontend/src/metabase/lib/query_time.js:215
+#: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
 msgstr[0] "Месяц года"
@@ -11543,7 +11573,7 @@ msgstr[1] "Месяцы года"
 msgstr[2] "Месяцы года"
 msgstr[3] "Месяцы года"
 
-#: frontend/src/metabase/lib/query_time.js:217
+#: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "Квартал года"
@@ -11551,9 +11581,10 @@ msgstr[1] "Кварталы года"
 msgstr[2] "Кварталы года"
 msgstr[3] "Кварталы года"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:79
+#: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} выборка"
@@ -11569,20 +11600,20 @@ msgstr "[?]?"
 msgid "This"
 msgstr "Этот"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:64
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
 msgstr "Некорректный"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:147
+#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
 msgstr "Добавить время"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:170
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
 msgstr "Нечего сравнивать с предыдущим {0}."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:517
+#: frontend/src/metabase-lib/lib/Dimension.js:678
 msgid "by {0}"
 msgstr "по {0}"
 
@@ -11877,35 +11908,35 @@ msgstr "Регистрация отложенной загрузки драйв�
 msgid "Error running query for Card {0}"
 msgstr "Ошибка выполнения запроса для карточки {0} "
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
 msgstr "Прошлая неделя"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This week"
 msgstr "Эта неделя"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
 msgstr "Последний месяц"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This month"
 msgstr "Этот месяц"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
 msgstr "Последний квартал"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
 msgstr "Этот квартал"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
 msgstr "Последний год"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This year"
 msgstr "Этот год"
 
@@ -12152,7 +12183,7 @@ msgid "[[CreateDate]] by quarter of the year"
 msgstr "[[CreateDate]] по кварталам года"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:200
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
 msgstr "Редактировать пользователя"
 
@@ -12160,12 +12191,12 @@ msgstr "Редактировать пользователя"
 msgid "New user"
 msgstr "Новый пользователь"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
 msgstr "Сбросить пароль"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:209
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
 msgstr "Деактивировать пользователя"
 
@@ -12177,40 +12208,40 @@ msgstr "Повторно активировать {0}?"
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
 msgstr "Мы не смогли отправить им приглашение по электронной почте, поэтому обязательно попросите их войти в систему, используя {0}, и этот пароль, который мы сгенерировали для них:"
 
-#: frontend/src/metabase/entities/collections.js:21
+#: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
 msgstr "коллекция"
 
-#: frontend/src/metabase/entities/collections.js:22
+#: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
 msgstr "коллекции"
 
-#: frontend/src/metabase/entities/dashboards.js:29
+#: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
 msgstr "дашборд"
 
-#: frontend/src/metabase/entities/dashboards.js:30
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
 msgstr "дашборды"
 
-#: frontend/src/metabase/entities/users.js:125
+#: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
 msgstr "Имя обязательно"
 
-#: frontend/src/metabase/entities/users.js:126
-#: frontend/src/metabase/entities/users.js:133
+#: frontend/src/metabase/entities/users.js:38
+#: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
 msgstr "Не более 100 символов"
 
-#: frontend/src/metabase/entities/users.js:132
+#: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
 msgstr "Фамилия обязательна"
 
-#: frontend/src/metabase/entities/users.js:138
+#: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
 msgstr "Емейл обязателен"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:90
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
 msgstr "здесь появится то, что вы заархивировали"
 
@@ -12218,11 +12249,11 @@ msgstr "здесь появится то, что вы заархивировал
 msgid "No description"
 msgstr "Нет описания"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:175
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
 msgstr "Сумма всех значений"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:183
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
 msgstr "Посмотреть уникальные значения"
 
@@ -12422,15 +12453,783 @@ msgstr "Добавление пользователя {0} в группу дос
 msgid "Adding User {0} to Admin permissions group..."
 msgstr "Добавление пользователя {0} в группу доступа Администратор..."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
 msgstr "Ошибка запроса"
 
-#: src/metabase/query_processor/async.clj
+#: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
 msgstr "Максимальное количество одновременных запросов для каждой подключенной базы данных."
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
 msgstr "Тайм-аут после {0} миллисекунд."
+
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
+msgid "Misfire Instruction"
+msgstr "Пропустить инструкцию"
+
+#: frontend/src/metabase/components/ArchiveModal.jsx:31
+msgid "Archive this?"
+msgstr "Архивировать это?"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:244
+msgid "Learn about our data"
+msgstr "Узнайте о ваших данных"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
+msgid "Use DNS SRV when connecting"
+msgstr "Использовать DNS SRV для подключения"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
+msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
+"an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
+"leave this disabled."
+msgstr "Использование этой опции требует предоставить FQDN хост. При подключении к Atlas cluster, вам потребуется разрешить эту опцию. Если вы не знаете что это значит - оставьте отключенным."
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
+msgid "Automatically run queries when doing simple filtering and summarizing"
+msgstr "Автоматически запускать запросы при простой фильтрации и суммировании"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr "Когда это включено, Metabase будет автоматически запускать запросы, когда пользователи выполняют простые исследования с помощью кнопок Summarize и Filter при просмотре таблицы или диаграммы. Вы можете отключить это, если запрос к этой базе данных медленный. Этот параметр не влияет на детализацию или запросы SQL."
+
+#: frontend/src/metabase/containers/Overworld.jsx:247
+msgid "Learn about this database"
+msgstr "Узнать об этой базе данных"
+
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+msgid "Archive this dashboard?"
+msgstr "Архивировать этот дашборд?"
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:113
+msgid "All results"
+msgstr "Все результаты"
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:180
+msgid "Our Analytics"
+msgstr "Наша аналитика"
+
+#: frontend/src/metabase/lib/schema_metadata.js:500
+msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
+msgstr "Добавочная сумма всех значений колонки.\\nнапример, общая выручка по времени."
+
+#: frontend/src/metabase/lib/schema_metadata.js:508
+msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
+msgstr "Добавочное количество строк.\\nнапример, количество продаж по времени."
+
+#: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
+msgid "Filter"
+msgstr "Фильтр"
+
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+msgid "record"
+msgid_plural "records"
+msgstr[0] "запись"
+msgstr[1] "записей"
+msgstr[2] "записей"
+msgstr[3] "записи"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:346
+msgid "Browse Data"
+msgstr "Просмотр данных"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:376
+msgid "Write SQL"
+msgstr "Написать SQL"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
+msgid "Simple question"
+msgstr "Простой запрос"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
+msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
+msgstr "Выберите данные, просмотрите, отфильтруйте, суммируйте и визуализируйте их."
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
+msgid "Custom question"
+msgstr "Пользовательский вопрос"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
+msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
+msgstr "Используйте расширенный редактор записной книжки, чтобы объединять данные, создавать пользовательские столбцы, выполнять математические операции и многое другое."
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+msgid "Basic Metrics"
+msgstr "Базовые метрики"
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+msgid "Custom…"
+msgstr "Произвольный..."
+
+#: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
+msgid "Add grouping"
+msgstr "Добавить группировку"
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
+msgid "Pick a limit"
+msgstr "Выберие предел"
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
+msgid "Show maximum"
+msgstr "Показать максимум"
+
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
+msgid "Get Preview"
+msgstr "Получить пример"
+
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
+msgid "Back to previous results"
+msgstr "Вернуться к предыдущим результатам"
+
+#: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
+msgid "Sample values"
+msgstr "Примерные значения"
+
+#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
+msgstr "Просмотрите содержимое ваших баз данных, таблиц и столбцов. Выберите базу данных, чтобы начать."
+
+#: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
+msgid "Visualize"
+msgstr "Визуализация"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
+msgid "Join data"
+msgstr "Присоединить данные"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
+msgid "Custom column"
+msgstr "Произвольная колонка"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
+msgid "Summarize"
+msgstr "Суммировать"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
+msgid "Aggregate"
+msgstr "Аггрегация"
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
+msgid "Breakout"
+msgstr "Разрыв"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
+msgid "Pick the metric you want to see"
+msgstr "Выберите метрику, которую хотите увидеть"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
+#: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
+msgid "Pick a column to group by"
+msgstr "Выберите колонки для группировки"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
+msgid "Pick your starting data"
+msgstr "Выберите начальные данные"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select None"
+msgstr "Отменить выбор"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select All"
+msgstr "Выбрать все"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
+msgid "Pick a table..."
+msgstr "Выберите таблицу..."
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
+msgid "Enter a limit"
+msgstr "Введите лимит"
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
+msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
+msgstr "Фигурные скобки вокруг {0} создают необязательное условие в шаблоне. Если \"переменная\" установлена, то условие подставляется в шаблон, иначе оно игнорируется."
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
+msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
+msgstr "При использовании Фильтра по полю, имя колонки не должно быть включено в SQL. Переменная будет отображаться в боковой панели."
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
+msgid "View the native query"
+msgstr "Просмотр исходного запроса"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
+msgid "Native query for this question"
+msgstr "Исходных запрос для этого вопроса"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
+msgid "Convert this question to a native query"
+msgstr "Преобразовать этот вопрос в нативный запрос"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
+msgid "SQL for this question"
+msgstr "SQL для этого вопроса"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
+msgid "Convert this question to SQL"
+msgstr "Конвертировать этот запрос в SQL"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
+msgid "Get alerts"
+msgstr "Получить предупреждения"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
+msgid "{0} breakout"
+msgid_plural "{0} breakouts"
+msgstr[0] "секция"
+msgstr[1] "секций"
+msgstr[2] "секций"
+msgstr[3] "секции"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
+msgid "Hide filters"
+msgstr "Скрыть фильтры"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
+msgid "Show filters"
+msgstr "Показать фильтры"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
+msgid "Started from"
+msgstr "Начать с"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
+msgid "{0} row"
+msgid_plural "{0} rows"
+msgstr[0] "строка"
+msgstr[1] "строк"
+msgstr[2] "строк"
+msgstr[3] "строки"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
+msgid "Show all rows"
+msgstr "Показать все строки"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
+msgid "Show {0}"
+msgstr "Показано {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
+msgid "Showing first {0}"
+msgstr "Показать первые {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
+msgid "Showing {0}"
+msgstr "Показать {0}"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
+msgid "Summarized"
+msgstr "Обобщенное"
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Hide editor"
+msgstr "Скрыть редактор"
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Show editor"
+msgstr "Показать редактор"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
+msgid "Pick the metric you'd like to see"
+msgstr "Выберите показатель, который вы хотели бы видеть"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
+msgid "{0} options"
+msgstr "{0} значений"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
+msgid "Choose a visualization"
+msgstr "Выбор визуализации"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
+msgid "Filter by"
+msgstr "Фильтровать по"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+msgid "Summarize by"
+msgstr "Обобщать по"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+msgid "Group by"
+msgstr "Группировать по"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+msgid "Add a metric"
+msgstr "Добавить метрику"
+
+#: frontend/src/metabase/user/components/UserSettings.jsx:57
+msgid "Profile"
+msgstr "Профиль"
+
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:548
+msgid "This is usually pretty fast but seems to be taking a while right now."
+msgstr "Это обычно довольно быстро, но, похоже, сейчас потребует чуть больше времени."
+
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
+msgid "Combo"
+msgstr "Комбо"
+
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
+msgid "Row"
+msgstr "Строка"
+
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
+msgid "Trend"
+msgstr "Тренд"
+
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:129
+msgid "Boolean"
+msgstr "Логическое"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+msgid "Unknown Segment"
+msgstr "Неизвестный сегмент"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+msgid "Unknown Filter"
+msgstr "Неизвестный фильтр"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
+msgid "Left outer join"
+msgstr "Left outer join"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
+msgid "Right outer join"
+msgstr "Right outer join"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
+msgid "Inner join"
+msgstr "Inner join"
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
+msgid "Full outer join"
+msgstr "Full outer join"
+
+#: src/metabase/api/card.clj
+msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
+msgstr "Переданные метаданные результата Карточки в API отсутствуют. Выполнение запроса для получения корректных метаданных."
+
+#: src/metabase/api/session.clj
+msgid "Problem connecting to LDAP server, will fall back to local authentication"
+msgstr "Проблема с подключением к серверу LDAP, приведет к локальной аутентификации."
+
+#: src/metabase/api/setup.clj
+msgid "Cannot create Database: cannot find driver {0}."
+msgstr "Невозможно создать базу: не обнаружен драйвер {0}."
+
+#: src/metabase/api/tiles.clj
+msgid "Query failed"
+msgstr "Запрос не выполнен"
+
+#: src/metabase/async/util.clj
+msgid "Warning: {0} returned `nil`"
+msgstr " Ошибка: {0} вернул `nil` "
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing result to output channel: already closed"
+msgstr "Неожиданная ошибка записи результата в выходной канал: канал закрыт"
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing exception to output channel: already closed"
+msgstr "Неожиданная ошибка записи исключения в выходной канал: уже закрыт"
+
+#: src/metabase/async/util.clj
+msgid "Request canceled, canceling future."
+msgstr "Запрос отменен, отмена будущего."
+
+#: src/metabase/cmd/load_from_h2.clj
+msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
+msgstr "Metabase может передавать данные только из H2 в Postgres или MySQL/MariaDB."
+
+#: src/metabase/db.clj
+msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
+msgstr "ВНИМАНИЕ: Использование Metabase со встроенной базой H2 не рекомендуется в промышленной эксплуатации."
+
+#: src/metabase/db.clj
+msgid "Application database setup"
+msgstr "Настройка базы данных приложения"
+
+#: src/metabase/driver.clj
+msgid "Could not find {0} driver."
+msgstr "Не удалось найти драйвер {0}."
+
+#: src/metabase/driver.clj
+msgid "Abstract drivers cannot derive from concrete parent drivers."
+msgstr "Абстрактные драйверы не могут быть получены из конкретных родительских драйверов."
+
+#: src/metabase/driver/mysql.clj
+msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
+msgstr "Вам потребуется добавить 'trustServerCertificate=true к дополнительным параметрам подключения для подключения по SSL."
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifer."
+msgstr "Невозможно определить алиас для {0}, ожидается Идентификатор."
+
+#: src/metabase/driver/sql_jdbc/execute.clj
+msgid "Client closed connection, canceling query"
+msgstr "Клиент закрыл соединение, отмена запроса"
+
+#: src/metabase/integrations/ldap.clj
+msgid "{0} is not a valid DN."
+msgstr "{0} некорректное значение DN."
+
+#: src/metabase/middleware/log.clj
+msgid "Error logging API request"
+msgstr "Ошибка логирования API запроса"
+
+#: src/metabase/middleware/misc.clj
+msgid "Failed to set site-url"
+msgstr "Ошибка установки site-url"
+
+#: src/metabase/models/database.clj
+msgid "Error destroying thread pool for DB."
+msgstr "Ошибка закрытия пула потоков для базы данных."
+
+#: src/metabase/models/humanization.clj
+msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
+msgstr "Обновление отображаемого имени {0} ''{1}'': ''{2}'' -> ''{3}''"
+
+#: src/metabase/models/humanization.clj
+msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
+msgstr "Некорректная стратегия хуманизации ''{{0}}''. Корректные стратегии: {1}"
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr "Изменение наименований Таблиц и Полей согласно стратегии хуманизации с ''{0}'' на ''{1}''."
+
+#: src/metabase/models/task_history.clj src/metabase/sync/util.clj
+msgid "Error saving task history"
+msgstr "Ошибка сохранения истории задач"
+
+#: src/metabase/plugins.clj
+msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
+msgstr "Плагин spark-deps.jar больше не требуется для Metabase начиная с версии 0.32.0. Вы можете удалить его из директории с плагинами."
+
+#: src/metabase/plugins/classloader.clj
+msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
+msgstr "Использование НОВОГО СОЗДАННОГО загрузчика классов как общего загрузчика классов: {0}"
+
+#: src/metabase/plugins/files.clj
+msgid "Failed to copy file"
+msgstr "Невозможно скопировать файл"
+
+#: src/metabase/public_settings.clj
+msgid "Invalid site URL: {0}"
+msgstr "Некорректный URL сайта: {0}"
+
+#: src/metabase/public_settings.clj
+msgid "site-url is invalid; returning nil for now. Will be reset on next request."
+msgstr "Некорректный site-url; возвращен пустой результат. Будет сброшен при следующем запросе."
+
+#: src/metabase/pulse/render/body.clj
+msgid "More results have been included as a file attachment"
+msgstr "Больше результатов есть в приложенном файле."
+
+#: src/metabase/pulse/render/body.clj
+msgid "This question has been included as a file attachment"
+msgstr "Этот вопрос был включен в качестве вложения"
+
+#: src/metabase/pulse/render/body.clj
+msgid "We were unable to display this Pulse."
+msgstr "Мы не смогли отобразить этот Пульс"
+
+#: src/metabase/pulse/render/body.clj
+msgid "Please view this card in Metabase."
+msgstr "Пожалуйста, просмотрите эту карту в Metabase."
+
+#: src/metabase/pulse/render/body.clj
+msgid "An error occurred while displaying this card."
+msgstr "Произошла ошибка при отображении этой карты."
+
+#: src/metabase/query_processor.clj
+msgid "Can only determine expected columns for MBQL queries."
+msgstr "Возможно определять только ожидаемые колонки для MBQL запросов."
+
+#: src/metabase/query_processor.clj
+msgid "No columns returned."
+msgstr "Нет колонок в результате"
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr "Предупреждение: невозможно определить поля для явного `source-query`, если вы также не включите` source-metadata`."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
+msgstr "Невозможно разрешить {0}: Поле не существует, или Таблица относится к другой Базе данных."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
+msgstr "Не удается разрешить :field-literal внутри :fk->, если внутри не объединено с явным :alias."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot find Table ID for {0}"
+msgstr "Невозможно найти идентификатор таблицы {0}"
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "No matching info found."
+msgstr "Не найдено подходящей информации."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Could not resolve {0}"
+msgstr "Невозможно разрешить {0}"
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Invalid fk-> clause: nowhere to add corresponding join."
+msgstr "Некорректный внешний ключ: невозможно добавить указанное слияние."
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "{0} driver does not support foreign keys."
+msgstr "Драйвер {0} не поддерживает внешние ключи."
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
+msgstr "Невозможно вывести `: source-metadata` для исходного запроса с собственным исходным запросом без метаданных источника."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Query processor error: number of columns returned by driver does not match results."
+msgstr "Ошибка обработчика запросов: количество возвращаемых драйвером столбцов не соответствует результатам."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Expected {0} columns, but first row of resuls has {1} columns."
+msgstr "Ожидаемо {0} столбцов, но первая строка результатов содержит {1} столбцов."
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "No expression named {0} found. Found: {1}"
+msgstr "Выражение {0} не найдено. Найдено: {1}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Distinct values of {0}"
+msgstr "Уникальные значения {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Average of {0}"
+msgstr "Среднее {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0}"
+msgstr "Сумма {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "SD of {0}"
+msgstr "Стандартное отклонение {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Min of {0}"
+msgstr "Минимум {0}"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Max of {0}"
+msgstr "Максимум {0}"
+
+#. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0} matching condition"
+msgstr "Сумма {0} по условию"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Share of rows matching condition"
+msgstr "Поделиться строками результата"
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Count of rows matching condition"
+msgstr "Количество строк, соответствующих условию"
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Request already canceled, will not run synchronous QP code."
+msgstr "Запрос уже отменён, синхронный QP код не будет выполнен."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unexpectedly got `nil` Query Processor response."
+msgstr "Неожиданный пустой результат от Обработчика Запросов."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Got InterruptedException. Canceling query."
+msgstr "Получено прерывающее исключение. Отмена запроса."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
+msgstr "Необрабатываемое исключение, ожидаем прослойку  `catch-exceptions` для обработки."
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Query timed out after %s"
+msgstr "Таймаут выполнения запроса после %s "
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Creating new query thread pool for Database {0}"
+msgstr "Создание нового потока пула запросов для Базы данных {0}"
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Destroying query thread pool for Database {0}"
+msgstr "Уничтожение пула запросов для Базы данных {0}"
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Request canceled, canceling pending query"
+msgstr "Запрос отменен, отмена ожидающего запроса"
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: query is missing source-metadata"
+msgstr "Невозможно обновить скомпанованное поле: в запросе отсутствуют метаданные источника."
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
+msgstr "Невозможно обновить скомпанованное поле: не удаётся найти метаданные источника для Поля ''{0}''"
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Using query processor cache backend: {0}"
+msgstr "Использование кэша бэкенда обработчика запросов: {0}"
+
+#: src/metabase/query_processor/middleware/expand_macros.clj
+msgid "Invalid metric: {0} reason: {1}"
+msgstr "Некорректная метрика: {0} по причине: {1}"
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unknown error"
+msgstr "Неизвестная ошибка"
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unexpected nil response from query processor."
+msgstr "Неожиданный пустой ответ от процессора запросов."
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Query canceled"
+msgstr "Запрос отменен"
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
+msgstr "Невозможно определить драйвер для запроса: `:database` ID некорректен или отсутствует."
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: Database {0} does not exist."
+msgstr "Невозможно найти драйвер для запроса: База данных {0} не существует."
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr "Невозможно использовать :fields :all в объединении исходного запроса без :source-metadata."
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
+msgstr "Некорректное условие :joined-field: слияние с алиасом ''{0}'' не существует. Найдено: {1}"
+
+#: src/metabase/query_processor/middleware/resolve_source_table.clj
+msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
+msgstr "Некорректная :source-table ''{0}'': будет разрешено по Идентификатору Таблицы."
+
+#: src/metabase/query_processor/store.clj
+msgid "Cannot store Tables or Fields before Database is stored."
+msgstr "Невозможно сохранить Таблицы или Поля до сохранения Базы данных."
+
+#: src/metabase/query_processor/store.clj
+msgid "Attempting to fetch second Database. Queries can only reference one Database."
+msgstr "Попытка обращения ко второй Базе данных: Запросы могут ссылать только на одну Базу данных."
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
+msgstr "Ошибка получения Таблицы {0}: Таблица не существует или относится к другой Базе данных."
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
+msgstr "Ошибка получения Поля {0}: Поле не существует или относится к другой Базе данных."
+
+#: src/metabase/routes/index.clj
+msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
+msgstr "Ошибка загрузки шаблона ''{0}''. Не забыли ли вы собрать Metabase frontend?"
+
+#: src/metabase/sample_data.clj
+msgid "Sample dataset DB file ''{0}'' cannot be found."
+msgstr "Файл ''{0}'' тестовой базы данных не найден."
+
+#: src/metabase/sample_data.clj
+msgid "Loading sample dataset..."
+msgstr "Загрузка тестовых данных..."
+
+#: src/metabase/sample_data.clj
+msgid "Failed to load sample dataset"
+msgstr "Невозможно загрузить тестовые данные"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Found new tables:"
+msgstr "Найдены новые таблицы:"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Marking tables as inactive:"
+msgstr "Отметка таблиц неактивными:"
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Updating description for tables:"
+msgstr "Обновление описания для таблиц:"
+
+#: src/metabase/task.clj
+msgid "Rescheduling job {0}"
+msgstr "Перепланирование задачи {0}"
+
+#: src/metabase/task.clj
+msgid "Error rescheduling job"
+msgstr "Ошибка перепланирования задачи"
+
+#: src/metabase/task/send_pulses.clj
+msgid "Starting Pulse Execution: {0}"
+msgstr "Начато выполнение Пульса: {0}"
+
+#: src/metabase/task/send_pulses.clj
+msgid "Finished Pulse Execution: {0}"
+msgstr "Завершено выполнение Пульса: {0}"
+
+#: src/metabase/task/sync_databases.clj
+msgid "Failed to schedule tasks for Database {0}"
+msgstr "Ошибка планирования задач для Базы данных {0}"
+
+#: src/metabase/util/schema.clj
+msgid "All elements must be distinct."
+msgstr "Все элементы должны быть уникальны"
+
+#: 
+msgctxt "Modal for selecting columns in source data or when doing a join."
+msgid "Pick the columns you want to include"
+msgstr "Выберите столбцы которые хотите включить"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr "Когда это включено, Metabase будет автоматически запускать запросы, когда пользователи выполняют простые исследования с помощью кнопок Итоги и Фильтр при просмотре таблицы или диаграммы. Вы можете отключить это, если запросы к этой базе данных выполняются медленно. Этот параметр не влияет на детализацию или запросы SQL."
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
+msgid "Change join type"
+msgstr "Изменить тип соединения"
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifier."
+msgstr "Невозможно определить алиас для {0}, ожидается Идентификатор."
+
+#: src/metabase/integrations/common.clj
+msgid "Error adding User {0} to Group {1}"
+msgstr "Ошибка добавления Пользователя {0} в Группу {1}"
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr "Изменение имён Таблиц и Полей стратегией хуманизации с ''{0}'' на ''{1}''"
+
+#: src/metabase/query_processor.clj
+msgid "Infinite loop detected: recursively preprocessed query {0} times."
+msgstr "Обнаружен бесконечный цикл: рекурсивное выполнение запроса {0} раз."
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr "Предупреждение: невозможно определить поля для явного `source-query`, если вы также не включите` source-metadata`."
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Error determining expected columns for query"
+msgstr "Ошибка определения ожидаемых столбцов для запроса"
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
+msgstr "Необрабатываемое исключение, ожидаем прослойку  `catch-exceptions` для обработки."
 

--- a/locales/tr.po
+++ b/locales/tr.po
@@ -28,18 +28,19 @@ msgstr "Bu verilere göz at"
 msgid "Select a database type"
 msgstr "Veritabanı türü seçin"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:75
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:401
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:71
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:182
+#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:410
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:74
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:203
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:180
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:197
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:193
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:171
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:180
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:164
 msgid "Save"
 msgstr "Kaydet"
@@ -59,7 +60,7 @@ msgid "This is a lightweight process that checks for\n"
 msgstr "Bu veritabanı şemasını güncelleyen, çok işlemci gücü istemeyen bir işlemdir. Genelde saatlik olarak işaretlenir."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:184
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
 msgid "Scan"
 msgstr "Tara"
 
@@ -75,126 +76,128 @@ msgid "Metabase can scan the values present in each\n"
 msgstr "Metabase , kontrol panelindeki onay kutu filtrelerini etkinleştirmek için veritabanındaki her alanda bulunan değerleri tarayabilir.\n"
 "Eğer büyük bir veritabanınız varsa bu süreç biraz yoğun olabilir."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:159
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Metabase alan değerlerini otomatik olarak taramayı ve önbelleğe almayı ne zaman yapmalıdır?"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:164
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
 msgstr "Düzenli olarak, belirtilen zamanda"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:195
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
 msgstr "Sadece yeni bir filtre aracı eklerken"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:199
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
 msgstr "Bir kullanıcı bir gösterge panosuna veya bir SQL sorgusuna yeni bir filtre eklediğinde, Metabase seçilebilir değerlerin listesini göstermek için o filtreyle eşlenen alanları tarayacaktır."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:210
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
 msgid "Never, I'll do this manually if I need to"
 msgstr "Asla, İhtiyacım olursa bunu manuel olarak yapacağım"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:222
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:222
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:426
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
 msgid "Saving..."
 msgstr "Kaydediliyor..."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:39
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
 msgid "Server error encountered"
 msgstr "Sunucu hatasıyla karşılaşıldı"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:58
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
 msgstr "Bu veritabanı silinsin mi?"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
 msgstr "Bu veritabanına dayanan tüm kayıtlı sorgular, metrikler ve segmentler kaybolacak."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:67
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
 msgstr "Bu geri alınamaz."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
 msgstr "Emin iseniz, lütfen yazın"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:53
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
 msgstr "SİL"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:71
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
 msgstr "Bu kutuda:"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:82
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:50
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:93
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:58
-#: frontend/src/metabase/admin/permissions/selectors.js:160
-#: frontend/src/metabase/admin/permissions/selectors.js:170
-#: frontend/src/metabase/admin/permissions/selectors.js:185
-#: frontend/src/metabase/admin/permissions/selectors.js:224
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:355
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:181
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:247
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:61
+#: frontend/src/metabase/admin/permissions/selectors.js:163
+#: frontend/src/metabase/admin/permissions/selectors.js:173
+#: frontend/src/metabase/admin/permissions/selectors.js:188
+#: frontend/src/metabase/admin/permissions/selectors.js:227
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:202
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:268
+#: frontend/src/metabase/components/ArchiveModal.jsx:35
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
-#: frontend/src/metabase/components/form/StandardForm.jsx:61
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:196
+#: frontend/src/metabase/components/form/StandardForm.jsx:62
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:198
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:289
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:162
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:153
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:38
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:189
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:24
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:48
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:41
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:92
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:259
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "İptal"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:88
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:121
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:132
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
 msgstr "Sil"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:128
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:74
-#: frontend/src/metabase/admin/permissions/selectors.js:320
-#: frontend/src/metabase/admin/permissions/selectors.js:327
-#: frontend/src/metabase/admin/permissions/selectors.js:423
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
+#: frontend/src/metabase/admin/permissions/selectors.js:323
+#: frontend/src/metabase/admin/permissions/selectors.js:330
+#: frontend/src/metabase/admin/permissions/selectors.js:426
 #: frontend/src/metabase/admin/routes.jsx:53
-#: frontend/src/metabase/nav/containers/Navbar.jsx:214
+#: frontend/src/metabase/nav/containers/Navbar.jsx:243
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
 msgstr "Veritabanları"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:129
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
 msgstr "Veritabanı ekle"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
 msgstr "Bağlantı"
@@ -203,107 +206,107 @@ msgstr "Bağlantı"
 msgid "Scheduling"
 msgstr "Zamanlama"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:78
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:84
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:26
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:221
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
 msgstr "Değişiklikleri kaydet"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:185
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:38
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:38
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
 msgstr "Eylemler"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:193
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
 msgstr "Veritabanı şemasını senkronize et"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:194
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:206
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:109
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
 msgstr "Başlıyor..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:195
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
 msgstr "Senkronizasyon yapılamadı"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
 msgstr "Senkronizasyon tetiklendi!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:205
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
 msgstr "Alan değerlerini şimdi yeniden tarayın"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:207
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
 msgstr "Tarama başlatılamadı"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
 msgstr "Tarama tetiklendi!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:215
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:401
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
 msgstr "Tehlikeli Bölge"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:221
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
 msgstr "Kaydedilen alan değerlerini iptal et"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
 msgstr "Bu veritabanını kaldır"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:73
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
 msgstr "Veritabanı ekle"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:85
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:36
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:36
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:122
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:32
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:399
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:446
 #: frontend/src/metabase/containers/EntitySearch.jsx:26
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:218
-#: frontend/src/metabase/entities/collections.js:93
-#: frontend/src/metabase/entities/dashboards.js:145
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:461
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:81
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:220
+#: frontend/src/metabase/entities/collections.js:94
+#: frontend/src/metabase/entities/dashboards.js:142
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
 msgstr "İsim"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:86
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
 msgstr "Makine"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:115
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
 msgstr "Siliniyor"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:145
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
 msgstr "Yükleniyor"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:161
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
 msgstr "Örnek veri kümesini geri getir"
 
@@ -320,9 +323,9 @@ msgid "Successfully saved!"
 msgstr "Başarıyla kaydedildi!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:177
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:197
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
 msgstr "Düzenle"
@@ -331,86 +334,90 @@ msgstr "Düzenle"
 msgid "Revision History"
 msgstr "Revizyon Geçmişi"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
 msgstr "Kaldır {0}?"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
 msgstr "Kaydedilen sorgular ve buna {0} bağlı diğer şeyler çalışmaya devam edecek, ancak bu {1} sorgu oluşturucudan seçilemez."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
 msgstr "Bunu {0} kaldırmak istediğinizden eminseniz, lütfen kaldırma nedeniniz ile ilgili kısa bir açıklama yazınız: "
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
 msgstr "Yaptığınız bu işlem etkinlik akışında gösterilecek,  {0}'ı kullanan ve oluşturan herkese mail  olarak gönderilecektir."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
 msgstr "Kaldır"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
 msgstr "Kaldırılıyor..."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
 msgstr "Başarısız"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
 msgstr "Başarılı"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:91
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
+#: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Ön izleme"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
 msgstr "Sütün açıklaması yok"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:135
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
 msgstr "Görünür bir alan seçiniz"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:210
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
 msgstr "Özel tip yok"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:211
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:148
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
 msgstr "Diğer"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:231
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Özel bir tip seçiniz"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:277
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
 msgstr "Bir hedef seç"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:77
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:89
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:106
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:122
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
 msgstr "Sütunlar"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Sütun"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:121
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:306
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
 msgstr "Görünürlük"
 
@@ -418,53 +425,53 @@ msgstr "Görünürlük"
 msgid "Type"
 msgstr "Tip"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
 msgstr "Güncel veritabanı:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
 msgstr "Orjinal şemayı göster"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:45
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
 msgstr "Veri Tipi"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
 msgstr "Ek Bilgi"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
 msgstr "Şema bul"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:51
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "{0} şema"
 msgstr[1] "{0} şemalar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
 msgstr "Neden Gizledin?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
 msgstr "Teknik Veri"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
 msgstr "Alakasız"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
 msgid "Queryable"
 msgstr "Sorgulanabilir"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:91
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
 msgstr "Gizli"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
 msgstr "Henüz tablo açıklaması yok"
 
@@ -472,65 +479,67 @@ msgstr "Henüz tablo açıklaması yok"
 msgid "Metadata Strength"
 msgstr "Metadata Gücü"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} Sorgulanabilir Tablo"
 msgstr[1] "{0} Sorgulanabilir Tablolar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:96
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} Gizli Tablo"
 msgstr[1] "{0} Gizli Tablolar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
 msgstr "Tablo bul"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
 msgstr "Şemalar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:24
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:137
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:68
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:56
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:190
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
 msgstr "Metrikler"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
 msgstr "Metrik Ekle"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:37
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Açıklamalar"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Sorgu oluşturucusundaki açılır/kapanır menüye eklemek için metrikler oluşturun"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:24
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:930
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:952
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:56
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Segmentler"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
 msgstr "Segment Ekle"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Sorgu oluşturucusundaki açılır/kapanır filtreye eklemek için segmentler oluşturun"
 
@@ -558,53 +567,53 @@ msgstr "Düzenlenmiş"
 msgid "made some changes"
 msgstr "Bazı değişiklikler yaptı"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
-#: frontend/src/metabase/home/components/Activity.jsx:80
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:332
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/home/components/Activity.jsx:82
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
 msgstr "Sen"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
 msgstr "Veri Modeli"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
 msgstr "Tarihçe"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:48
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
 msgstr "Revizyon Geçmişi için"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:239
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
 msgstr "{0} –Alan Ayarları"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
 msgstr "Metatabanında bu alanın görüneceği alan"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:329
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Bu alanda filtreleme"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Bu alan filtrede kullanıldığında, insanların filtrelemek istedikleri değeri girmek için ne kullanmaları gerekir?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:453
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Bu alan için henüz açıklama yok"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:379
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
 msgstr "Orjinal değer"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:380
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
 msgid "Mapped value"
 msgstr "Eşlenen değer"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:423
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
 msgstr "Değeri girin"
 
@@ -621,7 +630,7 @@ msgid "Custom mapping"
 msgstr "Özel eşleşme"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:155
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
 msgid "Unrecognized mapping type"
 msgstr "Tanınmayan eşleşme türü"
 
@@ -629,23 +638,23 @@ msgstr "Tanınmayan eşleşme türü"
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Geçerli alan yabancı anahtar değil veya hedef tablosundaki yabancı anahtar verileri eksik"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:187
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
 msgstr "Seçilen alan yabancı anahtar değildir"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:347
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
 msgstr "Ekran değerleri"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:348
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Orijinal değeri veritabanından göstermeyi seçin, veya bu alanın ilişkili veya özel bilgileri gösterilmesini sağlayın"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:268
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
 msgstr "Bir alan seç"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:289
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
 msgstr "Lütfen ekran için kullanılacak bir sütun seçin."
 
@@ -653,16 +662,16 @@ msgstr "Lütfen ekran için kullanılacak bir sütun seçin."
 msgid "Tip:"
 msgstr "Tavsiye:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Yaptığınız yeni seçimlerin mantıklı olduğundan emin olmak için alan adını güncellemek isteyebilirsiniz."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:364
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:102
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
 msgstr "Önbelleğe alınmış alan değerleri"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:365
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase, kontrol paneli filtrelerinde ve sorgularda onay kutu filtrelerini etkinleştirmek için bu alanın değerlerini tarayabilir."
 
@@ -671,167 +680,168 @@ msgid "Re-scan this field"
 msgstr "Bu alanı yeniden tara"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
 msgstr "Önbelleğe alınmış değerleri atın"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:118
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
 msgstr "Değerler alamadı"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard triggered!"
 msgstr "Tetik atın!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:105
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Şemasını görmek ve meta verileri eklemek veya düzenlemek için herhangi bir tablo seçin."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:37
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:34
-#: frontend/src/metabase/entities/collections.js:96
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "İsim gerekli"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:40
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
 msgstr "Açıklama gerekli"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:44
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:41
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
 msgstr "Revizyon mesajı gerekli"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:50
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
 msgstr "Toplama gerekli"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
 msgstr "Metriğini düzenle"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
 msgstr "Metriğini oluştur"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:115
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Metriğinizde değişiklikler yapın ve açıklayıcı bir not ekleyin."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Bu tabloya adlandırılmış bir metrik seçeneği eklemek için kayıtlı metrikler oluşturabilirsiniz. Kayıtlı metrikler, toplama türünü, toplanmış alanı ve isteğe bağlı olarak eklediğiniz herhangi bir filtreyi içerir. Örnek olarak, bir Siparişler tablosu için \"Ortalama Fiyat\" hesaplamasını oluşturmak için bu oluşturduğunuz metrikleri kullanabilirsiniz."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
 msgstr "Sonuç:"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
 msgstr "Metriğini adlandır"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
 msgstr "Başkalarına yardımcı olmak için metriğinize bir isim verin."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:162
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
 msgstr "Açıklayıcı bir şey ama çok uzun değil"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
 msgstr "Metriğini tanımla"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Metriğinize başkalarının ne ile ilgili olduğunu anlamasına yardımcı olmak için  bir açıklama verin."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Daha az belirgin metrik kuralları hakkında daha spesifik olmak için iyi bir yer"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:179
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
 msgstr "Değişiklik Nedeni"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:177
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Yaptığınız değişiklikleri ve neden gerekli olduklarını açıklamak için bir not bırakın."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Bu, metriklerin revizyon geçmişinde herkesin neden değiştiğini hatırlamasına yardımcı olacak."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
 msgstr "En az bir filtre gerekli"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
 msgstr "Segmentinizi düzenleyin"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
 msgstr "Segmentinizi oluşturun"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:121
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Segmentinizde değişiklikler yapın ve açıklayıcı not bırakın"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "{0} tablosu için yeni segmentinizi oluşturmak üzere filtre seçip ekleyin"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
 msgstr "Segmentinizi adlandırın"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:162
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
 msgstr "Segmentinize başkalarının bulmasına yardımcı olacak bir ad verin."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:170
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
 msgstr "Segmentinizi açıklayın"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Segmentinize diğerlerinin neyle ilgili olduğunu anlamalarına yardımcı olacak bir açıklama verin."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:175
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Bu daha az belirgin segment kuralları hakkında daha spesifik olmak için iyi bir yer"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:185
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Neden değiştiğini hatırlamalarını yardımcı olmak için bu segment revizyon geçmişinde görünecek."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:266
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:87
-#: frontend/src/metabase/nav/containers/Navbar.jsx:199
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:269
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:91
+#: frontend/src/metabase/nav/containers/Navbar.jsx:228
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:103
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase , gösterge tablolarında ve sorgularda onay kutusu filtrelerini etkinleştirmek için bu tablodaki değerleri tarayabilir."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:108
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
 msgstr "Bu tabloyu yeniden tara"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:253
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
 msgstr "Ekle"
 
@@ -840,20 +850,22 @@ msgstr "Ekle"
 msgid "Not a valid formatted email address"
 msgstr "Geçerli bir e-posta adresi değil"
 
+#: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:100
 msgid "First name"
 msgstr "İsim"
 
+#: frontend/src/metabase/entities/users.js:42
 #: frontend/src/metabase/setup/components/UserStep.jsx:203
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:117
 msgid "Last name"
 msgstr "Soyisim"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:77
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:158
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:161
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:470
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:481
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
@@ -867,34 +879,35 @@ msgstr "İzin grupları"
 msgid "Make this user an admin"
 msgstr "Bu kullanıcıyı yönetici yap"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:32
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
 msgstr "Tüm kullanıcılar {0} grubuna ait ve bundan kaldırılamaz.Bu grup için izinler ayarlamak yeni Metabase kullanıcılarının görebileceği şeylerden emin olmanın harika bir yoldur."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:41
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
 msgstr "Bu, üyeleri Metabase'de her şeyi görebilen ve izinleri de dahil olmak üzere Yönetici Paneli'ndeki ayarlara erişebilen ve bunlarda değişiklik yapabilen özel bir gruptur! Bu yüzden insanları bu gruba özenle ekleyin."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:45
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
 msgstr "Metabase'in kilitlenmediğinden emin olmak için bu grupta en az bir kullanıcı olması gerekir."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
 msgstr "Üyeler"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:124
-#: frontend/src/metabase/admin/settings/selectors.js:113
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
+#: frontend/src/metabase/admin/settings/selectors.js:110
+#: frontend/src/metabase/entities/users.js:50
 #: frontend/src/metabase/lib/core.js:55
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
 msgstr "E-posta"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:203
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
 msgstr "Bir grup sadece üyeleri kadar iyidir."
 
@@ -905,8 +918,8 @@ msgid "Admin"
 msgstr "Yönetici"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:237
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:290
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
 msgstr "ve"
 
@@ -935,13 +948,13 @@ msgid "Are you sure? All members of this group will lose any permissions setting
 msgstr "Emin misiniz? Bu grubun tüm üyeleri bu gruba dayalı tüm izin ayarlarını kaybedeceklerdir. Bu geri alınamaz."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
 msgstr "Evet"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
 msgstr "Hayır"
 
@@ -960,10 +973,11 @@ msgstr "Grubu Kaldır"
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:107
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:327
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:395
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:265
+#: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
 msgstr "Tamam"
 
@@ -973,9 +987,9 @@ msgstr "Grup adı"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:131
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:88
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
 msgstr "Gruplar"
 
@@ -1004,9 +1018,9 @@ msgid "Deactivate"
 msgstr "Devre dışı bırakmak"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:93
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
-#: frontend/src/metabase/nav/containers/Navbar.jsx:204
+#: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
 msgstr "İnsan"
 
@@ -1048,7 +1062,6 @@ msgid "We've re-sent {0}'s invite"
 msgstr "{0} 'ın davetini tekrar gönderdik"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
-#: frontend/src/metabase/tutorial/Tutorial.jsx:253
 msgid "Okay"
 msgstr "Tamam"
 
@@ -1080,13 +1093,13 @@ msgstr "Tekrar giriş yapabilecekler ve hesabı devre dışı bırakılmadan ön
 msgid "Reset {0}'s password?"
 msgstr "{0} şifresini sıfırlayın"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:77
+#: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
 msgstr "Sıfırla"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:44
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
 msgstr "Bunu yapmak istediğine emin misin?"
 
@@ -1102,76 +1115,78 @@ msgstr "Giriş yapmak ve şifrelerini değiştirmek için kullanabilecekleri ge�
 msgid "We've sent them an email with instructions for creating a new password."
 msgstr "Yeni bir şifre oluşturma ile ilgili talimatlar içeren bir e-posta gönderdik."
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:101
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
 msgstr "Aktif"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:127
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
 msgstr "Devre dışı"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:115
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
 msgstr "Birini ekle"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
 msgstr "Son giriş"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:153
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
 msgstr "Google üzerinden kaydoldu"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:158
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
 msgstr "LDAP ile kaydoldu"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:170
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
 msgstr "Bu hesabı yeniden etkinleştir"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:193
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
 msgstr "Asla"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:27
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
 msgstr[0] "{0} tablo"
 msgstr[1] "{0} tablolar"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:45
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
 msgstr "olacak"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:48
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
 msgstr "erişim verilen"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:53
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
 msgstr "ve"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:56
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
 msgstr "erişim reddedildi"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:70
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
 msgstr "artık mümkün olmayacak"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:71
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
 msgstr "şimdi mümkün olacak"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:79
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
 msgstr "için yerel sorgular"
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
-#: frontend/src/metabase/nav/containers/Navbar.jsx:219
+#: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
 msgstr "İzinler"
 
@@ -1196,15 +1211,15 @@ msgstr "İzinlerde değişiklik yapılmayacak."
 msgid "You've made changes to permissions."
 msgstr "İzinlerde değişiklik yaptınız."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:52
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
 msgstr "Bu koleksiyon için izinler"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
 msgstr "Kaydedilmemiş değişiklikleriniz mevcut"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:54
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
 msgstr "Bu sayfadan ayrılmak ve değişikliklerinizi gözardı etmek istiyor musunuz?"
 
@@ -1224,119 +1239,119 @@ msgstr "Her Metabase kullanıcısı Tüm Kullanıcılar grubuna aittir. Bir grub
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
 msgstr "MetaBot,Metabes'in Slack bot'udur. Buradan erişebileceği şeyi seçebilirsiniz."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:119
+#: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
 msgstr "\"{0}\" grubu bu gruba göre {1} farklı bir kümeye erişebilir, bu da bu gruba bazı {2} düzeylerine ek erişim sağlayabilir."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:124
+#: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
 msgstr "\"{0}\" grubu, bu ayarı geçersiz kılacak daha yüksek bir erişim düzeyine sahiptir. \"{1}\" grubunun bu öğeye erişimini sınırlandırmalı veya iptal etmelisiniz."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
 msgstr "Limit"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
 msgstr "Geri almak"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:156
+#: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
 msgstr "\"{0}\" daha fazla erişime sahip olsa bile erişimi sağlayın?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:258
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
 msgstr "Lİmit erişimi"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:223
-#: frontend/src/metabase/admin/permissions/selectors.js:266
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:226
+#: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
 msgstr "Erişimi iptal et"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:168
+#: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
 msgstr "Bu veritabanına erişimi sınırlı olacak şekilde değiştirilsin mi?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:169
+#: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
 msgstr "Değiştir"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:182
+#: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
 msgstr "Sorgu Yazmaya İzin Verilsin mi?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:183
+#: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
 msgstr "Bu ayrıca bu grubun Veritabanını bu veritabanı için Sınırsız olarak değiştirecektir."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:184
+#: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
 msgstr "İzin vermek"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:221
+#: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
 msgstr "Tüm tablolara erişimi iptal et?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:222
+#: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
 msgstr "Bu ayrıca bu grubun bu veritabanı için ham sorgulara erişimini iptal edecektir."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:251
+#: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
 msgstr "Sınırsız erişim izni ver"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:252
+#: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
 msgstr "Sınırsız erişim"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:259
+#: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
 msgstr "Sınırlı erişim"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:267
+#: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
 msgstr "Erişim yok"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:273
+#: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
 msgstr "Ham sorgular yaz"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:274
+#: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
 msgstr "Ham sorguları yazabilir"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:281
+#: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
 msgstr "Koleksiyonu ayarlayın"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:288
+#: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
 msgstr "Koleksiyonu görüntüle"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:331
-#: frontend/src/metabase/admin/permissions/selectors.js:427
-#: frontend/src/metabase/admin/permissions/selectors.js:524
+#: frontend/src/metabase/admin/permissions/selectors.js:334
+#: frontend/src/metabase/admin/permissions/selectors.js:430
+#: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
 msgstr "Veri Erişimi"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:492
-#: frontend/src/metabase/admin/permissions/selectors.js:649
-#: frontend/src/metabase/admin/permissions/selectors.js:654
+#: frontend/src/metabase/admin/permissions/selectors.js:495
+#: frontend/src/metabase/admin/permissions/selectors.js:652
+#: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
 msgstr "Tabloları görüntüle"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:590
+#: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
 msgstr "SQL Sorguları"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:660
+#: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
 msgstr "Şemaları görüntüle"
 
 #: frontend/src/metabase/admin/routes.jsx:59
-#: frontend/src/metabase/nav/containers/Navbar.jsx:209
+#: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
 msgstr "Veri örneği"
 
@@ -1345,30 +1360,30 @@ msgstr "Veri örneği"
 msgid "Sign in with Google"
 msgstr "Google ile giriş yap"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:13
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
 msgstr "Mevcut Metabase hesaplarına sahip kullanıcıların, Metabase kullanıcı adlarına ve şifrelerine ek olarak e-posta adresleriyle eşleşen bir Google hesabıyla oturum açmalarına izin verir."
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:17
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
 msgstr "Yapılandır"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
-#: frontend/src/metabase/admin/settings/selectors.js:207
+#: frontend/src/metabase/admin/settings/selectors.js:204
 msgid "LDAP"
 msgstr "LDAP(Basit İndeks Erişim Protokolü)"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:25
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
 msgstr "LDAP dizininizdeki kullanıcıların, LDAP kimlik bilgileriyle Metabase'de oturum açmasına ve LDAP gruplarının Metabase gruplarına otomatik olarak eşlenmesini sağlar."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
-#: frontend/src/metabase/admin/settings/selectors.js:160
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
 msgstr "Bu geçerli bir e-posta adresi değil"
 
@@ -1406,7 +1421,7 @@ msgstr "Anlaşılır"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:202
+#: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
 msgstr "Doğrulama"
 
@@ -1470,21 +1485,21 @@ msgstr "MetaBot için bir Slack Bot Kullanıcısı Oluştur"
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Orada bir isim verin ve {0} 'ı tıklayın. Ardından Bot API Tokeni aşağıdaki alana kopyalayıp yapıştırın. İşiniz bittiğinde, Slack'de bir \"metabase_files\" kanalı oluşturun. Metabase, grafikleri yüklemek için buna ihtiyaç duyar."
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:90
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
 msgstr "En yeni ve en büyük olan {0} Metabase'i çalıştırıyorsunuz!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:99
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
 msgstr "{0} metatabase'i kullanılabilir. Siz {1}'i çalıştırıyorsunuz."
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:112
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
 msgstr "Güncelleştirme"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:116
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
 msgstr "Değiştirilenler:"
 
@@ -1497,80 +1512,80 @@ msgstr "Harita ekle"
 msgid "URL"
 msgstr "URL"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:199
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
 msgstr "Özel haritayı sil"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:327
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:40
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:181
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
 msgstr "Kaldır"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:226
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:187
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:241
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:246
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
 msgstr "Seç..."
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:241
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
 msgstr "Örnek değerler:"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
 msgstr "Yeni harita ekle"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
 msgstr "Haritayı düzenle"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:280
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
 msgstr "Bu haritayı çağırmak için ne istersin?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
 msgstr "Örneğin. İngiltere, Brezilya, Mars"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:292
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
 msgstr "Kullanmak istediğiniz GeoJSON dosyasının URL'si"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:298
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
 msgstr "Https://my-mb-server.com/maps/my-map.json  gibi"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:33
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
 msgstr "Yenile"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
 msgstr "Yükle"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:315
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
 msgstr "Bölgenin kimliğini hangi özellik belirler?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:324
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
 msgstr "Hangi özellik bölgenin görünen adını belirtir?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:345
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
 msgstr "Önizlemeyi görmek için bir GeoJSON dosyası yükleyin"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
 msgstr "Haritayı kaydet"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
 msgstr "Harita ekle"
 
@@ -1582,11 +1597,11 @@ msgstr "Yerleştirme kullanma"
 msgid "By enabling embedding you're agreeing to the embedding license located at"
 msgstr "Yerleştirmeyi etkinleştirerek, yerleştirme lisansını kabul etmiş olursunuz."
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:19
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
 msgstr "Sade ingilizce, Kendi uygulamanızda metatabanından grafikler veya gösterge tabloları yerleştirdiğinizde,Bu uygulama Metatabanı'nın geri kalanını kapsayan Affero Genel Kamu Lisansına tabi değildir, eğer Metatabanı logosunu ve bu katıştırılanlarda \"Metatabanıyla Güçlendirildi\" ifadesini saklarsınız. Ancak yukarıda belirtilen lisans metnini okumalısınız. Çünkü özelliği etkinleştirerek kabul edeceğiniz asıl lisans budur."
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:32
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
 msgstr "Etkinleştirme"
 
@@ -1610,25 +1625,25 @@ msgstr "Bir token al"
 msgid "Enter a token"
 msgstr "Bir tokene girin"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:134
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
 msgstr "Eşlemeleri Düzenle"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:140
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
 msgstr "Grup Eşlemeleri"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:147
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
 msgstr "Bir eşleştirme oluşturma"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
 msgstr "Eşlemeler, Metatabanı'nin, dizin sunucusu tarafından sağlanan üyelik bilgilerine göre otomatik olarak grupların kullanıcılarını eklemesine ve kaldırmasına olanak tanır. Admin grubuna üyelik, eşleştirmeler yoluyla verilebilir. Ancak yanlış bir önlem olarak otomatik kaldırılmayacaktır."
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
 msgstr "Ayırt edici adı"
 
@@ -1640,43 +1655,43 @@ msgstr "Genel Bağlantı"
 msgid "Revoke Link"
 msgstr "Bağlantıyı İptal Et"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:121
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
 msgstr "Bu bağlantıyı devre dışı bırak?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:122
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
 msgstr "Artık çalışmazlar ve geri yüklenemezler, ancak yeni bağlantılar oluşturabilirsiniz."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
 msgstr "Genel Gösterge Listesi"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:152
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
 msgstr "Henüz hiçbir pano kullanılmadı."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:160
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
 msgstr "Genel Kart Listesi"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:163
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
 msgstr "Henüz hiç bir soru paylaşılmadı."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:172
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
 msgstr "Gömülü Pano Listeleme"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
 msgstr "Henüz hiçbir gösterge panosu yerleştirilmemiş."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:183
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
 msgstr "Gömülü Kart Listesi"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:184
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
 msgstr "Henüz hiçbir soru yerleştirilmedi."
 
@@ -1697,18 +1712,17 @@ msgid "Generate Key"
 msgstr "Anahtar Üret"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:78
-#: frontend/src/metabase/admin/settings/selectors.js:87
+#: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
 msgstr "Etkin"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:83
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:103
+#: frontend/src/metabase/admin/settings/selectors.js:82
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Engelli"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:116
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
 msgstr "Bilinmeyen ayar {0}"
 
@@ -1716,7 +1730,7 @@ msgstr "Bilinmeyen ayar {0}"
 msgid "Setup"
 msgstr "Kurmak"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
 msgstr "Genel"
@@ -1745,11 +1759,11 @@ msgstr "Varsayılan Veritabanı"
 msgid "Select a timezone"
 msgstr "Bir saat dilimi seçin"
 
-#: frontend/src/metabase/admin/settings/selectors.js:55
+#: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Tüm veritabanları saat dilimlerini desteklemez, bu durumda bu ayar geçerli olmaz."
 
-#: frontend/src/metabase/admin/settings/selectors.js:60
+#: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
 msgstr "Dil"
 
@@ -1757,202 +1771,202 @@ msgstr "Dil"
 msgid "Select a language"
 msgstr "Bir dil seç"
 
-#: frontend/src/metabase/admin/settings/selectors.js:70
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
 msgstr "Anonim İzleme"
 
-#: frontend/src/metabase/admin/settings/selectors.js:75
+#: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
 msgstr "Benzer Tablo ve Alan İsimleri"
 
-#: frontend/src/metabase/admin/settings/selectors.js:81
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Alt çizgi ve tire işaretlerini yalnızca boşluklarla değiştirin"
 
-#: frontend/src/metabase/admin/settings/selectors.js:91
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
 msgstr "İç İçe Sorguları Etkinleştir"
 
-#: frontend/src/metabase/admin/settings/selectors.js:102
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
 msgstr "Güncellemeler"
 
-#: frontend/src/metabase/admin/settings/selectors.js:107
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
 msgstr "Güncellemeleri kontrol et"
 
-#: frontend/src/metabase/admin/settings/selectors.js:118
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
 msgstr "SMTP Ana Bilgisayarı"
 
-#: frontend/src/metabase/admin/settings/selectors.js:126
+#: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
 msgstr "SMTP Bağlantı Noktası"
 
-#: frontend/src/metabase/admin/settings/selectors.js:130
-#: frontend/src/metabase/admin/settings/selectors.js:230
+#: frontend/src/metabase/admin/settings/selectors.js:127
+#: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
 msgstr "Bu geçerli bir bağlantı numarası değil"
 
-#: frontend/src/metabase/admin/settings/selectors.js:134
+#: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
 msgstr "SMTP Güvenliği"
 
-#: frontend/src/metabase/admin/settings/selectors.js:142
+#: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
 msgstr "SMTP Kullanıcı Adı"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
 msgstr "SMTP Şifresi"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
 msgstr "Kimden"
 
-#: frontend/src/metabase/admin/settings/selectors.js:170
+#: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
 msgstr "Slack API Tokeni"
 
-#: frontend/src/metabase/admin/settings/selectors.js:172
+#: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
 msgstr "Slack'ten aldığınız tokeni girin"
 
-#: frontend/src/metabase/admin/settings/selectors.js:189
+#: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
 msgstr "Tek seferlik"
 
-#: frontend/src/metabase/admin/settings/selectors.js:213
+#: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
 msgstr "LDAP Kimlik Doğrulaması"
 
-#: frontend/src/metabase/admin/settings/selectors.js:219
+#: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
 msgstr "LDAP Ana Bilgisayarı"
 
-#: frontend/src/metabase/admin/settings/selectors.js:227
+#: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
 msgstr "LDAP Bağlantı Noktası"
 
-#: frontend/src/metabase/admin/settings/selectors.js:234
+#: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
 msgstr "LDAP Güvenliği"
 
-#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
 msgstr "Kullanıcı adı veya DN"
 
-#: frontend/src/metabase/admin/settings/selectors.js:247
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:188
-#: frontend/src/metabase/user/components/UserSettings.jsx:72
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:191
+#: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
 msgstr "Parola"
 
-#: frontend/src/metabase/admin/settings/selectors.js:252
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "User search base"
 msgstr "Kullanıcı arama tabanı"
 
-#: frontend/src/metabase/admin/settings/selectors.js:258
+#: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
 msgstr "Kullanıcı filtresi"
 
-#: frontend/src/metabase/admin/settings/selectors.js:264
+#: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
 msgstr "Parantezlerinizi kontrol edin"
 
-#: frontend/src/metabase/admin/settings/selectors.js:270
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
 msgstr "Email özelliği"
 
-#: frontend/src/metabase/admin/settings/selectors.js:275
+#: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
 msgstr "İsim niteliği"
 
-#: frontend/src/metabase/admin/settings/selectors.js:280
+#: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
 msgstr "Soyisim niteliği"
 
-#: frontend/src/metabase/admin/settings/selectors.js:285
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
 msgstr "Grup üyeliklerini senkronize et"
 
-#: frontend/src/metabase/admin/settings/selectors.js:291
+#: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
 msgstr "Grup arama tabanı"
 
-#: frontend/src/metabase/admin/settings/selectors.js:300
+#: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
 msgstr "Haritalar"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
 msgstr "Harita yerleştirme URL'si"
 
-#: frontend/src/metabase/admin/settings/selectors.js:306
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase, varsayılan olarak OpenStreetMaps kullanır."
 
-#: frontend/src/metabase/admin/settings/selectors.js:311
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
 msgstr "Özel Haritalar"
 
-#: frontend/src/metabase/admin/settings/selectors.js:312
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Farklı bölge haritası görselleştirmelerini etkinleştirmek için kendi GeoJSON dosyalarınızı ekleyin"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
 msgstr "Genel Paylaşım"
 
-#: frontend/src/metabase/admin/settings/selectors.js:336
+#: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
 msgstr "Genel Paylaşımı Etkinleştir"
 
-#: frontend/src/metabase/admin/settings/selectors.js:341
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
 msgstr "Paylaşılan Panolar"
 
-#: frontend/src/metabase/admin/settings/selectors.js:347
+#: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
 msgstr "Paylaşılan Sorular"
 
-#: frontend/src/metabase/admin/settings/selectors.js:354
+#: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
 msgstr "Diğer Uygulamalarda Yerleştirme"
 
-#: frontend/src/metabase/admin/settings/selectors.js:381
+#: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Metabase'i Diğer Uygulamalara Yerleştirme özelliğini Etkinleştir"
 
-#: frontend/src/metabase/admin/settings/selectors.js:391
+#: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
 msgstr "Gizli anahtarı yerleştirme"
 
-#: frontend/src/metabase/admin/settings/selectors.js:397
+#: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
 msgstr "Yerleşmiş Panolar"
 
-#: frontend/src/metabase/admin/settings/selectors.js:403
+#: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
 msgstr "Yerleşmiş Sorular"
 
-#: frontend/src/metabase/admin/settings/selectors.js:410
+#: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
 msgstr "Önbelleğe alınıyor"
 
-#: frontend/src/metabase/admin/settings/selectors.js:415
+#: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
 msgstr "Önbelleğe almayı etkinleştir"
 
-#: frontend/src/metabase/admin/settings/selectors.js:420
+#: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
 msgstr "Minimum Sorgu Süresi"
 
-#: frontend/src/metabase/admin/settings/selectors.js:427
+#: frontend/src/metabase/admin/settings/selectors.js:424
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Önbellek Zaman-Canlı (TTL) çarpanı"
 
-#: frontend/src/metabase/admin/settings/selectors.js:434
+#: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
 msgstr "Maksimum Önbellek Giriş Boyutu"
 
@@ -1968,11 +1982,11 @@ msgstr "Uyarınız güncellendi."
 msgid "The alert was successfully deleted."
 msgstr "Uyarı başarıyla silindi."
 
-#: frontend/src/metabase/auth/auth.js:33
+#: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
 msgstr "Lütfen geçerli bir e-posta adresi girin."
 
-#: frontend/src/metabase/auth/auth.js:116
+#: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
@@ -2014,90 +2028,87 @@ msgstr "Şifre sıfırlama e-postası gönder"
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Şifrenizi nasıl sıfırlayacağınızla ilgili talimatlar için e-postanızı kontrol edin."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:128
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
 msgstr "Metabase oturumu açın"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:138
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
 msgstr "VEYA"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:157
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
 msgstr "Kullanıcı adı yada e-posta adresi"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:217
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
 msgstr "Oturum aç"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:230
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
 msgstr "Galiba şifremi unuttum"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
 msgstr "yeni bir sıfırlama e-postası iste"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:120
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
 msgstr "Whoops, bağlantı geçerlilik süresi doldu"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:122
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
 msgstr "Güvenlik nedeniyle, şifre sıfırlama bağlantıları bir süre sonra sona erer. Hala şifrenizi sıfırlamanız gerekiyorsa, {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:147
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
 msgstr "Yeni Şifre"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:149
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
 msgstr "Verilerinizi güvende tutmak için, şifreler {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:163
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
 msgstr "Yeni bir şifre oluştur"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:170
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:141
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
 msgstr "Yukarıdaki talimatlar gibi güvenli olduğundan emin olun"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:184
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:150
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
 msgstr "Yeni şifreyi onayla"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:191
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:159
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
 msgstr "Az önce girdiğiniz şifre ile eşleştiğinden emin olun."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:216
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
 msgstr "Şifreniz sıfırlandı."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:222
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:227
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
 msgstr "Yeni şifrenizle giriş yapın"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:182
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:251
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Kayıt başarısız"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:183
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:129
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:225
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:252
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
 msgstr "Kaydedildi"
 
@@ -2105,24 +2116,22 @@ msgstr "Kaydedildi"
 msgid "Ok"
 msgstr "Tamam"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:38
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
 msgstr "Bu koleksiyonu arşivlediniz mi?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:43
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Bu koleksiyondaki panolar, koleksiyonlar ve darbelerde arşivlenecektir."
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
-#: frontend/src/metabase/components/CollectionLanding.jsx:624
+#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: frontend/src/metabase/components/CollectionLanding.jsx:620
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:47
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:195
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:200
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:40
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:53
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
 msgstr "Arşiv"
@@ -2131,28 +2140,27 @@ msgstr "Arşiv"
 msgid "This {0} has been archived"
 msgstr "Bu {0} arşivlendi"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:715
+#: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
 msgstr "Arşivi görüntüle"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:43
+#: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
 msgstr "Bunu arşivden kaldır {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:70
-#: frontend/src/metabase/components/BrowseApp.jsx:132
-#: frontend/src/metabase/components/BrowseApp.jsx:225
+#: frontend/src/metabase/components/BrowseApp.jsx:39
+#: frontend/src/metabase/components/BrowseApp.jsx:102
+#: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
 msgstr "Verilerimiz"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:169
+#: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
 msgstr "X-ışını bu tablo"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:183
-#: frontend/src/metabase/containers/Overworld.jsx:246
+#: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
 msgstr "Bu tablo hakkında bilgi edinin"
 
@@ -2170,31 +2178,31 @@ msgstr "Kaydedildi!"
 msgid "Saving failed."
 msgstr "Kaydedilemedi."
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
 msgstr "Paz"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
 msgstr "Pzt"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
 msgstr "Sal"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
 msgstr "Çar"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
 msgstr "Per"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
 msgstr "Cum"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
 msgstr "Cmt"
 
@@ -2239,61 +2247,61 @@ msgstr "Pulsesler, en son verileri takımınıza e-posta veya gevşeklik aracıl
 msgid "Questions are a saved look at your data."
 msgstr "Sorular, verilerinize kaydedilmiş bir görünümdür."
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:287
+#: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
 msgstr "İğneler"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:341
+#: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
 msgstr "Üstüne sabitlemek için buraya bir şey sürükleyin"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:737
-#: frontend/src/metabase/components/CollectionLanding.jsx:353
-#: frontend/src/metabase/home/containers/SearchApp.jsx:35
-#: frontend/src/metabase/home/containers/SearchApp.jsx:92
+#: frontend/src/metabase/admin/permissions/selectors.js:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:352
+#: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
 msgstr "Koleksiyonlar"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:432
-#: frontend/src/metabase/components/CollectionLanding.jsx:455
+#: frontend/src/metabase/components/CollectionLanding.jsx:431
+#: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
 msgstr "Bu iğneyi kaldırmak için buraya sürükleyin"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:490
+#: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
 msgstr[0] "{0} öğe seçildi"
 msgstr[1] "{0} öğeler seçildi"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:522
+#: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
 msgstr "Öğeleri {0} taşı?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:523
+#: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
 msgstr "\"{0}\" taşı?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:631
+#: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
 msgstr "Taşı"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:692
+#: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
 msgstr "Bu koleksiyonu düzenle"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:700
+#: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
 msgstr "Bu koleksiyonu arşivle"
 
-#: frontend/src/metabase/components/CollectionList.jsx:64
-#: frontend/src/metabase/entities/collections.js:155
+#: frontend/src/metabase/components/CollectionList.jsx:67
+#: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
 msgstr "Kişisel koleksiyonum"
 
-#: frontend/src/metabase/components/CollectionList.jsx:106
+#: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
 msgstr "Yeni koleksiyon"
 
@@ -2301,11 +2309,11 @@ msgstr "Yeni koleksiyon"
 msgid "Copied!"
 msgstr "Kopyalanan!"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:216
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Veritabanı bağlantıları için bir SSH tüneli kullanın"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
@@ -2313,74 +2321,75 @@ msgstr "Bazı veritabanı kurulumlarına sadece bir SSH bastion ana bilgisayarı
 "Bu seçenek ayrıca bir VPN mevcut olmadığında ekstra bir güvenlik katmanı sağlar.\n"
 "Bunu etkinleştirmek genellikle doğrudan bir bağlantıdan daha yavaştır."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:271
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Bu büyük bir veritabanıdır, bu yüzden Metabase senkronize edip tarama yaparken benim seçmeme izin ver"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:273
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Varsayılan olarak, Metabase hafif bir saatlik senkronizasyon ve yoğun bir günlük alan taraması yapar. Büyük bir veritabanınız varsa bunu açmanızı ve alan değeri taramalarının ne zaman ve ne sıklıkta gerçekleştiğini gözden geçirmenizi öneririz."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:289
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} projeniz için bir Müşteri Kimliği ve Müşteri Sırrı oluşturmak "
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:291
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:353
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
 msgstr "Buraya tıklayın"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Uygulama türü olarak \"Diğer\" i seçin. Ne istersen söylemen yeter."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:316
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
 msgstr "Bir kimlik kodu almak için {0}"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:328
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
 msgstr "Google Drive izinleriyle"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:348
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Metabase'i  bu verilerle kullanmak için Google Developers Console'da API erişimini etkinleştirmeniz gerekir."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:351
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "Daha önce yapmadıysanız {0} konsoluna gitmek için."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
 msgstr "Bu veritabanına nasıl başvurmak istersiniz?"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:427
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:237
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:188
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:74
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:194
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:79
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
 msgstr "Sonraki"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:52
+#: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
 msgstr "Bunu sil {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:43
+#: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
 msgstr "Bu öğeyi sabitle"
 
-#: frontend/src/metabase/components/EntityItem.jsx:49
+#: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
 msgstr "Bu öğeyi taşı"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
 msgstr "Bu soruyu düzenle"
 
@@ -2393,6 +2402,7 @@ msgstr "Eylem Türü"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
 msgstr "Düzeltme geçmişini görüntüle"
 
@@ -2408,8 +2418,7 @@ msgstr "Arşiv hareketi"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:329
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:342
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
 msgstr "Gösterge tablosuna ekle"
 
@@ -2433,13 +2442,12 @@ msgstr "Başka bir eylem türü"
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:449
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:454
 msgid "Get alerts about this"
 msgstr "Bununla ilgili uyarılar alın"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
 msgstr "SQL'i görüntüle"
 
@@ -2459,43 +2467,43 @@ msgstr "Tam hata mesajı "
 msgid "Hi, Metabot here."
 msgstr "Merhaba, Metabot burada."
 
-#: frontend/src/metabase/components/ExplorePane.jsx:95
+#: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
 msgstr "Şemaya göre"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:174
+#: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
 msgstr "Ya bir bakiş"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:234
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
 msgstr "Listeyi ara"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:238
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
 msgstr "{0} ile ara"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
 msgstr " veya bir kimlik girin"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
 msgstr "Bir kimlik girin"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
 msgstr "Bir numara giriniz"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:248
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
 msgstr "Bir metin girin"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:355
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
 msgstr "Eşleşen {0} bulunamadı."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:363
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Filtrenizdeki her seçeneği eklemek muhtemelen pek bir şey yapmaz…"
 
@@ -2511,17 +2519,17 @@ msgstr "Bir hatayla karşılaştık. Sayfayı yenilemeyi deneyebilir veya sadece
 #: frontend/src/metabase/components/HeaderBar.jsx:45
 #: frontend/src/metabase/components/ListItem.jsx:37
 #: frontend/src/metabase/reference/components/Detail.jsx:47
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:158
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:213
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:191
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:205
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:209
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:209
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:161
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:216
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:194
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:208
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
 msgstr "Henüz bir açıklama yok"
 
 #: frontend/src/metabase/components/Header.jsx:112
-#: frontend/src/metabase/entities/containers/EntityForm.jsx:43
+#: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
 msgstr "Yeni {0}"
 
@@ -2529,54 +2537,53 @@ msgstr "Yeni {0}"
 msgid "Asked by {0}"
 msgstr "{0} tarafından soruldu"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:13
+#: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
 msgstr "Bugün, ␣"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:15
+#: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
 msgstr "Dün ␣"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:68
+#: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
 msgstr "İlk revizyon."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:70
+#: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
 msgstr "Önceki bir revizyona ve {0} ye  geri alındı"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:82
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:289
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:379
-#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
+#: frontend/src/metabase/components/HistoryModal.jsx:42
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
+#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
 msgstr "Revizyon Geçmişi"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:90
+#: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
 msgstr "Ne zaman"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:91
+#: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
 msgstr "Kim"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:92
+#: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
 msgstr "Ne"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:113
+#: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
 msgstr "Geri almak"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:114
+#: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
 msgstr "Geriye alıyor..."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:115
+#: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
 msgstr "Geri alma başarısız oldu"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:116
+#: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
 msgstr "Geri alındı"
 
@@ -2585,26 +2592,24 @@ msgid "Everything"
 msgstr "Her şey"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
-#: frontend/src/metabase/home/containers/SearchApp.jsx:69
 msgid "Dashboards"
 msgstr "Gösterge tabloları"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
-#: frontend/src/metabase/home/containers/SearchApp.jsx:115
 msgid "Questions"
 msgstr "Sorular"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:321
+#: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
 msgstr "Darbeler"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:103
+#: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
 msgstr "Geri"
 
-#: frontend/src/metabase/components/ListSearchField.jsx:18
+#: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
 msgstr "Bul..."
 
@@ -2641,14 +2646,14 @@ msgid "Temporary Password"
 msgstr "Geçici Parola"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
 msgstr "Gizle"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:412
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
 msgstr "Göster"
 
@@ -2713,7 +2718,7 @@ msgstr "15nci (Orta)"
 msgid "Calendar Day"
 msgstr "Takvim Günü"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:210
+#: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
 msgstr "Metatabanı saat diliminiz"
 
@@ -2742,11 +2747,11 @@ msgid "A component used to make a selection"
 msgstr "Bir seçim yapmak için kullanılan bir bileşen"
 
 #: frontend/src/metabase/components/Select.info.js:20
-#: frontend/src/metabase/components/Select.info.js:28
+#: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
 msgstr "seçilmiş"
 
-#: frontend/src/metabase/components/Select.jsx:297
+#: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
 msgstr "Seçecek bir şey yok"
 
@@ -2759,7 +2764,7 @@ msgid "Unknown error encountered"
 msgstr "Hata oluştu"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/nav/containers/Navbar.jsx:304
+#: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
 msgstr "Oluştur"
 
@@ -2768,13 +2773,11 @@ msgid "Create dashboard"
 msgstr "Dashboard oluştur"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:331
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:60
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
 msgstr "Tablo"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:306
 msgid "Database"
 msgstr "Veritabanı"
 
@@ -2782,22 +2785,20 @@ msgstr "Veritabanı"
 msgid "Creator"
 msgstr "Oluşturucu"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:238
+#: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
 msgstr "Sonuç bulunamadı"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:239
+#: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
 msgstr "Aradığınızı bulmak için filtrenizi ayarlamayı deneyin."
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:258
+#: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
 msgstr "Tarafından görüntüle"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:494
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:84
-#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:69
-#: frontend/src/metabase/tutorial/TutorialModal.jsx:34
+#: frontend/src/metabase/containers/EntitySearch.jsx:495
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
 msgstr "nın"
 
@@ -2810,13 +2811,13 @@ msgid "Once you connect your own data, I can show you some automatic exploration
 msgstr "Kendi verilerinizi bağladıktan sonra, Size x-ışınları denen bazı otomatik keşifler gösterebilirim. Örnek verilerle ilgili bazı örnekler."
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
-#: frontend/src/metabase/containers/Overworld.jsx:299
+#: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
 msgstr "Buradan başlayın"
 
-#: frontend/src/metabase/containers/Overworld.jsx:294
-#: frontend/src/metabase/entities/collections.js:147
+#: frontend/src/metabase/containers/Overworld.jsx:296
+#: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
 msgstr "Analizlerimiz"
@@ -2825,53 +2826,53 @@ msgstr "Analizlerimiz"
 msgid "Browse all items"
 msgstr "Tüm öğelere göz at"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:165
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
 msgstr "Değiştir veya yeni olarak kaydet"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:173
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
 msgstr "Orijinal soruyu değiştir, \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:178
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
 msgstr "Yeni soru olarak kaydet"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:187
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
 msgstr "İlk önce, sorunuzu kaydedin"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:188
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
 msgstr "Soru kaydet"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:224
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
 msgstr "Kartınızın adı nedir?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:232
-#: frontend/src/metabase/entities/collections.js:101
-#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:234
+#: frontend/src/metabase/entities/collections.js:102
+#: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/lib/core.js:50 frontend/src/metabase/lib/core.js:205
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:156
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:211
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:203
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:207
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:207
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:24
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:159
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:214
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:192
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:206
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:210
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
 msgstr "Açıklama"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:238
-#: frontend/src/metabase/entities/dashboards.js:153
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
+#: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
 msgstr "O isteğe bağlı ama, çok yararlı"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:245
-#: frontend/src/metabase/entities/dashboards.js:157
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
+#: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "Bu hangi koleksiyonda olmalı?"
 
@@ -2883,7 +2884,7 @@ msgstr "düzenlendi"
 msgid "item"
 msgstr "madde"
 
-#: frontend/src/metabase/containers/UndoListing.jsx:81
+#: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
 msgstr "Geri alma"
 
@@ -2907,15 +2908,15 @@ msgstr "Bu sorunun uyumlu olup olmadığından emin değiliz."
 msgid "Archive Dashboard"
 msgstr "Arşiv Paneli"
 
-#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:20
+#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Her seri için seçim yaptığınızdan emin olun, veya filtre bu kartta çalışmaz."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:300
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
 msgstr "Bu gösterge paneli boş görünüyor."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:301
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
 msgstr "Kullanmaya başlamak için bir soru ekleyin!"
 
@@ -2935,60 +2936,59 @@ msgstr "Tam ekrandan çık"
 msgid "Enter fullscreen"
 msgstr "Tam ekran yap"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:181
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:183
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Kaydediliyor..."
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:216
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
 msgstr "Bir soru ekle"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:219
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
 msgstr "Bu panele bir soru ekle"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:248
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
 msgstr "Filtre ekle"
 
 #. I don't speak Turkish but this doesn't look right to me.
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:254
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:78
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Parametreler"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:275
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
 msgstr "Bir metin kutusu ekle"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
 msgstr "Gösterge tablosunu taşı"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:302
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
 msgstr "Gösterge tablosunu düzenle"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:306
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
 msgstr "Gösterge Tablosu Düzen tasarımını Düzenle"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:369
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
 msgstr "Bir gösterge tablosunu düzenliyorsunuz"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:374
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
 msgstr "Her kart için filtrelenmesi gereken alanı seçin"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:28
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
 msgstr "Gösterge tablosu taşı .."
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:52
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
 msgstr "Gösterge tablosu {0} konumuna taşındı"
 
@@ -3003,7 +3003,7 @@ msgstr "Ne tür bir filtre?"
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:179
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
 msgstr "Kapat"
 
@@ -3043,174 +3043,174 @@ msgstr "İçinde yenileniyor"
 msgid "Remove this question?"
 msgstr "Bu soruyu kaldırılsın mı?"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:71
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
 msgstr "Paneliniz kadedildi"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:745
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:76
+#: frontend/src/metabase/components/CollectionLanding.jsx:744
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
 msgstr "Bu gör"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:137
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
 msgstr "Bunu kaydet"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:170
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
 msgstr "Hakkında daha fazla göster"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:140
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
 msgstr "Bu kartın, bu parametre türüne eşlenebilecek herhangi bir alanı veya parametresi yoktur."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:142
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Bu alandaki değerler, seçtiğiniz diğer alanların değerleriyle örtüşmez."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:186
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
 msgstr "Geçerli alan yok"
 
-#: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
 msgstr "İsim 100 karakter veya daha az olmalı"
 
-#: frontend/src/metabase/entities/collections.js:111
+#: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
 msgstr "Renk gereklidir"
 
-#: frontend/src/metabase/entities/dashboards.js:146
+#: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
 msgstr "Gösterge tablonuzun adı nedir?"
 
-#: frontend/src/metabase/home/components/Activity.jsx:92
+#: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
 msgstr "tanımlamak zor bazı süper müthiş şeyler yaptım"
 
-#: frontend/src/metabase/home/components/Activity.jsx:101
-#: frontend/src/metabase/home/components/Activity.jsx:116
+#: frontend/src/metabase/home/components/Activity.jsx:103
+#: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
 msgstr "-␣ hakkında bir uyarı oluşturuldu"
 
-#: frontend/src/metabase/home/components/Activity.jsx:126
-#: frontend/src/metabase/home/components/Activity.jsx:141
+#: frontend/src/metabase/home/components/Activity.jsx:128
+#: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
 msgstr "-alert hakkında bir uyarı silindi"
 
-#: frontend/src/metabase/home/components/Activity.jsx:152
+#: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
 msgstr "hakkında bir soru kaydedildi␣"
 
-#: frontend/src/metabase/home/components/Activity.jsx:165
+#: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
 msgstr "bir soru kaydedildi"
 
-#: frontend/src/metabase/home/components/Activity.jsx:169
+#: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
 msgstr "bir soru silindi"
 
-#: frontend/src/metabase/home/components/Activity.jsx:172
+#: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
 msgstr "bir gösterge tablolsu oluşturuldu"
 
-#: frontend/src/metabase/home/components/Activity.jsx:175
+#: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
 msgstr "bir gösterge tablosu silindi"
 
-#: frontend/src/metabase/home/components/Activity.jsx:181
-#: frontend/src/metabase/home/components/Activity.jsx:196
+#: frontend/src/metabase/home/components/Activity.jsx:183
+#: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
 msgstr "gösterge tablosuna bir soru ekledi"
 
-#: frontend/src/metabase/home/components/Activity.jsx:206
-#: frontend/src/metabase/home/components/Activity.jsx:221
+#: frontend/src/metabase/home/components/Activity.jsx:208
+#: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
 msgstr "gösterge tablosundan bir soru kaldırıldı"
 
-#: frontend/src/metabase/home/components/Activity.jsx:231
-#: frontend/src/metabase/home/components/Activity.jsx:238
+#: frontend/src/metabase/home/components/Activity.jsx:233
+#: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
 msgstr "en son veri alındı"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:621
-#: frontend/src/metabase/home/components/Activity.jsx:244
+#: frontend/src/metabase-lib/lib/Dimension.js:814
+#: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
 msgstr "Bilinmeyen"
 
-#: frontend/src/metabase/home/components/Activity.jsx:251
+#: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
 msgstr "Merhaba Dünya!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:252
+#: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
 msgstr "Metabase aktif ve çalışıyor."
 
-#: frontend/src/metabase/home/components/Activity.jsx:258
-#: frontend/src/metabase/home/components/Activity.jsx:288
+#: frontend/src/metabase/home/components/Activity.jsx:260
+#: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
 msgstr "metriği ekledi"
 
-#: frontend/src/metabase/home/components/Activity.jsx:272
-#: frontend/src/metabase/home/components/Activity.jsx:362
+#: frontend/src/metabase/home/components/Activity.jsx:274
+#: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
 msgstr "␣ya␣"
 
-#: frontend/src/metabase/home/components/Activity.jsx:282
-#: frontend/src/metabase/home/components/Activity.jsx:322
-#: frontend/src/metabase/home/components/Activity.jsx:372
-#: frontend/src/metabase/home/components/Activity.jsx:413
+#: frontend/src/metabase/home/components/Activity.jsx:284
+#: frontend/src/metabase/home/components/Activity.jsx:324
+#: frontend/src/metabase/home/components/Activity.jsx:374
+#: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
 msgstr "␣tablo"
 
-#: frontend/src/metabase/home/components/Activity.jsx:298
-#: frontend/src/metabase/home/components/Activity.jsx:328
+#: frontend/src/metabase/home/components/Activity.jsx:300
+#: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
 msgstr "metrikte değişiklik yaptı"
 
-#: frontend/src/metabase/home/components/Activity.jsx:312
-#: frontend/src/metabase/home/components/Activity.jsx:403
+#: frontend/src/metabase/home/components/Activity.jsx:314
+#: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
 msgstr "␣içinde␣"
 
-#: frontend/src/metabase/home/components/Activity.jsx:335
+#: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
 msgstr "Metriği kaldırdı"
 
-#: frontend/src/metabase/home/components/Activity.jsx:338
+#: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
 msgstr "darbe kuruldu"
 
-#: frontend/src/metabase/home/components/Activity.jsx:341
+#: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
 msgstr "darbe silindi"
 
-#: frontend/src/metabase/home/components/Activity.jsx:347
-#: frontend/src/metabase/home/components/Activity.jsx:378
+#: frontend/src/metabase/home/components/Activity.jsx:349
+#: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
 msgstr "filtreyi ekledi"
 
-#: frontend/src/metabase/home/components/Activity.jsx:388
-#: frontend/src/metabase/home/components/Activity.jsx:419
+#: frontend/src/metabase/home/components/Activity.jsx:390
+#: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
 msgstr "filtrede değişiklikler yapıldı"
 
-#: frontend/src/metabase/home/components/Activity.jsx:426
+#: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
 msgstr "{0} filtresini kaldırdı"
 
-#: frontend/src/metabase/home/components/Activity.jsx:429
+#: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
 msgstr "katıldı!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:529
+#: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
 msgstr "Hmmm, henüz hiçbir şey olmamış gibi görünüyor."
 
-#: frontend/src/metabase/home/components/Activity.jsx:532
+#: frontend/src/metabase/home/components/Activity.jsx:534
 msgid "Save a question and get this baby going!"
 msgstr "Soruyu kaydet ve kapat."
 
@@ -3258,21 +3258,21 @@ msgstr "Son Görüntülenen"
 msgid "You haven't looked at any dashboards or questions recently"
 msgstr "Son zamanlarda hiç gösterge tablosuna veya sorusuna bakmadınız"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:99
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
 msgstr "{0} öğe seçildi"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:121
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:172
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
 msgstr "Arşivden Çıkar"
 
-#: frontend/src/metabase/home/containers/HomepageApp.jsx:74
-#: frontend/src/metabase/nav/containers/Navbar.jsx:331
+#: frontend/src/metabase/home/containers/HomepageApp.jsx:77
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
 msgstr "Aktivite"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:28
+#: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
 msgstr "\"{0}\" için sonuçlar"
 
@@ -3337,6 +3337,7 @@ msgstr "Avatar Resmi URL'si"
 msgid "Common"
 msgstr "Genel"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
@@ -3373,8 +3374,9 @@ msgstr "Enlem"
 msgid "Longitude"
 msgstr "Boylam"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:149
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
 msgstr "Numara"
@@ -3471,7 +3473,7 @@ msgstr "Gol"
 
 #: frontend/src/metabase/lib/core.js:210
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:17
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
 msgstr "Başlık"
 
@@ -3528,8 +3530,9 @@ msgid "Metabase will never retrieve this field. Use this for sensitive or irrele
 msgstr "Metatabanı bu alanı asla alamaz. Hassas veya alakasız bilgiler için bunu kullanın."
 
 #: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:614
-#: frontend/src/metabase/visualizations/lib/utils.js:126
+#: frontend/src/metabase/lib/query.js:300
+#: frontend/src/metabase/visualizations/lib/utils.js:130
+#: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -3544,7 +3547,7 @@ msgstr "Kümülatif Sayım"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
-#: frontend/src/metabase/visualizations/lib/utils.js:127
+#: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
 msgstr "Toplam"
 
@@ -3553,7 +3556,7 @@ msgid "CumulativeSum"
 msgstr "KümülatifToplam"
 
 #: frontend/src/metabase/lib/expressions/config.js:11
-#: frontend/src/metabase/visualizations/lib/utils.js:128
+#: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
 msgstr "Farklı"
 
@@ -3562,35 +3565,35 @@ msgid "StandardDeviation"
 msgstr "Standart Sapma"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/visualizations/lib/utils.js:125
+#: frontend/src/metabase/visualizations/lib/utils.js:129
 msgid "Average"
 msgstr "Ortalama"
 
 #: frontend/src/metabase/lib/expressions/config.js:14
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:25
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
 msgstr "Min"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
 msgstr "Maksimum"
 
-#: frontend/src/metabase/lib/expressions/parser.js:384
+#: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
 msgstr "çok üzgün panda, lexing hataları tespit edildi"
 
-#: frontend/src/metabase/lib/formatting.js:707
+#: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} saniye"
 msgstr[1] "{0} saniyeler"
 
-#: frontend/src/metabase/lib/formatting.js:710
+#: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} dakika"
@@ -3629,222 +3632,224 @@ msgstr "Aklından ne geçiyor?"
 msgid "What do you want to find out?"
 msgstr "Ne öğrenmek istiyorsun?"
 
-#: frontend/src/metabase/lib/query.js:612
-#: frontend/src/metabase/lib/schema_metadata.js:451
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:246
+#: frontend/src/metabase/lib/query.js:298
+#: frontend/src/metabase/lib/schema_metadata.js:458
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
 msgstr "İşlenmemiş veri"
 
-#: frontend/src/metabase/lib/query.js:616
+#: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
 msgstr "Birikimli sayım"
 
-#: frontend/src/metabase/lib/query.js:619
+#: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
 msgstr "Ortalama ␣"
 
-#: frontend/src/metabase/lib/query.js:624
+#: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
 msgstr "Farklı değerler"
 
-#: frontend/src/metabase/lib/query.js:629
+#: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
 msgstr "Standart sapma␣"
 
-#: frontend/src/metabase/lib/query.js:634
+#: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
 msgstr "...nın Toplamı"
 
-#: frontend/src/metabase/lib/query.js:639
+#: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
 msgstr "... Toplam kümülatif toplamı"
 
-#: frontend/src/metabase/lib/query.js:644
+#: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
 msgstr "...nın Maksimumu"
 
-#: frontend/src/metabase/lib/query.js:649
+#: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
 msgstr "...nın Minimumu"
 
-#: frontend/src/metabase/lib/query.js:663
+#: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
 msgstr "Tarafından gruplandırıldı"
 
-#: frontend/src/metabase/lib/query.js:677
+#: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
 msgstr "Tarafından filtrelendi"
 
-#: frontend/src/metabase/lib/query.js:706
+#: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
 msgstr "Tarafından sıralandı"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
 msgstr "Doğru"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
 msgstr "Yanlış"
 
-#: frontend/src/metabase/lib/schema_metadata.js:305
+#: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
 msgstr "Boylam alanını seç"
 
-#: frontend/src/metabase/lib/schema_metadata.js:306
+#: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
 msgstr "Üstteki enlemi girin"
 
-#: frontend/src/metabase/lib/schema_metadata.js:307
+#: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
 msgstr "Sol boylamı giriniz"
 
-#: frontend/src/metabase/lib/schema_metadata.js:308
+#: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
 msgstr "Daha düşük enlem girin"
 
-#: frontend/src/metabase/lib/schema_metadata.js:309
+#: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
 msgstr "Doğru boylamı giriniz"
 
-#: frontend/src/metabase/lib/schema_metadata.js:345
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase-lib/lib/Dimension.js:505
+#: frontend/src/metabase-lib/lib/Dimension.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:351
+#: frontend/src/metabase/lib/schema_metadata.js:371
 #: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:387
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
 msgstr "ise"
 
-#: frontend/src/metabase/lib/schema_metadata.js:346
-#: frontend/src/metabase/lib/schema_metadata.js:366
-#: frontend/src/metabase/lib/schema_metadata.js:376
-#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/lib/schema_metadata.js:352
+#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:396
+#: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
 msgstr "Değil"
 
-#: frontend/src/metabase/lib/schema_metadata.js:347
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:369
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:353
+#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
 msgstr "boş"
 
-#: frontend/src/metabase/lib/schema_metadata.js:348
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:370
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:402
+#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
 msgstr "boş değil"
 
-#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
 msgstr "Eşittir"
 
-#: frontend/src/metabase/lib/schema_metadata.js:355
+#: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
 msgstr "Eşit değil"
 
-#: frontend/src/metabase/lib/schema_metadata.js:356
+#: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
 msgstr "den daha büyük"
 
-#: frontend/src/metabase/lib/schema_metadata.js:357
+#: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
 msgstr "Den daha küçük"
 
-#: frontend/src/metabase/lib/schema_metadata.js:358
-#: frontend/src/metabase/lib/schema_metadata.js:384
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:285
+#: frontend/src/metabase/lib/schema_metadata.js:364
+#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Arasında"
 
-#: frontend/src/metabase/lib/schema_metadata.js:359
+#: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
 msgstr "Den daha büyük veya eşit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:360
+#: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
 msgstr "Den daha az veya eşit"
 
-#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
 msgstr "İçerir"
 
-#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
 msgstr "İçermez"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
 msgstr "İle başlar"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
 msgstr "İle biter"
 
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:264
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Önce"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:271
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Sonra"
 
-#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
 msgstr "içeride"
 
-#: frontend/src/metabase/lib/schema_metadata.js:453
+#: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Sadece cevapta satırları olan bir tablo, ek işlem yok."
 
-#: frontend/src/metabase/lib/schema_metadata.js:459
+#: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
 msgstr "Satır sayısı"
 
-#: frontend/src/metabase/lib/schema_metadata.js:461
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
 msgstr "Yanıttaki toplam satır sayısı."
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
 msgstr "...nın Toplamı "
 
-#: frontend/src/metabase/lib/schema_metadata.js:469
+#: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
 msgstr "Bir sütunun tüm değerlerinin toplamı."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
 msgstr "...nın Ortalaması"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
 msgstr "Bir sütunun tüm değerlerinin ortalaması"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
 msgstr "...nın Farklı değerlerin sayısı"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Yanıttaki tüm satırlar arasında bir sütunun benzersiz değerlerinin sayısı."
 
-#: frontend/src/metabase/lib/schema_metadata.js:491
+#: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
 msgstr "...nın Birikmiş toplam "
 
@@ -3852,7 +3857,7 @@ msgstr "...nın Birikmiş toplam "
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Bir sütunun tüm değerlerinin toplamı. \\\\ ne.x. Zaman içinde toplam gelir."
 
-#: frontend/src/metabase/lib/schema_metadata.js:499
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
 msgstr "Kümülatif satır sayısı"
 
@@ -3860,105 +3865,105 @@ msgstr "Kümülatif satır sayısı"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Satırların sayısının toplam sayısı. \\\\ ne.x. Zaman içinde toplam satış sayısı."
 
-#: frontend/src/metabase/lib/schema_metadata.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
 msgstr "Standart sapma ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:509
+#: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Bir sütunun değerlerinin ne kadarının cevabın tüm satırları arasında değiştiğini ifade eden sayı."
 
-#: frontend/src/metabase/lib/schema_metadata.js:515
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
 msgstr "Minimum ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:517
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
 msgstr "Bir sütunun minimum değeri"
 
-#: frontend/src/metabase/lib/schema_metadata.js:523
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
 msgstr "Maksimum ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:525
+#: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
 msgstr "Bir sütunun maksimum değeri"
 
-#: frontend/src/metabase/lib/schema_metadata.js:533
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
 msgstr "Ölçüye göre ayrıl"
 
-#: frontend/src/metabase/lib/settings.js:93
+#: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
 msgstr "küçük harf"
 
-#: frontend/src/metabase/lib/settings.js:95
+#: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
 msgstr "büyük harf"
 
-#: frontend/src/metabase/lib/settings.js:97
+#: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "numara"
 
-#: frontend/src/metabase/lib/settings.js:99
+#: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
 msgstr "özel karakter"
 
-#: frontend/src/metabase/lib/settings.js:105
+#: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
 msgstr "olmalıdır"
 
-#: frontend/src/metabase/lib/settings.js:105
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:120
+#: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
 msgstr "karakter uzunluğu"
 
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
 msgstr "Olmalıdır"
 
-#: frontend/src/metabase/lib/settings.js:122
+#: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
 msgstr "ve dahil"
 
-#: frontend/src/metabase/lib/utils.js:92
+#: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
 msgstr "sıfır"
 
-#: frontend/src/metabase/lib/utils.js:93
+#: frontend/src/metabase/lib/utils.js:86
 msgid "one"
 msgstr "bir"
 
-#: frontend/src/metabase/lib/utils.js:94
+#: frontend/src/metabase/lib/utils.js:87
 msgid "two"
 msgstr "iki"
 
-#: frontend/src/metabase/lib/utils.js:95
+#: frontend/src/metabase/lib/utils.js:88
 msgid "three"
 msgstr "üç"
 
-#: frontend/src/metabase/lib/utils.js:96
+#: frontend/src/metabase/lib/utils.js:89
 msgid "four"
 msgstr "dört"
 
-#: frontend/src/metabase/lib/utils.js:97
+#: frontend/src/metabase/lib/utils.js:90
 msgid "five"
 msgstr "beş"
 
-#: frontend/src/metabase/lib/utils.js:98
+#: frontend/src/metabase/lib/utils.js:91
 msgid "six"
 msgstr "altı"
 
-#: frontend/src/metabase/lib/utils.js:99
+#: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
 msgstr "yedi"
 
-#: frontend/src/metabase/lib/utils.js:100
+#: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
 msgstr "sekiz"
 
-#: frontend/src/metabase/lib/utils.js:101
+#: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
 msgstr "dokuz"
 
@@ -4032,6 +4037,7 @@ msgstr "Zaman"
 msgid "Date range, relative date, time of day, etc."
 msgstr "Tarih aralığı, göreli tarih, günün saati vb."
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
@@ -4054,7 +4060,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Kategori, Tip, Model, Değerlendirme, vb."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
-#: frontend/src/metabase/user/components/UserSettings.jsx:54
+#: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
 msgstr "Hesap ayarları"
 
@@ -4066,56 +4072,56 @@ msgstr "Çıkış yöneticisi"
 msgid "Logs"
 msgstr "Kayıtlar"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:64
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
 msgstr "Yardım et"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:67
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
 msgstr "Metatabanı Hakkında"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:73
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
 msgstr "Oturumu Kapat"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:98
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
 msgstr "Kullandığınız için teşekkürler"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
 msgstr "Versiyondasın"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
 msgstr "Üzerine inşa"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:124
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
 msgstr "bir Ticari markasıdır"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:126
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
 msgstr "ve San Francisco, CA'da özenle inşa edilmiştir"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:194
+#: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
 msgstr "Metabase Yöneticisi"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:300
+#: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
 msgstr "Bir soru sor"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:309
+#: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
 msgstr "Yeni gösterge Paneli"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:315
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/nav/containers/Navbar.jsx:361
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
 msgstr "Yeni arama"
 
@@ -4123,16 +4129,16 @@ msgstr "Yeni arama"
 msgid "Reference"
 msgstr "Referans"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:83
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
 msgstr "Hangi metrik?"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:110
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Ekibiniz için ortak metrikler tanımlamak, soru sormayı daha da kolaylaştırır"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:113
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
 msgstr "Metrikler nasıl oluşturulur?"
 
@@ -4144,8 +4150,8 @@ msgstr "Eğilimleri veya değişiklikleri anlamanıza yardımcı olacak şekilde
 msgid "Custom"
 msgstr "Özel"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:150
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:517
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
 msgstr "Yeni soru"
 
@@ -4153,22 +4159,22 @@ msgstr "Yeni soru"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Trendleri, listelerin listesini görmek veya kendi metriklerinizi oluşturmak için basit soru oluşturucuyu kullanın."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:161
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Yerel sorgu"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:162
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Daha karmaşık sorular için, kendi SQL veya yerel sorgunuzu yazabilirsiniz."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:240
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
 msgstr "Bir varsayılan değer seç…"
 
-#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:149
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
 msgstr "Filtreyi güncelle"
 
@@ -4176,14 +4182,14 @@ msgstr "Filtreyi güncelle"
 #: frontend/src/metabase/lib/query_time.js:123
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:9
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Today"
 msgstr "Bugün"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
 msgstr "Dün"
 
@@ -4195,7 +4201,7 @@ msgstr " Geçmiş 7 gün "
 msgid "Past 30 days"
 msgstr "Geçmiş 30 gün "
 
-#: frontend/src/metabase/lib/query_time.js:195
+#: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:29
 #: src/metabase/api/table.clj
@@ -4204,7 +4210,7 @@ msgid_plural "Weeks"
 msgstr[0] "Hafta"
 msgstr[1] "Haftalar"
 
-#: frontend/src/metabase/lib/query_time.js:197
+#: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:30
 #: src/metabase/api/table.clj
@@ -4213,7 +4219,7 @@ msgid_plural "Months"
 msgstr[0] "Ay"
 msgstr[1] "Aylar"
 
-#: frontend/src/metabase/lib/query_time.js:201
+#: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:31
 #: src/metabase/api/table.clj
@@ -4263,6 +4269,7 @@ msgstr "Bir değer girin ..."
 msgid "Enter a default value..."
 msgstr "Varsayılan bir değer girin ..."
 
+#: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Bir hata oluştu"
@@ -4303,24 +4310,24 @@ msgstr "Yayınla"
 msgid "Code"
 msgstr "Kod"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:70
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
 msgstr "Stil"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
 msgstr "Bu gömülünün kullanıcıları hangi parametreleri kullanabilir?"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:83
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
 msgstr "Bu {0} henüz yapılandırılmamış parametreler içermiyor."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
 msgstr "Düzenlenebilir"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
 msgstr "Kilitli"
 
@@ -4328,19 +4335,19 @@ msgstr "Kilitli"
 msgid "Preview Locked Parameters"
 msgstr "Kilitli Parametrelerin Önizle"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:115
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
 msgstr "Bazı değerleri burada kilitli parametrelerinize geçirmeyi deneyin. Sunucumuz, bunu gerçek için kullanırken gerçek değerleri imzalı tokenin içinde vermek zorundadır."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
 msgstr "Tehlikeli bölge"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
 msgstr "Bu, bu {0} için gömülmeyi devre dışı bırakacaktır."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:128
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
 msgstr "Yayından Kaldır"
 
@@ -4380,64 +4387,64 @@ msgstr "Daha fazla {0}"
 msgid "examples on GitHub"
 msgstr "GitHub'daki örnekler"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:72
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
 msgstr "Paylaşımı etkinleştir"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
 msgstr "Bu genel bağlantıyı devre dışı bırakılsın mı?"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:77
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
 msgstr "Bu, mevcut bağlantının çalışmayı durdurmasına neden olur. Bunu yeniden etkinleştirebilirsiniz, ancak yaptığınız zaman farklı bir bağlantı olacaktır."
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
 msgstr "Genel bağlantı"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:118
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
 msgstr "Aşağıdaki {}}, aşağıdaki URL'yi kullanarak Metabase hesabına sahip olmayan kişilerle paylaşın:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:158
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
 msgstr "Genel gömmek"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:159
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
 msgstr "Bu snippet'i kopyalayıp yapıştırarak bunu {0} blog yayınlarına veya web sayfalarına ekleyin:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:176
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
 msgstr "Bu {0} uygulamasını bir uygulamaya gömün"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:177
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
 msgstr "Uygulama sunucusu kodunuza entegre ederek, Belirli bir kullanıcı, müşteri, kuruluş vb. ile sınırlı {0} güvenli bir istatistik sağlayabilirsiniz."
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
 msgstr "Eki kaldır"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:95
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
 msgstr "Dosyayı sonuçlarla ekle"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
 msgstr "Bu soru dosya eki olarak eklenecek"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:128
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
 msgstr "Bu soru, Aramaya dahil edilmeyecek"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:92
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
 msgstr "Bu arama artık {0} {1} adresine e-postayla gönderilmeyecek"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:94
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:376
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
 msgstr[0] "{0} adres"
@@ -4447,39 +4454,39 @@ msgstr[1] "{0} adresler"
 msgid "Slack channel {0} will no longer get this pulse {1}"
 msgstr "Boş kanal {0} artık bu darbeyi {1} almayacak"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:110
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
 msgstr "{0} kanalı artık bu aramayı {1} almayacak"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
 msgstr "Aramayı düzenle"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:131
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
 msgstr "Arama nedir?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:141
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
 msgstr "Anladım"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
 msgstr "Bu veriler nereye gitmeli?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:173
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
 msgstr "Arşivden çıkarılıyor ..."
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
 msgstr "Arşivden kaldırılamadı"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
 msgstr "Arşivlenmedi"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
 msgstr "Arama oluştur"
 
@@ -4489,7 +4496,7 @@ msgstr "Ek dosya"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:673
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
 msgstr "Dikkat et"
 
@@ -4510,6 +4517,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Bakliyatları küçük ve odaklanmış halde tutmanızı ve çalışabilmesini ve tüm ekip için faydalı olmasını sağlamanızı öneririz."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
+#: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
 msgstr "Verilerinizi seçin"
 
@@ -4525,47 +4533,47 @@ msgstr "E-postalar"
 msgid "Slack messages"
 msgstr "Slack mesajları"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Gönderilen"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:222
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} adresine gönderilecek"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:224
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Mesajlar"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Şimdi e-posta gönder"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:241
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Şimdi {0} adresine gönder"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Gönderiliyor ..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:244
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Gönderim başarısız"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Gönderme yapılmadı çünkü arama hiçbir sonuç vermedi."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:248
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Arama gönderildi"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:287
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} bir yönetici tarafından kurulmalıdır."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:302
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
 msgstr "Gevşek"
 
@@ -4614,21 +4622,21 @@ msgid "Before {0}"
 msgstr "{0} den önce"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:295
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Boş"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:301
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Boş değil"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:213
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Her zaman"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:154
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
 msgstr "Uygulamak"
 
@@ -4694,7 +4702,7 @@ msgstr "Dağıtım"
 msgid "View details"
 msgstr "Detayları göster"
 
-#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:54
+#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
 msgstr " {0}'in{1}'ni görüntüle "
 
@@ -4718,22 +4726,22 @@ msgstr "Ort"
 msgid "Distincts"
 msgstr "Farklar"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:32
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "{0}'ni görüntüle "
 msgstr[1] "{0}ları görüntüle"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:225
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
 msgstr "Yakınlaştır"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:19
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
 msgstr "Özel ifade"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
 msgstr "Genel Metrikler"
 
@@ -4741,7 +4749,7 @@ msgstr "Genel Metrikler"
 msgid "Metabasics"
 msgstr "Matabazitlerin"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
 msgstr "İsim: (İsteğe bağlı)"
 
@@ -4753,31 +4761,31 @@ msgstr "Bir toplama seçin"
 msgid "Set up your own alert"
 msgstr "Kendi uyarınızı ayarlayın"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:140
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
 msgstr "Abonelik Kaldırma ..."
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:145
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
 msgstr "Abonelikten çıkamadı"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:204
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
 msgstr "Aboneliğini"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:235
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
 msgstr "Kanal yok"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:263
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
 msgstr "Tamam, abonelikten çıktın"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:335
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
 msgstr "{0} adlı kullanıcının uyarılarını alıyorsunuz"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
 msgstr "{0} bir uyarı oluştur"
 
@@ -4833,147 +4841,147 @@ msgstr "Uyarınızı düzenleyin"
 msgid "Edit alert"
 msgstr "Uyarıyı düzenle"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:374
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
 msgstr "Bu uyarı artık {0} adresine e-postayla gönderilmeyecek."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:382
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
 msgstr "Slack kanalı {0} artık bu uyarıyı almayacak."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:386
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
 msgstr "Kanal {0} artık bu uyarıyı almayacak."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:403
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
 msgstr "Bu uyarıyı sil"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:405
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
 msgstr "Teslim işlemini durdurun ve bu uyarıyı silin. Geri alma yok, o yüzden dikkatli ol."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:413
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
 msgstr "Bu uyarıyı silinsin mi?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:497
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
 msgstr "Satırdayken beni uyar..."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:498
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
 msgstr "İlerleme çubuğuda beni uyar."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
 msgstr "Gol çizgisinin üzerinde gider"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
 msgstr "Hedefe ulaşır"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
 msgstr "Gol çizgisinin altına gider"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
 msgstr "Hedefin altında gider"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:512
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
 msgstr "İlk kez mi geçiyor, ya da her seferinde mi?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:513
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
 msgstr "İlk defa hedefe mi, yoksa her sefere mi?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
 msgstr "İlk defa"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:516
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
 msgstr "Her zaman"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:619
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
 msgstr "Bu uyarıları nereye göndermek istersiniz?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:630
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
 msgstr "E-posta uyarıları:"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:672
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
 msgstr "{0} Birden fazla satıra sahip grafikler için hedef tabanlı uyarılar henüz desteklenmiyor, Bu nedenle, grafik {1} olduğunda bu uyarı gönderilir."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
 msgstr "sonuçlar"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:679
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
 msgstr "{0} Bu tür bir uyarı, kaydedilen sorunuzu {1} herhangi bir sonuç döndürmediğinde en yararlı olanıdır, ama ne zaman olduğunu bilmek istiyorsun."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:680
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
 msgstr "Tür"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
 msgstr "genellikle"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:57
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
 msgstr "Bir segment veya tablo seçin"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
 msgstr "Bir veritabanı seç"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:88
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
 msgstr "Seç ..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:128
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
 msgstr "Tablo seç"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:793
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
 msgstr "Bu veritabanında hiçbir tablo bulunamadı."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:830
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
 msgstr "Eksik bir soru mu var?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:834
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
 msgstr "Yuvalanmış sorgular hakkında daha fazla bilgi edinin."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:868
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
 msgstr "Alanlar"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:946
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
 msgstr "Segment bulunamadı."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:969
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
 msgstr "Bir segment bul"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:46
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
 msgstr "Daha azını görüntüle"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:56
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
 msgstr "Daha fazla göster"
 
@@ -4982,60 +4990,65 @@ msgid "Pick a field to sort by"
 msgstr "Sıralamak için bir alan seçin"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
 msgstr "Çeşit"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
 msgstr "Satır sınırı"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:69
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
 msgstr "Bilinmeyen Alan"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
 msgstr "alan"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:114
+#: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
 msgstr "Maçlar"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
+#: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Cevabınızı daraltmak için filtreler ekleyin"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:284
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
 msgstr "Bir gruplama ekle"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:322
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:102
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:113
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:152
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:194
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:59
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:68
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:75
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:225
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:231
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:237
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:70
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:75
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:64
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:89
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:131
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:176
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:302
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:308
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:314
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Veri"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:352
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
 msgstr "Tarafından filtrelenmiş"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:369
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
 msgstr "Görünüm"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:386
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
 msgstr "Tarafından gruplandırılmış"
 
@@ -5043,23 +5056,23 @@ msgstr "Tarafından gruplandırılmış"
 msgid "None"
 msgstr "Yok"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:345
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
 msgstr "Bu soru {0} ile yazılmıştır."
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:353
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
 msgstr "Düzenleyiciyi Gizle"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:354
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
 msgstr "Sorguyu Gizle"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
 msgstr "Editör'ü Aç"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:360
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
 msgstr "Sorguyu Göster"
 
@@ -5080,15 +5093,15 @@ msgstr "Bu verileri indir"
 msgid "Warning"
 msgstr "Uyarı"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:52
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
 msgstr "Cevabınız çok sayıda satır içeriyor, bu yüzden indirilmesi biraz zaman alabilir."
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:53
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
 msgstr "Maksimum indirme boyutu 1 milyon satırdır."
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:232
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
 msgstr "Soruyu düzenle"
 
@@ -5104,17 +5117,17 @@ msgstr "İPTAL ETMEK"
 msgid "Move question"
 msgstr "Soru taşı"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:283
+#: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
 msgstr "Which collection should this be in?"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:313
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:110
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
+#: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
 msgstr "Değişkenler"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:432
+#: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
 msgstr "Verileriniz hakkında bilgi edinin"
 
@@ -5158,11 +5171,11 @@ msgstr "Bu soru için {0}"
 msgid "Convert this question to {0}"
 msgstr "Bu soruyu {0} olarak çevir"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:122
+#: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
 msgstr "Bu soru, yenilemek için yaklaşık {0} sürecek"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:131
+#: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
 msgstr "{0} güncellendi"
 
@@ -5180,11 +5193,11 @@ msgstr "İlk önce gösterilen {0} {1}"
 msgid "Showing {0} {1}"
 msgstr "{0} {1} gösteriliyor"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:281
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
 msgstr "İşleniyor"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:294
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
 msgstr "Bana biraz veri verirsen sana güzel bir şey gösterebilirim. Bir Sorguyu Çalıştırın!"
 
@@ -5192,7 +5205,7 @@ msgstr "Bana biraz veri verirsen sana güzel bir şey gösterebilirim. Bir Sorgu
 msgid "How do I use this thing?"
 msgstr "Bu şeyi nasıl kullanırım?"
 
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:28
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
 msgstr "Cevap almak"
 
@@ -5220,39 +5233,39 @@ msgstr "Afedersiniz. Bir şeyler yanlış gitti."
 msgid "Group time by"
 msgstr "Grup zamanı"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:46
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
 msgstr "Senin sorunun çok uzun sürdü"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:47
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
 msgstr "Veritabanından zamanında cevap alamadık, bu yüzden durmak zorunda kaldık. Bir dakika sonra tekrar deneyebilirsin, ya da problem devam ederse, bir yöneticiye bildirmek için e-posta gönderebilirsiniz."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:55
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
 msgstr "Sunucu sorunları yaşıyoruz"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:56
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
 msgstr "Bir ya da iki dakika bekledikten sonra sayfayı yenilemeyi deneyin. Sorun devam ederse, bir yöneticiye başvurmanızı öneririz."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:88
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
 msgstr "Sorunuzla ilgili bir sorun oluştu"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:89
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
 msgstr "Çoğu zaman geçersiz seçim veya kötü giriş değeri neden olur. Girişlerinizi iki kez kontrol edin ve sorgunuzu tekrar deneyin."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:60
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
 msgstr "Aradığınız cevap bu olabilir. Aksi halde, filtrelerinizi daha az spesifik hale getirmek için kaldırmayı veya değiştirmeyi deneyin."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
 msgstr "Bazı sonuçlar olduğunda {0} da yapabilirsiniz."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:68
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
 msgstr "bir uyarı al"
 
@@ -5260,11 +5273,11 @@ msgstr "bir uyarı al"
 msgid "Back to last run"
 msgstr "Son koşuya dönüş"
 
-#: frontend/src/metabase/query_builder/components/VisualizationSettings.jsx:100
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
 msgstr "Görüntüleme"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:96
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
 msgstr "Açıklama ayarlanmamış."
 
@@ -5276,7 +5289,7 @@ msgstr "Mevcut soru için kullan"
 msgid "Potentially useful questions"
 msgstr "Potansiyel olarak yararlı sorular"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:166
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
 msgstr "{0} gruba göre gruplandır"
 
@@ -5289,14 +5302,14 @@ msgstr "Tüm {0} değerlerinin toplamı"
 msgid "All distinct values of {0}"
 msgstr "Tüm farklı {0} değerleri"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:187
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
 msgstr "{1} ile gruplandırılmış {0} sayısı"
 
-#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5312,34 +5325,34 @@ msgstr "Veri Referansı"
 msgid "Learn more about your data structure to ask more useful questions"
 msgstr "Daha kullanışlı sorular sormak için veri yapınız hakkında daha fazla bilgi edinin."
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:58
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:84
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
 msgstr "Yeni bir soru oluşturmadan önce tablo meta verileri bulunamadı"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:80
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
 msgstr "{0} adresini gör"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:94
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
 msgstr "Metrik Tanımı"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:118
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
 msgstr "{0} ile filtrele"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:127
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
 msgstr "{0} sayısı"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
 msgstr "Tüm {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:148
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
 msgstr "Segment tanımı"
 
@@ -5351,7 +5364,7 @@ msgstr "Tablo yüklenirken bir hata oluştu"
 msgid "See the raw data for {0}"
 msgstr "{0} için ham verileri görün"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:180
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
 msgstr "Daha"
 
@@ -5363,24 +5376,24 @@ msgstr "Geçersiz ifade"
 msgid "unknown error"
 msgstr "bilinmeyen hata"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:46
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
 msgstr "Alan formülü"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:57
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Bunu bir e-tablo programında formül yazmak gibi bir şey olarak düşünün: Sayıları, bu tablodaki alanları, + gibi matematiksel sembolleri ve bazı işlevleri kullanabilirsiniz. Böylece Subtotal - Cost gibi bir şey yazabilirsiniz."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
 msgstr "Daha fazla bilgi edin"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:66
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
 msgstr "Bir isim ver"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:72
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
 msgstr "Güzel ve açıklayıcı bir şey"
 
@@ -5432,7 +5445,8 @@ msgstr "doğru"
 msgid "false"
 msgstr "yanlış"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
 msgstr "Filtre ekle"
 
@@ -5440,15 +5454,15 @@ msgstr "Filtre ekle"
 msgid "Item"
 msgstr "Madde"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:221
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
 msgstr "Önceki"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:252
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
 msgstr "Şimdiki"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:278
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
@@ -5459,7 +5473,7 @@ msgid "Enter desired number"
 msgstr "İstenen numarayı giriniz"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:100
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
 msgstr "Boş"
 
@@ -5483,35 +5497,35 @@ msgstr "Birden çok değeri virgülle ayırarak girebilirsiniz"
 msgid "Enter desired text"
 msgstr "İstenen metni girin"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
 msgstr "Deneyin"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
 msgstr "Bu ne için?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
 msgstr "Yerel sorgulardaki değişkenler, filtre widget'larını kullanarak veya URL'ler aracılığıyla sorgularınızdaki değerleri dinamik olarak değiştirmenize olanak tanır."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
 msgstr "{0}, \"variable_name\" adı verilen bu SQL şablonunda bir değişken oluşturur. an panelde değişkenler verilebilir, bu oların davranışlarını değiştirir. \"Alan Filtresi\" dışındaki tüm değişken türleri otomatik olarak bir filtre gerecinin bu soruya yerleştirilmesine neden olur; bu isteğe bağlıdır. Bu filtre aracı dolduğunda, Bu değer, SQL şablonundaki değişkeni değiştirir."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:121
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
 msgstr "Alan Filtreleri"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:123
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "\"Alan Filtresi\" türünde bir değişken, SQL kartlarını gösterge paneli filtre widget'lerine bağlamanıza veya SQL sorgunuzda daha fazla filtre aracı türünü kullanmanıza olanak tanır. Mevcut sütunlara filtre eklerken, Field Filter değişkeni, GUI sorgu oluşturucusu tarafından oluşturulana benzer SQL ekler."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:126
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
 msgstr "Bir Alan Filtresi değişkenini eklerken, belirli bir alana eşlemeniz gerekir. Daha sonra, sorunuza bir filtre widget'ı göstermeyi seçebilirsiniz, ama sen yapmasan bile,Şimdi bu soruyu bir kontrol paneline eklerken Alan Filtresi değişkeninizi bir gösterge tablosu filtresine eşleyebilirsiniz. Alan Filtreleri bir \"WHERE\" maddesinin içinde kullanılmalıdır."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:130
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
 msgstr "İsteğe bağlı Seçenekler"
 
@@ -5519,59 +5533,61 @@ msgstr "İsteğe bağlı Seçenekler"
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
 msgstr "{0} çevresindeki parantezler, şablonda isteğe bağlı bir öğe oluşturur. \"Değişken\" ayarlanırsa, daha sonra tüm yan tümce şablona yerleştirilir. Değilse, sonra tüm tümce göz ardı edilir."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:142
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
 msgstr "Birden çok isteğe bağlı madde kullanmak için En az bir isteğe bağlı WHERE yan tümcesini ve ardından \"AND\" ile başlayan isteğe bağlı sözcükleri ekleyebilirsiniz."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
 msgstr "Tüm belgeleri okuyun"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:127
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
 msgstr "Filtre etiketi"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:139
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
 msgstr "Değişken tip"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:143
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
 msgstr "Metin"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:150
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:119
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
 msgstr "Tarih"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
 msgstr "Alan Filtresi"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:157
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
 msgstr "Eşlenecek alan"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
 msgstr "Filtre aracı türünü filtrele"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:201
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
 msgstr "Gereklidir?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:211
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
 msgstr "Varsayılan filtre widget değeri"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:46
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
 msgstr "Bu soruyu arşivlediniz mi?"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:57
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Bu soru, onu kullanan herhangi bir gösterge tablosundan veya darbelerden çıkarılacaktır."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:136
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
 msgstr "Soru"
 
@@ -5588,21 +5604,21 @@ msgstr "Bu sayfayı düzenliyorsunuz"
 msgid "See this {0}"
 msgstr "Bunu {0} görün "
 
-#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:120
+#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
 msgstr "Altkümesi"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:68
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
 msgstr "Bir alan türü seçin"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:57
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
 msgstr "Alan türü yok"
 
@@ -5611,16 +5627,16 @@ msgid "by"
 msgstr "tarafından"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
-#: frontend/src/metabase/reference/databases/FieldList.jsx:152
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
+#: frontend/src/metabase/reference/databases/FieldList.jsx:155
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
 msgstr "Alan türü"
 
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:72
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
 msgstr "Yabancı Anahtar Seç"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:53
+#: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
 msgstr "{0} formülünü görüntüle"
 
@@ -5637,12 +5653,12 @@ msgid "Nothing important yet"
 msgstr "Henüz önemli bir şey yok"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:168
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:233
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:211
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:215
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:219
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:229
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:236
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:214
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
 msgstr "Henüz ilginç bir şey yok"
 
@@ -5651,12 +5667,12 @@ msgid "Things to be aware of about this {0}"
 msgstr "{0}ile ilgili bilinmesi gerekenler "
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:178
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:243
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:221
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:225
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:229
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:239
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:246
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:224
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
 msgstr "Henüz bilmeniz gereken bir şey yok"
 
@@ -5718,15 +5734,15 @@ msgstr "Değişikliklerin nedeni"
 msgid "Leave a note to explain what changes you made and why they were required"
 msgstr "Yaptığınız değişiklikleri ve neden gerekli olduklarını açıklamak için not bırakın"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:166
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
 msgstr "Bu veritabanı neden ilginç?"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:176
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
 msgstr "Bu veritabanı hakkında bilinmesi gerekenler"
 
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:46
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
 msgstr "Veritabanları ve tablolar"
@@ -5734,42 +5750,42 @@ msgstr "Veritabanları ve tablolar"
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:41
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:170
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:173
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:34
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:184
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:187
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:30
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:188
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:187
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:191
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:190
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
 msgstr "ayrıntılar"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
-#: frontend/src/metabase/reference/databases/TableList.jsx:111
+#: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
 msgstr "{0} alanındaki tablolar"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:222
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:200
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:218
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:203
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
 msgstr "Veritabanındaki gerçek isim"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:231
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:227
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
 msgstr "Bu alan neden ilginç?"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:241
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:237
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
 msgstr "Bu alan hakkında bilinmesi gerekenler"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:253
-#: frontend/src/metabase/reference/databases/FieldList.jsx:155
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:249
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
+#: frontend/src/metabase/reference/databases/FieldList.jsx:158
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
 msgstr "Veri tipi"
 
@@ -5778,13 +5794,13 @@ msgstr "Veri tipi"
 msgid "Fields in this table will appear here as they're added"
 msgstr "Bu tablodaki alanlar, eklendiklerinde burada görünecek"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:134
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:135
+#: frontend/src/metabase/reference/databases/FieldList.jsx:137
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
 msgstr "{0} daki alanlar"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:149
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:150
+#: frontend/src/metabase/reference/databases/FieldList.jsx:152
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
 msgstr "Alan adı"
 
@@ -5808,7 +5824,10 @@ msgstr "Yöneticileriniz bir kez ekledikten sonra veritabanları burada görüne
 msgid "Connect a database"
 msgstr "Bir veritabanı bağlayın"
 
+#. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
+#. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
+#: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
 msgstr "{0} sayısı"
 
@@ -5816,11 +5835,11 @@ msgstr "{0} sayısı"
 msgid "See raw data for {0}"
 msgstr "{0} için ham verileri görün"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:209
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
 msgstr "Bu tablo neden ilginç?"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:219
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
 msgstr "Bu tablo hakkında bilinmesi gerekenler"
 
@@ -5832,16 +5851,16 @@ msgstr "Bu veritabanındaki tablolar, eklendiklerinde burada görünecek"
 msgid "Questions about this table will appear here as they're added"
 msgstr "Bu tabloyla ilgili sorular, eklendiklerinde burada görünece"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:71
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:75
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:74
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
 msgstr "{0} ile ilgili sorular"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
 msgstr " {0} {1} tarafından düzenlendi"
 
@@ -5853,151 +5872,152 @@ msgstr "Bu tablodaki alanlar"
 msgid "Questions about this table"
 msgstr "Bu tabloyla ilgili sorular"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:157
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
 msgstr "Ekibinizin verilere başlamasına yardımcı olun."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:159
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
 msgstr "En iyi kontrol panelinizi, metriklerinizi ve segmentlerinizi seçerek ekibinize en önemli olanı gösterin."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:165
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
 msgstr "Başlamak"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:173
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
 msgstr "En önemli kontrol panelimiz"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:188
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
 msgstr "Dikkat ettiğimiz sayılar"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:213
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
 msgstr "Metrikler, şirketinizin önem verdiği önemli sayılardır. Genellikle işin nasıl yürüdüğünün temel bir göstergesidir."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:221
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
 msgstr "Tüm metrikleri görün"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:235
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
 msgstr "Segmentler ve tablolar"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
+#: frontend/src/metabase/home/containers/SearchApp.jsx:83
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
 msgstr "Tablolar"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:262
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
 msgstr "Segmentler ve tablolar, şirket verilerinizin yapı taşlarıdır. Tablolar, ham bilgilerin koleksiyonlarıdır; segmentler ise, {0} gibi spesifik anlamlara sahip belirli dilimlerdir."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:267
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
 msgstr "Tablolar, şirketinizin verilerinin yapı taşlarıdır."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:277
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
 msgstr "Tüm segmentleri gör"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:293
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
 msgstr "Tüm tabloları gör"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:301
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
 msgstr "Verilerimiz hakkında bilmeniz gereken diğer şeyler"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
 msgstr "Daha fazlasını bul"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:307
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
 msgstr "Verilerinizi tanımanın iyi bir yolu, farklı tabloları ve size sunulan diğer bilgileri keşfetmek için biraz zaman harcamaktır. Biraz zaman alabilir, ancak zamanla isimleri ve anlamları tanımlamaya başlayacaksınız."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:313
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
 msgstr "Verilerimizi keşfedin"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:321
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
 msgstr "Soruların var mı?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:326
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
 msgstr "{0} ile iletişim kurun"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:248
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
 msgstr "Yeni Metabase kullanıcılarının kendi yollarını bulmalarına yardımcı olun."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:251
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
 msgstr "Başlarken kılavuzu, en önemli olan gösterge tablosunu, metrikleri, segmentleri ve tabloları vurgular. Kullanıcılara, verilere girmeden önce bilmeleri gereken önemli şeyler hakkında bilgi verir."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:258
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
 msgstr "Ekibiniz için önemli bir gösterge paneli var mı?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:260
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
 msgstr "Şimdi bir gösterge panosu oluşturun"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:266
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
 msgstr "En önemli kontrol paneliniz nedir?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:285
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
 msgstr "Yaygın olarak başvurulan metrikleriniz var mı?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:287
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
 msgstr "Bir metriğin nasıl tanımlanacağını öğrenin"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:300
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
 msgstr "3-5 en sık başvurulan metrikleriniz neler?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:344
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
 msgstr "Başka bir metrik ekle"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:357
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
 msgstr "Sıklıkla başvurulan segmentleriniz veya tablolarınız var mı?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:359
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
 msgstr "Bir segmentin nasıl oluşturulacağını öğrenin"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:372
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
 msgstr "Bu kitleye faydalı olacak, 3-5 sıkça başvurulan segment veya tablo hangileridir?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:418
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
 msgstr "Başka bir segment veya tablo ekle"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:427
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
 msgstr "Kullanıcıların verilere erişmeye başlamadan önce anlamaları veya bilmeleri gereken bir şey var mı?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:433
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
 msgstr "Bu verilerden bir kullanıcı, erişmeye başlamadan önce neleri bilmelidir?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:437
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
 msgstr "Ör. Veri gizliliği ve kullanımı ile ilgili beklentiler, yaygın tuzaklar veya yanlış anlamalar, veri ambarı performansı hakkında bilgi, yasal uyarılar vb."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
 msgstr "Bu kılavuz hakkında kafası karıştığında, kullanıcılarınız yardım için iletişime geçebilecek biri var mı?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:457
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
 msgstr "Kullanıcılar bu veriler hakkında kafaları karıştıysa yardım için kiminle iletişime geçmeli?"
 
@@ -6006,39 +6026,39 @@ msgstr "Kullanıcılar bu veriler hakkında kafaları karıştıysa yardım içi
 msgid "Please enter a revision message"
 msgstr "Lütfen bir revizyon mesajı girin"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:213
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
 msgstr "Bu Metri neden ilginç?"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:223
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
 msgstr "Bu Metriğin bilinmesi gerekenler"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:233
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
 msgstr "Bu Metrik nasıl hesaplanır?"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:235
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
 msgstr "Henüz nasıl hesaplandığına dair bir şey yok"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:293
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
 msgstr "Bu metriği gruplayabileceğiniz diğer alanlar"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:294
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
 msgstr "Bu metriği gruplayabileceğiniz alanlar"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:23
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Metrikler, ekibinizin umurunda olduğu resmi numaralardır."
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Yöneticileriniz bir kez oluşturduğunuzda metrikler burada görünecek"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
 msgstr "Metrikleri nasıl oluşturacağınızı öğrenin"
 
@@ -6050,9 +6070,9 @@ msgstr "Bu metrikle ilgili sorular, eklendiklerinde burada görünecek"
 msgid "There are no revisions for this metric"
 msgstr "Bu metrik için düzeltme yok"
 
-#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:88
-#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
-#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:88
+#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
+#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
+#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
 msgstr "{0} için düzeltme tarihi"
 
@@ -6060,27 +6080,27 @@ msgstr "{0} için düzeltme tarihi"
 msgid "X-ray this metric"
 msgstr "Metrik X-ışını"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:217
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
 msgstr "Bu Segment neden ilginç?"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:227
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
 msgstr "Bu Bölüm hakkında bilinmesi gerekenler"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
 msgstr "Segmentler, tabloların ilginç alt kümeleridir"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Ekibiniz için ortak segmentler tanımlamak, soru sormayı daha da kolaylaştırır"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
 msgstr "Yöneticilerinizin bir süre önce oluşturdukları bölümler burada görünecek"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
 msgstr "Segment oluşturmayı öğrenin"
 
@@ -6102,13 +6122,13 @@ msgstr "Bu segmentle ilgili sorular"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:49
 msgid "X-ray this segment"
-msgstr "X-ışını bu segmentt"
+msgstr "Bu segmenti incele"
 
 #: frontend/src/metabase/routes.jsx:182
 msgid "Login"
 msgstr "Oturum aç"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:130
+#: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
 msgstr "Arama"
@@ -6125,100 +6145,100 @@ msgstr "Yeni soru"
 msgid "Select the type of Database you use"
 msgstr "Kullandığınız Veritabanı türünü seçin"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:141
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
 msgstr "Verilerinizi ekleyin"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:145
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
 msgstr "Sonra kendi verilerini ekleyeceğim"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
 msgstr "{0} öğesine bağlanıyor"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:165
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
 msgstr "Veritabanınız hakkında bazı bilgilere ihtiyacınız olacak, kullanıcı adı ve şifre gibi. Şu anda buna sahip değilsen, Metatabanı ayrıca başlayabileceğiniz örnek bir veri kümesi ile birlikte gelir."
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:196
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
 msgstr "Verilerimi daha sonra ekleyeceğim"
 
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:41
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
 msgstr "Otomatik taramaları denetle"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:53
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
 msgstr "Kullanım verileri tercihleri"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
 msgstr "Geliştirmemize yardımcı olduğunuz için teşekkürler"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:57
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
 msgstr "Herhangi bir kullanım etkinliği toplamayacağız"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:76
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Metatabanını geliştirmemize yardımcı olmak için Google Analytics’le kullanımla ilgili belirli verileri toplamak istiyoruz."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
 msgstr "İşte izlediğimiz her şeyin tam listesi ve nedeni."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:98
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Metatabanının kullanım olaylarını anonim olarak toplamasına izin ver"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metatabanı {0}, verileriniz veya soru sonuçlarınızla ilgili bir şeyler toplar."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:106
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
 msgstr "asla"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
 msgstr "Tüm koleksiyon tamamen anonimdir."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Koleksiyon, yönetici ayarlarınızdaki herhangi bir noktada kapatılabilir."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:45
+#: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
 msgstr "Sıkışmış hissediyorsan"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:52
+#: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
 msgstr "başlangıç kılavuzumuz"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:53
+#: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
 msgstr "sadece bir tık uzakta."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:95
+#: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
 msgstr "Metatabanına Hoş Geldiniz"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:96
+#: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Her şey çalışıyor gibi görünüyor. Şimdi sizi tanıyalım, verilerinize bağlanın ve size bazı cevaplar bulmaya başlayın!\n"
 "Onun şey çalışıyor gibi."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:100
+#: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
 msgstr "Başlayalım"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:145
+#: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
 msgstr "Her şey hazır!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:156
+#: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
 msgstr "Beni Metatabanına götür"
 
@@ -6235,7 +6255,7 @@ msgid "Create a password"
 msgstr "Şifre oluştur"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:116
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
 msgstr "Shhh ..."
 
@@ -6428,11 +6448,11 @@ msgstr "Google E-posta adresiyle giriş yap"
 msgid "User Details"
 msgstr "Kullanıcı detayları"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:275
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
 msgstr "Varsayılanlara dön"
 
-#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:133
+#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
 msgstr "bilinmeyen harita"
 
@@ -6444,24 +6464,24 @@ msgstr "Grid haritası, binned boylam / enlemi gerektirir."
 msgid "more"
 msgstr "haha"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:101
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
 msgstr "X ve Y eksenleri için hangi alanları kullanmak istiyorsunuz?"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:103
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:60
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
 msgstr "Alanları seç"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:204
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
 msgstr "Varsayılan görünüm olarak kaydet"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
 msgstr "Filtrelemek için çizim kutusu"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
 msgstr "Filtreyi iptal et"
 
@@ -6469,7 +6489,7 @@ msgstr "Filtreyi iptal et"
 msgid "Pin Map"
 msgstr "Pin Haritası"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:303
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
 msgstr "Ayarını kaldır"
 
@@ -6477,31 +6497,31 @@ msgstr "Ayarını kaldır"
 msgid "Rows {0}-{1} of {2}"
 msgstr "{0} - {1} - {2} satırda"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:189
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
 msgstr "Veriler {0} satırına kesildi."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:364
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
 msgstr "Görselleştirme bulunamadı"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:371
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
 msgstr "Grafik bu verileri görüntülenemedi."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:469
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
 msgstr "Sonuç yok!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:490
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
 msgstr "Hala bekliyorum ."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:493
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
 msgstr "Bu genellikle ortalama {0} alır."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:499
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Bu bir gösterge paneli için biraz uzun)"
 
@@ -6517,11 +6537,11 @@ msgstr "Bir alan seç"
 msgid "error"
 msgstr "hata"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:126
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
 msgstr "Siparişlerini değiştirmek için tıklayın ve sürükleyin"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:139
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
 msgstr "Aşağıdaki listeden alanlar ekleyin"
 
@@ -6611,7 +6631,7 @@ msgid "Highlight the whole row"
 msgstr "Tüm satırı vurgula"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:98
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Renkler"
 
@@ -6676,20 +6696,20 @@ msgstr "Bu tanımlayıcı ile görselleştirme zaten kayıtlı: ␣"
 msgid "No visualization for {0}"
 msgstr "{0} için görselleştirme yok"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:75
+#: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
 msgstr "\"{0}\", ayrılmamış bir alandır: x ekseni üzerindeki bir noktada birden fazla değere sahipse, değerler toplanır."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:91
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
 msgstr "Bu grafik türü en az 2 sütun gerektirir."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:96
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
 msgstr "Bu grafik türü, {0} veri dizisinden daha fazlasını desteklemiyor."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:51
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:297
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
 msgstr "Hedef"
 
@@ -6729,25 +6749,25 @@ msgstr "Ayarları Düzenle"
 msgid "xValues missing!"
 msgstr "xValues eksik!"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:114
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "X koordinatı"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:140
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
 msgstr "Dizi ayırma ekle ..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:153
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "X koordinatı"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:178
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
 msgstr "Başka bir seri ekle ..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:195
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
 msgstr "Kabarcık boyutu"
 
@@ -6761,7 +6781,7 @@ msgid "Curve"
 msgstr "Eğri"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:69
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
 msgstr "Adım"
 
@@ -6769,27 +6789,27 @@ msgstr "Adım"
 msgid "Show point markers on lines"
 msgstr "Satırlardaki nokta işaretleyicilerini göster"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:235
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
 msgstr "İstifleme"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:239
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
 msgstr "İstifleme"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:240
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
 msgstr "Yığın"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:241
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
 msgstr "Yığın -% 100"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:300
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
 msgstr "Hedefi göster"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:306
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
 msgstr "Hedef değeri"
 
@@ -6809,126 +6829,126 @@ msgstr "Hiçbir şey değil"
 msgid "Linear Interpolated"
 msgstr "Doğrusal İnterpolasyon"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:371
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
 msgstr "X ekseni ölçeği"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
 msgstr "Zaman serisi"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:391
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:409
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:381
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
 msgstr "Doğrusal"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:410
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:383
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
 msgstr "Güç"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:384
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
 msgstr "Giriş"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:396
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
 msgstr "Histogram"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:398
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
 msgstr "Sıra"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:404
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
 msgstr "Y ekseni ölçeği"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:417
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
 msgstr "X ekseni çizgisini ve işaretlerini göster"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:423
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
 msgstr "Kompakt"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:424
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
 msgstr "45 ° döndür"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
 msgstr "90 ° döndür"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
 msgstr "Y ekseni satırını ve işaretlerini göster"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
 msgstr "Otomatik y ekseni aralığı"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
 msgstr "Gerektiğinde bölünmüş bir y ekseni kullanın"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
 msgstr "X ekseni üzerindeki etiketi göster"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:501
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
 msgstr "X ekseni etiketi"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:510
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
 msgstr "Y ekseninde etiketi göster"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:516
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
 msgstr "Y ekseni etiketi"
 
-#: frontend/src/metabase/visualizations/lib/utils.js:129
+#: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
 msgstr "Standart sapma"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:275
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:17
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:256
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
 msgstr "Alan"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
 msgstr "alan şeması"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:276
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:16
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:257
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
 msgstr "Bubuk "
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
 msgstr "çubuk grafik"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
 msgstr "Hangi alanları kullanmak istiyorsunuz?"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
 msgstr "Huni"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:76
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:76
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Tedbir"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
 msgstr "Huni tipi"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:88
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
 msgstr "Çubuk grafik"
 
@@ -6936,141 +6956,141 @@ msgstr "Çubuk grafik"
 msgid "line chart"
 msgstr "Çizgi grafik"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:224
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Grafik ayarlarında boylam ve enlem sütunlarını seçiniz."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
 msgstr "Lütfen bir bölge haritası seçin."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Grafik ayarlarında lütfen bölge ve metrik sütunları seçin."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:38
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Harita"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:53
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
 msgstr "Harita türü"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:57
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:149
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
 msgstr "Bölge haritası"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
 msgstr "PIN haritası"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
 msgstr "Pin tipi"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
 msgstr "Fayans"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
 msgstr "İşaretleyiciler"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
 msgstr "Latitude alanı"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
 msgstr "Boylam alanı"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:142
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:168
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
 msgstr "Metrik alan"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
 msgstr "Bölge alanı"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
 msgstr "Yarıçap"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:198
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
 msgstr "Bulanıklık"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
 msgstr "Min Opaklık"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
 msgstr "Maksimum Zum"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:175
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
 msgstr "İlişki bulunamadı."
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:213
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
 msgstr "{0} ile"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:290
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
 msgstr "Bu {0} şuna bağlı:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:47
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
 msgstr "Nesne detay"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
 msgstr "nesne"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
 msgstr "Toplam"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Hangi sütunları kullanmak istiyorsunuz?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:44
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Turta"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Boyut"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:81
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Gösteriyi göster"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:86
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Gösterideki yüzdeleri göster"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:92
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Minimum dilim yüzdesi"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:146
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
 msgstr "Hedef bir araya geldi"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:148
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
 msgstr "Hedef aşıldı"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
 msgstr "Hedef {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
 msgstr "İlerleme görselleştirmesi bir sayı gerektirir."
 
@@ -7078,9 +7098,9 @@ msgstr "İlerleme görselleştirmesi bir sayı gerektirir."
 msgid "Progress"
 msgstr "İlerleme"
 
-#: frontend/src/metabase/entities/collections.js:108
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:176
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:57
+#: frontend/src/metabase/entities/collections.js:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Renk"
 
@@ -7092,7 +7112,7 @@ msgstr "Satır Grafiği"
 msgid "row chart"
 msgstr "satır grafiği"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:357
+#: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
 msgstr "Ayırıcı tarzı"
 
@@ -7100,15 +7120,15 @@ msgstr "Ayırıcı tarzı"
 msgid "Number of decimal places"
 msgstr "Ondalık yer sayısı"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:381
+#: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
 msgstr "Bir önek ekle"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:385
+#: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
 msgstr "Bir sonek ekle"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:374
+#: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
 msgstr "Bir sayı ile çarpın"
 
@@ -7120,7 +7140,7 @@ msgstr "dağatmak"
 msgid "scatter plot"
 msgstr "dağılım grafiği"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:78
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
 msgstr "Tabloyu döndür"
 
@@ -7129,7 +7149,8 @@ msgid "Visible fields"
 msgstr "Görünür alanlar"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-msgid "Write here, and use Markdown if you''d like"
+#, fuzzy
+msgid "Write here, and use Markdown if you'd like"
 msgstr "Buraya yaz ve istersen Markdown'u kullan."
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
@@ -7170,13 +7191,13 @@ msgstr "Sağ"
 msgid "Show background"
 msgstr "Arka planı göster"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:553
+#: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} kutu"
 msgstr[1] "{0} kutular"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:559
+#: frontend/src/metabase-lib/lib/Dimension.js:731
 msgid "Auto binned"
 msgstr "Otomatik olarak silindi"
 
@@ -7444,26 +7465,26 @@ msgstr "Otomatik kutu"
 msgid "Don''t bin"
 msgstr "Silme"
 
-#: frontend/src/metabase/lib/query_time.js:193 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "Gün"
 msgstr[1] "Günler"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
-#: frontend/src/metabase/lib/query_time.js:189 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Dakika"
 msgstr[1] "Dakikalar"
 
-#: frontend/src/metabase/lib/query_time.js:191 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Saat"
 msgstr[1] "Saat"
 
-#: frontend/src/metabase/lib/query_time.js:199 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
 msgstr[0] "Çeyrek"
@@ -7530,7 +7551,7 @@ msgid "Bin every 20 degrees"
 msgstr "Her 20 dericede kutu"
 
 #. returns `true` if successful -- see JavaDoc
-#: src/metabase/api/tiles.clj src/metabase/pulse/render.clj
+#: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
 msgstr "Uygun bir resim yazarı bulunamadı!"
 
@@ -7602,10 +7623,12 @@ msgstr "kümülatif toplam"
 msgid "{0} and {1}"
 msgstr "{0} ve {1}"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{1}'n {0} "
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
 msgstr "{1} tarafından olan {0}"
@@ -7618,9 +7641,12 @@ msgstr "{0} segmentinde {1}"
 msgid "{0} segment"
 msgstr "{0} segment"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
-msgstr "{0} metrik"
+msgid_plural "{0} metrics"
+msgstr[0] "{0} metrik"
+msgstr[1] ""
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
@@ -8201,6 +8227,7 @@ msgid "Cannot save Question: source query has circular references."
 msgstr "Soru kaydedilemiyor: Kaynak sorguda dairesel referanslar var."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
+#: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
 msgstr "{0} kartı mevcut değil."
@@ -8602,7 +8629,7 @@ msgstr "Tanınmayan kanal türü {0}"
 msgid "Error sending notification!"
 msgstr "Bildirim gönderilirken hata oluştu!"
 
-#: src/metabase/pulse/color.clj
+#: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
 msgstr "JS renk seçici '' {0} '' konumunda bulunamıyor"
 
@@ -8909,43 +8936,43 @@ msgstr "Veri izinleri"
 msgid "Collection permissions"
 msgstr "Koleksiyon izinleri"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:56
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
 msgstr "Tüm koleksiyon izinlerine bakın"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:25
+#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
 msgstr "Alt koleksiyonları da değiştir"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:282
+#: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
 msgstr "Bu koleksiyonu ve içeriğini düzenleyebilir"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:289
+#: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
 msgstr "Bu koleksiyondaki öğeleri görebilir"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:749
+#: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
 msgstr "Koleksiyon Erişimi"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:825
+#: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Bu grup, bu koleksiyonun en az bir alt koleksiyonunu görüntüleme iznine sahiptir."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:830
+#: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Bu grubun bu koleksiyonun en az bir alt koleksiyonunu düzenleme izni var."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
 msgstr "Alt koleksiyonları görüntüle"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:211
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
 msgstr "Beni hatırla"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:95
+#: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
 msgstr "Bu şema X-ışını"
 
@@ -8977,31 +9004,32 @@ msgstr "\"{0}\" içindeki gösterge panelini, soruları ve koleksiyonları kayde
 msgid "Access dashboards, questions, and collections in \"{0}\""
 msgstr "\"{0}\" içindeki gösterge paneli, sorulara ve koleksiyonlara erişin"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:221
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
 msgstr "Karşılaştır"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:229
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
 msgstr "Uzaklaştır"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:233
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
 msgstr "İlgili"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:293
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
 msgstr "Daha fazla X-rays"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:46
+#: frontend/src/metabase/home/containers/SearchApp.jsx:40
+#: src/metabase/pulse/render/body.clj
 msgid "No results"
 msgstr "Sonuç yok"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:47
+#: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
 msgstr "Metabase aramanız için herhangi bir sonuç bulamadı."
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:111
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
 msgstr "Metrik yok"
 
@@ -9043,7 +9071,7 @@ msgstr "İzin verme başarısız: {0}"
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
 msgstr "Şifreli dizenin şifresi çözülemiyor. MB_ENCRYPTION_SECRET_KEY'nı değiştirmeyi mi unuttunuz?"
 
-#: frontend/src/metabase/entities/collections.js:164
+#: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
 msgstr "Tüm kişisel koleksiyonlar"
 
@@ -9207,18 +9235,18 @@ msgstr "N/A"
 msgid "Windows domain"
 msgstr "Windows alanı"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:509
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:515
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:490
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:499
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
 msgstr "Etiketler"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:329
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
 msgstr "Üye ekle"
 
-#: frontend/src/metabase/entities/collections.js:115
+#: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
 msgstr "Koleksiyon kaydedildi"
 
@@ -9239,39 +9267,39 @@ msgid "Sharing"
 msgstr "Paylaşım"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:234
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:270
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:299
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:305
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:313
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:321
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:218
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:251
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:280
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:286
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:294
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:302
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:80
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:85
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:91
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:97
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:50
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:56
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
 msgstr "Göster"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:370
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:416
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:431
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:487
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:358
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:406
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:447
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
 msgstr "Eksen"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:222
-#: frontend/src/metabase/admin/settings/selectors.js:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
+#: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
@@ -9305,20 +9333,20 @@ msgstr "X-ışını"
 msgid "Compare to the rest"
 msgstr "Diğerleriyle karşılaştır"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:244
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Java Sanal Makine (JVM) zaman dilimini kullanın"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
 msgstr "Manuel saat dilimi yapmadığınız sürece bunu kaldırmanızı öneririz. Bu verilerle sorgularınızın çoğunda veya çoğunda yayınlanır."
 
-#: frontend/src/metabase/containers/Overworld.jsx:310
+#: frontend/src/metabase/containers/Overworld.jsx:312
 msgid "Your team's most important dashboards go here"
 msgstr "Ekibinizin en önemli gösterge panellerı buraya gider"
 
-#: frontend/src/metabase/containers/Overworld.jsx:311
+#: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
 msgstr "Herkes için bu alanda görünmesini sağlamak için {0} öğesindeki gösterge panellerını sabitleyin"
 
@@ -9334,32 +9362,32 @@ msgstr "JVM Zaman Dilimini Kullan"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Veri içinde gezebilmeniz için tabloları ve kolonları analiz ediyoruz."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
 msgstr "İpucu:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:258
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
 msgstr "Para birimi seçin"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:318
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
 msgstr "Alan Tipi"
 
 #: frontend/src/metabase/admin/routes.jsx:109
-#: frontend/src/metabase/nav/containers/Navbar.jsx:224
+#: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
 msgstr "Sorun Giderme"
 
-#: frontend/src/metabase/admin/settings/selectors.js:96
+#: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
 msgstr "X-Ray özelliklerini açın"
 
-#: frontend/src/metabase/admin/settings/selectors.js:323
+#: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
 msgstr "Formatlama Seçenekleri"
 
-#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:19
+#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
 msgstr "Görev Detayları"
 
@@ -9399,7 +9427,7 @@ msgstr "Para Birimi"
 msgid "Pick a user or channel..."
 msgstr "Kullanıcı veya kanal seçin"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
+#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
 msgstr "Formatlama seçeneği yok"
 
@@ -9507,31 +9535,31 @@ msgstr "HH:MM:SS.MS"
 msgid "Time style"
 msgstr "Saat biçimi"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:299
+#: frontend/src/metabase/visualizations/lib/settings/column.js:300
 msgid "Unit of currency"
 msgstr "Para birimi"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:319
+#: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
 msgstr "Para etiket stili"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:337
+#: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
 msgstr "Döviz biriminin gösterildiği yer"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:370
+#: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
 msgstr "En az ondalık basamak sayısı"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:271
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
 msgstr "Yığılı sütun tipi"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:314
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
 msgstr "Hedef etiketi"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:322
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
 msgstr "Eğim çizgisini göster"
 
@@ -9560,7 +9588,7 @@ msgstr "Çizgi + Çubuk"
 msgid "line and bar chart"
 msgstr "çizgi ve çubuk çzigesi"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:72
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
 msgstr "Gösterge için bir sayı gerekiyor."
 
@@ -9568,75 +9596,75 @@ msgstr "Gösterge için bir sayı gerekiyor."
 msgid "Gauge"
 msgstr "Gösterge"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
 msgstr "Gösterge aralığı"
 
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
 msgstr "Gösterilecek alan"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
 msgstr "son {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:185
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
 msgstr "{0}, {1} {2} idi."
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:52
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Zaman bağlı olarak değişimi görmek için zaman içeren alana göre gruplandırınız"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
 msgstr "Pozitif / negatif renklere geçilsin mi?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
 msgstr "Özet sütunu"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:107
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
 msgstr "Hücre sütunu"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:123
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
 msgstr "Görünen sütunlar"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:143
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
 msgstr "Koşullu biçimlendirme"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
 msgstr "Sütun başlığı"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
 msgstr "Küçük çubuk çizlgesi göster"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:183
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
 msgstr "Bağlantı"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:187
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
 msgstr "Bağlantıyı e-postala"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
 msgstr "Görüntü"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:195
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
 msgstr "Otomatik"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:200
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
 msgstr "Bağlantı ya da görüntü olarak izle"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
 msgstr "Bağlantı metni"
 
@@ -9900,7 +9928,7 @@ msgstr "Sorgulamanın önişlemi sırasında hata oluştu"
 msgid "No native form returned."
 msgstr "Hiçbir yerel form iade edilmedi."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
 msgstr "Veritabanı sürücüsünden geçerli cevap alınamadı. :status iletilmedi."
 
@@ -11266,7 +11294,7 @@ msgstr "`query-caching-max-kb` {0} olarak ayarlayamadı."
 msgid "Values greater than {1} are not allowed."
 msgstr "{1} değerinden büyük olan değerlere izin verilmez."
 
-#: src/metabase/query_processor/middleware/resolve_database.clj
+#: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
 msgstr "{0} veritabanı mevcut değil."
 
@@ -11315,7 +11343,7 @@ msgstr "Tetikleyici"
 msgid "View triggers"
 msgstr "Tetikleyicileri izle"
 
-#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:82
+#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
 msgstr "Zamanlayıcı bilgisi"
 
@@ -11347,7 +11375,7 @@ msgstr "Son tetikleme zamanı"
 msgid "May Fire Again?"
 msgstr "Tekrar tetiklensin mi?"
 
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:75
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
 msgstr "{0} için tetikleyiciler"
 
@@ -11359,19 +11387,19 @@ msgstr "Görevler"
 msgid "Jobs"
 msgstr "İşler"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
 msgstr "{0} kopyalandı"
 
-#: frontend/src/metabase/components/EntityItem.jsx:55
+#: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
 msgstr "Bu ögeyi kopyala"
 
-#: frontend/src/metabase/components/EntityItem.jsx:61
+#: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
 msgstr "Bu ögeyi arşivle"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:330
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
 msgstr "Bu panoyu kopyala"
 
@@ -11421,63 +11449,64 @@ msgstr "Geçen {0} {1}"
 msgid "{0} {1} from now"
 msgstr "Şu andan itibaren {0} {1}"
 
-#: frontend/src/metabase/lib/query_time.js:187
+#: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
 msgstr[0] "Güncel aralık"
 msgstr[1] "Güncel aralıklar"
 
-#: frontend/src/metabase/lib/query_time.js:203
+#: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
 msgstr[0] "Dakika"
 msgstr[1] "Dakikalar"
 
-#: frontend/src/metabase/lib/query_time.js:205
+#: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
 msgstr[0] "Saat"
 msgstr[1] "Saatler"
 
-#: frontend/src/metabase/lib/query_time.js:207
+#: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
 msgstr[0] "Gün"
 msgstr[1] "Günler"
 
-#: frontend/src/metabase/lib/query_time.js:209
+#: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
 msgstr[0] "Ayın günü"
 msgstr[1] "Ayın günleri"
 
-#: frontend/src/metabase/lib/query_time.js:211
+#: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
 msgstr[0] "Yılın günü"
 msgstr[1] "Yılın günleri"
 
-#: frontend/src/metabase/lib/query_time.js:213
+#: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
 msgstr[0] "Yılın haftası"
 msgstr[1] "Yılın haftaları"
 
-#: frontend/src/metabase/lib/query_time.js:215
+#: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
 msgstr[0] "Yılın ayı"
 msgstr[1] "Yılın ayları"
 
-#: frontend/src/metabase/lib/query_time.js:217
+#: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "Yılın çeyreği"
 msgstr[1] "Yılın çeyrekleri"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:79
+#: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} seçim"
@@ -11491,20 +11520,20 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "Bu"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:64
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
 msgstr "Geçersiz"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:147
+#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
 msgstr "Bir zaman ekleyin"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:170
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
 msgstr "Önceki {0} ile karşılaştırılacak bir şey yok."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:517
+#: frontend/src/metabase-lib/lib/Dimension.js:678
 msgid "by {0}"
 msgstr "{0} bazında"
 
@@ -11798,35 +11827,35 @@ msgstr "Geciktirmeli yükleme sürücü {0} kaydediliyor..."
 msgid "Error running query for Card {0}"
 msgstr "Kart {0}'a dair sorgu çalıştırılırken hata oluştu"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
 msgstr "Geçen hafta"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This week"
 msgstr "Bu hafta"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
 msgstr "Geçen ay"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This month"
 msgstr "Bu ay"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
 msgstr "Geçen çeyrek"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
 msgstr "Bu çeyrek"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
 msgstr "Geçen yıl"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This year"
 msgstr "Bu yıl"
 
@@ -12073,7 +12102,7 @@ msgid "[[CreateDate]] by quarter of the year"
 msgstr "[[CreateDate]] yılın çeyreğine göre"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:200
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
 msgstr "Kullanıcıyı düzenle"
 
@@ -12081,12 +12110,12 @@ msgstr "Kullanıcıyı düzenle"
 msgid "New user"
 msgstr "Yeni kullanıcı"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
 msgstr "Şifreyi sıfırla"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:209
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
 msgstr "Kullanıcıyı etkisiz kıl"
 
@@ -12098,40 +12127,40 @@ msgstr "{0} yeniden etkinleştirilsin mi?"
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
 msgstr "Onlara mail ile davetiye gönderemedik, {0}'ı  ve oluşturduğumuz bu şifreyi kullanarak giriş yapmalarını bildirin:"
 
-#: frontend/src/metabase/entities/collections.js:21
+#: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
 msgstr "derlem"
 
-#: frontend/src/metabase/entities/collections.js:22
+#: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
 msgstr "derlemler"
 
-#: frontend/src/metabase/entities/dashboards.js:29
+#: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
 msgstr "bilgi panosu"
 
-#: frontend/src/metabase/entities/dashboards.js:30
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
 msgstr "bilgi panoları"
 
-#: frontend/src/metabase/entities/users.js:125
+#: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
 msgstr "Ön adınız gerekli"
 
-#: frontend/src/metabase/entities/users.js:126
-#: frontend/src/metabase/entities/users.js:133
+#: frontend/src/metabase/entities/users.js:38
+#: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
 msgstr "En fazla 100 karakter ya da daha az olmalı"
 
-#: frontend/src/metabase/entities/users.js:132
+#: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
 msgstr "Soyadınız gerekli"
 
-#: frontend/src/metabase/entities/users.js:138
+#: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
 msgstr "E-Mail gerekli"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:90
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
 msgstr "Arşivlediğiniz kalemler burada görülecek."
 
@@ -12139,11 +12168,11 @@ msgstr "Arşivlediğiniz kalemler burada görülecek."
 msgid "No description"
 msgstr "Açıklama yok"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:175
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
 msgstr "Tüm değerlerin toplamı"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:183
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
 msgstr "Tüm ayrık  değerleri gör"
 
@@ -12343,15 +12372,777 @@ msgstr "Kullanıcı {0} tüm kullanıcılar izin grubuna ekleniyor..."
 msgid "Adding User {0} to Admin permissions group..."
 msgstr "Kullanıcı {0} yöneticiler izin grubuna ekleniyor..."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
 msgstr "Sorgu hatası"
 
-#: src/metabase/query_processor/async.clj
+#: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
 msgstr "Veritabanı başına izin verilen en fazla eşzamanlı sorgu sayısı."
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
 msgstr "{0} milisaniyenin ardından zaman aşımı."
+
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
+msgid "Misfire Instruction"
+msgstr ""
+
+#: frontend/src/metabase/components/ArchiveModal.jsx:31
+msgid "Archive this?"
+msgstr "Arşiv"
+
+#: frontend/src/metabase/components/BrowseApp.jsx:244
+msgid "Learn about our data"
+msgstr "Veri hakkında daha fazla"
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
+msgid "Use DNS SRV when connecting"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
+msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
+"an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
+"leave this disabled."
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
+msgid "Automatically run queries when doing simple filtering and summarizing"
+msgstr "Basit filteleme işlemleri yaparken sörfü sonuçlarını hemen göster "
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr ""
+
+#: frontend/src/metabase/containers/Overworld.jsx:247
+msgid "Learn about this database"
+msgstr "Veritabanı detayları "
+
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+msgid "Archive this dashboard?"
+msgstr "Bu dashboardu arşivle "
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:113
+msgid "All results"
+msgstr "Tüm sonuçlar "
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:180
+msgid "Our Analytics"
+msgstr "Analizler"
+
+#: frontend/src/metabase/lib/schema_metadata.js:500
+msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
+msgstr "Bir kolona ait dip toplam (ör: toplam sipariş tutarı ) "
+
+#: frontend/src/metabase/lib/schema_metadata.js:508
+msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
+msgstr "Toplam kayıt sayısı (ör : toplam sipariş sayısı)"
+
+#: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
+msgid "Filter"
+msgstr "Filtre"
+
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+msgid "record"
+msgid_plural "records"
+msgstr[0] "Kayıt "
+msgstr[1] "Kayıt "
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:346
+msgid "Browse Data"
+msgstr "Verileri incele"
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:376
+msgid "Write SQL"
+msgstr "SQL yaz"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
+msgid "Simple question"
+msgstr "Basit soru"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
+msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
+msgstr "Bir veri kümesi seçerek filtrele ya da görselleştir"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
+msgid "Custom question"
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
+msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+msgid "Basic Metrics"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+msgid "Custom…"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
+msgid "Add grouping"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
+msgid "Pick a limit"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
+msgid "Show maximum"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
+msgid "Get Preview"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
+msgid "Back to previous results"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
+msgid "Sample values"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
+msgid "Visualize"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
+msgid "Join data"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
+msgid "Custom column"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
+msgid "Summarize"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
+msgid "Aggregate"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
+msgid "Breakout"
+msgstr "Kirilim"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
+msgid "Pick the metric you want to see"
+msgstr "Görmek istediğiniz metriği seçiniz "
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
+#: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
+msgid "Pick a column to group by"
+msgstr "Gruplamak istediğiniz kolonu seçiniz"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
+msgid "Pick your starting data"
+msgstr "başlangıç verinizi seçiniz "
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select None"
+msgstr "Seçileni temizle"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select All"
+msgstr "Hepsini seç "
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
+msgid "Pick a table..."
+msgstr "Bir tablo seçiniz "
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
+msgid "Enter a limit"
+msgstr "Bir limit giriniz"
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
+msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
+msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
+msgid "View the native query"
+msgstr "Oluşan sorguyu göster "
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
+msgid "Native query for this question"
+msgstr "Oluşan sorguyu göster "
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
+msgid "Convert this question to a native query"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
+msgid "SQL for this question"
+msgstr "Soruya ait SQL sorgusu"
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
+msgid "Convert this question to SQL"
+msgstr "Bu soruyu SQL sorgusuna çevir "
+
+#: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
+msgid "Get alerts"
+msgstr "Alarmlar"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
+msgid "{0} breakout"
+msgid_plural "{0} breakouts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
+msgid "Hide filters"
+msgstr "Filtreleri gizle"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
+msgid "Show filters"
+msgstr "Filtreleri göster "
+
+#: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
+msgid "Started from"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
+msgid "{0} row"
+msgid_plural "{0} rows"
+msgstr[0] ""
+msgstr[1] ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
+msgid "Show all rows"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
+msgid "Show {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
+msgid "Showing first {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
+msgid "Showing {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
+msgid "Summarized"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Hide editor"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Show editor"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
+msgid "Pick the metric you'd like to see"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
+msgid "{0} options"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
+msgid "Choose a visualization"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
+msgid "Filter by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+msgid "Summarize by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+msgid "Group by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+msgid "Add a metric"
+msgstr ""
+
+#: frontend/src/metabase/user/components/UserSettings.jsx:57
+msgid "Profile"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:548
+msgid "This is usually pretty fast but seems to be taking a while right now."
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
+msgid "Combo"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
+msgid "Row"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
+msgid "Trend"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:129
+msgid "Boolean"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+msgid "Unknown Segment"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+msgid "Unknown Filter"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
+msgid "Left outer join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
+msgid "Right outer join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
+msgid "Inner join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
+msgid "Full outer join"
+msgstr ""
+
+#: src/metabase/api/card.clj
+msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
+msgstr ""
+
+#: src/metabase/api/session.clj
+msgid "Problem connecting to LDAP server, will fall back to local authentication"
+msgstr ""
+
+#: src/metabase/api/setup.clj
+msgid "Cannot create Database: cannot find driver {0}."
+msgstr ""
+
+#: src/metabase/api/tiles.clj
+msgid "Query failed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Warning: {0} returned `nil`"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing result to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing exception to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Request canceled, canceling future."
+msgstr ""
+
+#: src/metabase/cmd/load_from_h2.clj
+msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "Application database setup"
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Could not find {0} driver."
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Abstract drivers cannot derive from concrete parent drivers."
+msgstr ""
+
+#: src/metabase/driver/mysql.clj
+msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifer."
+msgstr ""
+
+#: src/metabase/driver/sql_jdbc/execute.clj
+msgid "Client closed connection, canceling query"
+msgstr ""
+
+#: src/metabase/integrations/ldap.clj
+msgid "{0} is not a valid DN."
+msgstr ""
+
+#: src/metabase/middleware/log.clj
+msgid "Error logging API request"
+msgstr ""
+
+#: src/metabase/middleware/misc.clj
+msgid "Failed to set site-url"
+msgstr ""
+
+#: src/metabase/models/database.clj
+msgid "Error destroying thread pool for DB."
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/models/task_history.clj src/metabase/sync/util.clj
+msgid "Error saving task history"
+msgstr ""
+
+#: src/metabase/plugins.clj
+msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
+msgstr ""
+
+#: src/metabase/plugins/classloader.clj
+msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
+msgstr ""
+
+#: src/metabase/plugins/files.clj
+msgid "Failed to copy file"
+msgstr ""
+
+#: src/metabase/public_settings.clj
+msgid "Invalid site URL: {0}"
+msgstr ""
+
+#: src/metabase/public_settings.clj
+msgid "site-url is invalid; returning nil for now. Will be reset on next request."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "More results have been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "This question has been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "We were unable to display this Pulse."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "Please view this card in Metabase."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "An error occurred while displaying this card."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Can only determine expected columns for MBQL queries."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "No columns returned."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot find Table ID for {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "No matching info found."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Could not resolve {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Invalid fk-> clause: nowhere to add corresponding join."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "{0} driver does not support foreign keys."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Query processor error: number of columns returned by driver does not match results."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Expected {0} columns, but first row of resuls has {1} columns."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "No expression named {0} found. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Distinct values of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Average of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "SD of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Min of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Max of {0}"
+msgstr ""
+
+#. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0} matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Share of rows matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Count of rows matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Request already canceled, will not run synchronous QP code."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unexpectedly got `nil` Query Processor response."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Got InterruptedException. Canceling query."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Query timed out after %s"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Creating new query thread pool for Database {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Destroying query thread pool for Database {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Request canceled, canceling pending query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: query is missing source-metadata"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Using query processor cache backend: {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/expand_macros.clj
+msgid "Invalid metric: {0} reason: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unknown error"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unexpected nil response from query processor."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Query canceled"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: Database {0} does not exist."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_source_table.clj
+msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Cannot store Tables or Fields before Database is stored."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Attempting to fetch second Database. Queries can only reference one Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
+msgstr ""
+
+#: src/metabase/routes/index.clj
+msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Sample dataset DB file ''{0}'' cannot be found."
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Loading sample dataset..."
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Failed to load sample dataset"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Found new tables:"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Marking tables as inactive:"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Updating description for tables:"
+msgstr ""
+
+#: src/metabase/task.clj
+msgid "Rescheduling job {0}"
+msgstr ""
+
+#: src/metabase/task.clj
+msgid "Error rescheduling job"
+msgstr ""
+
+#: src/metabase/task/send_pulses.clj
+msgid "Starting Pulse Execution: {0}"
+msgstr ""
+
+#: src/metabase/task/send_pulses.clj
+msgid "Finished Pulse Execution: {0}"
+msgstr ""
+
+#: src/metabase/task/sync_databases.clj
+msgid "Failed to schedule tasks for Database {0}"
+msgstr ""
+
+#: src/metabase/util/schema.clj
+msgid "All elements must be distinct."
+msgstr ""
+
+#: 
+msgctxt "Modal for selecting columns in source data or when doing a join."
+msgid "Pick the columns you want to include"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
+msgid "Change join type"
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifier."
+msgstr ""
+
+#: src/metabase/integrations/common.clj
+msgid "Error adding User {0} to Group {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Infinite loop detected: recursively preprocessed query {0} times."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Error determining expected columns for query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
+msgstr ""
 

--- a/locales/uk.po
+++ b/locales/uk.po
@@ -10,11 +10,11 @@ msgstr ""
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:24
 msgid "Your database has been added!"
-msgstr "Вашу базу Даних Було додано!"
+msgstr "Вашу базу даних додано!"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:28
 msgid "We took a look at your data, and we have some automated explorations that we can show you!"
-msgstr "Ми подивилися на ваші дані і ось результат нашого автоматичного дослідження!"
+msgstr "Ми глянули на ваші дані і ось результат нашого автоматичного дослідження!"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:35
 msgid "I'm good thanks"
@@ -22,46 +22,47 @@ msgstr "Все гаразд, спасибі"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:42
 msgid "Explore this data"
-msgstr "дослідити дані"
+msgstr "Дослідити дані"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:42
 msgid "Select a database type"
 msgstr "Оберіть тип бази даних"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:75
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:401
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:71
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:182
+#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:410
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:74
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:203
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:180
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:197
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:193
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:171
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:180
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:164
 msgid "Save"
 msgstr "Зберегти"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:122
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
-msgstr "Ми повинні просканувати вашу базу даних. Ми так само будемо періодично повторювати цю дію для актуальності даних. Нижче ви можете контролювати періодичність."
+msgstr "Ми повинні просканувати вашу базу даних. Періодично ми повторюватимемо цю дію для підтримки актуальності даних. Нижче ви можете контролювати періодичність."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:127
 msgid "Database syncing"
-msgstr "База даних до процесі сінхронізації"
+msgstr "Синхронізація бази даних"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:128
 msgid "This is a lightweight process that checks for\n"
 "updates to this database’s schema. In most cases, you should be fine leaving this\n"
 "set to sync hourly."
-msgstr "Це легкий процес перевіряючий оновлення структури цієї бази даних. У більшості випадків Вам буде достатньо залишити повсякчасне оновлення"
+msgstr "Це легкий процес перевірки оновлень структури цієї бази даних. У більшості випадків достатньо щогодинного запуску."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:184
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
 msgid "Scan"
-msgstr "Скануваті"
+msgstr "Сканувати"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:152
 msgid "Scanning for Filter Values"
@@ -72,344 +73,350 @@ msgid "Metabase can scan the values present in each\n"
 "field in this database to enable checkbox filters in dashboards and questions. This\n"
 "can be a somewhat resource-intensive process, particularly if you have a very large\n"
 "database."
-msgstr "Metabase може просканувати значення кожного поля бази даних і зробити доступними checkbox-фільтри на панелях індикаторів і в питаннях. Процес досить ресурсозатратне, особливо, якщо мова йде про дуже великий базі даних."
+msgstr "Metabase може просканувати значення кожного поля бази даних і зробити доступними checkbox-фільтри на панелях індикаторів і в питаннях. Процес досить ресурсозатратний, особливо для дуже великої бази даних."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:159
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Коли Metabase повинен автоматично сканувати і кешувати значення?"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:164
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
-msgstr "Регулярно, за Расписание"
+msgstr "Регулярно, за розкладом"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:195
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
 msgstr "Тільки коли додається новий віджет фільтрації"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:199
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
-msgstr "Коли користувач додає новий фільтр до дешборду або SQL запит, Метабейз сканує поля пов'язані з цим фільтром для відображення опцій"
+msgstr "Коли користувач додає новий фільтр до дешборду або SQL запит, Metabase сканує поля, пов'язані з цим фільтром, для відображення переліку опцій."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:210
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
 msgid "Never, I'll do this manually if I need to"
-msgstr "Ніколи, я зрозлю це вручну, коли нужно"
+msgstr "Ніколи, я зроблю це вручну при необхідності"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:222
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:222
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:426
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
 msgid "Saving..."
-msgstr "Збереження ..."
+msgstr "Збереження..."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:39
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
 msgid "Server error encountered"
 msgstr "Помилка на сервері"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:58
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
-msgstr "ВИДАЛИТИ Цю базу Даних?"
+msgstr "Видалити цю базу даних?"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
 msgstr "Всі збережені запити, метрики і сегменти, які залежать від цієї бази даних, будуть втрачені."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:67
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
-msgstr "Ця дія є незворотнім."
+msgstr "Ця дія незворотна."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
 msgstr "Якщо ви впевнені, напишіть"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:53
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
 msgstr "ВИЛУЧИТИ"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:71
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
-msgstr "в цьому полі:"
+msgstr "у цьому полі:"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:82
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:50
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:93
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:58
-#: frontend/src/metabase/admin/permissions/selectors.js:160
-#: frontend/src/metabase/admin/permissions/selectors.js:170
-#: frontend/src/metabase/admin/permissions/selectors.js:185
-#: frontend/src/metabase/admin/permissions/selectors.js:224
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:355
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:181
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:247
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:61
+#: frontend/src/metabase/admin/permissions/selectors.js:163
+#: frontend/src/metabase/admin/permissions/selectors.js:173
+#: frontend/src/metabase/admin/permissions/selectors.js:188
+#: frontend/src/metabase/admin/permissions/selectors.js:227
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:202
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:268
+#: frontend/src/metabase/components/ArchiveModal.jsx:35
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
-#: frontend/src/metabase/components/form/StandardForm.jsx:61
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:196
+#: frontend/src/metabase/components/form/StandardForm.jsx:62
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:198
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:289
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:162
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:153
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:38
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:189
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:24
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:48
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:41
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:92
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:259
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Відмінити"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:88
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:121
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:132
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
-msgstr "ВИДАЛИТИ"
+msgstr "Вилучити"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:128
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:74
-#: frontend/src/metabase/admin/permissions/selectors.js:320
-#: frontend/src/metabase/admin/permissions/selectors.js:327
-#: frontend/src/metabase/admin/permissions/selectors.js:423
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
+#: frontend/src/metabase/admin/permissions/selectors.js:323
+#: frontend/src/metabase/admin/permissions/selectors.js:330
+#: frontend/src/metabase/admin/permissions/selectors.js:426
 #: frontend/src/metabase/admin/routes.jsx:53
-#: frontend/src/metabase/nav/containers/Navbar.jsx:214
+#: frontend/src/metabase/nav/containers/Navbar.jsx:243
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
 msgstr "Бази даних"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:129
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
-msgstr "Додати базу Даних"
+msgstr "Додати базу даних"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
-msgstr "з'єднання"
+msgstr "З'єднання"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:61
 msgid "Scheduling"
 msgstr "Розклад"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:78
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:84
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:26
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:221
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
 msgstr "Зберегти зміни"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:185
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:38
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:38
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
 msgstr "Дії"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:193
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
-msgstr "Провести синхронізацію схеми"
+msgstr "Синхронізувати структуру БД"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:194
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:206
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:109
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
-msgstr "Починаю ..."
+msgstr "Починаю..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:195
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
 msgstr "Помилка синхронізації"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
 msgstr "Синхронізація почалася!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:205
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
 msgstr "Пересканувати значення полів"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:207
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
 msgstr "Неможливо розпочати сканування"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
-msgstr "Сканування заплановано!"
+msgstr "Сканування почалося!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:215
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:401
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
 msgstr "Небезпечна зона"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:221
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
 msgstr "Скинути збережені значення полів"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
-msgstr "ВИДАЛИТИ Цю базу Даних"
+msgstr "Вилучити цю базу даних"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:73
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
-msgstr "Додати базу Даних"
+msgstr "Додати базу даних"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:85
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:36
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:36
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:122
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:32
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:399
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:446
 #: frontend/src/metabase/containers/EntitySearch.jsx:26
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:218
-#: frontend/src/metabase/entities/collections.js:93
-#: frontend/src/metabase/entities/dashboards.js:145
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:461
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:81
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:220
+#: frontend/src/metabase/entities/collections.js:94
+#: frontend/src/metabase/entities/dashboards.js:142
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
 msgstr "Ім'я"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:86
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
-msgstr "Двигун"
+msgstr "Рушій"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:115
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
-msgstr "Відалення ..."
+msgstr "Вилучення..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:145
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
-msgstr "Завантаження ..."
+msgstr "Завантаження..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:161
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
-msgstr "Повернути дані прикладів"
+msgstr "Відновити зразки наборів даних"
 
 #: frontend/src/metabase/admin/databases/database.js:175
 msgid "Couldn't connect to the database. Please check the connection details."
-msgstr "Не можемо з'єднатися з базою даних. Будь ласка, перевірте налаштування з'єднання."
+msgstr "Неможливо з'єднатися з базою даних. Будь ласка, перевірте налаштування з'єднання."
 
 #: frontend/src/metabase/admin/databases/database.js:383
 msgid "Successfully created!"
-msgstr "Успешно Створено!"
+msgstr "Успішно створено!"
 
 #: frontend/src/metabase/admin/databases/database.js:393
 msgid "Successfully saved!"
-msgstr "Успешно Збережи!"
+msgstr "Успішно збережено!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:177
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:197
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
-msgstr "Редагуваті"
+msgstr "Редагувати"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:59
 msgid "Revision History"
 msgstr "Журнал змін"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
 msgstr "Прибрати {0}?"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
-msgstr "Збережені питання і інші складові, які залежать від {0}, продовжать працювати, але {1} вже не можна буде вибрати в майстра запитів."
+msgstr "Збережені питання і інші складові, які залежать від {0}, продовжать працювати, але {1} вже не можна буде вибрати у майстрі запитів."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
-msgstr "Якщо ви впевнені, що хочете прибрати {0}, будь ласка, напишіть короткий пояснення до ваших дій:"
+msgstr "Якщо ви впевнені, що хочете прибрати {0}, будь ласка, напишіть коротке пояснення ваших дій:"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
-msgstr "Це буде відображено в списку дій і в повідомленнях, які будуть відправлені будь-якого зі складу вашої команди, хто створив щось, яке використовує {0}."
+msgstr "Це буде відображено в списку дій і в повідомленнях, які будуть відправлені будь кому з вашої команди, хто створив щось, що використовує {0}."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
 msgstr "Прибрати"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
-msgstr "Видалення ..."
+msgstr "Видалення..."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
 msgstr "Завершено з помилкою"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
-msgstr "успішно завершено"
+msgstr "Завершено успішно"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:91
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
+#: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Попередній перегляд"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
-msgstr "Ще немає опису стоблца"
+msgstr "Опис стовпця відсутній"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:135
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
 msgstr "Виберіть видимість поля"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:210
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
 msgstr "Без спеціального типу"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:211
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:148
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
 msgstr "Інше"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:231
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Вибрати спеціальний тип"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:277
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
-msgstr "вибрати мета"
+msgstr "Вибрати призначення"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:77
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:89
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:106
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:122
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
-msgstr "Колонки"
+msgstr "Стовпці"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
-msgstr "колонка"
+msgstr "Стовпець"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:121
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:306
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
 msgstr "Видимість"
 
@@ -417,127 +424,129 @@ msgstr "Видимість"
 msgid "Type"
 msgstr "Тип"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
 msgstr "Поточна база даних:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
 msgstr "Показати оригінальну схему"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:45
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
 msgstr "Тип даних"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
-msgstr "додаткова інформація"
+msgstr "Додаткова інформація"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
-msgstr "знайти схему"
+msgstr "Знайти схему"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:51
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "{0} схема"
 msgstr[1] "{0} схем"
 msgstr[2] "{0} схем"
-msgstr[3] "{0} схемы"
+msgstr[3] "{0} схеми"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
 msgstr "Навіщо приховувати?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
 msgstr "Технічні дані"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
 msgstr "Не важливо / Мотлох"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
 msgid "Queryable"
 msgstr "Доступно в запитах"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:91
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
 msgstr "Приховано"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
-msgstr "Ще немає опису таблиці"
+msgstr "Таблиця без опису"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:124
 msgid "Metadata Strength"
 msgstr "складність метаданих"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
-msgstr[0] "{0} доступних для запиту таблиць"
-msgstr[1] "{0} доступных для запроса таблиц"
-msgstr[2] "{0} доступных для запроса таблиц"
-msgstr[3] "{0} доступных для запроса таблиц"
+msgstr[0] "{0} доступна для запиту таблиця"
+msgstr[1] "{0} доступних для запиту таблиць"
+msgstr[2] "{0} доступних для запиту таблиць"
+msgstr[3] "{0} доступних для запиту таблиць"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:96
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} прихована таблиця"
-msgstr[1] "{0} скрытых таблиц"
-msgstr[2] "{0} скрытых таблиц"
-msgstr[3] "{0} скрытых таблиц"
+msgstr[1] "{0} прихованих таблиць"
+msgstr[2] "{0} прихованих таблиць"
+msgstr[3] "{0} прихованих таблиць"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
-msgstr "знайти таблицю"
+msgstr "Знайти таблицю"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
-msgstr "схеми"
+msgstr "Схеми"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:24
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:137
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:68
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:56
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:190
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
 msgstr "Метрики"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
 msgstr "Додати Метрику"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:37
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
-msgstr "визначення"
+msgstr "Визначення"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
-msgstr "Створити метрики для їх додавання у випадаюче меню майстура запитів"
+msgstr "Створити метрики для їх додавання у випадаюче меню майстра запитів"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:24
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:930
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:952
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:56
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Сегменти"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
 msgstr "Додати Сегмент"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
-msgstr "Створити сегменти для додавання у випадаюче меню фільтра майстра запитів"
+msgstr "Створити сегменти для їх додавання у випадаюче меню фільтра майстра запитів"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "created"
@@ -563,53 +572,53 @@ msgstr "змінено"
 msgid "made some changes"
 msgstr "зроблені деякі зміни"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
-#: frontend/src/metabase/home/components/Activity.jsx:80
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:332
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/home/components/Activity.jsx:82
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
 msgstr "ви"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
 msgstr "модель даних"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
 msgstr "Історія"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:48
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
 msgstr "Історія змін за"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:239
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
 msgstr "{0} - установки поля"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
 msgstr "Де це поле буде відображено в системі"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:329
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Фільтрація цього поля"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Якщо це поле використовується як фільтр, який вид інформації повинні використовувати користувачі для фільтрації?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:453
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Для цього поля поки немає опису"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:379
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
-msgstr "Оригінальна значення"
+msgstr "Оригінальне значення"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:380
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
 msgid "Mapped value"
-msgstr "пов'язане значення"
+msgstr "Пов'язане значення"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:423
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
 msgstr "Введіть значення"
 
@@ -623,34 +632,34 @@ msgstr "Використовувати зовнішній ключ"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Custom mapping"
-msgstr "своя зв'язок"
+msgstr "Власний зв'язок"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:155
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
 msgid "Unrecognized mapping type"
-msgstr "Непізнаний вид зв'язку"
+msgstr "Нерозпізнаний вид зв'язку"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
-msgstr "Дане поле не є зовнішнім ключем або метадані іншої таблиці, що містить зовнішній ключ, відсутні"
+msgstr "Дане поле не є зовнішнім ключем або зовнішній ключ цільової таблиці метаданих відсутній"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:187
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
 msgstr "Обраний поле не є зовнішньому ключем"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:347
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
 msgstr "Показати значення"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:348
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Виберіть, що відобразити в поле: початкове значення з бази даних, асоційовану або іншу налаштовувану інформацію."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:268
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
 msgstr "Виберіть поле"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:289
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
 msgstr "Будь ласка, виберіть стовпець для відображення."
 
@@ -658,16 +667,16 @@ msgstr "Будь ласка, виберіть стовпець для відоб
 msgid "Tip:"
 msgstr "Підказка:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Можливо, ви захочете відновити найменування поля, щоб переконатися, що воно відповідає обраному варіанту перепризначення зв'язку."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:364
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:102
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
 msgstr "Кешовані значення полів"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:365
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase може сканувати значення даного поля і включити можливість використання checkbox-фільтрів на панелі індикаторів і в питаннях."
 
@@ -676,167 +685,168 @@ msgid "Re-scan this field"
 msgstr "Пересканувати це поле"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
 msgstr "Скинути кешування значення полів"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:118
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
 msgstr "Чи не вдалося скинути значення"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard triggered!"
 msgstr "Скидання значень почався!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:105
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Вибрати базу даних щоб побачити її схему або змінити метадані."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:37
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:34
-#: frontend/src/metabase/entities/collections.js:96
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "ім'я обов'язково"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:40
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
 msgstr "опис обов'язково"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:44
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:41
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
 msgstr "Опис внесених змін обов'язково"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:50
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
 msgstr "агрегація обов'язкове"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
 msgstr "Змінити Вашу Метрику"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
 msgstr "Створити Вашу Метрику"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:115
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Внесіть зміни в метрику і залиште до них пояснення."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Можна створити збережені метрики, щоб додати в цю таблицю параметр іменованої метрики. Збережені метрики включають тип агрегації, агреговане поле і, при необхідності, будь-який фільтр, який ви додасте. Наприклад, ви можете використовувати їх, щоб створити щось на зразок єдиного офіційного способу обчислення \"Середньої ціни\" для таблиці \"Замовлення\"."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
 msgstr "результати:"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
 msgstr "Назвіть вашу Метрику"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
 msgstr "Дайте ім'я вашій метриці, щоб інші користувачі змогли її знайти."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:162
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
 msgstr "Що-небудь описову, але не занадто довге"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
 msgstr "Опишіть вашу Метрику"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Вкажіть опис вашої метрики, щоб допомогти іншим зрозуміти про що вона."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Саме час для більш конкретних даних щодо найменш очевидних метричних правил"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:179
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
 msgstr "Причина змін"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:177
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Залиште опис внесених вами змін і чому вони були необхідні."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Дане повідомлення з'явиться в історії змін метрики і допоможе всім відновити хід подій"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
 msgstr "Необхідний як мінімум один фільтр"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
 msgstr "Змінити ваш Сегмент"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
 msgstr "Створити ваш Сегмент"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:121
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Внесіть зміни в ваш сегмент і залиште до них пояснення."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Виберіть і додайте фільтри для створення вашого нового сегмента до таблиці {0}"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
 msgstr "Задайте ім'я для вашого Сегмента"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:162
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
 msgstr "Задайте ім'я для вашого сегмента, щоб інші змогли його знайти."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:170
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
 msgstr "Опишіть ваш Сегмент"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Вкажіть опис вашого сегменту, щоб допомогти іншим зрозуміти про що він."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:175
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Це ідеальне місце, щоб бути більш конкретним щодо менш очевидних правил визначення сегмента"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:185
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Дане повідомлення з'явиться в історії змін сегмента і допоможе всім відновити хід подій"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:266
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:87
-#: frontend/src/metabase/nav/containers/Navbar.jsx:199
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:269
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:91
+#: frontend/src/metabase/nav/containers/Navbar.jsx:228
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
 msgstr "Налаштування"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:103
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase може сканувати значення в цій таблиці для того, щоб увімкнути фільтри прапорців для фільтрів в панелі інструментів і запитів."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:108
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
 msgstr "Пересканувати цю таблицю"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:253
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
 msgstr "Додати"
 
@@ -845,20 +855,22 @@ msgstr "Додати"
 msgid "Not a valid formatted email address"
 msgstr "Email вказано невірно"
 
+#: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:100
 msgid "First name"
 msgstr "Ім'я"
 
+#: frontend/src/metabase/entities/users.js:42
 #: frontend/src/metabase/setup/components/UserStep.jsx:203
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:117
 msgid "Last name"
 msgstr "Прізвище"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:77
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:158
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:161
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:470
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:481
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
@@ -872,34 +884,35 @@ msgstr "Групи Дозволів"
 msgid "Make this user an admin"
 msgstr "Призначити адміністратором"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:32
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
 msgstr "Всі користувачі входять в групу {0} і не можуть бути з неї виключені. Встановіть дозволу для даної групи - так ви будете впевнені в тому, що зможуть побачити нові користувачі Metabase."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:41
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
 msgstr "Це спеціальна група, члени якої зможуть бачити всі, що пов'язано з даними екземпляром Metabase, мати доступ і редагувати настройки в Панелі адміністратора, включаючи повноваження! Тому включайте користувачів до цієї групи дотримуючись запобіжних заходів."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:45
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
 msgstr "У даній групі повинен залишатися хоча б один користувач, інакше доступ до Metabase буде блокований."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
 msgstr "Учасники"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:124
-#: frontend/src/metabase/admin/settings/selectors.js:113
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
+#: frontend/src/metabase/admin/settings/selectors.js:110
+#: frontend/src/metabase/entities/users.js:50
 #: frontend/src/metabase/lib/core.js:55
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
 msgstr "Email"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:203
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
 msgstr "Група також хороша, як і її члени."
 
@@ -910,8 +923,8 @@ msgid "Admin"
 msgstr "Адміністратор"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:237
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:290
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
 msgstr "і"
 
@@ -942,13 +955,13 @@ msgid "Are you sure? All members of this group will lose any permissions setting
 msgstr "Ви впевнені? Всі учасники цієї групи втратять всі повноваження засновані на цій групі. Дана дія не може бути скасовано."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
 msgstr "Так"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
 msgstr "немає"
 
@@ -967,10 +980,11 @@ msgstr "видалити групу"
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:107
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:327
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:395
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:265
+#: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
 msgstr "Готово"
 
@@ -980,9 +994,9 @@ msgstr "Ім'я групи"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:131
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:88
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
 msgstr "Групи"
 
@@ -1011,9 +1025,9 @@ msgid "Deactivate"
 msgstr "деактивувати"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:93
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
-#: frontend/src/metabase/nav/containers/Navbar.jsx:204
+#: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
 msgstr "Люди"
 
@@ -1053,7 +1067,6 @@ msgid "We've re-sent {0}'s invite"
 msgstr "Ми переотправілі запрошення {0}"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
-#: frontend/src/metabase/tutorial/Tutorial.jsx:253
 msgid "Okay"
 msgstr "добре"
 
@@ -1085,13 +1098,13 @@ msgstr "Вони зможуть зайти знову, і їм будуть по
 msgid "Reset {0}'s password?"
 msgstr "Скинути пароль для {0}?"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:77
+#: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
 msgstr "скинути"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:44
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
 msgstr "Ви впевнені що хочете виконати цю дію?"
 
@@ -1107,40 +1120,40 @@ msgstr "Це тимчасовий пароль, з яким вони зможу�
 msgid "We've sent them an email with instructions for creating a new password."
 msgstr "Ми відправили повідомлення електронної пошти з інструкцією по установці нового пароля."
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:101
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
 msgstr "активний"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:127
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
 msgstr "неактивний"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:115
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
 msgstr "Додати кого-небудь"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
 msgstr "Останній вхід"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:153
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
 msgstr "Вхід за допомогою Google"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:158
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
 msgstr "Вхід за допомогою LDAP"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:170
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
 msgstr "Повторно активувати цей обліковий запис"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:193
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
 msgstr "ніколи"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:27
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
@@ -1149,36 +1162,38 @@ msgstr[1] "{0} таблицы"
 msgstr[2] "{0} таблиц"
 msgstr[3] "{0} таблиц"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:45
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
 msgstr "будуть"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:48
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
 msgstr "надано доступ до"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:53
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
 msgstr "і"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:56
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
 msgstr "доступ заборонений для"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:70
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
 msgstr "ніколи не зможуть"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:71
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
 msgstr "тепер зможуть"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:79
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
 msgstr "прямі запити до"
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
-#: frontend/src/metabase/nav/containers/Navbar.jsx:219
+#: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
 msgstr "Дозволи"
 
@@ -1203,15 +1218,15 @@ msgstr "Ніяких змін доступу виконано не буде."
 msgid "You've made changes to permissions."
 msgstr "Ви внесли зміни в налаштування доступу."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:52
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
 msgstr "Дозволи для цієї колекції"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
 msgstr "У вас є незбережені зміни"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:54
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
 msgstr "Ви дійсно бажаєте залишити цю сторінку і скасувати зміни?"
 
@@ -1231,119 +1246,119 @@ msgstr "Кожен користувач Metabase відноситься до г�
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
 msgstr "MetaBot це Slack бот Metabase. Тут ви можете вибрати до чого він буде мати доступ."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:119
+#: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
 msgstr "Група \"{0}\" має доступ до інших {1}, ніж дана група, що дозволить їй отримати доступ до {2}."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:124
+#: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
 msgstr "Група \"{0}\" має більший рівень доступу, ніж цей, що перевизначити цей параметр. Вам слід обмежити або відкликати доступ групи \"{1}\" до даного елементу."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
 msgstr "обмеження"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
 msgstr "відкликати"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:156
+#: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
 msgstr "доступ, навіть якщо \"{0}\" має більший доступ?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:258
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
 msgstr "обмежити доступ"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:223
-#: frontend/src/metabase/admin/permissions/selectors.js:266
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:226
+#: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
 msgstr "відкликати доступ"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:168
+#: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
 msgstr "Обмежити доступ до цієї бази даних?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:169
+#: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
 msgstr "змінити"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:182
+#: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
 msgstr "Дозволити написання прямих запитів?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:183
+#: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
 msgstr "Це також надасть цій групі Необмежений доступ до бази даних."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:184
+#: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
 msgstr "Дозволити"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:221
+#: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
 msgstr "Відкликати доступ до всіх таблиць?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:222
+#: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
 msgstr "Це також відкличе доступ групи до прямих запитам до бази даних."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:251
+#: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
 msgstr "Надати необмежений доступ"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:252
+#: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
 msgstr "необмежений доступ"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:259
+#: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
 msgstr "Обмежений доступ"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:267
+#: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
 msgstr "Немає доступу"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:273
+#: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
 msgstr "Написання прямих запитів"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:274
+#: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
 msgstr "Може писати прямі запити"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:281
+#: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
 msgstr "управляти колекцією"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:288
+#: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
 msgstr "Подивитися колекцію"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:331
-#: frontend/src/metabase/admin/permissions/selectors.js:427
-#: frontend/src/metabase/admin/permissions/selectors.js:524
+#: frontend/src/metabase/admin/permissions/selectors.js:334
+#: frontend/src/metabase/admin/permissions/selectors.js:430
+#: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
 msgstr "Доступ до даних"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:492
-#: frontend/src/metabase/admin/permissions/selectors.js:649
-#: frontend/src/metabase/admin/permissions/selectors.js:654
+#: frontend/src/metabase/admin/permissions/selectors.js:495
+#: frontend/src/metabase/admin/permissions/selectors.js:652
+#: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
 msgstr "Подивитися таблиці"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:590
+#: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
 msgstr "SQL запити"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:660
+#: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
 msgstr "Подивитися схеми"
 
 #: frontend/src/metabase/admin/routes.jsx:59
-#: frontend/src/metabase/nav/containers/Navbar.jsx:209
+#: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
 msgstr "модель даних"
 
@@ -1352,30 +1367,30 @@ msgstr "модель даних"
 msgid "Sign in with Google"
 msgstr "Увійти за допомогою Google"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:13
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
 msgstr "Дозволити користувачам з існуючими Metabase акаунтами входити за допомогою Google акаунтів при збігу email адрес, в додаток до їх Metabase логіну та паролю."
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:17
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
 msgstr "налаштувати"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
-#: frontend/src/metabase/admin/settings/selectors.js:207
+#: frontend/src/metabase/admin/settings/selectors.js:204
 msgid "LDAP"
 msgstr "LDAP"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:25
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
 msgstr "Дозволяє користувачам в каталозі LDAP входити в Metabase з обліковими даними LDAP, а також автоматично пов'язує групи LDAP з групами Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
-#: frontend/src/metabase/admin/settings/selectors.js:160
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
 msgstr "Це не дійсний email адреса"
 
@@ -1413,7 +1428,7 @@ msgstr "Очистити"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:202
+#: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
 msgstr "Аутентифікація"
 
@@ -1477,21 +1492,21 @@ msgstr "Створити Slack Bot користувача для MetaBot"
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Поки ви тут, дайте ім'я та натисніть {0}. Потім скопіюйте і вставте Bot API токен в поле нижче. Після цього, створіть канал \"metabase_files\" в Slack. Це потрібно Metabase для завантаження графіків."
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:90
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
 msgstr "Ви запустили останню і найкращу версію Metanase {0}!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:99
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0} доступна. Ви використовуєте {1}"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:112
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
 msgstr "оновити"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:116
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
 msgstr "Що змінено:"
 
@@ -1504,80 +1519,80 @@ msgstr "Додати карту"
 msgid "URL"
 msgstr "Посилання"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:199
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
 msgstr "Видалити поточну карту"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:327
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:40
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:181
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
 msgstr "вилучити"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:226
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:187
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:241
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:246
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
 msgstr "Вибрати ..."
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:241
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
 msgstr "Приклади значень:"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
 msgstr "Додати нову карту"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
 msgstr "змінити карту"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:280
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
 msgstr "Як ви хочете назвати цю карту?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
 msgstr "наприклад, Великобританія, Бразилія, Марс"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:292
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
 msgstr "URL до файлу GeoJSON, який потрібно використовувати"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:298
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
 msgstr "Наприклад, https://my-mb-server.com/maps/my-map.json"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:33
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
 msgstr "оновити"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
 msgstr "Завантажити"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:315
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
 msgstr "Яка ознака визначає ідентифікатор регіону?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:324
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
 msgstr "Яка ознака визначає відображення найменування регіону?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:345
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
 msgstr "Завантажте файл GeoJSON для попереднього перегляду"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
 msgstr "зберегти карту"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
 msgstr "Додати карту"
 
@@ -1589,11 +1604,11 @@ msgstr "Використання вбудовування"
 msgid "By enabling embedding you're agreeing to the embedding license located at"
 msgstr "Дохволяючи вбудовування, ви погоджуєтеся з вбудованням ліцензії з розташованої в"
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:19
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
 msgstr "Простіше кажучи, коли ви вбудовуєте графіки і панелі індикаторів Metabase в ваш додаток, такий додаток не є суб'єктом Affero General Public License, яке охоплює решту Metabase, за умови, якщо на вбудованих елементах буде залишатися логотип Metabase і напис \"Powered by Metabase \". Однак, в будь-якому випадку, вам слід ознайомитися з ліцензією за посиланням вище, чинну редакцію якої ви приймаєте, включаючи дану функцію."
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:32
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
 msgstr "Увімкнути"
 
@@ -1617,25 +1632,25 @@ msgstr "купити токен"
 msgid "Enter a token"
 msgstr "ввести токен"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:134
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
 msgstr "змінити зіставлення"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:140
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
 msgstr "групове зіставлення"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:147
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
 msgstr "створити зіставлення"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
 msgstr "Зіставлення дозволяє Metabase автоматично додавати і виключати користувачів з груп на підставі інформації з каталогу сервера. Доступ до групи Адміністраторів може бути надано на підставі зіставлення, але не буде знятий автоматично як запобіжний засіб."
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
 msgstr "відмітна найменування"
 
@@ -1647,43 +1662,43 @@ msgstr "публічна посилання"
 msgid "Revoke Link"
 msgstr "видалити посилання"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:121
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
 msgstr "Відключити це посилання?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:122
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
 msgstr "Вони більше не працюють і не можуть бути відновлені, але ви можете створити нові посилання."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
 msgstr "Перелік відкритих панелей індикаторів"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:152
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
 msgstr "До жодної з панелі індикаторів загальний доступ ще не надано."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:160
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
 msgstr "Перелік загальних Карток"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:163
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
 msgstr "До жодного питання загальний доступ ще не надано."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:172
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
 msgstr "Перелік вбудованих панелей індикаторів"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
 msgstr "Жодна панель індикаторів ще не вбудована."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:183
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
 msgstr "Список вбудованих карток"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:184
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
 msgstr "Жодне питання ще не вбудований."
 
@@ -1704,18 +1719,17 @@ msgid "Generate Key"
 msgstr "згенерувати ключ"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:78
-#: frontend/src/metabase/admin/settings/selectors.js:87
+#: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
 msgstr "Включено"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:83
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:103
+#: frontend/src/metabase/admin/settings/selectors.js:82
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Відключено"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:116
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
 msgstr "Невідома настройка {0}"
 
@@ -1723,7 +1737,7 @@ msgstr "Невідома настройка {0}"
 msgid "Setup"
 msgstr "налаштувати"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
 msgstr "Загальні"
@@ -1752,11 +1766,11 @@ msgstr "За замовчуванням для бази даних"
 msgid "Select a timezone"
 msgstr "Вибрати часовий пояс"
 
-#: frontend/src/metabase/admin/settings/selectors.js:55
+#: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Не всі бази даних підтримують часові пояси, тому цей параметр може не спрацювати."
 
-#: frontend/src/metabase/admin/settings/selectors.js:60
+#: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
 msgstr "Мова"
 
@@ -1764,202 +1778,202 @@ msgstr "Мова"
 msgid "Select a language"
 msgstr "Вибрати мову"
 
-#: frontend/src/metabase/admin/settings/selectors.js:70
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
 msgstr "анонімне відстеження"
 
-#: frontend/src/metabase/admin/settings/selectors.js:75
+#: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
 msgstr "Зрозумілі імена таблиць і полів"
 
-#: frontend/src/metabase/admin/settings/selectors.js:81
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Тільки замініть знаки нижнього підкреслення і точки пробілами"
 
-#: frontend/src/metabase/admin/settings/selectors.js:91
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
 msgstr "Включити вкладені запити"
 
-#: frontend/src/metabase/admin/settings/selectors.js:102
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
 msgstr "оновлення"
 
-#: frontend/src/metabase/admin/settings/selectors.js:107
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
 msgstr "перевірити оновлення"
 
-#: frontend/src/metabase/admin/settings/selectors.js:118
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
 msgstr "SMTP хост"
 
-#: frontend/src/metabase/admin/settings/selectors.js:126
+#: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
 msgstr "SMTP порт"
 
-#: frontend/src/metabase/admin/settings/selectors.js:130
-#: frontend/src/metabase/admin/settings/selectors.js:230
+#: frontend/src/metabase/admin/settings/selectors.js:127
+#: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
 msgstr "Некоректний номер порту"
 
-#: frontend/src/metabase/admin/settings/selectors.js:134
+#: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
 msgstr "Безпека SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:142
+#: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
 msgstr "SMTP користувач"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
 msgstr "SMTP пароль"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
 msgstr "Від кого"
 
-#: frontend/src/metabase/admin/settings/selectors.js:170
+#: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
 msgstr "Slack API Token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:172
+#: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
 msgstr "Введіть токен отриманий від Slack"
 
-#: frontend/src/metabase/admin/settings/selectors.js:189
+#: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
 msgstr "єдиний вхід"
 
-#: frontend/src/metabase/admin/settings/selectors.js:213
+#: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
 msgstr "Аутентифікація LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:219
+#: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
 msgstr "LDAP хост"
 
-#: frontend/src/metabase/admin/settings/selectors.js:227
+#: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
 msgstr "LDAP порт"
 
-#: frontend/src/metabase/admin/settings/selectors.js:234
+#: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
 msgstr "Безпека LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
 msgstr "Користувач або DN"
 
-#: frontend/src/metabase/admin/settings/selectors.js:247
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:188
-#: frontend/src/metabase/user/components/UserSettings.jsx:72
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:191
+#: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
 msgstr "Пароль"
 
-#: frontend/src/metabase/admin/settings/selectors.js:252
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "User search base"
 msgstr "База для пошуку користувача"
 
-#: frontend/src/metabase/admin/settings/selectors.js:258
+#: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
 msgstr "Фільтр користувача"
 
-#: frontend/src/metabase/admin/settings/selectors.js:264
+#: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
 msgstr "Перевірте круглі дужки"
 
-#: frontend/src/metabase/admin/settings/selectors.js:270
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
 msgstr "Email аттрибут"
 
-#: frontend/src/metabase/admin/settings/selectors.js:275
+#: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
 msgstr "Атрибут імені"
 
-#: frontend/src/metabase/admin/settings/selectors.js:280
+#: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
 msgstr "Атрибут прізвища"
 
-#: frontend/src/metabase/admin/settings/selectors.js:285
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
 msgstr "Синхронізувати членство в групі"
 
-#: frontend/src/metabase/admin/settings/selectors.js:291
+#: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
 msgstr "База для пошуку групи"
 
-#: frontend/src/metabase/admin/settings/selectors.js:300
+#: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
 msgstr "карти"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
 msgstr "URL сервера плиточної веб-карти"
 
-#: frontend/src/metabase/admin/settings/selectors.js:306
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "За замовчуванням, Metabase використовує OpenStreetMaps."
 
-#: frontend/src/metabase/admin/settings/selectors.js:311
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
 msgstr "Налаштовувана карта"
 
-#: frontend/src/metabase/admin/settings/selectors.js:312
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Додайте власні GeoJSON файли для можливості візуалізації різних регіонів на картах"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
 msgstr "Загальний доступ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:336
+#: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
 msgstr "Включити загальний доступ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:341
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
 msgstr "Спільні панелі інструментів"
 
-#: frontend/src/metabase/admin/settings/selectors.js:347
+#: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
 msgstr "публічні запити"
 
-#: frontend/src/metabase/admin/settings/selectors.js:354
+#: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
 msgstr "Вбудовування в інших Додатках"
 
-#: frontend/src/metabase/admin/settings/selectors.js:381
+#: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Включити вбудовування Metabase в інших Додатках"
 
-#: frontend/src/metabase/admin/settings/selectors.js:391
+#: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
 msgstr "Секретний ключ для вбудовування"
 
-#: frontend/src/metabase/admin/settings/selectors.js:397
+#: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
 msgstr "Вбудовувані панелі інструментів"
 
-#: frontend/src/metabase/admin/settings/selectors.js:403
+#: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
 msgstr "Вбудовувані запити"
 
-#: frontend/src/metabase/admin/settings/selectors.js:410
+#: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
 msgstr "кешування"
 
-#: frontend/src/metabase/admin/settings/selectors.js:415
+#: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
 msgstr "включити кешування"
 
-#: frontend/src/metabase/admin/settings/selectors.js:420
+#: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
 msgstr "Мінімальний час запиту"
 
-#: frontend/src/metabase/admin/settings/selectors.js:427
+#: frontend/src/metabase/admin/settings/selectors.js:424
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Множник Cache Time-To-Live (TTL)"
 
-#: frontend/src/metabase/admin/settings/selectors.js:434
+#: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
 msgstr "Максимальний розмір запису кеша"
 
@@ -1975,11 +1989,11 @@ msgstr "Попередження було збережено."
 msgid "The alert was successfully deleted."
 msgstr "Попередження успішно видалено."
 
-#: frontend/src/metabase/auth/auth.js:33
+#: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
 msgstr "Введіть коректний email"
 
-#: frontend/src/metabase/auth/auth.js:116
+#: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
@@ -2021,91 +2035,88 @@ msgstr "Послати емаил для скидання пароля"
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Послати емаил з інструкцією як скинути пароль."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:128
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
 msgstr "Увійти в Metabase"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:138
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
 msgstr "АБО"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:157
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
 msgstr "Ім'я користувача або email"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:217
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
 msgstr "Увійти"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:230
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
 msgstr "Схоже що я забув свій пароль"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
 msgstr "запросити новий лист із запитом на скидання пароля"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:120
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
 msgstr "Уууупс, здається ця посилання застаріла."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:122
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
 msgstr "З міркувань безпеки, посилання на скидання пароля через деякий час закінчуються.\n"
 "Якщо вам все ще потрібно скинути пароль, ви можете {0}."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:147
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
 msgstr "Новий пароль"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:149
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
 msgstr "Заради безпеки, паролі {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:163
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
 msgstr "Створити новий пароль"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:170
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:141
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
 msgstr "Переконайтеся що пароль відповідає рекомендації безпеки вище"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:184
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:150
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
 msgstr "Підтвердіть новий пароль"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:191
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:159
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
 msgstr "Переконайтеся що він відповідає тому який ви вже ввели"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:216
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
 msgstr "Ваш пароль був скинутий."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:222
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:227
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
 msgstr "Зайди з вашим новим паролем"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:182
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:251
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Збереження не вдалося"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:183
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:129
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:225
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:252
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
 msgstr "Збережено"
 
@@ -2113,24 +2124,22 @@ msgstr "Збережено"
 msgid "Ok"
 msgstr "Ок"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:38
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
 msgstr "Перемістити колекцію в архів?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:43
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Панелі інструментів, збірки та пульси в цій збірці також будуть заархівовані."
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
-#: frontend/src/metabase/components/CollectionLanding.jsx:624
+#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: frontend/src/metabase/components/CollectionLanding.jsx:620
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:47
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:195
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:200
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:40
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:53
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
 msgstr "Архів"
@@ -2139,28 +2148,27 @@ msgstr "Архів"
 msgid "This {0} has been archived"
 msgstr "Цей {0} переміщений в архів."
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:715
+#: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
 msgstr "Переглянути архів"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:43
+#: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
 msgstr "Востоновіть цей {0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:70
-#: frontend/src/metabase/components/BrowseApp.jsx:132
-#: frontend/src/metabase/components/BrowseApp.jsx:225
+#: frontend/src/metabase/components/BrowseApp.jsx:39
+#: frontend/src/metabase/components/BrowseApp.jsx:102
+#: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
 msgstr "Наші дані"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:169
+#: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
 msgstr "Просканувати цю таблицю"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:183
-#: frontend/src/metabase/containers/Overworld.jsx:246
+#: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
 msgstr "Дізнатися більше про цю таблиці"
 
@@ -2178,31 +2186,31 @@ msgstr "Збережено!"
 msgid "Saving failed."
 msgstr "Не вийшло зберегти."
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
 msgstr "Нд"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
 msgstr "за"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
 msgstr "Вт"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
 msgstr "Ср"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
 msgstr "чт"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
 msgstr "Пт"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
 msgstr "Сб"
 
@@ -2247,27 +2255,26 @@ msgstr "Пульси дозволяють вам відправляти акту
 msgid "Questions are a saved look at your data."
 msgstr "Запити - це збережений погляд на ваші дані."
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:287
+#: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
 msgstr "прикріплені"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:341
+#: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
 msgstr "Перемістіть щось для того щоб закріпити нагорі"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:737
-#: frontend/src/metabase/components/CollectionLanding.jsx:353
-#: frontend/src/metabase/home/containers/SearchApp.jsx:35
-#: frontend/src/metabase/home/containers/SearchApp.jsx:92
+#: frontend/src/metabase/admin/permissions/selectors.js:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:352
+#: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
 msgstr "колекції"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:432
-#: frontend/src/metabase/components/CollectionLanding.jsx:455
+#: frontend/src/metabase/components/CollectionLanding.jsx:431
+#: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
 msgstr "Перемістіть щоб відкріпити"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:490
+#: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
 msgstr[0] "{0} елемент обраний"
@@ -2275,35 +2282,36 @@ msgstr[1] "{0} элемента выбрано"
 msgstr[2] "{0} элементов выбрано"
 msgstr[3] "{0} элементов выбрано"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:522
+#: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
 msgstr "Перемістити {0} елементів?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:523
+#: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
 msgstr "Перемістити \"{0}\"?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:631
+#: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
 msgstr "перемістити"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:692
+#: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
 msgstr "Змінити цю колекцію"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:700
+#: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
 msgstr "Перемістити колекцію в архів"
 
-#: frontend/src/metabase/components/CollectionList.jsx:64
-#: frontend/src/metabase/entities/collections.js:155
+#: frontend/src/metabase/components/CollectionList.jsx:67
+#: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
 msgstr "Моя особиста колекція"
 
-#: frontend/src/metabase/components/CollectionList.jsx:106
+#: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
 msgstr "Нова колекція"
 
@@ -2311,11 +2319,11 @@ msgstr "Нова колекція"
 msgid "Copied!"
 msgstr "Скопійовано!"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:216
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Використовувати SSH-тунель для зв'язку з базою даних"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
@@ -2323,75 +2331,76 @@ msgstr "Деякі інсталяції баз даних можуть бути 
 "Ця опція також надає додатковий рівень безпеки, коли VPN є недоступним.\n"
 "Використання може знизити швидкість в порівнянні з прямим з'єднанням."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:271
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Це велика база даних, так що дайте мені вибрати коли Мetabase синхронізує і сканує"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:273
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "За замовчуванням, Metabase виконує поверхневе сканування кожну годину і повне сканування значень полів щодня.\n"
 "Якщо у вас велика база даних, ми рекомендуємо увімкнуте це та дивитися коли і як часто відбувається сканування значень полів."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:289
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} для генерації Client ID та Client Secret для вашого проекту."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:291
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:353
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
 msgstr "Натисніть тут"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Виберіть \"Інше\" як тип програми. Назвіть його на ваш смак."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:316
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
 msgstr "{0} для отримання коду аутентифікації"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:328
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
 msgstr "з дозволами Google Drive"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:348
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Вам необхідно дозволити доступ по API в Google Developers Console, щоб використовувати ці дані в Metabase."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:351
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} перейдіть в консоль, якщо ви цього ще не зробили"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
 msgstr "Як би ви хотіли звертатися до цієї бази даних?"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:427
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:237
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:188
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:74
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:194
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:79
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
 msgstr "далі"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:52
+#: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
 msgstr "Видалити цей {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:43
+#: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
 msgstr "Закріпити цей елемент"
 
-#: frontend/src/metabase/components/EntityItem.jsx:49
+#: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
 msgstr "Перемістити цей елемент"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
 msgstr "Змінити цей запит"
 
@@ -2404,6 +2413,7 @@ msgstr "Тип дії"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
 msgstr "переглянути історію"
 
@@ -2419,8 +2429,7 @@ msgstr "заархівувати дію"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:329
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:342
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
 msgstr "Додати до панелі інструментів"
 
@@ -2444,13 +2453,12 @@ msgstr "Інший вид дії"
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:449
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:454
 msgid "Get alerts about this"
 msgstr "Отримувати сповіщення про це"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
 msgstr "Подивитися SQL"
 
@@ -2470,43 +2478,43 @@ msgstr "Повний текст повідомлення про помилку"
 msgid "Hi, Metabot here."
 msgstr "Привіт, Metabot тут."
 
-#: frontend/src/metabase/components/ExplorePane.jsx:95
+#: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
 msgstr "Засноване на схемі"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:174
+#: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
 msgstr "Погляньте на"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:234
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
 msgstr "Пошук в списку"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:238
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
 msgstr "Шукати по {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
 msgstr "або введітеь ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
 msgstr "Введіть ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
 msgstr "ведіть номер"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:248
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
 msgstr "Введіть текст"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:355
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
 msgstr "Чи не знайдено сходст в {0}."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:363
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Припускаю, що вибір всіх значень фільтра справі не допоможе ..."
 
@@ -2522,17 +2530,17 @@ msgstr "Ми зіткнулися з помилкою. Спробуйте оно
 #: frontend/src/metabase/components/HeaderBar.jsx:45
 #: frontend/src/metabase/components/ListItem.jsx:37
 #: frontend/src/metabase/reference/components/Detail.jsx:47
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:158
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:213
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:191
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:205
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:209
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:209
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:161
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:216
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:194
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:208
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
 msgstr "Опис не заповнено"
 
 #: frontend/src/metabase/components/Header.jsx:112
-#: frontend/src/metabase/entities/containers/EntityForm.jsx:43
+#: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
 msgstr "Новий {0}"
 
@@ -2540,54 +2548,53 @@ msgstr "Новий {0}"
 msgid "Asked by {0}"
 msgstr "Заданий {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:13
+#: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
 msgstr "сьогодні,"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:15
+#: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
 msgstr "вчора,"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:68
+#: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
 msgstr "перша ревізія"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:70
+#: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
 msgstr "Повернуто до більш ранньої редакції і {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:82
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:289
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:379
-#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
+#: frontend/src/metabase/components/HistoryModal.jsx:42
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
+#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
 msgstr "Історія ревізій"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:90
+#: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
 msgstr "коли"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:91
+#: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
 msgstr "хто"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:92
+#: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
 msgstr "що"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:113
+#: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
 msgstr "повернути"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:114
+#: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
 msgstr "Повернення ..."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:115
+#: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
 msgstr "Повернення не вдався"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:116
+#: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
 msgstr "повернуто"
 
@@ -2596,26 +2603,24 @@ msgid "Everything"
 msgstr "Усе"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
-#: frontend/src/metabase/home/containers/SearchApp.jsx:69
 msgid "Dashboards"
 msgstr "панелі"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
-#: frontend/src/metabase/home/containers/SearchApp.jsx:115
 msgid "Questions"
 msgstr "питання"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:321
+#: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
 msgstr "Пульси"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:103
+#: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
 msgstr "назад"
 
-#: frontend/src/metabase/components/ListSearchField.jsx:18
+#: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
 msgstr "Знайти ..."
 
@@ -2652,14 +2657,14 @@ msgid "Temporary Password"
 msgstr "Тимчасовий пароль"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
 msgstr "приховати"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:412
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
 msgstr "Показати"
 
@@ -2724,7 +2729,7 @@ msgstr "15-е (середина)"
 msgid "Calendar Day"
 msgstr "день календаря"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:210
+#: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
 msgstr "часовий пояс вашого Metabase"
 
@@ -2753,11 +2758,11 @@ msgid "A component used to make a selection"
 msgstr "Компонент використаний для можливості вибору"
 
 #: frontend/src/metabase/components/Select.info.js:20
-#: frontend/src/metabase/components/Select.info.js:28
+#: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
 msgstr "обрано"
 
-#: frontend/src/metabase/components/Select.jsx:297
+#: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
 msgstr "Нічого не вибрано"
 
@@ -2770,7 +2775,7 @@ msgid "Unknown error encountered"
 msgstr "Виникла невідома помилка"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/nav/containers/Navbar.jsx:304
+#: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
 msgstr "Створити"
 
@@ -2779,13 +2784,11 @@ msgid "Create dashboard"
 msgstr "Створити панель інструментів"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:331
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:60
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
 msgstr "Таблиця"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:306
 msgid "Database"
 msgstr "База даних"
 
@@ -2793,22 +2796,20 @@ msgstr "База даних"
 msgid "Creator"
 msgstr "творець"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:238
+#: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
 msgstr "Нічого не знайдено"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:239
+#: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
 msgstr "Спробуйте встановити фільтр для того щоб знайти те, що шукали."
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:258
+#: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
 msgstr "Переглянуто"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:494
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:84
-#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:69
-#: frontend/src/metabase/tutorial/TutorialModal.jsx:34
+#: frontend/src/metabase/containers/EntitySearch.jsx:495
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
 msgstr "з"
 
@@ -2821,13 +2822,13 @@ msgid "Once you connect your own data, I can show you some automatic exploration
 msgstr "Як тільки ви підключите власні дані я зможу показати деякі автоматичні вишукування, названі X-ray. Ось кілька прикладів на даних, які є у мене."
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
-#: frontend/src/metabase/containers/Overworld.jsx:299
+#: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
 msgstr "Почніть тут"
 
-#: frontend/src/metabase/containers/Overworld.jsx:294
-#: frontend/src/metabase/entities/collections.js:147
+#: frontend/src/metabase/containers/Overworld.jsx:296
+#: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
 msgstr "Наша статистика"
@@ -2836,53 +2837,53 @@ msgstr "Наша статистика"
 msgid "Browse all items"
 msgstr "Переглянути всі елементи"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:165
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
 msgstr "Замінити або зберегти як новий?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:173
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
 msgstr "Замінити вихідний питання, \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:178
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
 msgstr "Зберегти як новий запит"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:187
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
 msgstr "Для початку, збережіть ваш запит"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:188
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
 msgstr "зберегти запит"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:224
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
 msgstr "Як називається ваша картка?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:232
-#: frontend/src/metabase/entities/collections.js:101
-#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:234
+#: frontend/src/metabase/entities/collections.js:102
+#: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/lib/core.js:50 frontend/src/metabase/lib/core.js:205
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:156
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:211
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:203
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:207
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:207
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:24
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:159
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:214
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:192
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:206
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:210
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
 msgstr "опис"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:238
-#: frontend/src/metabase/entities/dashboards.js:153
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
+#: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
 msgstr "Це не обов'язково, але може бути корисним"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:245
-#: frontend/src/metabase/entities/dashboards.js:157
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
+#: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "В яку збріку слід це включити?"
 
@@ -2894,7 +2895,7 @@ msgstr "змінено"
 msgid "item"
 msgstr "елемент"
 
-#: frontend/src/metabase/containers/UndoListing.jsx:81
+#: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
 msgstr "Скасувати"
 
@@ -2918,15 +2919,15 @@ msgstr "Ми не впевнені, чи поєднується дане пит�
 msgid "Archive Dashboard"
 msgstr "Архівувати Панель індикаторів"
 
-#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:20
+#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Переконайтеся що зроблений вибір для кожної з серій, інакше фільтр не буде працювати на цій картці."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:300
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
 msgstr "Панель індикаторів здається порожньо."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:301
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
 msgstr "Додайте питання і зробіть її корисною!"
 
@@ -2946,59 +2947,58 @@ msgstr "Вихід з повноекранного режиму"
 msgid "Enter fullscreen"
 msgstr "Повноекранний режим"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:181
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:183
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Збереження ..."
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:216
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
 msgstr "Додати запит"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:219
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
 msgstr "Додати запит до цієї панелі інструментів"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:248
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
 msgstr "Додати фільтр"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:254
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:78
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "параметри"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:275
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
 msgstr "Додати текстове поле"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
 msgstr "Перемісти панелі інструментів"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:302
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
 msgstr "Змінити панель інструментів"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:306
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
 msgstr "Змінити макет панелі інструментів"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:369
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
 msgstr "Ви редагуєте панель інструментів"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:374
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
 msgstr "Виберіть поле, яке повинно бути фільтром в кожній з карт"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:28
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
 msgstr "Перемістити панелі інструментів"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:52
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
 msgstr "Панель інструментів переміщена в {0}"
 
@@ -3013,7 +3013,7 @@ msgstr "Який тип фільтра?"
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:179
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
 msgstr "Вимкнути"
 
@@ -3053,174 +3053,174 @@ msgstr "оновлення через"
 msgid "Remove this question?"
 msgstr "Видалити цей запит?"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:71
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
 msgstr "Ваша панель інструментів була збережена"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:745
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:76
+#: frontend/src/metabase/components/CollectionLanding.jsx:744
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
 msgstr "переглянути"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:137
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
 msgstr "зберегти"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:170
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
 msgstr "Показати більше про це"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:140
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
 msgstr "Картка не містить полів або параметрів які можуть бути співставлені з цим типом параметра."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:142
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Значення цього поля не покривають значення ніяких полів, які ви вибрали."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:186
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
 msgstr "Немає коректних полів"
 
-#: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
 msgstr "Ім'я не повинно перевищувати 100 символів"
 
-#: frontend/src/metabase/entities/collections.js:111
+#: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
 msgstr "колір обов'язковий"
 
-#: frontend/src/metabase/entities/dashboards.js:146
+#: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
 msgstr "Як називається ваша панель інструментів?"
 
-#: frontend/src/metabase/home/components/Activity.jsx:92
+#: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
 msgstr "зробив супер-пупер фінт, який складно описати словами"
 
-#: frontend/src/metabase/home/components/Activity.jsx:101
-#: frontend/src/metabase/home/components/Activity.jsx:116
+#: frontend/src/metabase/home/components/Activity.jsx:103
+#: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
 msgstr "створив оповіщення про -"
 
-#: frontend/src/metabase/home/components/Activity.jsx:126
-#: frontend/src/metabase/home/components/Activity.jsx:141
+#: frontend/src/metabase/home/components/Activity.jsx:128
+#: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
 msgstr "видалив оповіщення про -"
 
-#: frontend/src/metabase/home/components/Activity.jsx:152
+#: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
 msgstr "зберегти питання про"
 
-#: frontend/src/metabase/home/components/Activity.jsx:165
+#: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
 msgstr "зберіг запит"
 
-#: frontend/src/metabase/home/components/Activity.jsx:169
+#: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
 msgstr "видалив запит"
 
-#: frontend/src/metabase/home/components/Activity.jsx:172
+#: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
 msgstr "створив панель індикаторів"
 
-#: frontend/src/metabase/home/components/Activity.jsx:175
+#: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
 msgstr "видалив панель індикаторів"
 
-#: frontend/src/metabase/home/components/Activity.jsx:181
-#: frontend/src/metabase/home/components/Activity.jsx:196
+#: frontend/src/metabase/home/components/Activity.jsx:183
+#: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
 msgstr "доавіл питання на панель індикаторів -"
 
-#: frontend/src/metabase/home/components/Activity.jsx:206
-#: frontend/src/metabase/home/components/Activity.jsx:221
+#: frontend/src/metabase/home/components/Activity.jsx:208
+#: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
 msgstr "видалив питання з панелі індикаторів -"
 
-#: frontend/src/metabase/home/components/Activity.jsx:231
-#: frontend/src/metabase/home/components/Activity.jsx:238
+#: frontend/src/metabase/home/components/Activity.jsx:233
+#: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
 msgstr "останні дані отримані"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:621
-#: frontend/src/metabase/home/components/Activity.jsx:244
+#: frontend/src/metabase-lib/lib/Dimension.js:814
+#: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
 msgstr "невідомо"
 
-#: frontend/src/metabase/home/components/Activity.jsx:251
+#: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
 msgstr "Привіт Світ!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:252
+#: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
 msgstr "Metabase запущено"
 
-#: frontend/src/metabase/home/components/Activity.jsx:258
-#: frontend/src/metabase/home/components/Activity.jsx:288
+#: frontend/src/metabase/home/components/Activity.jsx:260
+#: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
 msgstr "додав метрику"
 
-#: frontend/src/metabase/home/components/Activity.jsx:272
-#: frontend/src/metabase/home/components/Activity.jsx:362
+#: frontend/src/metabase/home/components/Activity.jsx:274
+#: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
 msgstr "до"
 
-#: frontend/src/metabase/home/components/Activity.jsx:282
-#: frontend/src/metabase/home/components/Activity.jsx:322
-#: frontend/src/metabase/home/components/Activity.jsx:372
-#: frontend/src/metabase/home/components/Activity.jsx:413
+#: frontend/src/metabase/home/components/Activity.jsx:284
+#: frontend/src/metabase/home/components/Activity.jsx:324
+#: frontend/src/metabase/home/components/Activity.jsx:374
+#: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
 msgstr "таблиця"
 
-#: frontend/src/metabase/home/components/Activity.jsx:298
-#: frontend/src/metabase/home/components/Activity.jsx:328
+#: frontend/src/metabase/home/components/Activity.jsx:300
+#: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
 msgstr "змінив метрику"
 
-#: frontend/src/metabase/home/components/Activity.jsx:312
-#: frontend/src/metabase/home/components/Activity.jsx:403
+#: frontend/src/metabase/home/components/Activity.jsx:314
+#: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
 msgstr "в"
 
-#: frontend/src/metabase/home/components/Activity.jsx:335
+#: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
 msgstr "видалив метрику"
 
-#: frontend/src/metabase/home/components/Activity.jsx:338
+#: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
 msgstr "Створив Пульс"
 
-#: frontend/src/metabase/home/components/Activity.jsx:341
+#: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
 msgstr "Видалив Пульс"
 
-#: frontend/src/metabase/home/components/Activity.jsx:347
-#: frontend/src/metabase/home/components/Activity.jsx:378
+#: frontend/src/metabase/home/components/Activity.jsx:349
+#: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
 msgstr "Додати фільтр"
 
-#: frontend/src/metabase/home/components/Activity.jsx:388
-#: frontend/src/metabase/home/components/Activity.jsx:419
+#: frontend/src/metabase/home/components/Activity.jsx:390
+#: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
 msgstr "змінив фільтр"
 
-#: frontend/src/metabase/home/components/Activity.jsx:426
+#: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
 msgstr "видалив фільтр {0}"
 
-#: frontend/src/metabase/home/components/Activity.jsx:429
+#: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
 msgstr "прієднався!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:529
+#: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
 msgstr "Хммм, схоже нічого не сталося."
 
-#: frontend/src/metabase/home/components/Activity.jsx:532
+#: frontend/src/metabase/home/components/Activity.jsx:534
 msgid "Save a question and get this baby going!"
 msgstr "Збережіть питання і змусьте цю дитинку йти!"
 
@@ -3268,21 +3268,21 @@ msgstr "Нещодавно переглянуті"
 msgid "You haven't looked at any dashboards or questions recently"
 msgstr "Ви не переглядали жодних панелей чи запитів останнім часом"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:99
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
 msgstr "{0} елементів вибрано"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:121
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:172
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
 msgstr "Розархівувати"
 
-#: frontend/src/metabase/home/containers/HomepageApp.jsx:74
-#: frontend/src/metabase/nav/containers/Navbar.jsx:331
+#: frontend/src/metabase/home/containers/HomepageApp.jsx:77
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
 msgstr "Активність"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:28
+#: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
 msgstr "Результати для \"{0}\""
 
@@ -3347,6 +3347,7 @@ msgstr "Посилання на аватар"
 msgid "Common"
 msgstr "Загальна"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
@@ -3383,8 +3384,9 @@ msgstr "широта"
 msgid "Longitude"
 msgstr "довгота"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:149
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
 msgstr "число"
@@ -3481,7 +3483,7 @@ msgstr "результат"
 
 #: frontend/src/metabase/lib/core.js:210
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:17
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
 msgstr "Заголовок"
 
@@ -3538,8 +3540,9 @@ msgid "Metabase will never retrieve this field. Use this for sensitive or irrele
 msgstr "Metabase ніколи не отримає це поле. Використовуйте для чутливої ​​нерелевантною інформації."
 
 #: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:614
-#: frontend/src/metabase/visualizations/lib/utils.js:126
+#: frontend/src/metabase/lib/query.js:300
+#: frontend/src/metabase/visualizations/lib/utils.js:130
+#: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -3554,7 +3557,7 @@ msgstr "Накопичувальне кількість"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
-#: frontend/src/metabase/visualizations/lib/utils.js:127
+#: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
 msgstr "сума"
 
@@ -3563,7 +3566,7 @@ msgid "CumulativeSum"
 msgstr "Накопичувальна сума"
 
 #: frontend/src/metabase/lib/expressions/config.js:11
-#: frontend/src/metabase/visualizations/lib/utils.js:128
+#: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
 msgstr "унікальні"
 
@@ -3572,29 +3575,29 @@ msgid "StandardDeviation"
 msgstr "Стандартне відхилення"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/visualizations/lib/utils.js:125
+#: frontend/src/metabase/visualizations/lib/utils.js:129
 msgid "Average"
 msgstr "середнє"
 
 #: frontend/src/metabase/lib/expressions/config.js:14
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:25
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
 msgstr "Мінімальна"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
 msgstr "максимальне"
 
-#: frontend/src/metabase/lib/expressions/parser.js:384
+#: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
 msgstr "сумна сумна панда, виявлені лексичні помилки"
 
-#: frontend/src/metabase/lib/formatting.js:707
+#: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} секунда"
@@ -3602,7 +3605,7 @@ msgstr[1] "{0} секунд"
 msgstr[2] "{0} секунд"
 msgstr[3] "{0} секунды"
 
-#: frontend/src/metabase/lib/formatting.js:710
+#: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} хвилина"
@@ -3643,222 +3646,224 @@ msgstr "Що в вас на думці?"
 msgid "What do you want to find out?"
 msgstr "Що ви хочете дізнатися?"
 
-#: frontend/src/metabase/lib/query.js:612
-#: frontend/src/metabase/lib/schema_metadata.js:451
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:246
+#: frontend/src/metabase/lib/query.js:298
+#: frontend/src/metabase/lib/schema_metadata.js:458
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
 msgstr "Вихідні дані"
 
-#: frontend/src/metabase/lib/query.js:616
+#: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
 msgstr "Накопичувальне кількість"
 
-#: frontend/src/metabase/lib/query.js:619
+#: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
 msgstr "середнє"
 
-#: frontend/src/metabase/lib/query.js:624
+#: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
 msgstr "унікальні значення"
 
-#: frontend/src/metabase/lib/query.js:629
+#: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
 msgstr "Стандартне відхилення"
 
-#: frontend/src/metabase/lib/query.js:634
+#: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
 msgstr "сума"
 
-#: frontend/src/metabase/lib/query.js:639
+#: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
 msgstr "Накопичувальна сума"
 
-#: frontend/src/metabase/lib/query.js:644
+#: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
 msgstr "максимум"
 
-#: frontend/src/metabase/lib/query.js:649
+#: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
 msgstr "мінімум"
 
-#: frontend/src/metabase/lib/query.js:663
+#: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
 msgstr "згруповано за"
 
-#: frontend/src/metabase/lib/query.js:677
+#: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
 msgstr "відфільтровано по"
 
-#: frontend/src/metabase/lib/query.js:706
+#: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
 msgstr "згруповано за"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
 msgstr "істина"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
 msgstr "брехня"
 
-#: frontend/src/metabase/lib/schema_metadata.js:305
+#: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
 msgstr "Виберіть поле з довготою"
 
-#: frontend/src/metabase/lib/schema_metadata.js:306
+#: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
 msgstr "Введіть верхню широту"
 
-#: frontend/src/metabase/lib/schema_metadata.js:307
+#: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
 msgstr "Введіть ліву довготу"
 
-#: frontend/src/metabase/lib/schema_metadata.js:308
+#: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
 msgstr "Введіть нижню широту"
 
-#: frontend/src/metabase/lib/schema_metadata.js:309
+#: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
 msgstr "Введіть праву довготу"
 
-#: frontend/src/metabase/lib/schema_metadata.js:345
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase-lib/lib/Dimension.js:505
+#: frontend/src/metabase-lib/lib/Dimension.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:351
+#: frontend/src/metabase/lib/schema_metadata.js:371
 #: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:387
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
 msgstr "-"
 
-#: frontend/src/metabase/lib/schema_metadata.js:346
-#: frontend/src/metabase/lib/schema_metadata.js:366
-#: frontend/src/metabase/lib/schema_metadata.js:376
-#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/lib/schema_metadata.js:352
+#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:396
+#: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
 msgstr "Чи не"
 
-#: frontend/src/metabase/lib/schema_metadata.js:347
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:369
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:353
+#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
 msgstr "Пусто"
 
-#: frontend/src/metabase/lib/schema_metadata.js:348
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:370
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:402
+#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
 msgstr "Чи не порожньо"
 
-#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
 msgstr "Так само"
 
-#: frontend/src/metabase/lib/schema_metadata.js:355
+#: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
 msgstr "Не дорівнює"
 
-#: frontend/src/metabase/lib/schema_metadata.js:356
+#: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
 msgstr "Більше ніж"
 
-#: frontend/src/metabase/lib/schema_metadata.js:357
+#: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
 msgstr "Менше ніж"
 
-#: frontend/src/metabase/lib/schema_metadata.js:358
-#: frontend/src/metabase/lib/schema_metadata.js:384
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:285
+#: frontend/src/metabase/lib/schema_metadata.js:364
+#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "між"
 
-#: frontend/src/metabase/lib/schema_metadata.js:359
+#: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
 msgstr "Більше або дорівнює"
 
-#: frontend/src/metabase/lib/schema_metadata.js:360
+#: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
 msgstr "Менше або дорівнює"
 
-#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
 msgstr "містить"
 
-#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
 msgstr "Не містить"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
 msgstr "Починається з"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
 msgstr "закінчується"
 
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:264
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "до"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:271
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "після"
 
-#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
 msgstr "усередині"
 
-#: frontend/src/metabase/lib/schema_metadata.js:453
+#: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Просто таблиця з рядками результатів, без додаткових операцій."
 
-#: frontend/src/metabase/lib/schema_metadata.js:459
+#: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
 msgstr "Кількість записів"
 
-#: frontend/src/metabase/lib/schema_metadata.js:461
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
 msgstr "Загальна кількість рядків у відповіді"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
 msgstr "Кількість ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:469
+#: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
 msgstr "Кількість всіх значень колонки."
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
 msgstr "Середнє ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
 msgstr "Середнє всіх значень колонки."
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
 msgstr "Унікальні значення ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Кількість унікальних значень стовпця серед всіх записів у відповіді."
 
-#: frontend/src/metabase/lib/schema_metadata.js:491
+#: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
 msgstr "Сума наростаючим підсумком ..."
 
@@ -3866,7 +3871,7 @@ msgstr "Сума наростаючим підсумком ..."
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Сукупна сума всіх значень стовпця. \\\\ ne.x. всього дохід за часовий інтервал."
 
-#: frontend/src/metabase/lib/schema_metadata.js:499
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
 msgstr "Наростаючий підсумок"
 
@@ -3874,105 +3879,105 @@ msgstr "Наростаючий підсумок"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Сукупна кількість записів. \\\\ ne.x. всього продажів за часовий інтервал."
 
-#: frontend/src/metabase/lib/schema_metadata.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
 msgstr "Стандартне відхилення…"
 
-#: frontend/src/metabase/lib/schema_metadata.js:509
+#: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Число, що відображає наскільки значення стовпця відхиляються від всіх записів відповіді."
 
-#: frontend/src/metabase/lib/schema_metadata.js:515
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
 msgstr "Мінімум ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:517
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
 msgstr "Мінімальне значення стовпця"
 
-#: frontend/src/metabase/lib/schema_metadata.js:523
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
 msgstr "Максимум ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:525
+#: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
 msgstr "Максимальне значення колонки"
 
-#: frontend/src/metabase/lib/schema_metadata.js:533
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
 msgstr "Розбити по вимірюванню"
 
-#: frontend/src/metabase/lib/settings.js:93
+#: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
 msgstr "буква в нижньому регістрі"
 
-#: frontend/src/metabase/lib/settings.js:95
+#: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
 msgstr "буква в верхньому регістрі"
 
-#: frontend/src/metabase/lib/settings.js:97
+#: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "число"
 
-#: frontend/src/metabase/lib/settings.js:99
+#: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
 msgstr "спеціальний символ"
 
-#: frontend/src/metabase/lib/settings.js:105
+#: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
 msgstr "повинен містити не менше"
 
-#: frontend/src/metabase/lib/settings.js:105
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:120
+#: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
 msgstr "символів"
 
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
 msgstr "Повинен містити не менш"
 
-#: frontend/src/metabase/lib/settings.js:122
+#: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
 msgstr "і містити як мінімум"
 
-#: frontend/src/metabase/lib/utils.js:92
+#: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
 msgstr "нуль"
 
-#: frontend/src/metabase/lib/utils.js:93
+#: frontend/src/metabase/lib/utils.js:86
 msgid "one"
 msgstr "один"
 
-#: frontend/src/metabase/lib/utils.js:94
+#: frontend/src/metabase/lib/utils.js:87
 msgid "two"
 msgstr "два"
 
-#: frontend/src/metabase/lib/utils.js:95
+#: frontend/src/metabase/lib/utils.js:88
 msgid "three"
 msgstr "три"
 
-#: frontend/src/metabase/lib/utils.js:96
+#: frontend/src/metabase/lib/utils.js:89
 msgid "four"
 msgstr "чотири"
 
-#: frontend/src/metabase/lib/utils.js:97
+#: frontend/src/metabase/lib/utils.js:90
 msgid "five"
 msgstr "п'ять"
 
-#: frontend/src/metabase/lib/utils.js:98
+#: frontend/src/metabase/lib/utils.js:91
 msgid "six"
 msgstr "шість"
 
-#: frontend/src/metabase/lib/utils.js:99
+#: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
 msgstr "сім"
 
-#: frontend/src/metabase/lib/utils.js:100
+#: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
 msgstr "вісім"
 
-#: frontend/src/metabase/lib/utils.js:101
+#: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
 msgstr "дев'ять"
 
@@ -4046,6 +4051,7 @@ msgstr "час"
 msgid "Date range, relative date, time of day, etc."
 msgstr "Часовий інтервал, відносна дата, час дня, інше."
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
@@ -4068,7 +4074,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Категорія, Тип, Модель, Рейтинг, інше."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
-#: frontend/src/metabase/user/components/UserSettings.jsx:54
+#: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
 msgstr "Налаштування облікового запису"
 
@@ -4080,56 +4086,56 @@ msgstr "Вийти з адміністрування"
 msgid "Logs"
 msgstr "Список"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:64
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
 msgstr "Допомога"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:67
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
 msgstr "Про Metabase"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:73
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
 msgstr "Вихід"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:98
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
 msgstr "Дякуємо за використання"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
 msgstr "Ваша версія"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
 msgstr "Побудовано"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:124
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
 msgstr "Торговий знак"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:126
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
 msgstr "і було створено з турботою в Сан Франциско, Каліфорнія"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:194
+#: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
 msgstr "управління Metabase"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:300
+#: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
 msgstr "Задати питання"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:309
+#: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
 msgstr "Нова панель інструментів"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:315
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/nav/containers/Navbar.jsx:361
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
 msgstr "Нова Пульс"
 
@@ -4137,16 +4143,16 @@ msgstr "Нова Пульс"
 msgid "Reference"
 msgstr "довідник"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:83
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
 msgstr "Яка метрика?"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:110
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Визначення загальних метрик для вашої команди ще більше полегшує ставлення запитань"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:113
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
 msgstr "Як створити метрики"
 
@@ -4158,8 +4164,8 @@ msgstr "Дивиться дані у часі у вигляді карт та з
 msgid "Custom"
 msgstr "Майстер запитів"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:150
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:517
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
 msgstr "Новий запит"
 
@@ -4167,22 +4173,22 @@ msgstr "Новий запит"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Використовуйте просту програму створення запитів для перегляду трендів, списків або створення власних метрик."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:161
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Прямий запит"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:162
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Для відповіді на більш складні запитання, ви можете написати власний SQL або прямий запит."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:240
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
 msgstr "Виберіть значення за замовчуванням ..."
 
-#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:149
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
 msgstr "оновити фільтр"
 
@@ -4190,14 +4196,14 @@ msgstr "оновити фільтр"
 #: frontend/src/metabase/lib/query_time.js:123
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:9
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Today"
 msgstr "Сьогодні"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
 msgstr "Вчора"
 
@@ -4209,7 +4215,7 @@ msgstr "Минулі 7 днів"
 msgid "Past 30 days"
 msgstr "Минулі 30 днів"
 
-#: frontend/src/metabase/lib/query_time.js:195
+#: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:29
 #: src/metabase/api/table.clj
@@ -4220,7 +4226,7 @@ msgstr[1] "тиждень"
 msgstr[2] "тиждень"
 msgstr[3] "тиждень"
 
-#: frontend/src/metabase/lib/query_time.js:197
+#: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:30
 #: src/metabase/api/table.clj
@@ -4231,7 +4237,7 @@ msgstr[1] "місяць"
 msgstr[2] "місяць"
 msgstr[3] "місяць"
 
-#: frontend/src/metabase/lib/query_time.js:201
+#: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:31
 #: src/metabase/api/table.clj
@@ -4283,6 +4289,7 @@ msgstr "Введіть значення ..."
 msgid "Enter a default value..."
 msgstr "Введіть значення по-умовчання ..."
 
+#: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Виникла помилка"
@@ -4323,24 +4330,24 @@ msgstr "Опублікувати"
 msgid "Code"
 msgstr "код"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:70
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
 msgstr "Стиль"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
 msgstr "Які параметри можуть використовуватися для вбудовування?"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:83
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
 msgstr "{0} не містить параметрів, що настроюються."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
 msgstr "редаговані"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
 msgstr "заблоковано"
 
@@ -4348,19 +4355,19 @@ msgstr "заблоковано"
 msgid "Preview Locked Parameters"
 msgstr "Попередній перегляд заблокованих параметрів"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:115
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
 msgstr "Спробуйте додати значення для заблокованих параметрів. Надалі ваш сервер буде надавати актуальні значення в підписаному токені."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
 msgstr "небезпечна зона"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
 msgstr "Це відключить вкладання {0}."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:128
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
 msgstr "Зняти з публікації"
 
@@ -4400,64 +4407,64 @@ msgstr "Більше {0}"
 msgid "examples on GitHub"
 msgstr "приклади на GitHub"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:72
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
 msgstr "Включити загальний доступ"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
 msgstr "Відключити цю публічну посилання?"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:77
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
 msgstr "Це отлючіт працездатність існуючої посилання. Ви можете повторно включити її, але при цьому буде створено нову посилання."
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
 msgstr "публічна посилання"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:118
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
 msgstr "Поділитися {0} з людьми, якими не мають облікових записів в Metabase використовуючи посилання нижче:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:158
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
 msgstr "Вбудувати в режимі загального доступу"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:159
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
 msgstr "Вбудуйте {0} в повідомлення блогу чи веб-сторінки, скопіювавши і вставивши наступний сниппет:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:176
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
 msgstr "Вбудувати {0} в додаток"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:177
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
 msgstr "Ви можете інтегрувати в серверну частину коду вашої програми безпечну статистику {0}, обмежену конкретним користувачем, покупцем, організацією і т.п."
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
 msgstr "Видалити додаток"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:95
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
 msgstr "Прикріпити файл з результатами"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
 msgstr "Цей запит буде додано у вигляді прикріпленого файлу"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:128
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
 msgstr "Цей запит не може бути включений в Пульс"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:92
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
 msgstr "Цей Пульс більше не буде відправлятися на email {0} {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:94
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:376
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
 msgstr[0] "{0} Адреса"
@@ -4469,39 +4476,39 @@ msgstr[3] "{0} Адреси"
 msgid "Slack channel {0} will no longer get this pulse {1}"
 msgstr "Канал Slack {0} більше не буде отримувати цей пульс {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:110
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
 msgstr "Канал {0} більше не буде отримувати цей пульс {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
 msgstr "Змінити пульс"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:131
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
 msgstr "Що таке Пульс?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:141
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
 msgstr "Зрозуміло"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
 msgstr "Куди слід відправити ці дані?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:173
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
 msgstr "Розархівація ..."
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
 msgstr "Не вдалося розархівувати"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
 msgstr "Розархівовано"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
 msgstr "Створити Пульс"
 
@@ -4511,7 +4518,7 @@ msgstr "Додаток"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:673
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
 msgstr "Увага"
 
@@ -4532,6 +4539,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Ми рекомендуємо залишати Пульси невеликими і цілеспрямованими, щоб зробити їх легкими для використання та корисний для всієї команди."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
+#: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
 msgstr "Виберіть дані"
 
@@ -4547,47 +4555,47 @@ msgstr "Електронні адреси"
 msgid "Slack messages"
 msgstr "повідомлення Slack"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Відправлено"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:222
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} Буде відправлено на"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:224
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Повідомлення"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Надіслати Email прямо зараз"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:241
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Надіслати {0} прямо зараз"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Відправлення ..."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:244
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Не вдалося відправити"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Не відправлено, тому що Пульс не містить результатів."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:248
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Пульс відправлений"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:287
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} Має бути налагоджене адміністратором."
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:302
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
 msgstr "Slack"
 
@@ -4636,21 +4644,21 @@ msgid "Before {0}"
 msgstr "До {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:295
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Пусто"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:301
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Чи не порожньо"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:213
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Весь час"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:154
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
 msgstr "застосувати"
 
@@ -4716,7 +4724,7 @@ msgstr "поширення"
 msgid "View details"
 msgstr "Переглянути деталі"
 
-#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:54
+#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
 msgstr "Переглянути {0} {1}"
 
@@ -4740,7 +4748,7 @@ msgstr "середнє"
 msgid "Distincts"
 msgstr "унікальні"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:32
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Показати {0}"
@@ -4748,16 +4756,16 @@ msgstr[1] "Показати {0}"
 msgstr[2] "Показати {0}"
 msgstr[3] "Показати {0}"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:225
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
 msgstr "наблизити"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:19
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
 msgstr "Довільний вираз"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
 msgstr "Загальні метрики"
 
@@ -4765,7 +4773,7 @@ msgstr "Загальні метрики"
 msgid "Metabasics"
 msgstr "Metabasics"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
 msgstr "Ім'я (не обов'язково)"
 
@@ -4777,31 +4785,31 @@ msgstr "Виберіть агрегацію"
 msgid "Set up your own alert"
 msgstr "Налаштування власне попередження"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:140
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
 msgstr "Відписка ..."
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:145
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
 msgstr "Помилка при її анулювання"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:204
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
 msgstr "Відмовитися"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:235
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
 msgstr "немає каналу"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:263
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
 msgstr "Відмінно, ви відписалися"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:335
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
 msgstr "Вами отримано {0} попереджень"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
 msgstr "{0} встановив оповіщення"
 
@@ -4857,147 +4865,147 @@ msgstr "Змінити ваше попередження"
 msgid "Edit alert"
 msgstr "змінити попередження"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:374
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
 msgstr "Це попередження більше не буде відправлятися на {0}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:382
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
 msgstr "Канал Slack {0} більше не буде отримувати дане попередження."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:386
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
 msgstr "Канал {0} більше не буде отримувати дане попередження."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:403
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
 msgstr "Видалити це попередження"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:405
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
 msgstr "Зупинити доставку і видалити це попередження. Дія не може бути скасовано, будьте уважні."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:413
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
 msgstr "Видалити це попередження?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:497
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
 msgstr "Попередити мене коли лінія ..."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:498
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
 msgstr "Попередити мене коли прогрес ..."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
 msgstr "Перевищить лінію мети"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
 msgstr "досягне мети"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
 msgstr "Опуститься нижче лінії цілі"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
 msgstr "Опуститься нижче цілі"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:512
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
 msgstr "При першому перетині, або кожен раз?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:513
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
 msgstr "При першому досягненні мети, або кожен раз?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
 msgstr "Перший раз"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:516
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
 msgstr "Кожен раз"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:619
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
 msgstr "Куди ви хочете відправляти дані попередження?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:630
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
 msgstr "Надсилати попереджувальні на:"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:672
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
 msgstr "{0} Повідомлення засновані на цілях ще не підтримуються для графіків з більш ніж однієї кривої. Отже це повідомлення буде надіслано як тільки значення графіка досягне {1}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
 msgstr "результати"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:679
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
 msgstr "{0} Це повідомлення особливо корисно коли ваш збережений питання не {1} повертає ніяких результатів, але ви хочете знати коли це станеться."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:680
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
 msgstr "Підказка"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
 msgstr "зазвичай"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:57
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
 msgstr "Прикріпіть сегмент або таблицю"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
 msgstr "Виберіть базу даних"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:88
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
 msgstr "Вибрати ..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:128
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
 msgstr "Виберіть таблицю"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:793
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
 msgstr "У цій базі даних не знайдено жодної таблиці."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:830
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
 msgstr "Якщо пропустити запит?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:834
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
 msgstr "Дізнатися більше про вкладених запитах"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:868
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
 msgstr "поля"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:946
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
 msgstr "Сегменти не знайдені."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:969
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
 msgstr "знайти сегмент"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:46
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
 msgstr "менше"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:56
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
 msgstr "більше"
 
@@ -5006,60 +5014,65 @@ msgid "Pick a field to sort by"
 msgstr "Виберіть поле для сортування"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
 msgstr "Сортувати"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
 msgstr "Кількість рядків"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:69
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
 msgstr "невідоме поле"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
 msgstr "поле"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:114
+#: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
 msgstr "збіги"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
+#: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Додайте фільтри щоб скоротити результати запиту"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:284
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
 msgstr "Додати групування"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:322
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:102
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:113
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:152
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:194
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:59
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:68
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:75
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:225
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:231
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:237
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:70
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:75
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:64
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:89
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:131
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:176
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:302
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:308
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:314
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "дані"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:352
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
 msgstr "відфільтровано по"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:369
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
 msgstr "Вид"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:386
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
 msgstr "згруповано за"
 
@@ -5067,23 +5080,23 @@ msgstr "згруповано за"
 msgid "None"
 msgstr "0"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:345
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
 msgstr "Цей запит написаний в {0}."
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:353
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
 msgstr "Приховати редактор"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:354
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
 msgstr "приховати Запит"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
 msgstr "Відкрити редактор"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:360
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
 msgstr "Показати Запит"
 
@@ -5104,15 +5117,15 @@ msgstr "Завантажити ці дані"
 msgid "Warning"
 msgstr "попередження"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:52
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
 msgstr "Ваш результат містить велику кількість рядків і займе якийсь час на завантаження."
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:53
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
 msgstr "Максимальний розмір завантажених 1 мільйон рядків."
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:232
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
 msgstr "змінити запит"
 
@@ -5128,17 +5141,17 @@ msgstr "СКАСУВАТИ"
 msgid "Move question"
 msgstr "перемістити запит"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:283
+#: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
 msgstr "Яка колекція повинна бути тут?"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:313
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:110
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
+#: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
 msgstr "Змінні"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:432
+#: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
 msgstr "Дізнатися про свої дані"
 
@@ -5182,11 +5195,11 @@ msgstr "{0} для цього запиту"
 msgid "Convert this question to {0}"
 msgstr "Перетворити цей запит в {0}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:122
+#: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
 msgstr "Оновлення запиту займе {0}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:131
+#: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
 msgstr "Оновлене {0}"
 
@@ -5206,11 +5219,11 @@ msgstr "Перегляд перших {0} {1}"
 msgid "Showing {0} {1}"
 msgstr "Перегляд {0} {1}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:281
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
 msgstr "наукові дослідження"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:294
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
 msgstr "Якщо ви дасте мені дані я зможу показати щось круте. Запустіть запит!"
 
@@ -5218,7 +5231,7 @@ msgstr "Якщо ви дасте мені дані я зможу показат�
 msgid "How do I use this thing?"
 msgstr "Як це використовувати?"
 
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:28
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
 msgstr "Отримати відповідь"
 
@@ -5246,39 +5259,39 @@ msgstr "Просимо вибачення. Щось пішло не так."
 msgid "Group time by"
 msgstr "Групувати час по"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:46
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
 msgstr "Ваш запит займає надто багато часу"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:47
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
 msgstr "Ми не отримали відповідь від Вашої бази даних вчасно, так що нам довелося зупинитися. Ви можете спробувати ще раз через пару хвилин, або якщо проблема зберігається оповістити адміністратора по електронній пошті"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:55
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
 msgstr "У нас складнощі з сервером"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:56
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
 msgstr "Спробуйте оновити сторінку, почекавши одну-дві хвилини. Якщо проблема повториться, рекомендуємо звернутися до адміністратора."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:88
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
 msgstr "З вашим запитів виникла проблема"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:89
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
 msgstr "У більшості випадків це пов'язано з помилкою вибору або введеного значення. Перевірте дані та повторіть запит."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:60
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
 msgstr "Можливо, ми знайшли те, що ви шукали. Якщо немає, спробуйте скасувати або змінити фільтри, зробивши їх менш суворими."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
 msgstr "Ми також можете {0} після отримання результату."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:68
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
 msgstr "отримати попередження"
 
@@ -5286,11 +5299,11 @@ msgstr "отримати попередження"
 msgid "Back to last run"
 msgstr "Повернутися до останнього запуску"
 
-#: frontend/src/metabase/query_builder/components/VisualizationSettings.jsx:100
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
 msgstr "візуалізація"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:96
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
 msgstr "Опис не задано."
 
@@ -5302,7 +5315,7 @@ msgstr "Використовувати поточний запит."
 msgid "Potentially useful questions"
 msgstr "Потенційно корисні запити."
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:166
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
 msgstr "Групувати за {0}"
 
@@ -5315,14 +5328,14 @@ msgstr "Сума всіх значень {0}"
 msgid "All distinct values of {0}"
 msgstr "Унікальні значення {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:187
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
 msgstr "Число {0} згрупованих за {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5338,34 +5351,34 @@ msgstr "Відповідність Даних"
 msgid "Learn more about your data structure to ask more useful questions"
 msgstr "Дізнайтеся більше про структуру ваших даних для створення корисних запитів"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:58
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:84
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
 msgstr "Не вдалося знайти метадані таблиці до створення нового питання"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:80
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
 msgstr "Подивитися {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:94
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
 msgstr "Визначення Метрики"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:118
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
 msgstr "Відфільтровано по {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:127
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
 msgstr "Число {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
 msgstr "Дивитися всі {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:148
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
 msgstr "визначення сегмента"
 
@@ -5377,7 +5390,7 @@ msgstr "При завантаженні таблиці сталася помил
 msgid "See the raw data for {0}"
 msgstr "Подивитися вихідні дані для {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:180
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
 msgstr "більше"
 
@@ -5389,24 +5402,24 @@ msgstr "некоректне вираз"
 msgid "unknown error"
 msgstr "невідома помилка"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:46
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
 msgstr "Формула поля"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:57
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Подумайте про це як про те, як написати формулу в програмі для роботи з електронними таблицями: ви можете використовувати числа, поля таблиці, математичні символи, такі як +, і деякі функції. Таким чином, ви можете ввести щось на зразок Разом - Вартість."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
 msgstr "Дізнатися більше"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:66
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
 msgstr "Дати ім'я"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:72
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
 msgstr "Що-небудь чудове і зрозуміле"
 
@@ -5458,7 +5471,8 @@ msgstr "істина"
 msgid "false"
 msgstr "брехня"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
 msgstr "Додати фільтр"
 
@@ -5466,15 +5480,15 @@ msgstr "Додати фільтр"
 msgid "Item"
 msgstr "елемент"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:221
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
 msgstr "Попередній"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:252
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
 msgstr "Поточний"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:278
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
@@ -5485,7 +5499,7 @@ msgid "Enter desired number"
 msgstr "Введіть бажаний номер"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:100
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
 msgstr "Пусто"
 
@@ -5509,35 +5523,35 @@ msgstr "Ви можете ввести безліч значень, розділ
 msgid "Enter desired text"
 msgstr "Введіть бажаний текст"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
 msgstr "Спробувати"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
 msgstr "Для чого це?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
 msgstr "Змінні в прямих запитах дозволяють динамічно замінювати значення у ваших запитах за допомогою віджетів фільтрів або через URL-адресу."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
 msgstr "{0} створює змінну в цьому шаблоні SQL з ім'ям \"variable_name\". Змінні можуть бути задані типами на бічній панелі, що змінює їх поведінку. Всі типи змінних, відмінні від \"Фільтр поля\", автоматично викликають віджет фільтра з цього питання; з \"Фільтром поля\" це необов'язково. При заповненні цього віджет фільтра, це значення замінює змінну в шаблоні SQL."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:121
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
 msgstr "Фільтри поля"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:123
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Присвоєння змінній типу \"Фільтр поля\" дозволяє зв'язати картки SQL з віджетами фільтра панелі моніторингу або використовувати додаткові типи віджетів фільтра в запиті SQL. Мінлива фільтра поля вставляє SQL, подібний до того, який генерується будівником запитів GUI при додаванні фільтрів на існуючі стовпчики."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:126
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
 msgstr "При додаванні змінної \"Фільтр поля\" необхідно зіставити її з певним полем. Після цього ви можете відобразити віджет фільтра для вашого запиту, але навіть якщо ви цього не зробите, тепер можна зіставити змінну \"Фільтр поля\" з фільтром панелі інструментів при додаванні цього питання на панель інструментів. \"Фільтри поля\" повинні використовуватися всередині положення \"WHERE\"."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:130
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
 msgstr "Опціональні положення"
 
@@ -5545,59 +5559,61 @@ msgstr "Опціональні положення"
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
 msgstr "Дужки навколо {0} створюють опциональне положення в шаблоні. Якщо \"Змінна\" встановлена, тоді все положення включається в шаблон. Якщо ні - все положення ігнорується."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:142
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
 msgstr "Для використання декількох опціональних положень, ви можете включити принаймні одне обов'язкове положення WHERE, доповнивши його опціональними через \"AND\"."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
 msgstr "Ознайомитися з повною документацією"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:127
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
 msgstr "Тема фільтра"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:139
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
 msgstr "Тип змінної"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:143
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
 msgstr "текст"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:150
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:119
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
 msgstr "Дата"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
 msgstr "Фільтр поля"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:157
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
 msgstr "сполучні поля"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
 msgstr "Тип фільтра віджета"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:201
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
 msgstr "Обов'язково?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:211
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
 msgstr "Значення за замовчуванням для фільтра віджета"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:46
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
 msgstr "Перемістити цей запит в архів?"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:57
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Цей запит буде видалений з усіх панелей інструментів або Пульсів, де він був доданий."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:136
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
 msgstr "запит"
 
@@ -5614,21 +5630,21 @@ msgstr "Ви редагуєте цю сторінку"
 msgid "See this {0}"
 msgstr "Подивитися {0}"
 
-#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:120
+#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
 msgstr "безліч"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:68
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
 msgstr "Виберіть тип поля"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:57
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
 msgstr "Ні типу поля"
 
@@ -5637,16 +5653,16 @@ msgid "by"
 msgstr "по"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
-#: frontend/src/metabase/reference/databases/FieldList.jsx:152
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
+#: frontend/src/metabase/reference/databases/FieldList.jsx:155
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
 msgstr "Тип поля"
 
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:72
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
 msgstr "Виберіть зовнішній ключ"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:53
+#: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
 msgstr "Переглянути формулу {0}"
 
@@ -5663,12 +5679,12 @@ msgid "Nothing important yet"
 msgstr "Поки нічого важливого"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:168
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:233
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:211
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:215
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:219
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:229
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:236
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:214
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
 msgstr "Поки нічого цікавого"
 
@@ -5677,12 +5693,12 @@ msgid "Things to be aware of about this {0}"
 msgstr "Що потрібно знати про {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:178
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:243
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:221
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:225
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:229
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:239
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:246
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:224
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
 msgstr "Поки нічого не відомо"
 
@@ -5744,15 +5760,15 @@ msgstr "причини зміни"
 msgid "Leave a note to explain what changes you made and why they were required"
 msgstr "Залиште опис, щоб пояснити які зміни Ви зробили і чому вони необхідні"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:166
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
 msgstr "Чому ця база даних може бути цікава"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:176
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
 msgstr "Що потрібно знати про цю базі даних"
 
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:46
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
 msgstr "Бази даних і таблиці"
@@ -5760,42 +5776,42 @@ msgstr "Бази даних і таблиці"
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:41
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:170
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:173
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:34
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:184
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:187
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:30
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:188
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:187
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:191
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:190
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
 msgstr "Деталі"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
-#: frontend/src/metabase/reference/databases/TableList.jsx:111
+#: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
 msgstr "Таблиці в {0}"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:222
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:200
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:218
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:203
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
 msgstr "Справня назва в базі даних"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:231
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:227
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
 msgstr "Чому це поле може бути цікаво"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:241
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:237
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
 msgstr "Що потрібно знати про це поле"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:253
-#: frontend/src/metabase/reference/databases/FieldList.jsx:155
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:249
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
+#: frontend/src/metabase/reference/databases/FieldList.jsx:158
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
 msgstr "Тип даних"
 
@@ -5804,13 +5820,13 @@ msgstr "Тип даних"
 msgid "Fields in this table will appear here as they're added"
 msgstr "Поля в цій таблицю з'являться після їх додавання"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:134
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:135
+#: frontend/src/metabase/reference/databases/FieldList.jsx:137
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
 msgstr "Поля в {0}"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:149
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:150
+#: frontend/src/metabase/reference/databases/FieldList.jsx:152
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
 msgstr "Назва поля"
 
@@ -5834,7 +5850,10 @@ msgstr "Бази даних з'явиться тут після додаванн
 msgid "Connect a database"
 msgstr "Підключити базу даних"
 
+#. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
+#. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
+#: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
 msgstr "Кількість {0}"
 
@@ -5842,11 +5861,11 @@ msgstr "Кількість {0}"
 msgid "See raw data for {0}"
 msgstr "Подивитися вихідні дані для {0}"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:209
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
 msgstr "Чому ця таблиця може бути цікава"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:219
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
 msgstr "Що потрібно знати про цю таблиці"
 
@@ -5858,16 +5877,16 @@ msgstr "Таблиці в цій базі даних з'являться піс�
 msgid "Questions about this table will appear here as they're added"
 msgstr "Запити про цю таблиці з'являться після додавання"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:71
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:75
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:74
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
 msgstr "Запити про {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
 msgstr "Створено {0} користувачем {1}"
 
@@ -5879,151 +5898,152 @@ msgstr "Поля в цій таблиці"
 msgid "Questions about this table"
 msgstr "Запити про цю таблиці"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:157
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
 msgstr "Допоможіть вашій команді з вашими даними."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:159
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
 msgstr "Покажіть вашій команді найбільш важливе, вибравши найкращі панелі інструментів, метрики і сегменти."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:165
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
 msgstr "почнемо"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:173
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
 msgstr "Наша найважливіша панелі інструментів"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:188
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
 msgstr "Числа, які потребують уваги"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:213
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
 msgstr "Метрики - це важливі для компанії показники. Вони часто являють собою основні показники того, як працює бізнес."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:221
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
 msgstr "Подивитися всі метрики"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:235
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
 msgstr "Сегменти і таблиці"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
+#: frontend/src/metabase/home/containers/SearchApp.jsx:83
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
 msgstr "таблиці"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:262
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
 msgstr "Сегменти і таблиці є складовими блоками даних вашої компанії. Таблиці є збіркою необробленої інформації, а сегменти - це конкретні зрізи зі специфічними значеннями, наприклад {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:267
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
 msgstr "Таблиці є складовими блоками даних вашої компанії."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:277
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
 msgstr "Подивитися всі сегменти"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:293
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
 msgstr "Подивитися всі таблиці"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:301
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
 msgstr "Інші речі, які потрібно знати про наших даних"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
 msgstr "знайти більше"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:307
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
 msgstr "Хороший спосіб познайомитися з вашими даними - витратити трохи часу на вивчення різних таблиць та іншої інформації, доступної вам. Це може зайняти деякий час, але ви з часом ви станете дізнаватися їх назви та значення."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:313
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
 msgstr "дослідити дані"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:321
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
 msgstr "Залишилися питання?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:326
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
 msgstr "Зв'яжіться з {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:248
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
 msgstr "Допоможіть новим користувачам Metabase знайти свій шлях."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:251
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
 msgstr "У керівництві Getting Started основна увага приділяється панелі, метрик, сегментам і таблицями, які інформують ваших користувачів про важливі речі, які вони повинні знати, перш ніж вникати в дані."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:258
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
 msgstr "Ця панель інструментів важлива для вашої команди?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:260
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
 msgstr "Створити панель інструментів зараз"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:266
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
 msgstr "Яка панель інструментів є найбільш важливою?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:285
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
 msgstr "Чи є у вас які-небудь часто згадувані метрики?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:287
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
 msgstr "Дізнайтеся як визначити метрику"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:300
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
 msgstr "Які ваші 3-5 найбільш часто згадувані метрики?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:344
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
 msgstr "Додати іншу метрику"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:357
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
 msgstr "Чи є у вас які-небудь часто згадувані сегменти або таблиці?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:359
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
 msgstr "Дізнайтеся як створити сегмент"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:372
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
 msgstr "Які 3-5 часто згадуваних сегментів або таблиць, які були б корисні для цієї аудиторії?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:418
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
 msgstr "Додати ще один сегмент або таблицю"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:427
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
 msgstr "Чи є що-небудь, що ваші користувачі повинні розуміти або знати, перш ніж вони отримають доступ до даних?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:433
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
 msgstr "Що повинен знати користувач про ці дані перед тим, як до них звертатися?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:437
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
 msgstr "Наприклад, очікування щодо конфіденційності та використання даних, типові помилки або непорозуміння, інформація про продуктивність сховища даних, яке правове повідомлення і т.д."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
 msgstr "Чи можуть користувачі до вас звертатися при виникненні питань?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:457
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
 msgstr "З ким повинні пов'язувати користувачі для допомоги при виникненні питань за даними?"
 
@@ -6032,39 +6052,39 @@ msgstr "З ким повинні пов'язувати користувачі д
 msgid "Please enter a revision message"
 msgstr "Будь ласка, додайте повідомлення ревізії"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:213
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
 msgstr "Чому ця Метрика може бути цікавою"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:223
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
 msgstr "Що потрібно знати про цю метриці"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:233
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
 msgstr "Як розраховується ця метрика"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:235
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
 msgstr "Поки нічого не розраховане"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:293
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
 msgstr "Інші поля, за якими ви можете групувати цю метрику"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:294
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
 msgstr "Метрика може бути згрупована за такими полями"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:23
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Метрики це офіційні цифри, якими опікується ваша команда"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Метрики будуть з'являтися тут як тільки ваші адміни їх зроблять"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
 msgstr "Дізнайтеся як створити метрику"
 
@@ -6076,9 +6096,9 @@ msgstr "Запити про цю метриці з'являться після �
 msgid "There are no revisions for this metric"
 msgstr "Дана метрика не містить ревізій"
 
-#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:88
-#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
-#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:88
+#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
+#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
+#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
 msgstr "Історія ревізій {0}"
 
@@ -6086,27 +6106,27 @@ msgstr "Історія ревізій {0}"
 msgid "X-ray this metric"
 msgstr "Просканувати цю метрику"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:217
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
 msgstr "Чому цей сегмент цікавий"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:227
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
 msgstr "Що потрібно знати про цей сегмент"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
 msgstr "Сегменти є цікавими підмножинами таблиць"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Визначення загальних сегментів для вашої команди спрощує створення запитів"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
 msgstr "Сегменти з'являться тут після того як адміністратори їх створять"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
 msgstr "Дізнайтеся як створювати сегменти"
 
@@ -6134,7 +6154,7 @@ msgstr "Просканувати цей сегмент"
 msgid "Login"
 msgstr "Логін"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:130
+#: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
 msgstr "Пошук"
@@ -6151,99 +6171,99 @@ msgstr "Нове питання"
 msgid "Select the type of Database you use"
 msgstr "Виберіть тип бази даних"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:141
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
 msgstr "Додайте свої дані"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:145
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
 msgstr "Я додам дані пізніше"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
 msgstr "Підключення до {0}"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:165
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
 msgstr "Вам необхідно деяка інформація про вашу базі даних, така як ім'я користувача і пароль. Якщо у вас неї її прямо зараз - Metabase поставляється з набором тестових даних, з яким ви можете почати."
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:196
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
 msgstr "Я додам мої дані пізніше"
 
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:41
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
 msgstr "Контроль за автоматичним скануванням"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:53
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
 msgstr "Налаштування використання даних"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
 msgstr "Дякую за допомогу в поліпшенні"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:57
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
 msgstr "Ми не хочемо збирати ніякі події використання"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:76
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Для поліпшення Metabase, ми б хотіли збирати деякі дані по використанню через Google Analytics."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
 msgstr "Ось повний список всього що ми відстежуємо і чому."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:98
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Дозволити Metabase збирати анонімні дані про використання"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} збирає що або про ваших даних або результатах питань."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:106
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
 msgstr "ніколи"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
 msgstr "Всі колекції повністю анонімні."
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Колекція може бути відключена в будь-який момент в налаштуваннях адміністратора."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:45
+#: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
 msgstr "Якщо ви застрягли"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:52
+#: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
 msgstr "Наше керівництво по початку роботи"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:53
+#: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
 msgstr "всього в одному кліці від вас."
 
-#: frontend/src/metabase/setup/components/Setup.jsx:95
+#: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
 msgstr "Ласкаво просимо в Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:96
+#: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Схоже, все працює. Тепер давайте познайомимося ближче: налаштуйте підключення до даних і підемо шукати відповіді!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:100
+#: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
 msgstr "почнемо"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:145
+#: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
 msgstr "Все налаштоване!"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:156
+#: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
 msgstr "Покажіть мені Metabase"
 
@@ -6260,7 +6280,7 @@ msgid "Create a password"
 msgstr "Створіть пароль"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:116
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
 msgstr "Тссс ..."
 
@@ -6453,11 +6473,11 @@ msgstr "Увійти за допомогою облікового запису G
 msgid "User Details"
 msgstr "Деталі користувача"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:275
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
 msgstr "Скинути по замовчуванню"
 
-#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:133
+#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
 msgstr "невідома карта"
 
@@ -6469,24 +6489,24 @@ msgstr "Карта потребує відповідних градусах до
 msgid "more"
 msgstr "більше"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:101
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
 msgstr "Які поля ви хочете використовувати для осей X і Y?"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:103
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:60
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
 msgstr "Виберіть поля"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:204
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
 msgstr "Зберегти як вид за замовчуванням"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
 msgstr "Намалюйте \"коробку\" для фільтрації"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
 msgstr "Скасувати фільтр"
 
@@ -6494,7 +6514,7 @@ msgstr "Скасувати фільтр"
 msgid "Pin Map"
 msgstr "закріпити карту"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:303
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
 msgstr "зняти вибір"
 
@@ -6502,31 +6522,31 @@ msgstr "зняти вибір"
 msgid "Rows {0}-{1} of {2}"
 msgstr "Записи {0} - {1} з {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:189
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
 msgstr "Дані скорочені до {0} рядків."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:364
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
 msgstr "Неможливо знайти візуалізацію"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:371
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
 msgstr "Неможливо відобразити графік з поточними даними."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:469
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
 msgstr "Немає результатів!"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:490
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
 msgstr "Очікування ..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:493
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
 msgstr "Це в середньому займає {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:499
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
 msgstr "Це трохи задовго для панелі інструментів"
 
@@ -6542,11 +6562,11 @@ msgstr "Виберіть поле"
 msgid "error"
 msgstr "помилка"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:126
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
 msgstr "Натисніть і перетягніть для зміни їх порядку"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:139
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
 msgstr "Додати поля до списку нижче"
 
@@ -6636,7 +6656,7 @@ msgid "Highlight the whole row"
 msgstr "Підсвітити всю рядок"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:98
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "кольори"
 
@@ -6701,20 +6721,20 @@ msgstr "Візуалізація з цим ідентифікатором вже
 msgid "No visualization for {0}"
 msgstr "Немає візуалізації для {0}"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:75
+#: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
 msgstr "{0} - НЕ агрегування поле: якщо в точці осі x є більше двох значень - вони будуть підсумовані."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:91
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
 msgstr "Даний тип графіка вимагає як мінімум 2 стовпчика."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:96
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
 msgstr "Даний тип графіка не підтримує більше ніж {0} наборів даних."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:51
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:297
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
 msgstr "мета"
 
@@ -6759,25 +6779,25 @@ msgstr "Змінити налаштування"
 msgid "xValues missing!"
 msgstr "X-значення відсутні!"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:114
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "вісь абсцис"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:140
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
 msgstr "Додати розрив серії ..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:153
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "вісь ординат"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:178
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
 msgstr "Додати іншу серію ..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:195
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
 msgstr "Розмір бульбашки"
 
@@ -6791,7 +6811,7 @@ msgid "Curve"
 msgstr "крива"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:69
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
 msgstr "крок"
 
@@ -6799,27 +6819,27 @@ msgstr "крок"
 msgid "Show point markers on lines"
 msgstr "Показати позначки точок на лініях"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:235
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
 msgstr "об'єднання"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:239
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
 msgstr "Чи не об'єднувати"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:240
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
 msgstr "об'єднати"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:241
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
 msgstr "Об'єднати - 100%"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:300
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
 msgstr "Показати мета"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:306
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
 msgstr "значення мети"
 
@@ -6839,126 +6859,126 @@ msgstr "нічого"
 msgid "Linear Interpolated"
 msgstr "лінійна інтерполяція"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:371
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
 msgstr "Шкала осі абсцис"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
 msgstr "тимчасова шкала"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:391
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:409
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:381
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
 msgstr "лінійний"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:410
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:383
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
 msgstr "У ступені"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:384
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
 msgstr "лог"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:396
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
 msgstr "Гістограма"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:398
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
 msgstr "порядковий"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:404
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
 msgstr "Масштаб Y осі"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:417
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
 msgstr "Показати рядок і мітки по осі x"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:423
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
 msgstr "компактно"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:424
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
 msgstr "Перевернути на 45 °"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
 msgstr "Перевернути на 90 °"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
 msgstr "Показати рядок і мітки по осі y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
 msgstr "Авто діапазон осі ординат"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
 msgstr "Використовувати розриви школи ординат коли це необхідно"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
 msgstr "Показати мітку на X осі"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:501
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
 msgstr "Мітка X осі"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:510
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
 msgstr "Показати мітку на Y осі"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:516
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
 msgstr "Мітка Y осі"
 
-#: frontend/src/metabase/visualizations/lib/utils.js:129
+#: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
 msgstr "Стандартне відхилення"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:275
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:17
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:256
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
 msgstr "область"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
 msgstr "область графіка"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:276
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:16
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:257
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
 msgstr "Гістограма"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
 msgstr "гістограма"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
 msgstr "Яке поле ви хочете використовувати?"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
 msgstr "воронка"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:76
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:76
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Вимірювання"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
 msgstr "Тип воронки"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:88
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
 msgstr "Гістограма"
 
@@ -6966,141 +6986,141 @@ msgstr "Гістограма"
 msgid "line chart"
 msgstr "Графік"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:224
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Будь ласка виберіть колонки, що містять широту і довготу для настройки графіка."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
 msgstr "Будь ласка виберіть карту регіону."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Будь ласка виберіть область і стовпці метрик в налаштуваннях графіка."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:38
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Мапа"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:53
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
 msgstr "Тип карти"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:57
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:149
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
 msgstr "Карта регіону"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
 msgstr "закріпити карту"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
 msgstr "Тип значка"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
 msgstr "плитка"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
 msgstr "маркери"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
 msgstr "поле широти"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
 msgstr "поле довготи"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:142
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:168
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
 msgstr "поле вимірювання"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
 msgstr "поле регіону"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
 msgstr "радіус"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:198
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
 msgstr "Розумієте"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
 msgstr "мінімальна прозорість"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
 msgstr "максимальне наближення"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:175
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
 msgstr "Зв'язки не знайдені."
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:213
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
 msgstr "через {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:290
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
 msgstr "{0} пов'язано з:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:47
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
 msgstr "Деталі об'єкту"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
 msgstr "об'єкт"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
 msgstr "всього"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Які колонки ви хочете використовувати?"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:44
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "пиріг"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Вимірювання"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:81
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Показати легенду"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:86
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Показати процентовку в легенді"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:92
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Мінімальний процентаж зрізу"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:146
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
 msgstr "Мета досягнута"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:148
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
 msgstr "Мета досягнута"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
 msgstr "Мета {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
 msgstr "Візуалізація прогрес потрібно число."
 
@@ -7108,9 +7128,9 @@ msgstr "Візуалізація прогрес потрібно число."
 msgid "Progress"
 msgstr "прогрес"
 
-#: frontend/src/metabase/entities/collections.js:108
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:176
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:57
+#: frontend/src/metabase/entities/collections.js:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "колір"
 
@@ -7122,7 +7142,7 @@ msgstr "лінійна діаграма"
 msgid "row chart"
 msgstr "лінійна діаграма"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:357
+#: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
 msgstr "Стиль роздільника"
 
@@ -7130,15 +7150,15 @@ msgstr "Стиль роздільника"
 msgid "Number of decimal places"
 msgstr "Кількість десяткових знаків"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:381
+#: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
 msgstr "Додати префікс"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:385
+#: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
 msgstr "Додати суфікс"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:374
+#: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
 msgstr "Помножити на число"
 
@@ -7150,7 +7170,7 @@ msgstr "розкид"
 msgid "scatter plot"
 msgstr "точкова діаграма"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:78
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
 msgstr "звід таблиці"
 
@@ -7159,7 +7179,8 @@ msgid "Visible fields"
 msgstr "видимі поля"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-msgid "Write here, and use Markdown if you''d like"
+#, fuzzy
+msgid "Write here, and use Markdown if you'd like"
 msgstr "Напишіть тут, і використовується якщо хочете Markdown"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
@@ -7200,7 +7221,7 @@ msgstr "право"
 msgid "Show background"
 msgstr "Показати фон"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:553
+#: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "контейнер"
@@ -7208,7 +7229,7 @@ msgstr[1] "контейнеров"
 msgstr[2] "контейнеры"
 msgstr[3] "контейнер"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:559
+#: frontend/src/metabase-lib/lib/Dimension.js:731
 msgid "Auto binned"
 msgstr "Авт. скомпоновано"
 
@@ -7476,7 +7497,7 @@ msgstr "авто компоновка"
 msgid "Don''t bin"
 msgstr "Чи не компонувати"
 
-#: frontend/src/metabase/lib/query_time.js:193 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "день"
@@ -7485,7 +7506,7 @@ msgstr[2] "дней"
 msgstr[3] "дней"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
-#: frontend/src/metabase/lib/query_time.js:189 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "хвилина"
@@ -7493,7 +7514,7 @@ msgstr[1] "хвилин"
 msgstr[2] "хвилин"
 msgstr[3] "хвилин"
 
-#: frontend/src/metabase/lib/query_time.js:191 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "Година"
@@ -7501,7 +7522,7 @@ msgstr[1] "Годин"
 msgstr[2] "Годин"
 msgstr[3] "Годин"
 
-#: frontend/src/metabase/lib/query_time.js:199 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
 msgstr[0] "квартал"
@@ -7570,7 +7591,7 @@ msgid "Bin every 20 degrees"
 msgstr "Конт. кожні 20 градусів"
 
 #. returns `true` if successful -- see JavaDoc
-#: src/metabase/api/tiles.clj src/metabase/pulse/render.clj
+#: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
 msgstr "Не вдалося знайти відповідний обробник зображень!"
 
@@ -7642,10 +7663,12 @@ msgstr "накопичувальна сума"
 msgid "{0} and {1}"
 msgstr "{0} і {1}"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} з {1}"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
 msgstr "{0} по {1}"
@@ -7658,9 +7681,14 @@ msgstr "{0} в {1} сегменті"
 msgid "{0} segment"
 msgstr "{0} сегмент"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
-msgstr "{0} метрика"
+msgid_plural "{0} metrics"
+msgstr[0] "{0} метрика"
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
@@ -8241,6 +8269,7 @@ msgid "Cannot save Question: source query has circular references."
 msgstr "Неможливо зберегти питання: джерело запиту має циклічні посилання."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
+#: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
 msgstr "Card {0} не існує."
@@ -8642,7 +8671,7 @@ msgstr "Нерозпізнаний тип каналу {0}"
 msgid "Error sending notification!"
 msgstr "Помилка відправки повідомлення!"
 
-#: src/metabase/pulse/color.clj
+#: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
 msgstr "Чи не можете знайти JS селектор кольору в «» {0} «»"
 
@@ -8949,43 +8978,43 @@ msgstr "Дозволи даних"
 msgid "Collection permissions"
 msgstr "Дозволи Колекції"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:56
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
 msgstr "Всі права збору"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:25
+#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
 msgstr "Крім того, змініть підколекції"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:282
+#: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
 msgstr "Може редагувати цю колекцію і її вміст"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:289
+#: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
 msgstr "Ви можете переглянути елементи в цій колекції"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:749
+#: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
 msgstr "збір доступу"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:825
+#: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Ця група має дозвіл на перегляд, щонайменше, один підколекції цієї колекції."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:830
+#: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Ця група має дозволу на зміну, щонайменше, один підколекції цієї колекції."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
 msgstr "Перегляд суб-колекція"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:211
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
 msgstr "Пам'ятай мене"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:95
+#: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
 msgstr "Просканувати цю схема"
 
@@ -9017,31 +9046,32 @@ msgstr "Зберегти приладові панелі, питання і ко
 msgid "Access dashboards, questions, and collections in \"{0}\""
 msgstr "Щитки доступу, питання і колекція в «{0}»"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:221
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
 msgstr "порівняти"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:229
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
 msgstr "Зменшення"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:233
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
 msgstr "споріднений"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:293
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
 msgstr "Більше X-Rays"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:46
+#: frontend/src/metabase/home/containers/SearchApp.jsx:40
+#: src/metabase/pulse/render/body.clj
 msgid "No results"
 msgstr "Немає результатів"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:47
+#: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
 msgstr "Metabase не змогли знайти ніяких результатів пошуку."
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:111
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
 msgstr "Немає метрик"
 
@@ -9083,7 +9113,7 @@ msgstr "Не вдався надати дозвіл: {0}"
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
 msgstr "Неможливо розшифрувати зашифровану рядок. Ви змінили або забули встановити MB_ENCRYPTION_SECRET_KEY?"
 
-#: frontend/src/metabase/entities/collections.js:164
+#: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
 msgstr "Всі персональні колекції"
 
@@ -9247,18 +9277,18 @@ msgstr "N / A"
 msgid "Windows domain"
 msgstr "домен Windows,"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:509
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:515
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:490
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:499
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
 msgstr "етикетки"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:329
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
 msgstr "Додати користувачів"
 
-#: frontend/src/metabase/entities/collections.js:115
+#: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
 msgstr "Колекція вона зберігається в"
 
@@ -9279,39 +9309,39 @@ msgid "Sharing"
 msgstr "поділ"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:234
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:270
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:299
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:305
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:313
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:321
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:218
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:251
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:280
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:286
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:294
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:302
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:80
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:85
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:91
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:97
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:50
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:56
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
 msgstr "дисплей"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:370
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:416
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:431
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:487
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:358
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:406
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:447
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
 msgstr "сокири"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:222
-#: frontend/src/metabase/admin/settings/selectors.js:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
+#: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
@@ -9345,21 +9375,21 @@ msgstr "X-ray"
 msgid "Compare to the rest"
 msgstr "У порівнянні з іншими"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:244
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Використання віртуальної машини Java (JVM) часовий пояс"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
 msgstr "Ми пропонуємо вам залишити цю опцію, якщо ви робите ручну виливок часового поясу в\n"
 "багато чи більшість ваших запитів з цими даними."
 
-#: frontend/src/metabase/containers/Overworld.jsx:310
+#: frontend/src/metabase/containers/Overworld.jsx:312
 msgid "Your team's most important dashboards go here"
 msgstr "Найбільш важливі Щитки вашої команди йдуть сюди"
 
-#: frontend/src/metabase/containers/Overworld.jsx:311
+#: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
 msgstr "Pin Щитки в {0}, щоб вони відображалися в цьому просторі для всіх"
 
@@ -9375,32 +9405,32 @@ msgstr "Використання віртуальної машини Java Time Z
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Ми в даний час аналізує таблиці і поля, які допоможуть вам вивчити ваші дані."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
 msgstr "Порада:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:258
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
 msgstr "Виберіть тип валюти"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:318
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
 msgstr "Тип поля"
 
 #: frontend/src/metabase/admin/routes.jsx:109
-#: frontend/src/metabase/nav/containers/Navbar.jsx:224
+#: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
 msgstr "Вирішення проблем"
 
-#: frontend/src/metabase/admin/settings/selectors.js:96
+#: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
 msgstr "Включити функції X-ray"
 
-#: frontend/src/metabase/admin/settings/selectors.js:323
+#: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
 msgstr "параметри форматування"
 
-#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:19
+#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
 msgstr "Деталі про завдання"
 
@@ -9440,7 +9470,7 @@ msgstr "валюта"
 msgid "Pick a user or channel..."
 msgstr "Виберіть користувача або канал ..."
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
+#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
 msgstr "Немає настройки форматування"
 
@@ -9548,31 +9578,31 @@ msgstr "HH: MM: SS.MS"
 msgid "Time style"
 msgstr "Стиль часу"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:299
+#: frontend/src/metabase/visualizations/lib/settings/column.js:300
 msgid "Unit of currency"
 msgstr "Грошова одиниця"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:319
+#: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
 msgstr "Стиль позначення валюти"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:337
+#: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
 msgstr "Де відображати одиницю валюти?"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:370
+#: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
 msgstr "Мінімальна кількість знаків після коми"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:271
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
 msgstr "Stacked тип діаграми"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:314
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
 msgstr "етикетка Мета"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:322
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
 msgstr "Показати лінії тренду"
 
@@ -9601,7 +9631,7 @@ msgstr "Лінія + Бар"
 msgid "line and bar chart"
 msgstr "лінія і гістограма"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:72
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
 msgstr "візуалізація Gauge вимагає ряду."
 
@@ -9609,75 +9639,75 @@ msgstr "візуалізація Gauge вимагає ряду."
 msgid "Gauge"
 msgstr "вимірювальний прилад"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
 msgstr "діапазони Калібрувальні"
 
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
 msgstr "поле показати"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
 msgstr "останній {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:185
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
 msgstr "{0} був {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:52
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Угруповання по полю часу, щоб побачити, як це змінилося з плином часу"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
 msgstr "Перейдіть позитивні / негативні кольору?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
 msgstr "колонка Pivot"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:107
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
 msgstr "колонка Cell"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:123
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
 msgstr "видимі стовпці"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:143
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
 msgstr "умовне форматування"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
 msgstr "Назва колонки"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
 msgstr "Показати міні-гистограмму"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:183
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
 msgstr "посилання"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:187
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
 msgstr "Надіслати посилання"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
 msgstr "зображення"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:195
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
 msgstr "автоматична"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:200
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
 msgstr "Перегляд у вигляді посилання або зображення"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
 msgstr "текст"
 
@@ -9941,7 +9971,7 @@ msgstr "Помилка запиту попередньої обробки"
 msgid "No native form returned."
 msgstr "Немає нативной форми не повернувся."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
 msgstr "Неправильна відповідь від драйвера бази даних. Ні: статус надається."
 
@@ -11307,7 +11337,7 @@ msgstr "Помилка установки `запиту кешування-Max-k
 msgid "Values greater than {1} are not allowed."
 msgstr "Значення більше {1} не допускаються."
 
-#: src/metabase/query_processor/middleware/resolve_database.clj
+#: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
 msgstr "База даних {0} не існує."
 
@@ -11356,7 +11386,7 @@ msgstr "тригери"
 msgid "View triggers"
 msgstr "Перегляд спускові"
 
-#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:82
+#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
 msgstr "планувальник інформація"
 
@@ -11388,7 +11418,7 @@ msgstr "Заключний Вогонь Час"
 msgid "May Fire Again?"
 msgstr "Може Знову пожежа?"
 
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:75
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
 msgstr "Тригери для {0}"
 
@@ -11400,19 +11430,19 @@ msgstr "Завдання"
 msgid "Jobs"
 msgstr "Роботи"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
 msgstr "Дубльований {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:55
+#: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
 msgstr "Дублюйте цей пункт"
 
-#: frontend/src/metabase/components/EntityItem.jsx:61
+#: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
 msgstr "Архів цього пункту"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:330
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
 msgstr "дублікат панель"
 
@@ -11462,7 +11492,7 @@ msgstr "{0} {1} назад"
 msgid "{0} {1} from now"
 msgstr "{0} {1} тепер"
 
-#: frontend/src/metabase/lib/query_time.js:187
+#: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
 msgstr[0] "період за замовчуванням"
@@ -11470,7 +11500,7 @@ msgstr[1] "Периоды по умолчанию"
 msgstr[2] "Периоды по умолчанию"
 msgstr[3] "Периоды по умолчанию"
 
-#: frontend/src/metabase/lib/query_time.js:203
+#: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
 msgstr[0] "хвилина годину"
@@ -11478,7 +11508,7 @@ msgstr[1] "хвилина годину"
 msgstr[2] "хвилина годину"
 msgstr[3] "хвилина годину"
 
-#: frontend/src/metabase/lib/query_time.js:205
+#: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
 msgstr[0] "час дня"
@@ -11486,7 +11516,7 @@ msgstr[1] "час дня"
 msgstr[2] "час дня"
 msgstr[3] "час дня"
 
-#: frontend/src/metabase/lib/query_time.js:207
+#: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
 msgstr[0] "день тижня"
@@ -11494,7 +11524,7 @@ msgstr[1] "день тижня"
 msgstr[2] "день тижня"
 msgstr[3] "день тижня"
 
-#: frontend/src/metabase/lib/query_time.js:209
+#: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
 msgstr[0] "день місяця"
@@ -11502,7 +11532,7 @@ msgstr[1] "день місяця"
 msgstr[2] "день місяця"
 msgstr[3] "день місяця"
 
-#: frontend/src/metabase/lib/query_time.js:211
+#: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
 msgstr[0] "день року"
@@ -11510,7 +11540,7 @@ msgstr[1] "день року"
 msgstr[2] "день року"
 msgstr[3] "день року"
 
-#: frontend/src/metabase/lib/query_time.js:213
+#: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
 msgstr[0] "тиждень року"
@@ -11518,7 +11548,7 @@ msgstr[1] "тиждень року"
 msgstr[2] "тиждень року"
 msgstr[3] "тиждень року"
 
-#: frontend/src/metabase/lib/query_time.js:215
+#: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
 msgstr[0] "місяць року"
@@ -11526,7 +11556,7 @@ msgstr[1] "місяць року"
 msgstr[2] "місяць року"
 msgstr[3] "місяць року"
 
-#: frontend/src/metabase/lib/query_time.js:217
+#: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "чверть року"
@@ -11534,9 +11564,10 @@ msgstr[1] "чверть року"
 msgstr[2] "чверть року"
 msgstr[3] "чверть року"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:79
+#: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "{0} вибору"
@@ -11552,20 +11583,20 @@ msgstr "[Q] Q"
 msgid "This"
 msgstr "це"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:64
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
 msgstr "недійсний"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:147
+#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
 msgstr "Додати час"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:170
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
 msgstr "Ніщо не порівняти для попередньої {0}."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:517
+#: frontend/src/metabase-lib/lib/Dimension.js:678
 msgid "by {0}"
 msgstr "{0}"
 
@@ -11859,35 +11890,35 @@ msgstr "Реєстрація ледачого водія завантаженн�
 msgid "Error running query for Card {0}"
 msgstr "Помилка при виконанні запиту для карти {0}"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
 msgstr "Минулого тижня"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This week"
 msgstr "Цього тижня"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
 msgstr "Останній місяця"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This month"
 msgstr "Цього місяця"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
 msgstr "Останній квартал"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
 msgstr "У цьому кварталі"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
 msgstr "Минулого року"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This year"
 msgstr "Цього року"
 
@@ -12134,79 +12165,79 @@ msgid "[[CreateDate]] by quarter of the year"
 msgstr "[[CreateDate]] на чверть року"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:200
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
-msgstr ""
+msgstr "Редагувати користувача"
 
 #: frontend/src/metabase/admin/people/containers/NewUserModal.jsx:13
 msgid "New user"
-msgstr ""
+msgstr "Створити користувача"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
-msgstr ""
+msgstr "Скинути гасло"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:209
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
-msgstr ""
+msgstr "Деактивувати користувача"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:47
 msgid "Reactivate {0}?"
-msgstr ""
+msgstr "Активувати {0} повторно?"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:63
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
-msgstr ""
+msgstr "Ми не могли надіслати їм запрошення електронною поштою, тому не забудьте повідомити їх про використання {0} для входу і цього гасла, яке ми створили для них:"
 
-#: frontend/src/metabase/entities/collections.js:21
+#: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
-msgstr ""
+msgstr "колекція"
 
-#: frontend/src/metabase/entities/collections.js:22
+#: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
-msgstr ""
+msgstr "колекції"
 
-#: frontend/src/metabase/entities/dashboards.js:29
+#: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
-msgstr ""
+msgstr "приладова дошка"
 
-#: frontend/src/metabase/entities/dashboards.js:30
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
-msgstr ""
+msgstr "приладові дошки"
 
-#: frontend/src/metabase/entities/users.js:125
+#: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
-msgstr ""
+msgstr "Ім'я - обов'язкове"
 
-#: frontend/src/metabase/entities/users.js:126
-#: frontend/src/metabase/entities/users.js:133
+#: frontend/src/metabase/entities/users.js:38
+#: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
-msgstr ""
+msgstr "Не більше 100 символів"
 
-#: frontend/src/metabase/entities/users.js:132
+#: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
-msgstr ""
+msgstr "Прізвище - обов'язкове"
 
-#: frontend/src/metabase/entities/users.js:138
+#: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
-msgstr ""
+msgstr "Електронна пошта - обов'язкова"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:90
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
-msgstr ""
+msgstr "Заархівовані елементи з'являться тут"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:16
 msgid "No description"
-msgstr ""
+msgstr "Немає опису"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:175
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
-msgstr ""
+msgstr "Підсумок"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:183
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
-msgstr ""
+msgstr "Переглянути усі унікальні значення"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:12
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started"
@@ -12322,7 +12353,7 @@ msgstr ""
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Exception in API call"
-msgstr ""
+msgstr "Помилка виклику API"
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Request canceled before finishing."
@@ -12404,15 +12435,783 @@ msgstr ""
 msgid "Adding User {0} to Admin permissions group..."
 msgstr ""
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
 msgstr ""
 
-#: src/metabase/query_processor/async.clj
+#: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
 msgstr ""
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
+msgstr ""
+
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
+msgid "Misfire Instruction"
+msgstr ""
+
+#: frontend/src/metabase/components/ArchiveModal.jsx:31
+msgid "Archive this?"
+msgstr ""
+
+#: frontend/src/metabase/components/BrowseApp.jsx:244
+msgid "Learn about our data"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
+msgid "Use DNS SRV when connecting"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
+msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
+"an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
+"leave this disabled."
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
+msgid "Automatically run queries when doing simple filtering and summarizing"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr ""
+
+#: frontend/src/metabase/containers/Overworld.jsx:247
+msgid "Learn about this database"
+msgstr ""
+
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+msgid "Archive this dashboard?"
+msgstr ""
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:113
+msgid "All results"
+msgstr ""
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:180
+msgid "Our Analytics"
+msgstr ""
+
+#: frontend/src/metabase/lib/schema_metadata.js:500
+msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
+msgstr ""
+
+#: frontend/src/metabase/lib/schema_metadata.js:508
+msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
+msgstr ""
+
+#: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
+msgid "Filter"
+msgstr ""
+
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+msgid "record"
+msgid_plural "records"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:346
+msgid "Browse Data"
+msgstr ""
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:376
+msgid "Write SQL"
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
+msgid "Simple question"
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
+msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
+msgid "Custom question"
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
+msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+msgid "Basic Metrics"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+msgid "Custom…"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
+msgid "Add grouping"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
+msgid "Pick a limit"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
+msgid "Show maximum"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
+msgid "Get Preview"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
+msgid "Back to previous results"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
+msgid "Sample values"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
+msgid "Visualize"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
+msgid "Join data"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
+msgid "Custom column"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
+msgid "Summarize"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
+msgid "Aggregate"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
+msgid "Breakout"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
+msgid "Pick the metric you want to see"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
+#: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
+msgid "Pick a column to group by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
+msgid "Pick your starting data"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select None"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select All"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
+msgid "Pick a table..."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
+msgid "Enter a limit"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
+msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
+msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
+msgid "View the native query"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
+msgid "Native query for this question"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
+msgid "Convert this question to a native query"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
+msgid "SQL for this question"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
+msgid "Convert this question to SQL"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
+msgid "Get alerts"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
+msgid "{0} breakout"
+msgid_plural "{0} breakouts"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
+msgid "Hide filters"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
+msgid "Show filters"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
+msgid "Started from"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
+msgid "{0} row"
+msgid_plural "{0} rows"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
+msgid "Show all rows"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
+msgid "Show {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
+msgid "Showing first {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
+msgid "Showing {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
+msgid "Summarized"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Hide editor"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Show editor"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
+msgid "Pick the metric you'd like to see"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
+msgid "{0} options"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
+msgid "Choose a visualization"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
+msgid "Filter by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+msgid "Summarize by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+msgid "Group by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+msgid "Add a metric"
+msgstr ""
+
+#: frontend/src/metabase/user/components/UserSettings.jsx:57
+msgid "Profile"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:548
+msgid "This is usually pretty fast but seems to be taking a while right now."
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
+msgid "Combo"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
+msgid "Row"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
+msgid "Trend"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:129
+msgid "Boolean"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+msgid "Unknown Segment"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+msgid "Unknown Filter"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
+msgid "Left outer join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
+msgid "Right outer join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
+msgid "Inner join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
+msgid "Full outer join"
+msgstr ""
+
+#: src/metabase/api/card.clj
+msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
+msgstr ""
+
+#: src/metabase/api/session.clj
+msgid "Problem connecting to LDAP server, will fall back to local authentication"
+msgstr ""
+
+#: src/metabase/api/setup.clj
+msgid "Cannot create Database: cannot find driver {0}."
+msgstr ""
+
+#: src/metabase/api/tiles.clj
+msgid "Query failed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Warning: {0} returned `nil`"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing result to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing exception to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Request canceled, canceling future."
+msgstr ""
+
+#: src/metabase/cmd/load_from_h2.clj
+msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "Application database setup"
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Could not find {0} driver."
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Abstract drivers cannot derive from concrete parent drivers."
+msgstr ""
+
+#: src/metabase/driver/mysql.clj
+msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifer."
+msgstr ""
+
+#: src/metabase/driver/sql_jdbc/execute.clj
+msgid "Client closed connection, canceling query"
+msgstr ""
+
+#: src/metabase/integrations/ldap.clj
+msgid "{0} is not a valid DN."
+msgstr ""
+
+#: src/metabase/middleware/log.clj
+msgid "Error logging API request"
+msgstr ""
+
+#: src/metabase/middleware/misc.clj
+msgid "Failed to set site-url"
+msgstr ""
+
+#: src/metabase/models/database.clj
+msgid "Error destroying thread pool for DB."
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/models/task_history.clj src/metabase/sync/util.clj
+msgid "Error saving task history"
+msgstr ""
+
+#: src/metabase/plugins.clj
+msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
+msgstr ""
+
+#: src/metabase/plugins/classloader.clj
+msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
+msgstr ""
+
+#: src/metabase/plugins/files.clj
+msgid "Failed to copy file"
+msgstr ""
+
+#: src/metabase/public_settings.clj
+msgid "Invalid site URL: {0}"
+msgstr ""
+
+#: src/metabase/public_settings.clj
+msgid "site-url is invalid; returning nil for now. Will be reset on next request."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "More results have been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "This question has been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "We were unable to display this Pulse."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "Please view this card in Metabase."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "An error occurred while displaying this card."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Can only determine expected columns for MBQL queries."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "No columns returned."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot find Table ID for {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "No matching info found."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Could not resolve {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Invalid fk-> clause: nowhere to add corresponding join."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "{0} driver does not support foreign keys."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Query processor error: number of columns returned by driver does not match results."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Expected {0} columns, but first row of resuls has {1} columns."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "No expression named {0} found. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Distinct values of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Average of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "SD of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Min of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Max of {0}"
+msgstr ""
+
+#. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0} matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Share of rows matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Count of rows matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Request already canceled, will not run synchronous QP code."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unexpectedly got `nil` Query Processor response."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Got InterruptedException. Canceling query."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Query timed out after %s"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Creating new query thread pool for Database {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Destroying query thread pool for Database {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Request canceled, canceling pending query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: query is missing source-metadata"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Using query processor cache backend: {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/expand_macros.clj
+msgid "Invalid metric: {0} reason: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unknown error"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unexpected nil response from query processor."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Query canceled"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: Database {0} does not exist."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_source_table.clj
+msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Cannot store Tables or Fields before Database is stored."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Attempting to fetch second Database. Queries can only reference one Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
+msgstr ""
+
+#: src/metabase/routes/index.clj
+msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Sample dataset DB file ''{0}'' cannot be found."
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Loading sample dataset..."
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Failed to load sample dataset"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Found new tables:"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Marking tables as inactive:"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Updating description for tables:"
+msgstr ""
+
+#: src/metabase/task.clj
+msgid "Rescheduling job {0}"
+msgstr ""
+
+#: src/metabase/task.clj
+msgid "Error rescheduling job"
+msgstr ""
+
+#: src/metabase/task/send_pulses.clj
+msgid "Starting Pulse Execution: {0}"
+msgstr ""
+
+#: src/metabase/task/send_pulses.clj
+msgid "Finished Pulse Execution: {0}"
+msgstr ""
+
+#: src/metabase/task/sync_databases.clj
+msgid "Failed to schedule tasks for Database {0}"
+msgstr ""
+
+#: src/metabase/util/schema.clj
+msgid "All elements must be distinct."
+msgstr ""
+
+#: 
+msgctxt "Modal for selecting columns in source data or when doing a join."
+msgid "Pick the columns you want to include"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
+msgid "Change join type"
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifier."
+msgstr ""
+
+#: src/metabase/integrations/common.clj
+msgid "Error adding User {0} to Group {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Infinite loop detected: recursively preprocessed query {0} times."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Error determining expected columns for query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr ""
 

--- a/locales/vi.po
+++ b/locales/vi.po
@@ -28,18 +28,19 @@ msgstr "Khám phá dữ liệu này"
 msgid "Select a database type"
 msgstr "Chọn kiểu cơ sở dữ liệu"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:75
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:401
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:71
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:182
+#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:410
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:74
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:203
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:180
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:197
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:193
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:171
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:180
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:164
 msgid "Save"
 msgstr "Lưu"
@@ -59,7 +60,7 @@ msgid "This is a lightweight process that checks for\n"
 msgstr "thiết lập đồng bộ hóa hàng giờ"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:184
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
 msgid "Scan"
 msgstr "Quét"
 
@@ -75,126 +76,128 @@ msgid "Metabase can scan the values present in each\n"
 msgstr "Metabase có thể quét các giá trị hiện tại trong mỗi \n"
 "\" \"có thể là một quá trình tốn nhiều tài nguyên, đặc biệt nếu bạn có \\ n rất lớn\" \"cơ sở dữ liệ"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:159
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Khi nào Metabase sẽ tự động quét và lưu các giá trị trường bộ đệm "
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:164
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
 msgstr "Thường xuyên, theo lịch trình"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:195
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
 msgstr "Chỉ khi thêm tiện ích bộ lọc mới"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:199
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
 msgstr "Khi người dùng thêm bộ lọc mới vào bảng điều khiển hoặc câu hỏi SQL, Metabase sẽ quét (các) trường được ánh xạ tới bộ lọc đó để hiển thị danh sách các giá trị có thể chọn."
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:210
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
 msgid "Never, I'll do this manually if I need to"
 msgstr "Không bao giờ, tôi sẽ làm thủ công nếu cần thiết"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:222
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:222
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:426
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
 msgid "Saving..."
 msgstr "Đang lưu..."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:39
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
 msgid "Server error encountered"
 msgstr "Máy chủ lỗi"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:58
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
 msgstr "Xoá cơ sở dữ liệu này?"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
 msgstr "Tất cả các câu hỏi, số liệu và phân đoạn đã lưu dựa trên cơ sở dữ liệu này sẽ bị mất."
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:67
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
 msgstr "Hành động này không thể khôi phục"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
 msgstr "Nếu chắc chắn, hãy gõ vào"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:53
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
 msgstr "XOÁ"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:71
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
 msgstr "trong hộp thoại này:"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:82
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:50
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:93
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:58
-#: frontend/src/metabase/admin/permissions/selectors.js:160
-#: frontend/src/metabase/admin/permissions/selectors.js:170
-#: frontend/src/metabase/admin/permissions/selectors.js:185
-#: frontend/src/metabase/admin/permissions/selectors.js:224
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:355
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:181
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:247
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:61
+#: frontend/src/metabase/admin/permissions/selectors.js:163
+#: frontend/src/metabase/admin/permissions/selectors.js:173
+#: frontend/src/metabase/admin/permissions/selectors.js:188
+#: frontend/src/metabase/admin/permissions/selectors.js:227
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:202
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:268
+#: frontend/src/metabase/components/ArchiveModal.jsx:35
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
-#: frontend/src/metabase/components/form/StandardForm.jsx:61
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:196
+#: frontend/src/metabase/components/form/StandardForm.jsx:62
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:198
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:289
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:162
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:153
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:38
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:189
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:24
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:48
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:41
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:92
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:259
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "Huỷ"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:88
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:121
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:132
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
 msgstr "Xoá"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:128
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:74
-#: frontend/src/metabase/admin/permissions/selectors.js:320
-#: frontend/src/metabase/admin/permissions/selectors.js:327
-#: frontend/src/metabase/admin/permissions/selectors.js:423
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
+#: frontend/src/metabase/admin/permissions/selectors.js:323
+#: frontend/src/metabase/admin/permissions/selectors.js:330
+#: frontend/src/metabase/admin/permissions/selectors.js:426
 #: frontend/src/metabase/admin/routes.jsx:53
-#: frontend/src/metabase/nav/containers/Navbar.jsx:214
+#: frontend/src/metabase/nav/containers/Navbar.jsx:243
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
 msgstr "Các cơ sở dữ liệu"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:129
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
 msgstr "Thêm cơ sở dữ liệu"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
 msgstr "Kết nối"
@@ -203,107 +206,107 @@ msgstr "Kết nối"
 msgid "Scheduling"
 msgstr "Lên lịch"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:78
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:84
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:26
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:221
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
 msgstr "Lưu thay đổi"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:185
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:38
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:38
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
 msgstr "Các thao tác"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:193
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
 msgstr "Đồng bộ cấu trúc cơ sở dữ liệu ngay bây giờ"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:194
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:206
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:109
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
 msgstr "Đang bắt đầu..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:195
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
 msgstr "Đồng bộ thất bại"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
 msgstr "Đã kích hoạt đồng bộ!"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:205
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
 msgstr "Quét lại các trường giá trị ngay bây giờ"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:207
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
 msgstr "Bắt đầu quét thất bại"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
 msgstr "Đã kích hoạt quét"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:215
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:401
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
 msgstr "Khu vực nguy hiểm"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:221
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
 msgstr "Huỷ những trường giá trị đã lưu"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
 msgstr "Xoá cơ sở dữ liệu này"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:73
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
 msgstr "Thêm cơ sở dữ liệu"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:85
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:36
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:36
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:122
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:32
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:399
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:446
 #: frontend/src/metabase/containers/EntitySearch.jsx:26
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:218
-#: frontend/src/metabase/entities/collections.js:93
-#: frontend/src/metabase/entities/dashboards.js:145
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:461
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:81
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:220
+#: frontend/src/metabase/entities/collections.js:94
+#: frontend/src/metabase/entities/dashboards.js:142
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
 msgstr "Tên"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:86
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
 msgstr "Động c"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:115
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
 msgstr "Đang xoá..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:145
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
 msgstr "Đang tải..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:161
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
 msgstr "Khôi phục lại dữ liệu mẫu"
 
@@ -320,9 +323,9 @@ msgid "Successfully saved!"
 msgstr "Lưu thành công!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:177
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:197
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
 msgstr "Sửa"
@@ -331,86 +334,90 @@ msgstr "Sửa"
 msgid "Revision History"
 msgstr "Lịch sử sửa đổi"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
 msgstr "Không sử dụng {0} nữa"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
 msgstr "Các câu hỏi đã lưu và những thứ khác phụ thuộc vào {0} này sẽ tiếp tục hoạt động, nhưng {1} này sẽ không còn có thể được chọn từ trình tạo truy vấn."
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
 msgstr "Nếu bạn chắc chắn muốn rút về {0} này, vui lòng viết một lời giải thích nhanh về lý do tại sao nó được rút về:"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
 msgstr "Điều này sẽ hiển thị trong nguồn cấp dữ liệu hoạt động và trong email sẽ được gửi cho bất kỳ ai trong nhóm của bạn, người đã tạo ra thứ gì đó sử dụng {0} này"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
 msgstr "Thu hồi"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
 msgstr "Đang thu hồi"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
 msgstr "Thất bại"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
 msgstr "Thành công"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:91
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
+#: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "Xem trước"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
 msgstr "Chưa có cột mô tả"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:135
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
 msgstr "Chọn một trường hiển thị"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:210
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
 msgstr "Không có kiểu đặc biệt"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:211
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:148
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
 msgstr "Khác"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:231
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "Chọn một kiểu đặc biệt"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:277
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
 msgstr "Chọn một mục tiêu"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:77
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:89
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:106
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:122
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
 msgstr "Các cột"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "Cột"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:121
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:306
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
 msgstr "Hiển thị"
 
@@ -418,52 +425,52 @@ msgstr "Hiển thị"
 msgid "Type"
 msgstr "Kiểu"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
 msgstr "Cơ sở dữ liệu hiện tại:"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
 msgstr "Đưa ra schema gốc"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:45
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
 msgstr "Kiểu dữ liệu"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
 msgstr "Thông tin thêm"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
 msgstr "Tìm một schema"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:51
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "{0} Schema"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
 msgstr "Tại sao ẩn ?"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
 msgstr "Dữ liệu kỹ thuật"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
 msgstr "Không liên quan / Tuần dương"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
 msgid "Queryable"
 msgstr "Có thể truy vấn"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:91
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
 msgstr "Ẩn"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
 msgstr "Bảng chưa có mô tả"
 
@@ -471,63 +478,65 @@ msgstr "Bảng chưa có mô tả"
 msgid "Metadata Strength"
 msgstr "Sức mạnh siêu dữ liệu"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0} Bảng có thể truy vấn"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:96
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0} Bảng ẩn"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
 msgstr "Tìm bảng"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
 msgstr "Các schema"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:24
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:137
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:68
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:56
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:190
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
 msgstr "Số liệu"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
 msgstr "Thêm một số liệu"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:37
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "Định nghĩa"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "Tạo số liệu để thêm chúng vào danh sách thả xuống Chế độ xem trong trình tạo truy vấn"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:24
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:930
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:952
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:56
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "Phân khúc"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
 msgstr "Thêm một phân khúc"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "Tạo các phân đoạn để thêm chúng vào danh sách thả xuống Bộ lọc trong trình tạo truy vấn "
 
@@ -555,53 +564,53 @@ msgstr "sửa "
 msgid "made some changes"
 msgstr "tạo một vài thay đổi"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
-#: frontend/src/metabase/home/components/Activity.jsx:80
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:332
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/home/components/Activity.jsx:82
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
 msgstr "Bạn"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
 msgstr "Dữ liệu mẫu"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
 msgstr " Lịch sử"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:48
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
 msgstr "Lịch sử thay đổi cho"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:239
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
 msgstr "{0} - Cài đặt trường"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
 msgstr "Trường này sẽ xuất hiện trên khắp Metabase"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:329
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "Lọc trên trường này"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "Khi trường này được sử dụng trong bộ lọc, mọi người nên sử dụng gì để nhập giá trị họ muốn lọc?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:453
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "Chưa có mô tả cho trường này"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:379
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
 msgstr "Giá trị gốc"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:380
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
 msgid "Mapped value"
 msgstr "Giá trị đã được ánh xạ"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:423
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
 msgstr "Nhập giá trị"
 
@@ -618,7 +627,7 @@ msgid "Custom mapping"
 msgstr "Tuỳ chỉnh ánh xạ"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:155
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
 msgid "Unrecognized mapping type"
 msgstr "Không nhận diện được kiểu ảnh xạ"
 
@@ -626,23 +635,23 @@ msgstr "Không nhận diện được kiểu ảnh xạ"
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "Trường hiện tại không phải khoá ngoài hoặc thiếu bảng đích của khoá ngoài"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:187
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
 msgstr "Trường đã chọn không phải khoá ngoài"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:347
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
 msgstr "Các giá trị hiển thị"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:348
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "Chọn hiển thị giá trị gốc từ cơ sở dữ liệu hoặc hiển thị trường này liên quan hoặc thông tin tùy chỉnh."
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:268
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
 msgstr "Chọn một trường"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:289
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
 msgstr "Vui lòng chọn một cột để hiển thị."
 
@@ -650,16 +659,16 @@ msgstr "Vui lòng chọn một cột để hiển thị."
 msgid "Tip:"
 msgstr "Mẹo:"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "Bạn có thể muốn cập nhật tên trường để đảm bảo nó vẫn có ý nghĩa dựa trên các lựa chọn ánh xạ lại của bạn."
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:364
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:102
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
 msgstr "Giá trị trường lưu trữ"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:365
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase có thể quét các giá trị cho trường này để bật các bộ lọc hộp kiểm trong bảng điều khiển và câu hỏi."
 
@@ -668,167 +677,168 @@ msgid "Re-scan this field"
 msgstr "Quét lại trường này"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
 msgstr "Hủy giá trị trường được lưu trong bộ nhớ cache"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:118
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
 msgstr "Không thể loại bỏ các giá trị"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard triggered!"
 msgstr "Hủy kích hoạt!"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:105
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "Chọn bất kỳ bảng nào để xem lược đồ của nó và thêm hoặc chỉnh sửa siêu dữ liệu."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:37
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:34
-#: frontend/src/metabase/entities/collections.js:96
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "Tên là bắt buộc"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:40
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
 msgstr "Mô tả là bắt buộc"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:44
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:41
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
 msgstr "Thông điệp sửa đổi là bắt buộc"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:50
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
 msgstr "Tổng hợp là cần thiết"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
 msgstr "Chỉnh sửa số liệu của bạn"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
 msgstr "Tạo số liệu của bạn"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:115
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "Thay đổi số liệu của bạn và để lại lời giải thích"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "Bạn có thể tạo số liệu đã lưu để thêm tùy chọn số liệu được đặt tên vào bảng này. Số liệu đã lưu bao gồm loại tổng hợp, trường tổng hợp và tùy chọn bất kỳ bộ lọc nào bạn thêm. Ví dụ: bạn có thể sử dụng điều này để tạo một cái gì đó giống như cách tính chính thức \\ \"Giá trung bình \" cho bảng Đơn hàng."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
 msgstr "Kết quả: "
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
 msgstr "Đặt tên số liệu của bạn"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
 msgstr "Đặt tên số liệu của bạn để giúp người khác tìm thấy nó"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:162
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
 msgstr "Một vài mô tả không quá dài"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
 msgstr "Mô tả số liệu của bạn"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "Cho số liệu của bạn một lời mô tả để giúp người khác hiểu nó là gì"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "Đây là một nơi tốt để cụ thể hơn về các quy tắc số liệu ít rõ ràng hơn"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:179
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
 msgstr "Lý do thay đổi"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:177
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "Để lại một ghi chú để giải thích những thay đổi bạn đã thực hiện và tại sao chúng được yêu cầu."
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "Điều này sẽ hiển thị trong lịch sử sửa đổi cho số liệu này để giúp mọi người nhớ tại sao mọi thứ thay đổi"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
 msgstr "Bắt buộc có ít nhất một giá trị lọc"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
 msgstr "Chỉnh sửa phân khúc của bạn"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
 msgstr "Tạo phân khúc của bạn"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:121
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "Thay đổi phân khúc của bạn và để lại một ghi chú giải thích."
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "Chọn và thêm các bộ lọc để tạo phân khúc mới của bạn cho bảng {0}"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
 msgstr "Đặt tên phân khúc của bạn"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:162
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
 msgstr "Đặt tên cho phân khúc của bạn để giúp người khác tìm thấy nó"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:170
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
 msgstr "Mô tả phân khúc của bạn"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "Cho phân khúc của bạn một lời mô tả để giúp người khác hiểu nó là gì"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:175
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "Đây là một nơi tốt để cụ thể hơn về các quy tắc phân khúc ít rõ ràng hơn"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:185
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "Điều này sẽ hiển thị trong lịch sử sửa đổi cho phân khúc này để giúp mọi người nhớ tại sao mọi thứ thay đổi"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:266
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:87
-#: frontend/src/metabase/nav/containers/Navbar.jsx:199
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:269
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:91
+#: frontend/src/metabase/nav/containers/Navbar.jsx:228
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
 msgstr "Cài đặt"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:103
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase có thể quét các giá trị trong bảng này để bật các bộ lọc hộp kiểm trong bảng điều khiển và câu hỏi."
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:108
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
 msgstr "Quét lại bảng này"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:253
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
 msgstr "Thêm"
 
@@ -837,20 +847,22 @@ msgstr "Thêm"
 msgid "Not a valid formatted email address"
 msgstr "Không phải là một địa chỉ email được định dạng hợp lệ"
 
+#: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:100
 msgid "First name"
 msgstr "Tên"
 
+#: frontend/src/metabase/entities/users.js:42
 #: frontend/src/metabase/setup/components/UserStep.jsx:203
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:117
 msgid "Last name"
 msgstr "Họ"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:77
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:158
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:161
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:470
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:481
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
@@ -864,34 +876,35 @@ msgstr "Nhóm quyền"
 msgid "Make this user an admin"
 msgstr "Cho người dùng này làm quản trị viên"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:32
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
 msgstr "Tất cả người dùng thuộc nhóm {0} và không thể xóa khỏi nhóm. Đặt quyền cho nhóm này là một cách tuyệt vời để đảm bảo bạn biết những gì người dùng Metabase mới sẽ có thể nhìn thấy."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:41
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
 msgstr "Đây là một nhóm đặc biệt mà các thành viên có thể nhìn thấy mọi thứ trong ví dụ Metabase và những người có thể truy cập và thay đổi các cài đặt trong Bảng quản trị, bao gồm thay đổi quyền! Vì vậy, thêm người vào nhóm này một cách cẩn thận."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:45
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
 msgstr "Để đảm bảo bạn không bị khóa khỏi Metabase, luôn phải có ít nhất một người dùng trong nhóm này."
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
 msgstr "Các thành viên"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:124
-#: frontend/src/metabase/admin/settings/selectors.js:113
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
+#: frontend/src/metabase/admin/settings/selectors.js:110
+#: frontend/src/metabase/entities/users.js:50
 #: frontend/src/metabase/lib/core.js:55
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
 msgstr "Email"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:203
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
 msgstr "Một nhóm chỉ tốt như các thành viên của nó."
 
@@ -902,8 +915,8 @@ msgid "Admin"
 msgstr "Quản trị viên"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:237
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:290
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
 msgstr "và"
 
@@ -932,13 +945,13 @@ msgstr "Bạn chắc chứ? Tất cả thành viên trong nhóm sẽ mất các 
 "Hành động này không thể khôi phục."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
 msgstr "Vâng"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
 msgstr "Không"
 
@@ -957,10 +970,11 @@ msgstr "Xoá nhóm"
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:107
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:327
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:395
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:265
+#: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
 msgstr "Xong"
 
@@ -970,9 +984,9 @@ msgstr "Tên nhóm"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:131
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:88
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
 msgstr "Các nhóm"
 
@@ -1001,9 +1015,9 @@ msgid "Deactivate"
 msgstr "Huỷ kích hoạt"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:93
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
-#: frontend/src/metabase/nav/containers/Navbar.jsx:204
+#: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
 msgstr "Mọi người"
 
@@ -1043,7 +1057,6 @@ msgid "We've re-sent {0}'s invite"
 msgstr "Chúng tôi đã gửi lại thư mời cho {0}"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
-#: frontend/src/metabase/tutorial/Tutorial.jsx:253
 msgid "Okay"
 msgstr "Đồng ý"
 
@@ -1075,13 +1088,13 @@ msgstr "Họ sẽ có thể đăng nhập lại được, và sẽ trở về nh
 msgid "Reset {0}'s password?"
 msgstr "Đặt lại mật khẩu của {0}?"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:77
+#: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
 msgstr "Đặt lại"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:44
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
 msgstr "Bạn chắc chắn muốn thực hiện chứ?"
 
@@ -1097,75 +1110,77 @@ msgstr "Đây là mật khẩu tạm thời họ có thể dùng để đăng nh
 msgid "We've sent them an email with instructions for creating a new password."
 msgstr "Chúng tôi đã gửi cho họ một email hướng dẫn tạo mật khẩu mới."
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:101
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
 msgstr "Kích hoạt"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:127
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
 msgstr "Huỷ kích hoạt"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:115
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
 msgstr "Thêm ai đó"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
 msgstr "Đăng nhập cuối"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:153
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
 msgstr "Đăng ký qua Google"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:158
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
 msgstr "Đăng ký qua LDAP"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:170
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
 msgstr "Kích hoạt lại tài khoản này"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:193
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
 msgstr "Không bao giờ"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:27
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
 msgstr[0] "{0} bản"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:45
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
 msgstr " sẽ được "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:48
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
 msgstr "cấp quyền truy cập tới"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:53
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
 msgstr " và "
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:56
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
 msgstr "chặn truy cập tới"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:70
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
 msgstr " sẽ không thể"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:71
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
 msgstr " bây giờ có thể"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:79
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
 msgstr "truy vấn gốc cho"
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
-#: frontend/src/metabase/nav/containers/Navbar.jsx:219
+#: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
 msgstr "Các quyền"
 
@@ -1190,15 +1205,15 @@ msgstr "Không có thay đổi gì về quyền."
 msgid "You've made changes to permissions."
 msgstr "Bạn đã tạo thay đổi về quyền."
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:52
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
 msgstr "Quyền hạn cho bộ sưu tập này"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
 msgstr "Bạn có những thay đổi chưa được lưu"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:54
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
 msgstr "Bạn có muốn rời trang này và huỷ các thay đổi?"
 
@@ -1218,119 +1233,119 @@ msgstr "Tất cả người dùng Metabase nằm trong nhóm \"Tất cả ngư�
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
 msgstr "MetaBot là một con bot của Metabase trên Slack. Bạn có thể chọn những thứ nó có thể truy cập ở đây."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:119
+#: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
 msgstr "Nhóm \\ \"{0} \" có thể có quyền truy cập vào một nhóm {1} khác với nhóm này, nhóm này có thể cung cấp cho nhóm này quyền truy cập bổ sung vào một số {2}."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:124
+#: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
 msgstr "Nhóm \\ \"{0} \" có mức truy cập cao hơn nhóm này, sẽ ghi đè cài đặt này. Bạn nên giới hạn hoặc thu hồi quyền truy cập của nhóm \\ \"{1} \" vào mục này."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
 msgstr "Giới hạn"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
 msgstr "Thu hồi"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:156
+#: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
 msgstr "truy cập mặc dù \\ \"{0} \" có quyền truy cập lớn hơn?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:258
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
 msgstr "Giới hạn truy cập"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:223
-#: frontend/src/metabase/admin/permissions/selectors.js:266
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:226
+#: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
 msgstr "Thu hồi quyền truy cập"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:168
+#: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
 msgstr "Thay đổi quyền truy cập tới cơ sở dữ liệu này thành giới hạn?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:169
+#: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
 msgstr "Thay đổi"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:182
+#: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
 msgstr "Cho phép viết truy vấn thuần tuý"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:183
+#: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
 msgstr "Điều này cũng sẽ thay đổi quyền truy cập dữ liệu của nhóm này thành Không giới hạn đối với cơ sở dữ liệu này."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:184
+#: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
 msgstr "Cho phép"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:221
+#: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
 msgstr "Thu hồi quyền truy cập tới tất cả cá bảng?"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:222
+#: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
 msgstr "Điều này cũng sẽ thu hồi quyền truy cập của nhóm này vào các truy vấn thô cho cơ sở dữ liệu này."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:251
+#: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
 msgstr "Cấp quyền truy cập không hạn chế"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:252
+#: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
 msgstr "Truy cập không hạn chế"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:259
+#: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
 msgstr "Giới hạn truy cập"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:267
+#: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
 msgstr "Không truy cập"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:273
+#: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
 msgstr "Viết truy vấn thuần tuý"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:274
+#: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
 msgstr "Có thể viết các truy vấn thuần tuý"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:281
+#: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
 msgstr "Bộ sưu tập"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:288
+#: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
 msgstr "Xem bộ sưu tập"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:331
-#: frontend/src/metabase/admin/permissions/selectors.js:427
-#: frontend/src/metabase/admin/permissions/selectors.js:524
+#: frontend/src/metabase/admin/permissions/selectors.js:334
+#: frontend/src/metabase/admin/permissions/selectors.js:430
+#: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
 msgstr "Truy cập dữ liệu"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:492
-#: frontend/src/metabase/admin/permissions/selectors.js:649
-#: frontend/src/metabase/admin/permissions/selectors.js:654
+#: frontend/src/metabase/admin/permissions/selectors.js:495
+#: frontend/src/metabase/admin/permissions/selectors.js:652
+#: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
 msgstr "Xem bảng"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:590
+#: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
 msgstr "Truy vấn SQL"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:660
+#: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
 msgstr "Xem schema"
 
 #: frontend/src/metabase/admin/routes.jsx:59
-#: frontend/src/metabase/nav/containers/Navbar.jsx:209
+#: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
 msgstr "Dữ liệu mẫu"
 
@@ -1339,30 +1354,30 @@ msgstr "Dữ liệu mẫu"
 msgid "Sign in with Google"
 msgstr "Đăng nhập với Google"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:13
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
 msgstr "Cho phép người dùng có tài khoản Metabase hiện tại đăng nhập bằng tài khoản Google khớp với địa chỉ email của họ bên cạnh tên người dùng và mật khẩu Metabase của họ."
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:17
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
 msgstr "Cấu hình"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
-#: frontend/src/metabase/admin/settings/selectors.js:207
+#: frontend/src/metabase/admin/settings/selectors.js:204
 msgid "LDAP"
 msgstr "LDAP"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:25
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
 msgstr "Cho phép người dùng trong thư mục LDAP của bạn đăng nhập vào Metabase bằng thông tin LDAP của họ và cho phép tự động ánh xạ các nhóm LDAP sang các nhóm Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
-#: frontend/src/metabase/admin/settings/selectors.js:160
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
 msgstr "Đó không phải là một địa chỉ email hợp lệ"
 
@@ -1400,7 +1415,7 @@ msgstr "Xoá"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:202
+#: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
 msgstr "Xác thực"
 
@@ -1464,21 +1479,21 @@ msgstr "Tạo một tài khoản Slack Bot cho MetaBot"
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "Khi bạn đã ở đó, hãy đặt tên cho nó và nhấp vào {0}. Sau đó sao chép và dán mã thông báo Bot API vào trường bên dưới. Khi bạn đã hoàn tất, hãy tạo kênh \\ \"metabase_files \" trong Slack. Metabase cần điều này để tải lên biểu đồ."
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:90
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
 msgstr "Bạn đang chạy Metabase {0}, đây là phiên bản mới nhất và tốt nhất!"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:99
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Đã có Metabase {0}. Bạn đang sử dụng {1}"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:112
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
 msgstr "Cập nhật"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:116
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
 msgstr "Những thay đổi:"
 
@@ -1491,80 +1506,80 @@ msgstr "Thêm một bản đồ"
 msgid "URL"
 msgstr "URL"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:199
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
 msgstr "Xoá bản đồ tuỳ chỉnh"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:327
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:40
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:181
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
 msgstr "Xoá"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:226
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:187
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:241
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:246
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
 msgstr "Chọn..."
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:241
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
 msgstr "Các giá trị mẫu:"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
 msgstr "Thêm một bản đồ mới"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
 msgstr "Sửa bản đồ"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:280
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
 msgstr "Bạn muốn gọi bản đồ này là gì?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
 msgstr "ví dụ: Việt Nam, Thái lan, Mặt trăng"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:292
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
 msgstr "URL đến file GeoJSON bạn muốn sử dụng"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:298
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
 msgstr "Ví dụ như https://my-mb-server.com/maps/my-map.json"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:33
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
 msgstr "Làm mới"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
 msgstr "Tải"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:315
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
 msgstr "Thuộc tính nào xác định định danh của vùng"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:324
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
 msgstr "Thuộc tính nào xác định tên của vùng"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:345
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
 msgstr "Tải file GeoJSON để xem trước"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
 msgstr "Lưu bản đồ"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
 msgstr "Thêm bản đồ"
 
@@ -1576,11 +1591,11 @@ msgstr "Sử dụng nhúng"
 msgid "By enabling embedding you're agreeing to the embedding license located at"
 msgstr "Bằng cách cho phép nhúng, bạn đồng ý với giấy phép nhúng nằm ở"
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:19
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
 msgstr "Nói một cách dễ hiểu, khi bạn nhúng biểu đồ hoặc bảng điều khiển từ Metabase vào ứng dụng của riêng bạn, ứng dụng đó không phải tuân theo Giấy phép Công cộng Chung bao gồm phần còn lại của Metabase, miễn là bạn giữ logo Metabase và \\ \"Được cung cấp bởi Metabase \\ \"Hiển thị trên các nhúng. Tuy nhiên, bạn nên đọc văn bản giấy phép được liên kết ở trên vì đó là giấy phép thực tế mà bạn sẽ đồng ý bằng cách bật tính năng này."
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:32
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
 msgstr "Bật"
 
@@ -1604,25 +1619,25 @@ msgstr "Mua một mã"
 msgid "Enter a token"
 msgstr "Nhập một mã"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:134
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
 msgstr "Sửa các ánh xạ"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:140
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
 msgstr "Nhóm các ánh xạ"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:147
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
 msgstr "Tạo một ánh xạ"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
 msgstr "Ánh xạ cho phép Metabase tự động thêm và xóa người dùng khỏi các nhóm dựa trên thông tin thành viên được cung cấp bởi máy chủ thư mục. Tư cách thành viên của nhóm Quản trị viên có thể được cấp thông qua ánh xạ, nhưng sẽ không tự động bị xóa như một biện pháp không an toàn."
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
 msgstr "Tên phân biệt"
 
@@ -1634,43 +1649,43 @@ msgstr "Liên kết công khai"
 msgid "Revoke Link"
 msgstr "Thu hồi liên kết"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:121
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
 msgstr "Vô hiệu hoá liên kết này?"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:122
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
 msgstr "Nó sẽ không hoạt động nữa, và cũng không thể khôi phục, tuy nhiên bạn có thể tạo các liên kết mới."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
 msgstr "Danh sách trang tổng quan công khai"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:152
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
 msgstr "Chưa có trang tổng quan nào được chia sẻ công khai."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:160
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
 msgstr "Danh sách thẻ công khai"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:163
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
 msgstr "Chưa có câu hỏi nào được chia sẻ không khai."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:172
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
 msgstr "Danh sách trang nhúng tổng quan"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
 msgstr "Chưa có trang tổng quan nào được nhúng."
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:183
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
 msgstr "Danh sách thẻ nhúng"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:184
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
 msgstr "Chưa có câu hỏi nào được nhúng."
 
@@ -1691,18 +1706,17 @@ msgid "Generate Key"
 msgstr "Sinh mã khoá"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:78
-#: frontend/src/metabase/admin/settings/selectors.js:87
+#: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
 msgstr "Bật"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:83
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:103
+#: frontend/src/metabase/admin/settings/selectors.js:82
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "Tắt"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:116
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
 msgstr "Cài đặt {0} không xác định"
 
@@ -1710,7 +1724,7 @@ msgstr "Cài đặt {0} không xác định"
 msgid "Setup"
 msgstr "Thiết lập"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
 msgstr "Tổng quan"
@@ -1739,11 +1753,11 @@ msgstr "Cơ sở dữ liệu mặc định"
 msgid "Select a timezone"
 msgstr "Chọn múi giờ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:55
+#: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "Không phải tất cả cơ sở dữ liệu đều hõ trợ múi giờ, trong trường hợp đó cài đặt này sẽ không có tác dụng."
 
-#: frontend/src/metabase/admin/settings/selectors.js:60
+#: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
 msgstr "Ngôn ngữ"
 
@@ -1751,202 +1765,202 @@ msgstr "Ngôn ngữ"
 msgid "Select a language"
 msgstr "Chọn một ngôn ngữ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:70
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
 msgstr "Theo dõi nặc danh"
 
-#: frontend/src/metabase/admin/settings/selectors.js:75
+#: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
 msgstr "Bảng và trường dữ liệu thân thiện"
 
-#: frontend/src/metabase/admin/settings/selectors.js:81
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
 msgstr "Chỉ thay thế các dấu gạch dưới và các dấu gạch ngang bằng các dấu cách"
 
-#: frontend/src/metabase/admin/settings/selectors.js:91
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
 msgstr "Cho phép các truy vấn lồng nhau"
 
-#: frontend/src/metabase/admin/settings/selectors.js:102
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
 msgstr "Các cập nhật"
 
-#: frontend/src/metabase/admin/settings/selectors.js:107
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
 msgstr "Kiểm tra các cập nhật"
 
-#: frontend/src/metabase/admin/settings/selectors.js:118
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
 msgstr "Máy chủ SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:126
+#: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
 msgstr "Cổng SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:130
-#: frontend/src/metabase/admin/settings/selectors.js:230
+#: frontend/src/metabase/admin/settings/selectors.js:127
+#: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
 msgstr "Đó không phải là một giá trị cổng hợp lệ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:134
+#: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
 msgstr "Bảo mật SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:142
+#: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
 msgstr "Tên tài khoản SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
 msgstr "Mật khẩu SMTP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
 msgstr "Địa chỉ gửi"
 
-#: frontend/src/metabase/admin/settings/selectors.js:170
+#: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
 msgstr "Slack API Token"
 
-#: frontend/src/metabase/admin/settings/selectors.js:172
+#: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
 msgstr "Nhập token bạn lấy từ Slack"
 
-#: frontend/src/metabase/admin/settings/selectors.js:189
+#: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
 msgstr "Đăng nhập một lần"
 
-#: frontend/src/metabase/admin/settings/selectors.js:213
+#: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
 msgstr "Xác thực LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:219
+#: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
 msgstr "Máy chủ LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:227
+#: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
 msgstr "Cổng LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:234
+#: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
 msgstr "Bảo mật LDAP"
 
-#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
 msgstr "Tên tài khoản hoặc tên miền"
 
-#: frontend/src/metabase/admin/settings/selectors.js:247
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:188
-#: frontend/src/metabase/user/components/UserSettings.jsx:72
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:191
+#: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
 msgstr "Mật khẩu"
 
-#: frontend/src/metabase/admin/settings/selectors.js:252
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "User search base"
 msgstr "Cơ sở tìm kiếm người dùng"
 
-#: frontend/src/metabase/admin/settings/selectors.js:258
+#: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
 msgstr "Lọc người dùng"
 
-#: frontend/src/metabase/admin/settings/selectors.js:264
+#: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
 msgstr "Kiểm tra dấu ngoặc đơn"
 
-#: frontend/src/metabase/admin/settings/selectors.js:270
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
 msgstr "Thuộc tính email"
 
-#: frontend/src/metabase/admin/settings/selectors.js:275
+#: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
 msgstr "Thuộc tính tên"
 
-#: frontend/src/metabase/admin/settings/selectors.js:280
+#: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
 msgstr "Thuộc tính họ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:285
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
 msgstr "Đồng bộ thành viên nhóm"
 
-#: frontend/src/metabase/admin/settings/selectors.js:291
+#: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
 msgstr "Cơ sở tìm kiếm nhóm"
 
-#: frontend/src/metabase/admin/settings/selectors.js:300
+#: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
 msgstr "Các bản đồ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
 msgstr "Đường dẫn đến máy chủ mảnh bản đồ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:306
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase mặc định sử dụngOpenStreetMaps"
 
-#: frontend/src/metabase/admin/settings/selectors.js:311
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
 msgstr "Tuỳ chỉnh các bản đồ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:312
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "Thêm các file GeoJSON của bạn để có thể hiển thị các khu vực bản đồ khác nhau"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
 msgstr "Chia sẻ công khai"
 
-#: frontend/src/metabase/admin/settings/selectors.js:336
+#: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
 msgstr "Bật chia sẻ công khai"
 
-#: frontend/src/metabase/admin/settings/selectors.js:341
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
 msgstr "Các trang tổng quan được chi sẻ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:347
+#: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
 msgstr "Các câu hỏi được chia sẻ"
 
-#: frontend/src/metabase/admin/settings/selectors.js:354
+#: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
 msgstr "Nhung vào các ứng dụng khác"
 
-#: frontend/src/metabase/admin/settings/selectors.js:381
+#: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "Cho phép nhúng Metabase vào các ứng dụng khác"
 
-#: frontend/src/metabase/admin/settings/selectors.js:391
+#: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
 msgstr "Mã nhúng khoá bí mật"
 
-#: frontend/src/metabase/admin/settings/selectors.js:397
+#: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
 msgstr "Các trang tổng quan được nhúng"
 
-#: frontend/src/metabase/admin/settings/selectors.js:403
+#: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
 msgstr "Các câu hỏi được nhúng"
 
-#: frontend/src/metabase/admin/settings/selectors.js:410
+#: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
 msgstr "Bộ nhớ đệm"
 
-#: frontend/src/metabase/admin/settings/selectors.js:415
+#: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
 msgstr "Kích hoạt bộ nhớ đệm"
 
-#: frontend/src/metabase/admin/settings/selectors.js:420
+#: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
 msgstr "Thời gian truy vấn tối thiểu"
 
-#: frontend/src/metabase/admin/settings/selectors.js:427
+#: frontend/src/metabase/admin/settings/selectors.js:424
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "Bộ nhớ đệm hệ số nhân thời gian sống (TTL)"
 
-#: frontend/src/metabase/admin/settings/selectors.js:434
+#: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
 msgstr "Kích thước mục nhập bộ nhớ cache tối đa"
 
@@ -1962,11 +1976,11 @@ msgstr "Cảnh báo của bạn đã được cập nhật."
 msgid "The alert was successfully deleted."
 msgstr "Đã xoá cảnh báo thành công."
 
-#: frontend/src/metabase/auth/auth.js:33
+#: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
 msgstr "Vui lòng nhập một email hợp lệ"
 
-#: frontend/src/metabase/auth/auth.js:116
+#: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
@@ -2008,90 +2022,87 @@ msgstr "Gửi email khôi phục mật khẩu"
 msgid "Check your email for instructions on how to reset your password."
 msgstr "Hãy kiểm tra email hướng dẫn cách đặt lại mật khẩu."
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:128
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
 msgstr "Đăng nhập vào Metabase"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:138
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
 msgstr "HOẶC"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:157
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
 msgstr "Tên tài khoản hoặc địa chỉ email"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:217
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
 msgstr "Đăng nhập"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:230
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
 msgstr "Có vẻ như tôi đã quên mật khẩu của mình"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
 msgstr "yêu cầu một email đặt lại mật khẩu"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:120
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
 msgstr "Ôi, liên kết đó đã hết hạn"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:122
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
 msgstr "Vì lý do bảo mật, liên kết đặt lại mật khẩu sẽ hết hạn trong một khoảng thời gian. Nếu bạn vẫn cần đặt lại mật khẩu, bạn có thể {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:147
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
 msgstr "Mật khẩu mới"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:149
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
 msgstr "Để giữ cho dữ liệu của bạn được bảo mật, mật khẩu {0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:163
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
 msgstr "Tạo mật khẩu mới"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:170
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:141
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
 msgstr "Hãy chắc rằng nó bảo mật như hướng dẫn bên trên"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:184
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:150
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
 msgstr "Xác nhận mật khẩu mới"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:191
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:159
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
 msgstr "Hãy đảm bảo rằng nó khớp với giá trị bạn vừa nhập"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:216
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
 msgstr "Mật khẩu của bạn đã được đặt lại."
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:222
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:227
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
 msgstr "Đăng nhập với mật khẩu mới"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:182
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:251
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "Lưu thất bại"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:183
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:129
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:225
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:252
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
 msgstr "Đã lưu"
 
@@ -2099,24 +2110,22 @@ msgstr "Đã lưu"
 msgid "Ok"
 msgstr "Được"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:38
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
 msgstr "Lưu trữ bộ sưu tập này?"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:43
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "Bảng điều khiển, bộ sưu tập và xung trong bộ sưu tập này cũng sẽ được lưu trữ."
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
-#: frontend/src/metabase/components/CollectionLanding.jsx:624
+#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: frontend/src/metabase/components/CollectionLanding.jsx:620
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:47
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:195
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:200
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:40
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:53
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
 msgstr "Lưu trữ"
@@ -2125,28 +2134,27 @@ msgstr "Lưu trữ"
 msgid "This {0} has been archived"
 msgstr "{0} này đã được lưu trữ"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:715
+#: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
 msgstr "Xem lưu trữ"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:43
+#: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
 msgstr "Bỏ lưu trữ {0} này"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:70
-#: frontend/src/metabase/components/BrowseApp.jsx:132
-#: frontend/src/metabase/components/BrowseApp.jsx:225
+#: frontend/src/metabase/components/BrowseApp.jsx:39
+#: frontend/src/metabase/components/BrowseApp.jsx:102
+#: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
 msgstr "Dữ liệu của chúng ta"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:169
+#: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
 msgstr "X-ray bảng này"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:183
-#: frontend/src/metabase/containers/Overworld.jsx:246
+#: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
 msgstr "Học hỏi về bảng này"
 
@@ -2164,31 +2172,31 @@ msgstr "Đã lưu!"
 msgid "Saving failed."
 msgstr "Lưu thất bại."
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
 msgstr "CN"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
 msgstr "T2"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
 msgstr "T3"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
 msgstr "T4"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
 msgstr "T5"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
 msgstr "T6"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
 msgstr "T7"
 
@@ -2233,60 +2241,60 @@ msgstr "Các xung cho phép bạn gửi dữ liệu mới nhất đến nhóm c�
 msgid "Questions are a saved look at your data."
 msgstr "Các câu hỏi là một cái nhìn lưu vào dữ liệu của bạn."
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:287
+#: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
 msgstr "Các ghim"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:341
+#: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
 msgstr "Kéo thứ gì đó vào đây để ghim nó lên đầu"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:737
-#: frontend/src/metabase/components/CollectionLanding.jsx:353
-#: frontend/src/metabase/home/containers/SearchApp.jsx:35
-#: frontend/src/metabase/home/containers/SearchApp.jsx:92
+#: frontend/src/metabase/admin/permissions/selectors.js:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:352
+#: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
 msgstr "Các bộ sưu tập"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:432
-#: frontend/src/metabase/components/CollectionLanding.jsx:455
+#: frontend/src/metabase/components/CollectionLanding.jsx:431
+#: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
 msgstr "Kéo vào đây để bỏ ghim"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:490
+#: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
 msgstr[0] "{0} mục đã chọn"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:522
+#: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
 msgstr "Di chuyển {0} mục"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:523
+#: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
 msgstr "Di chuyển \"{0}\"?"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:631
+#: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
 msgstr "Di chuyển"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:692
+#: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
 msgstr "Chỉnh sửa bộ sưu tập này"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:700
+#: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
 msgstr "Lưu trữ bộ sưu tập này"
 
-#: frontend/src/metabase/components/CollectionList.jsx:64
-#: frontend/src/metabase/entities/collections.js:155
+#: frontend/src/metabase/components/CollectionList.jsx:67
+#: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
 msgstr "Bộ sưu tập cá nhân của tôi"
 
-#: frontend/src/metabase/components/CollectionList.jsx:106
+#: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
 msgstr "Bộ sưu tập mới"
 
@@ -2294,11 +2302,11 @@ msgstr "Bộ sưu tập mới"
 msgid "Copied!"
 msgstr "Đã sao chép!"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:216
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
 msgstr "Sử dụng một SSH-tunnel cho các kết nối tới cơ sở dữ liệu này"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
@@ -2306,74 +2314,75 @@ msgstr "Một vài cài đặt cơ sở dữ liệu chỉ có thể truy cập b
 "Lựa chọn này cung cấp một tầng bảo mật khi VPN không khả dụng.\n"
 "Bật tính năng này sẽ làm chậm hết nối hơn là kết nối trực tiếp."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:271
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "Đây là một cơ sở dữ liệu lớn, vậy nên hãy để tôi chọn khi nào thì Metabase đồng bộ và quét"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:273
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "Nếu bạn có cơ sở dữ liệu lớn, chúng tôi khuyên bạn nên bật tính năng này và xem xét thời điểm và tần suất quét giá trị trường xảy ra."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:289
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0} để sinh Client ID và Client Secret cho dự án của bạn."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:291
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:353
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
 msgstr "Nhấn vào đây"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "Chọn \"Khác\" cho kiểu ứng dụng. Đặt tên tuỳ ý bạn thích"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:316
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
 msgstr "{0} để lấy mã xác thực"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:328
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
 msgstr "với quyền của Google Drive"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:348
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "Để sử dụng Metabase với dữ liệu này bạn phải bật tính năng API access trên giao diện Google Developers Console."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:351
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "{0} để đi tới bảng điều khiển nếu bạn chưa làm thế."
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
 msgstr "Bạn muốn tham khảo cơ sở dữ liệu này như thế nào?"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:427
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:237
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:188
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:74
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:194
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:79
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
 msgstr "Tiếp theo"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:52
+#: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
 msgstr "Xoá {0} này"
 
-#: frontend/src/metabase/components/EntityItem.jsx:43
+#: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
 msgstr "Ghim cái này"
 
-#: frontend/src/metabase/components/EntityItem.jsx:49
+#: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
 msgstr "Di chuyển cái này"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
 msgstr "Sửa câu hỏi này"
 
@@ -2386,6 +2395,7 @@ msgstr "Kiểu hành động"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
 msgstr "Xem lịch sử thay đổi"
 
@@ -2401,8 +2411,7 @@ msgstr "Hành động lưu trữ"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:329
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:342
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
 msgstr "Thêm vào bảng tổng quan"
 
@@ -2426,13 +2435,12 @@ msgstr "Kiểu hành đông khác"
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:449
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:454
 msgid "Get alerts about this"
 msgstr "Nhận cảnh báo về cái này"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
 msgstr "Xem câu truy vấn SQL"
 
@@ -2452,43 +2460,43 @@ msgstr "Đây là chi tiết thông báo lỗi"
 msgid "Hi, Metabot here."
 msgstr "Xin chào, Metabot đây."
 
-#: frontend/src/metabase/components/ExplorePane.jsx:95
+#: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
 msgstr "Dựa vào schema"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:174
+#: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
 msgstr "Nhìn vào cái của bạn"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:234
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
 msgstr "Tìm kiếm trong danh sách"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:238
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
 msgstr "Tìm kiếm theo {0}"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
 msgstr " hoặc nhập vào một ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
 msgstr "Nhập vào một ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
 msgstr "Nhập vào một số"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:248
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
 msgstr "Nhập vào vài dòng chữ"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:355
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
 msgstr "Không có {0} nào khớp."
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:363
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "Bao gồm mọi tùy chọn trong bộ lọc của bạn có thể sẽ không làm được nhiều"
 
@@ -2504,17 +2512,17 @@ msgstr "Đã gặp lỗi. Bạn có  thể thử làm mới lại trang, hoặc 
 #: frontend/src/metabase/components/HeaderBar.jsx:45
 #: frontend/src/metabase/components/ListItem.jsx:37
 #: frontend/src/metabase/reference/components/Detail.jsx:47
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:158
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:213
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:191
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:205
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:209
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:209
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:161
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:216
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:194
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:208
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
 msgstr "Chưa có mô tả"
 
 #: frontend/src/metabase/components/Header.jsx:112
-#: frontend/src/metabase/entities/containers/EntityForm.jsx:43
+#: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
 msgstr "{0} mới"
 
@@ -2522,54 +2530,53 @@ msgstr "{0} mới"
 msgid "Asked by {0}"
 msgstr "Được hỏi bởi {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:13
+#: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
 msgstr "Hôm nay "
 
-#: frontend/src/metabase/components/HistoryModal.jsx:15
+#: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
 msgstr "Hôm qua "
 
-#: frontend/src/metabase/components/HistoryModal.jsx:68
+#: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
 msgstr "Phiên bản đầu tiên."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:70
+#: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
 msgstr "Khôi phục về phiên bản trước đó và {0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:82
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:289
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:379
-#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
+#: frontend/src/metabase/components/HistoryModal.jsx:42
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
+#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
 msgstr "Lịch sử thay đổi"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:90
+#: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
 msgstr "Khi"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:91
+#: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
 msgstr "Ai"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:92
+#: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
 msgstr "Cái gì"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:113
+#: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
 msgstr "Khôi phục"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:114
+#: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
 msgstr "Đang khôi phục..."
 
-#: frontend/src/metabase/components/HistoryModal.jsx:115
+#: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
 msgstr "Không phục thất lại"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:116
+#: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
 msgstr "Đã khôi phục"
 
@@ -2578,26 +2585,24 @@ msgid "Everything"
 msgstr "Tất cả mọi thứ"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
-#: frontend/src/metabase/home/containers/SearchApp.jsx:69
 msgid "Dashboards"
 msgstr "Các trang tổng quan"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
-#: frontend/src/metabase/home/containers/SearchApp.jsx:115
 msgid "Questions"
 msgstr "Các câu hỏi"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:321
+#: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
 msgstr "Xung"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:103
+#: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
 msgstr "Trở lại"
 
-#: frontend/src/metabase/components/ListSearchField.jsx:18
+#: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
 msgstr "Tìm..."
 
@@ -2634,14 +2639,14 @@ msgid "Temporary Password"
 msgstr "Mật khẩu tạm thời"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
 msgstr "Ẩn"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:412
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
 msgstr "Hiện"
 
@@ -2706,7 +2711,7 @@ msgstr "15 (điểm giữa)"
 msgid "Calendar Day"
 msgstr "Lịch ngày"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:210
+#: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
 msgstr "Múi giờ Metabase của bạn"
 
@@ -2735,11 +2740,11 @@ msgid "A component used to make a selection"
 msgstr "Một yếu tố được sử dụng để tạo lựa chọ"
 
 #: frontend/src/metabase/components/Select.info.js:20
-#: frontend/src/metabase/components/Select.info.js:28
+#: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
 msgstr "Đã chọn"
 
-#: frontend/src/metabase/components/Select.jsx:297
+#: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
 msgstr "Không có gì để chọn"
 
@@ -2752,7 +2757,7 @@ msgid "Unknown error encountered"
 msgstr "Lỗi không xác định"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/nav/containers/Navbar.jsx:304
+#: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
 msgstr "Tạo"
 
@@ -2761,13 +2766,11 @@ msgid "Create dashboard"
 msgstr "Tạo trang tổng quan"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:331
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:60
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
 msgstr "Bảng"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:306
 msgid "Database"
 msgstr "Cơ sở dữ liệu"
 
@@ -2775,22 +2778,20 @@ msgstr "Cơ sở dữ liệu"
 msgid "Creator"
 msgstr "Người tạo"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:238
+#: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
 msgstr "Không có kết quả"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:239
+#: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
 msgstr "Thử chỉnh sửa lọc để tìm những gì bạn đang tìm kiếm."
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:258
+#: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
 msgstr "Xem bởi"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:494
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:84
-#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:69
-#: frontend/src/metabase/tutorial/TutorialModal.jsx:34
+#: frontend/src/metabase/containers/EntitySearch.jsx:495
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
 msgstr "của"
 
@@ -2803,13 +2804,13 @@ msgid "Once you connect your own data, I can show you some automatic exploration
 msgstr "Một khi bạn kết nối dữ liệu của mình, Tôi có thể cho bạn một vài khám phá tự động gọi là x-rays. Đây là một vài ví dụ với mẫu dữ liệu."
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
-#: frontend/src/metabase/containers/Overworld.jsx:299
+#: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
 msgstr "Bắt đầu ở đây"
 
-#: frontend/src/metabase/containers/Overworld.jsx:294
-#: frontend/src/metabase/entities/collections.js:147
+#: frontend/src/metabase/containers/Overworld.jsx:296
+#: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
 msgstr "Các phân tích của chúng ta"
@@ -2818,53 +2819,53 @@ msgstr "Các phân tích của chúng ta"
 msgid "Browse all items"
 msgstr "Duyệt tất cả"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:165
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
 msgstr "Thay thế hoặc lưu mới?"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:173
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
 msgstr "Thay thế câu hỏi gốc, \"{0}\""
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:178
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
 msgstr "Lưu ra câu hỏi mới"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:187
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
 msgstr "Đầu tiên, hãy lưu câu hỏi của bạn"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:188
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
 msgstr "Lưu câu hỏi"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:224
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
 msgstr "Tên thẻ của bạn là gì?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:232
-#: frontend/src/metabase/entities/collections.js:101
-#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:234
+#: frontend/src/metabase/entities/collections.js:102
+#: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/lib/core.js:50 frontend/src/metabase/lib/core.js:205
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:156
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:211
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:203
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:207
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:207
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:24
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:159
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:214
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:192
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:206
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:210
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
 msgstr "Mô tả"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:238
-#: frontend/src/metabase/entities/dashboards.js:153
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
+#: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
 msgstr "Nó không bắt buộc, nhưng có ích đó"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:245
-#: frontend/src/metabase/entities/dashboards.js:157
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
+#: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "Cái này nên đi vào bộ sưu tập nào?"
 
@@ -2876,7 +2877,7 @@ msgstr "Đã điều chỉnh"
 msgid "item"
 msgstr "mục"
 
-#: frontend/src/metabase/containers/UndoListing.jsx:81
+#: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
 msgstr "Làm lại"
 
@@ -2900,15 +2901,15 @@ msgstr "Chúng tôi không chắc câu hỏi này là phù hợp"
 msgid "Archive Dashboard"
 msgstr "Lưu trữ bảng điều khiển"
 
-#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:20
+#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "Đảm bảo thực hiện lựa chọn cho từng chuỗi hoặc bộ lọc sẽ không hoạt động trên thẻ này."
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:300
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
 msgstr "Bảng điều khiển này trống"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:301
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
 msgstr "Thêm một câu hỏi để bắt đầu khiến nó hữu ích"
 
@@ -2928,59 +2929,58 @@ msgstr "Thoát toàn màn hình"
 msgid "Enter fullscreen"
 msgstr "Vào toàn màn hình"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:181
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:183
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "Đang lưu..."
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:216
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
 msgstr "Thêm một câu hỏi"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:219
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
 msgstr "Thêm một câu hỏi vào bảng điều khiển này"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:248
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
 msgstr "Thêm một bộ lọc"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:254
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:78
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "Thông số"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:275
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
 msgstr "Thêm một hộp văn bản"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
 msgstr "Di chuyển bảng điều khiển"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:302
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
 msgstr "Chỉnh sửa bảng điều khiển"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:306
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
 msgstr "Chỉnh sửa bố cục bảng điều khiển"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:369
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
 msgstr "Bạn đang chỉnh sửa bảng điều khiển"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:374
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
 msgstr "Chọn trường được lọc cho mỗi thẻ"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:28
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
 msgstr "Di chuyển bảng điều khiển đến..."
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:52
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
 msgstr "Bảng điều khiển đã di chuyển tới {0}"
 
@@ -2995,7 +2995,7 @@ msgstr "Kiểu của bộ lọc là gì?"
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:179
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
 msgstr "Tắt"
 
@@ -3035,174 +3035,174 @@ msgstr "Làm mới trong"
 msgid "Remove this question?"
 msgstr "Bỏ câu hỏi này?"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:71
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
 msgstr "Bảng điều khiển của bạn đã được lưu"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:745
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:76
+#: frontend/src/metabase/components/CollectionLanding.jsx:744
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
 msgstr "Xem nó"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:137
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
 msgstr "Lưu"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:170
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
 msgstr "Hiển thị thêm về điều nàys"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:140
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
 msgstr "Thẻ này không có bất kỳ trường hoặc tham số nào có thể được ánh xạ tới loại tham số này."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:142
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "Các giá trị trong trường này không trùng với giá trị của bất kỳ trường nào khác bạn đã chọn."
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:186
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
 msgstr "Trường không khả dụng"
 
-#: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
 msgstr "Tên phải chứa ít hơn 100 kí tự"
 
-#: frontend/src/metabase/entities/collections.js:111
+#: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
 msgstr "Màu sắc là bắt buộc"
 
-#: frontend/src/metabase/entities/dashboards.js:146
+#: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
 msgstr "Tên của bảng điều khiển của bạn là gì?"
 
-#: frontend/src/metabase/home/components/Activity.jsx:92
+#: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
 msgstr "Những thứ tuyệt vời này có khó để mô tả không?"
 
-#: frontend/src/metabase/home/components/Activity.jsx:101
-#: frontend/src/metabase/home/components/Activity.jsx:116
+#: frontend/src/metabase/home/components/Activity.jsx:103
+#: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
 msgstr "Đã tạo một cảnh báo về - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:126
-#: frontend/src/metabase/home/components/Activity.jsx:141
+#: frontend/src/metabase/home/components/Activity.jsx:128
+#: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
 msgstr "Đã xóa một cảnh báo về - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:152
+#: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
 msgstr "Đã lưu một câu hỏi về"
 
-#: frontend/src/metabase/home/components/Activity.jsx:165
+#: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
 msgstr "Đã lưu một câu hỏi"
 
-#: frontend/src/metabase/home/components/Activity.jsx:169
+#: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
 msgstr "Đã xóa một câu hỏi"
 
-#: frontend/src/metabase/home/components/Activity.jsx:172
+#: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
 msgstr "Đã tạo một bảng điều khiển"
 
-#: frontend/src/metabase/home/components/Activity.jsx:175
+#: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
 msgstr "Đã xóa một bảng điều khiển"
 
-#: frontend/src/metabase/home/components/Activity.jsx:181
-#: frontend/src/metabase/home/components/Activity.jsx:196
+#: frontend/src/metabase/home/components/Activity.jsx:183
+#: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
 msgstr "Đã thêm một câu hỏi vào bảng điều khiển - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:206
-#: frontend/src/metabase/home/components/Activity.jsx:221
+#: frontend/src/metabase/home/components/Activity.jsx:208
+#: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
 msgstr "Đã loại bỏ một câu hỏi từ bảng điều khiển - "
 
-#: frontend/src/metabase/home/components/Activity.jsx:231
-#: frontend/src/metabase/home/components/Activity.jsx:238
+#: frontend/src/metabase/home/components/Activity.jsx:233
+#: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
 msgstr "Đã nhận dữ liệu mới nhất từ"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:621
-#: frontend/src/metabase/home/components/Activity.jsx:244
+#: frontend/src/metabase-lib/lib/Dimension.js:814
+#: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
 msgstr "Không biết"
 
-#: frontend/src/metabase/home/components/Activity.jsx:251
+#: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
 msgstr "Xin chào thế giới!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:252
+#: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
 msgstr "Metabase đang hoạt động"
 
-#: frontend/src/metabase/home/components/Activity.jsx:258
-#: frontend/src/metabase/home/components/Activity.jsx:288
+#: frontend/src/metabase/home/components/Activity.jsx:260
+#: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
 msgstr "Đã thêm số liệu"
 
-#: frontend/src/metabase/home/components/Activity.jsx:272
-#: frontend/src/metabase/home/components/Activity.jsx:362
+#: frontend/src/metabase/home/components/Activity.jsx:274
+#: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
 msgstr "Đến"
 
-#: frontend/src/metabase/home/components/Activity.jsx:282
-#: frontend/src/metabase/home/components/Activity.jsx:322
-#: frontend/src/metabase/home/components/Activity.jsx:372
-#: frontend/src/metabase/home/components/Activity.jsx:413
+#: frontend/src/metabase/home/components/Activity.jsx:284
+#: frontend/src/metabase/home/components/Activity.jsx:324
+#: frontend/src/metabase/home/components/Activity.jsx:374
+#: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
 msgstr "Bảng"
 
-#: frontend/src/metabase/home/components/Activity.jsx:298
-#: frontend/src/metabase/home/components/Activity.jsx:328
+#: frontend/src/metabase/home/components/Activity.jsx:300
+#: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
 msgstr "Đã thay đổi số liệu"
 
-#: frontend/src/metabase/home/components/Activity.jsx:312
-#: frontend/src/metabase/home/components/Activity.jsx:403
+#: frontend/src/metabase/home/components/Activity.jsx:314
+#: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
 msgstr "trong"
 
-#: frontend/src/metabase/home/components/Activity.jsx:335
+#: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
 msgstr "Đã loại bỏ số liệu"
 
-#: frontend/src/metabase/home/components/Activity.jsx:338
+#: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
 msgstr "Tạo một xung"
 
-#: frontend/src/metabase/home/components/Activity.jsx:341
+#: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
 msgstr "Đã xóa một xung"
 
-#: frontend/src/metabase/home/components/Activity.jsx:347
-#: frontend/src/metabase/home/components/Activity.jsx:378
+#: frontend/src/metabase/home/components/Activity.jsx:349
+#: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
 msgstr "Đã thêm bộ lọc"
 
-#: frontend/src/metabase/home/components/Activity.jsx:388
-#: frontend/src/metabase/home/components/Activity.jsx:419
+#: frontend/src/metabase/home/components/Activity.jsx:390
+#: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
 msgstr "Đã thay đổi bộ lọc"
 
-#: frontend/src/metabase/home/components/Activity.jsx:426
+#: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
 msgstr "Bỏ bộ lọc {0}"
 
-#: frontend/src/metabase/home/components/Activity.jsx:429
+#: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
 msgstr "Đã tham gia"
 
-#: frontend/src/metabase/home/components/Activity.jsx:529
+#: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
 msgstr "Hmmm, trông như chưa có gì xảy ra"
 
-#: frontend/src/metabase/home/components/Activity.jsx:532
+#: frontend/src/metabase/home/components/Activity.jsx:534
 msgid "Save a question and get this baby going!"
 msgstr "Lưu một câu hỏi và khiến "
 
@@ -3250,21 +3250,21 @@ msgstr "Xem gần đây"
 msgid "You haven't looked at any dashboards or questions recently"
 msgstr "Bạn không xem bảng điều khiển hay câu hỏi nào gần đây"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:99
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
 msgstr "{0} mục được chọn"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:121
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:172
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
 msgstr "Bỏ lưu trữ"
 
-#: frontend/src/metabase/home/containers/HomepageApp.jsx:74
-#: frontend/src/metabase/nav/containers/Navbar.jsx:331
+#: frontend/src/metabase/home/containers/HomepageApp.jsx:77
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
 msgstr "Hoạt động"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:28
+#: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
 msgstr "Kết quả cho \"{0}\""
 
@@ -3329,6 +3329,7 @@ msgstr "URL ảnh đại diện"
 msgid "Common"
 msgstr "Chung"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
@@ -3365,8 +3366,9 @@ msgstr "Vĩ độ"
 msgid "Longitude"
 msgstr "Kinh độ"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:149
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
 msgstr "Số"
@@ -3463,7 +3465,7 @@ msgstr "Điểm"
 
 #: frontend/src/metabase/lib/core.js:210
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:17
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
 msgstr "Tiêu đề"
 
@@ -3520,8 +3522,9 @@ msgid "Metabase will never retrieve this field. Use this for sensitive or irrele
 msgstr "Cơ sở dữ liệu tích lũy sẽ không bao giờ lấy lại trường này. Sử dụng điều này cho thông tin nhạy cảm hoặc không liên quan."
 
 #: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:614
-#: frontend/src/metabase/visualizations/lib/utils.js:126
+#: frontend/src/metabase/lib/query.js:300
+#: frontend/src/metabase/visualizations/lib/utils.js:130
+#: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -3536,7 +3539,7 @@ msgstr "Số tích lũy"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
-#: frontend/src/metabase/visualizations/lib/utils.js:127
+#: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
 msgstr "Tổng"
 
@@ -3545,7 +3548,7 @@ msgid "CumulativeSum"
 msgstr "Tổng tích lũy"
 
 #: frontend/src/metabase/lib/expressions/config.js:11
-#: frontend/src/metabase/visualizations/lib/utils.js:128
+#: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
 msgstr "Phân biệt"
 
@@ -3554,34 +3557,34 @@ msgid "StandardDeviation"
 msgstr "Độ lệch chuẩn"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/visualizations/lib/utils.js:125
+#: frontend/src/metabase/visualizations/lib/utils.js:129
 msgid "Average"
 msgstr "Trung bình"
 
 #: frontend/src/metabase/lib/expressions/config.js:14
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:25
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
 msgstr "Nhỏ nhất"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
 msgstr "Lớn nhất"
 
-#: frontend/src/metabase/lib/expressions/parser.js:384
+#: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
 msgstr "Lỗi lexing được phát hiệ"
 
-#: frontend/src/metabase/lib/formatting.js:707
+#: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0} giây"
 
-#: frontend/src/metabase/lib/formatting.js:710
+#: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0} phút"
@@ -3619,222 +3622,224 @@ msgstr "Bạn đang nghĩ gì?"
 msgid "What do you want to find out?"
 msgstr "Bạn muốn tìm cái gì?"
 
-#: frontend/src/metabase/lib/query.js:612
-#: frontend/src/metabase/lib/schema_metadata.js:451
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:246
+#: frontend/src/metabase/lib/query.js:298
+#: frontend/src/metabase/lib/schema_metadata.js:458
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
 msgstr "Dữ liệu gốc"
 
-#: frontend/src/metabase/lib/query.js:616
+#: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
 msgstr "Số tích lũy"
 
-#: frontend/src/metabase/lib/query.js:619
+#: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
 msgstr "Trung bình của"
 
-#: frontend/src/metabase/lib/query.js:624
+#: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
 msgstr "Giá trị riêng biệt của"
 
-#: frontend/src/metabase/lib/query.js:629
+#: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
 msgstr "Độ lệch chuẩn của"
 
-#: frontend/src/metabase/lib/query.js:634
+#: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
 msgstr "Tổng của"
 
-#: frontend/src/metabase/lib/query.js:639
+#: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
 msgstr "Tổng cộng của"
 
-#: frontend/src/metabase/lib/query.js:644
+#: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
 msgstr "Lớn nhất của"
 
-#: frontend/src/metabase/lib/query.js:649
+#: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
 msgstr "Nhỏ nhất của"
 
-#: frontend/src/metabase/lib/query.js:663
+#: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
 msgstr "Được nhóm bởi"
 
-#: frontend/src/metabase/lib/query.js:677
+#: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
 msgstr "Được lọc bởi"
 
-#: frontend/src/metabase/lib/query.js:706
+#: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
 msgstr "Được sắp xếp bởi"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
 msgstr "Đúng"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
 msgstr "Sai"
 
-#: frontend/src/metabase/lib/schema_metadata.js:305
+#: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
 msgstr "Chọn trường kinh độ"
 
-#: frontend/src/metabase/lib/schema_metadata.js:306
+#: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
 msgstr "Nhập vĩ độ cao hơn"
 
-#: frontend/src/metabase/lib/schema_metadata.js:307
+#: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
 msgstr "Nhập kinh độ trái"
 
-#: frontend/src/metabase/lib/schema_metadata.js:308
+#: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
 msgstr "Nhập vĩ độ thấp hơn"
 
-#: frontend/src/metabase/lib/schema_metadata.js:309
+#: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
 msgstr "Nhập kinh độ phải"
 
-#: frontend/src/metabase/lib/schema_metadata.js:345
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase-lib/lib/Dimension.js:505
+#: frontend/src/metabase-lib/lib/Dimension.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:351
+#: frontend/src/metabase/lib/schema_metadata.js:371
 #: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:387
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
 msgstr "Là"
 
-#: frontend/src/metabase/lib/schema_metadata.js:346
-#: frontend/src/metabase/lib/schema_metadata.js:366
-#: frontend/src/metabase/lib/schema_metadata.js:376
-#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/lib/schema_metadata.js:352
+#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:396
+#: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
 msgstr "Không là"
 
-#: frontend/src/metabase/lib/schema_metadata.js:347
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:369
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:353
+#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
 msgstr "Trống"
 
-#: frontend/src/metabase/lib/schema_metadata.js:348
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:370
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:402
+#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
 msgstr "Không trống"
 
-#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
 msgstr "Bằng"
 
-#: frontend/src/metabase/lib/schema_metadata.js:355
+#: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
 msgstr "Không bằng"
 
-#: frontend/src/metabase/lib/schema_metadata.js:356
+#: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
 msgstr "Lớn hơn"
 
-#: frontend/src/metabase/lib/schema_metadata.js:357
+#: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
 msgstr "Ít hơn"
 
-#: frontend/src/metabase/lib/schema_metadata.js:358
-#: frontend/src/metabase/lib/schema_metadata.js:384
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:285
+#: frontend/src/metabase/lib/schema_metadata.js:364
+#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "Giữa"
 
-#: frontend/src/metabase/lib/schema_metadata.js:359
+#: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
 msgstr "Lớn hơn hoặc bằng"
 
-#: frontend/src/metabase/lib/schema_metadata.js:360
+#: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
 msgstr "Ít hơn hoặc bằng"
 
-#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
 msgstr "Bao gồm"
 
-#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
 msgstr "Không bao gồm"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
 msgstr "Bắt đầu với"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
 msgstr "Kết thúc với"
 
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:264
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "Trước"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:271
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "Sau"
 
-#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
 msgstr "Bên trong"
 
-#: frontend/src/metabase/lib/schema_metadata.js:453
+#: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "Chỉ cần một bảng với các hàng trong câu trả lời, không có thao tác bổ sung."
 
-#: frontend/src/metabase/lib/schema_metadata.js:459
+#: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
 msgstr "Đếm số hàng"
 
-#: frontend/src/metabase/lib/schema_metadata.js:461
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
 msgstr "Tổng số dòng trong câu trả lời"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
 msgstr "Tổng của ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:469
+#: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
 msgstr "Tổng tất cả giá trị của một cột"
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
 msgstr "Trung bình của..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
 msgstr "Trung bình tất cả giá trị của một cột"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
 msgstr "Số lượng giá trị riêng biệt của ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "Số giá trị duy nhất của một cột trong số tất cả các hàng trong câu trả lời."
 
-#: frontend/src/metabase/lib/schema_metadata.js:491
+#: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
 msgstr "Tổng cộng của"
 
@@ -3842,7 +3847,7 @@ msgstr "Tổng cộng của"
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "Tổng cộng của tất cả các giá trị của một cột. \\\\ ne.x. tổng doanh thu theo thời gian."
 
-#: frontend/src/metabase/lib/schema_metadata.js:499
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
 msgstr "Số hàng tích lũy"
 
@@ -3850,105 +3855,105 @@ msgstr "Số hàng tích lũy"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "Tổng số phụ của số lượng hàng. \\\\ ne.x. tổng số lượng bán hàng theo thời gian."
 
-#: frontend/src/metabase/lib/schema_metadata.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
 msgstr "Độ lệch chuẩn của ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:509
+#: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "Số biểu thị số lượng giá trị của một cột khác nhau giữa tất cả các hàng trong câu trả lời."
 
-#: frontend/src/metabase/lib/schema_metadata.js:515
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
 msgstr "Nhỏ nhất của..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:517
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
 msgstr "Giá trị nhỏ nhất của cột"
 
-#: frontend/src/metabase/lib/schema_metadata.js:523
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
 msgstr "Lớn nhất của ..."
 
-#: frontend/src/metabase/lib/schema_metadata.js:525
+#: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
 msgstr "Giá trị cao nhất của cột"
 
-#: frontend/src/metabase/lib/schema_metadata.js:533
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
 msgstr "Thoát ra theo chiều"
 
-#: frontend/src/metabase/lib/settings.js:93
+#: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
 msgstr "chữ thường"
 
-#: frontend/src/metabase/lib/settings.js:95
+#: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
 msgstr "chữ hoa"
 
-#: frontend/src/metabase/lib/settings.js:97
+#: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "số"
 
-#: frontend/src/metabase/lib/settings.js:99
+#: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
 msgstr "Kí tự đặc biệt"
 
-#: frontend/src/metabase/lib/settings.js:105
+#: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
 msgstr "Phải là"
 
-#: frontend/src/metabase/lib/settings.js:105
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:120
+#: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
 msgstr "Độ dài kí tự"
 
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
 msgstr "Phải là"
 
-#: frontend/src/metabase/lib/settings.js:122
+#: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
 msgstr "và bao gồm"
 
-#: frontend/src/metabase/lib/utils.js:92
+#: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
 msgstr "không"
 
-#: frontend/src/metabase/lib/utils.js:93
+#: frontend/src/metabase/lib/utils.js:86
 msgid "one"
 msgstr "một"
 
-#: frontend/src/metabase/lib/utils.js:94
+#: frontend/src/metabase/lib/utils.js:87
 msgid "two"
 msgstr "hai"
 
-#: frontend/src/metabase/lib/utils.js:95
+#: frontend/src/metabase/lib/utils.js:88
 msgid "three"
 msgstr "ba"
 
-#: frontend/src/metabase/lib/utils.js:96
+#: frontend/src/metabase/lib/utils.js:89
 msgid "four"
 msgstr "bốn"
 
-#: frontend/src/metabase/lib/utils.js:97
+#: frontend/src/metabase/lib/utils.js:90
 msgid "five"
 msgstr "năm"
 
-#: frontend/src/metabase/lib/utils.js:98
+#: frontend/src/metabase/lib/utils.js:91
 msgid "six"
 msgstr "sáu"
 
-#: frontend/src/metabase/lib/utils.js:99
+#: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
 msgstr "bảy"
 
-#: frontend/src/metabase/lib/utils.js:100
+#: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
 msgstr "tám"
 
-#: frontend/src/metabase/lib/utils.js:101
+#: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
 msgstr "chín"
 
@@ -4022,6 +4027,7 @@ msgstr "Thời gian"
 msgid "Date range, relative date, time of day, etc."
 msgstr "Khoảng thời gian, ngày tương đối, thời gian trong ngày, ..."
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
@@ -4044,7 +4050,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "Ngành, loại, mẫu, đánh giá,..."
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
-#: frontend/src/metabase/user/components/UserSettings.jsx:54
+#: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
 msgstr "Cài đặt tài khoản"
 
@@ -4056,56 +4062,56 @@ msgstr "Thoát người quản lý"
 msgid "Logs"
 msgstr "Nhật kí"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:64
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
 msgstr "Trợ giúp"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:67
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
 msgstr "Về Metabase"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:73
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
 msgstr "Thoát ra"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:98
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
 msgstr "Cảm ơn vì đã sử dụng"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
 msgstr "Bạn đang ở phiên bản"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
 msgstr "đã xây dựng trên"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:124
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
 msgstr "là nhãn hiệu của"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:126
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
 msgstr "và được xây dựng cẩn thận ở San Francisco, CA"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:194
+#: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
 msgstr "Quản trị viên Metabase"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:300
+#: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
 msgstr "Hỏi một câu hỏi"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:309
+#: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
 msgstr "Bảng điều khiển mới"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:315
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/nav/containers/Navbar.jsx:361
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
 msgstr "Xung mới"
 
@@ -4113,16 +4119,16 @@ msgstr "Xung mới"
 msgid "Reference"
 msgstr "Tham khảo"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:83
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
 msgstr "Số liệu nào?"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:110
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "Xác định các số liệu phổ biến cho nhóm của bạn giúp đặt câu hỏi dễ dàng hơn"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:113
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
 msgstr "Cách tạo số liệu"
 
@@ -4134,8 +4140,8 @@ msgstr "Xem dữ liệu theo thời gian, dưới dạng bản đồ hoặc xoay
 msgid "Custom"
 msgstr "Tập quán"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:150
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:517
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
 msgstr "Câu hỏi mới"
 
@@ -4143,22 +4149,22 @@ msgstr "Câu hỏi mới"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "Sử dụng trình tạo câu hỏi đơn giản để xem xu hướng, danh sách các thứ hoặc để tạo số liệu của riêng bạn."
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:161
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "Truy vấn gốc"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:162
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "Với nhiều câu hỏi phức tạp hơn, bạn có thể viết SQL hoặc truy vấn gốc của bạn."
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:240
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
 msgstr "Chọn một giá trị mặc định..."
 
-#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:149
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
 msgstr "Cập nhật bộ lọc"
 
@@ -4166,14 +4172,14 @@ msgstr "Cập nhật bộ lọc"
 #: frontend/src/metabase/lib/query_time.js:123
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:9
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Today"
 msgstr "Hôm nay"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
 msgstr "Hôm qua"
 
@@ -4185,7 +4191,7 @@ msgstr "7 ngày vừa qua"
 msgid "Past 30 days"
 msgstr "30 ngày vừa qua"
 
-#: frontend/src/metabase/lib/query_time.js:195
+#: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:29
 #: src/metabase/api/table.clj
@@ -4193,7 +4199,7 @@ msgid "Week"
 msgid_plural "Weeks"
 msgstr[0] "tuần"
 
-#: frontend/src/metabase/lib/query_time.js:197
+#: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:30
 #: src/metabase/api/table.clj
@@ -4201,7 +4207,7 @@ msgid "Month"
 msgid_plural "Months"
 msgstr[0] "tháng"
 
-#: frontend/src/metabase/lib/query_time.js:201
+#: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:31
 #: src/metabase/api/table.clj
@@ -4250,6 +4256,7 @@ msgstr "Nhập một giá trị..."
 msgid "Enter a default value..."
 msgstr "Nhập một giá trị mặc định..."
 
+#: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "Có lỗi xảy ra"
@@ -4290,24 +4297,24 @@ msgstr "Xuất bản"
 msgid "Code"
 msgstr "Mã"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:70
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
 msgstr "Phong cách"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
 msgstr "Những thông số nào người dùng có thể sử dụng nhúng này"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:83
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
 msgstr "{0} này chưa có bất kì thông số nào để định cấu hình."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
 msgstr "Có thể chỉnh sửa"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
 msgstr "Đã khóa"
 
@@ -4315,19 +4322,19 @@ msgstr "Đã khóa"
 msgid "Preview Locked Parameters"
 msgstr "Xem trước thông số đã khóa"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:115
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
 msgstr "Hãy thử chuyển một số giá trị cho các tham số bị khóa của bạn ở đây. Máy chủ của bạn sẽ phải cung cấp các giá trị thực tế trong mã thông báo đã ký khi sử dụng giá trị thực này."
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
 msgstr "Khu vực nguy hiểm"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
 msgstr "Điều này sẽ vô hiệu nhúng cho {0}"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:128
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
 msgstr "Hủy xuất bản"
 
@@ -4367,64 +4374,64 @@ msgstr "Nhiều {0} hơn"
 msgid "examples on GitHub"
 msgstr "Ví dụ trên GitHub"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:72
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
 msgstr "Cho phép chia sẻ"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
 msgstr "Vô hiệu hóa đường dẫn công khai này?"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:77
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
 msgstr "Điều này sẽ khiến liên kết hiện tại ngừng hoạt động. Bạn có thể kích hoạt lại nó, nhưng khi bạn làm điều đó sẽ là một liên kết khác."
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
 msgstr "Đường dẫn công khai"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:118
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
 msgstr "Chia sẻ {0} này với người không có tài khoản Metabase sử dụng URL phía dưới:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:158
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
 msgstr "Nhúng công khai"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:159
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
 msgstr "Nhúng {0} này vào các bài đăng trên blog hoặc trang web bằng cách sao chép và dán đoạn mã này:"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:176
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
 msgstr "Nhúng {0} này trong ứng dụng"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:177
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
 msgstr "Bằng cách tích hợp với mã máy chủ ứng dụng của bạn, bạn có thể cung cấp số liệu thống kê an toàn {0} giới hạn cho một người dùng, khách hàng, tổ chức cụ thể, v.v."
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
 msgstr "Loại bỏ đính kèm"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:95
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
 msgstr "Đính kèm tệp với các kết quả"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
 msgstr "Câu hỏi này sẽ được thêm vào như một tệp đính kèm"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:128
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
 msgstr "Câu hỏi này sẽ không được bao gồm trong Xung của bạn"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:92
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
 msgstr "Xung này sẽ không còn được gửi qua email tới {0} {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:94
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:376
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
 msgstr[0] "Địa chỉ {0}"
@@ -4433,39 +4440,39 @@ msgstr[0] "Địa chỉ {0}"
 msgid "Slack channel {0} will no longer get this pulse {1}"
 msgstr "Kênh Slack {0} sẽ không còn nhận được xung này {1} "
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:110
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
 msgstr "Kênh {0} sẽ không còn nhận được xung này {1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
 msgstr "Chỉnh sửa xung"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:131
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
 msgstr "Xung là gì?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:141
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
 msgstr "Đã hiểu"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
 msgstr "Dữ liệu này nên đến đâu?"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:173
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
 msgstr "Đang bỏ lưu trữ..."
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
 msgstr "Bỏ lưu trữ thất bại"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
 msgstr "Đã bỏ lưu trữ"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
 msgstr "Tạo xung"
 
@@ -4475,7 +4482,7 @@ msgstr "Đính kèm"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:673
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
 msgstr "Đứng lên"
 
@@ -4496,6 +4503,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "Chúng tôi khuyên bạn nên giữ xung nhỏ và tập trung để giúp giữ cho chúng dễ tiêu hóa và hữu ích cho cả nhóm."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
+#: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
 msgstr "Chọn dữ liệu của bạn"
 
@@ -4511,47 +4519,47 @@ msgstr "Email"
 msgid "Slack messages"
 msgstr "Tin nhắn Slack"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "Đã gửi"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:222
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0} sẽ được gửi tại"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:224
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "Tin nhắn"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "Gửi email bây giờ"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:241
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "Gửi đến {0} bây giờ"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "Đang gửi"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:244
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "Gửi thất bại"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "Không gửi vì xung không có kết quả"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:248
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "Đã gửi xung"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:287
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0} cần được cài đặt bởi quản trị viên"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:302
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
 msgstr "Slack"
 
@@ -4600,21 +4608,21 @@ msgid "Before {0}"
 msgstr "Trước {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:295
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "Trống rỗng"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:301
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "Không trống rỗng"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:213
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "Tất cả thời gian"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:154
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
 msgstr "Áp dụng"
 
@@ -4680,7 +4688,7 @@ msgstr "Phân phối"
 msgid "View details"
 msgstr "Xem chi tiết"
 
-#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:54
+#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
 msgstr "Xem {0} của {1}"
 
@@ -4704,21 +4712,21 @@ msgstr "Trung bình"
 msgid "Distincts"
 msgstr "Khác biệt"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:32
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "Xem {0}"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:225
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
 msgstr "Phóng to"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:19
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
 msgstr "Biểu hiện tùy chỉnh"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
 msgstr "Số liệu chung"
 
@@ -4726,7 +4734,7 @@ msgstr "Số liệu chung"
 msgid "Metabasics"
 msgstr "Metabasics"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
 msgstr "Tên (tùy chọn)"
 
@@ -4738,31 +4746,31 @@ msgstr "Chọn một tập hợp"
 msgid "Set up your own alert"
 msgstr "Thiết lập cảnh báo của riêng bạn"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:140
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
 msgstr "Đang bỏ theo dõi..."
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:145
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
 msgstr "Thất bại bỏ theo dõi"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:204
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
 msgstr "Bỏ theo dõi"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:235
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
 msgstr "Không có kênh nào"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:263
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
 msgstr "Được rồi, bạn đã hủy đăng ký "
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:335
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
 msgstr "Bạn đang nhận cảnh báo của {0}"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
 msgstr "{0} thiết lập một cảnh bảo"
 
@@ -4818,147 +4826,147 @@ msgstr "Chỉnh sửa cảnh báo của bạn"
 msgid "Edit alert"
 msgstr "Chỉnh sửa cảnh báo"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:374
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
 msgstr "Thông báo này sẽ không còn được gửi qua email tới {0}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:382
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
 msgstr "Kênh Slack {0} sẽ không còn nhận được cảnh báo này nữa"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:386
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
 msgstr "Kênh {0} sẽ không còn nhận được cảnh báo này nữa"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:403
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
 msgstr "Xóa thông báo này"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:405
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
 msgstr "Dừng giao hàng và xóa thông báo này. Không có hoàn tác, vì vậy hãy cẩn thận."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:413
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
 msgstr "Xóa cảnh báo này?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:497
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
 msgstr "Thông báo cho tôi khi đường..."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:498
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
 msgstr "Thông báo cho tôi khi thanh tiến trình"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
 msgstr "Đi trên vạch đích"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
 msgstr "Đạt được mục tiêu"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
 msgstr "Đi dưới vạch đích"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
 msgstr "Đi dưới mục tiêu"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:512
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
 msgstr "Lần đầu tiên nó đi qua, hay mỗi lần?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:513
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
 msgstr "Lần đầu tiên nó đạt được mục tiêu, hay mọi lần?"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
 msgstr "Lần đầu tiên"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:516
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
 msgstr "Mỗi lần"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:619
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
 msgstr "Bạn muốn gửi những thông báo này tới đâu"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:630
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
 msgstr "Thông báo email tới:"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:672
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
 msgstr "{0} Cảnh báo dựa trên mục tiêu chưa được hỗ trợ cho các biểu đồ có nhiều hơn một dòng, vì vậy cảnh báo này sẽ được gửi bất cứ khi nào biểu đồ có {1}."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
 msgstr "kết quả"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:679
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
 msgstr "{0} Loại cảnh báo này hữu ích nhất khi câu hỏi đã lưu của bạn không {1} trả về bất kỳ kết quả nào, nhưng bạn muốn biết khi nào nó xảy ra."
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:680
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
 msgstr "Tip"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
 msgstr "thường"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:57
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
 msgstr "Chọn một phân đoạn hoặc bảng"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
 msgstr "Chọn một cơ sở dữ liệu"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:88
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
 msgstr "Lựa chọn..."
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:128
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
 msgstr "Chọn một bảng"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:793
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
 msgstr "Không có bảng nào được tìm thấy trong cơ sở dữ liệu này"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:830
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
 msgstr "Có phải một câu hỏi đang thiếu?"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:834
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
 msgstr "Tìm hiểu thêm về các truy vấn lồng nhau"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:868
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
 msgstr "Các trường"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:946
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
 msgstr "Không có phân đoạn nào được tìm thấy"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:969
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
 msgstr "Tìm một phân đoạn"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:46
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
 msgstr "Xem ít hơn"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:56
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
 msgstr "Xem nhiều hơn"
 
@@ -4967,60 +4975,65 @@ msgid "Pick a field to sort by"
 msgstr "Chọn một trường để phân loại"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
 msgstr "Phân loại"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
 msgstr "Giới hạn dòng"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:69
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
 msgstr "Trường không xác định"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
 msgstr "trường"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:114
+#: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
 msgstr "Những sự kết hợp"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
+#: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "Thêm bộ lọc để thu hẹp câu trả lời của bạn"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:284
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
 msgstr "Thêm một nhóm"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:322
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:102
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:113
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:152
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:194
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:59
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:68
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:75
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:225
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:231
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:237
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:70
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:75
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:64
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:89
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:131
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:176
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:302
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:308
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:314
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "Dữ liệu"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:352
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
 msgstr "Lọc bởi"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:369
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
 msgstr "Xem"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:386
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
 msgstr "Được nhóm bởi"
 
@@ -5028,23 +5041,23 @@ msgstr "Được nhóm bởi"
 msgid "None"
 msgstr "Không"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:345
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
 msgstr "Câu hỏi này được viết bằng {0}"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:353
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
 msgstr "Ẩn biên tập"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:354
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
 msgstr "Ẩn truy vấn"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
 msgstr "Mở trình chỉnh sửa"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:360
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
 msgstr "Hiển thị truy vấn"
 
@@ -5065,15 +5078,15 @@ msgstr "Tải xuống dữ liệu này"
 msgid "Warning"
 msgstr "Cảnh báo"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:52
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
 msgstr "Câu trả lời của bạn có số lượng lớn các hàng để có thể mất một lúc để tải xuống."
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:53
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
 msgstr "Kích thước tải xuống tối đa là 1 triệu hàng."
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:232
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
 msgstr "Chỉnh sửa câu hỏi"
 
@@ -5089,17 +5102,17 @@ msgstr "HỦY BỎ"
 msgid "Move question"
 msgstr "Di chuyển câu hỏi"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:283
+#: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
 msgstr "Cái này nên ở trong bộ sưu tập nào?"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:313
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:110
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
+#: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
 msgstr "Các biến"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:432
+#: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
 msgstr "Tìm hiểu về dữ liệu của bạn"
 
@@ -5143,11 +5156,11 @@ msgstr "{0} cho câu hỏi này"
 msgid "Convert this question to {0}"
 msgstr "Chuyển đổi câu hỏi này thành {0}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:122
+#: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
 msgstr "Câu hỏi này sẽ mất khoảng {0} để làm mới"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:131
+#: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
 msgstr "Đã cập nhật {0}"
 
@@ -5164,11 +5177,11 @@ msgstr "Hiển thị đầu tiên {0} {1}"
 msgid "Showing {0} {1}"
 msgstr "Hiển thị {0} {1}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:281
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
 msgstr "Làm khoa học"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:294
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
 msgstr "Nếu bạn cho tôi một số dữ liệu tôi có thể cho bạn thấy một cái gì đó tuyệt vời. Chạy một truy vấn!"
 
@@ -5176,7 +5189,7 @@ msgstr "Nếu bạn cho tôi một số dữ liệu tôi có thể cho bạn th�
 msgid "How do I use this thing?"
 msgstr "Làm thế nào để tôi sử dụng điều này?"
 
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:28
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
 msgstr "Nhận câu trả lời"
 
@@ -5204,39 +5217,39 @@ msgstr "Lấy làm tiếc. Đã xảy ra lỗi."
 msgid "Group time by"
 msgstr "Nhóm thời gian bằng"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:46
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
 msgstr "Câu hỏi của bạn mất quá nhiều thời gian"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:47
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
 msgstr "Chúng tôi đã không nhận được câu trả lời từ cơ sở dữ liệu của bạn kịp thời, vì vậy chúng tôi đã phải dừng lại. Bạn có thể thử lại sau một phút hoặc nếu sự cố vẫn còn, bạn có thể gửi email cho quản trị viên để thông báo cho họ biết."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:55
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
 msgstr "Chúng tôi đang gặp sự cố máy chủ"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:56
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
 msgstr "Hãy thử làm mới trang sau khi đợi một hoặc hai phút. Nếu vấn đề vẫn còn, chúng tôi khuyên bạn nên liên hệ với quản trị viên."
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:88
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
 msgstr "Có một vấn đề với câu hỏi của bạn"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:89
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
 msgstr "Hầu hết thời gian này là do lựa chọn không hợp lệ hoặc giá trị đầu vào xấu. Kiểm tra lại đầu vào của bạn và thử lại truy vấn của bạn."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:60
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
 msgstr "Đây có thể là câu trả lời mà bạn đang tìm kiếm. Nếu không, hãy thử loại bỏ hoặc thay đổi các bộ lọc của bạn để làm cho chúng ít cụ thể hơn."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
 msgstr "Bạn cũng có thể {0} khi có một số kết quả."
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:68
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
 msgstr "nhận một thông báo"
 
@@ -5244,11 +5257,11 @@ msgstr "nhận một thông báo"
 msgid "Back to last run"
 msgstr "Quay lại lần chạy trước"
 
-#: frontend/src/metabase/query_builder/components/VisualizationSettings.jsx:100
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
 msgstr "Hình ảnh hóa"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:96
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
 msgstr "Không có bộ mô tả."
 
@@ -5260,7 +5273,7 @@ msgstr "Sử dụng cho câu hỏi hiện tại"
 msgid "Potentially useful questions"
 msgstr "Câu hỏi tiềm năng hữu ích"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:166
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
 msgstr "Nhóm theo {0}"
 
@@ -5273,14 +5286,14 @@ msgstr "Tổng tất cả các giá trị của {0}"
 msgid "All distinct values of {0}"
 msgstr "Tất cả các giá trị riêng biệt của {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:187
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
 msgstr "Số {0} được nhóm theo {1}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5296,34 +5309,34 @@ msgstr "Dữ liệu tham khảo"
 msgid "Learn more about your data structure to ask more useful questions"
 msgstr "Tìm hiểu thêm về cấu trúc dữ liệu của bạn để hỏi những câu hỏi hữu ích hơn"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:58
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:84
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
 msgstr "Không thể tìm thấy siêu dữ liệu bảng trước khi tạo câu hỏi mới"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:80
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
 msgstr "Xem {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:94
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
 msgstr "Định nghĩa số liệu"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:118
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
 msgstr "Lọc bởi {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:127
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
 msgstr "Số của {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
 msgstr "Xem tất cả {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:148
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
 msgstr "Định nghĩa phân đoạn"
 
@@ -5335,7 +5348,7 @@ msgstr "Lỗi xảy ra khi tải bảng"
 msgid "See the raw data for {0}"
 msgstr "Xem dữ liệu thô cho {0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:180
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
 msgstr "Nhiều hơn"
 
@@ -5347,24 +5360,24 @@ msgstr "Biểu hiện không hợp lệ"
 msgid "unknown error"
 msgstr "lỗi không xác định"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:46
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
 msgstr "Công thức trường"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:57
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "Hãy nghĩ về điều này giống như viết một công thức trong chương trình bảng tính: bạn có thể sử dụng các số, các trường trong bảng này, các ký hiệu toán học như + và một số hàm. Vì vậy, bạn có thể gõ một cái gì đó như tổng phụ - Chi phí."
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
 msgstr "Tìm hiểu thêm"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:66
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
 msgstr "Đặt tên cho nó"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:72
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
 msgstr "Một cái gì đó tốt đẹp và mô tả"
 
@@ -5416,7 +5429,8 @@ msgstr "đúng"
 msgid "false"
 msgstr "sai"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
 msgstr "Thêm bộ lọc"
 
@@ -5424,15 +5438,15 @@ msgstr "Thêm bộ lọc"
 msgid "Item"
 msgstr "mục"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:221
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
 msgstr "Trước"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:252
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
 msgstr "Hiện tại"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:278
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
@@ -5443,7 +5457,7 @@ msgid "Enter desired number"
 msgstr "Nhập số mong muốn"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:100
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
 msgstr "Rỗng"
 
@@ -5467,35 +5481,35 @@ msgstr "Bạn có thể nhập nhiều giá trị được ngăn cách bởi d�
 msgid "Enter desired text"
 msgstr "Nhập văn bản mong muốn"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
 msgstr "Thử"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
 msgstr "Cái này để làm gì?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
 msgstr "Các biến trong các truy vấn gốc cho phép bạn thay thế linh hoạt các giá trị trong các truy vấn của mình bằng các tiện ích bộ lọc hoặc thông qua URL."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
 msgstr "{0} tạo một biến trong mẫu SQL này được gọi là \\ \"biến_name \". Các biến có thể được đưa ra các loại trong bảng điều khiển bên, làm thay đổi hành vi của chúng. Tất cả các loại biến khác ngoài \\ \"Bộ lọc trường \" sẽ tự động khiến tiện ích bộ lọc được đặt vào câu hỏi này; với Bộ lọc trường, đây là tùy chọn. Khi tiện ích bộ lọc này được điền vào, giá trị đó sẽ thay thế biến trong mẫu SQL."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:121
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
 msgstr "Bộ lọc trường"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:123
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "Đưa ra một biến loại \\ \"Bộ lọc trường \" cho phép bạn liên kết thẻ SQL với các tiện ích bộ lọc bảng điều khiển hoặc sử dụng nhiều loại tiện ích bộ lọc hơn cho câu hỏi SQL của bạn. Biến Bộ lọc trường chèn SQL tương tự như được tạo bởi trình tạo truy vấn GUI khi thêm bộ lọc vào các cột hiện có."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:126
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
 msgstr "Khi thêm biến Bộ lọc trường, bạn sẽ cần ánh xạ nó tới một trường cụ thể. Sau đó, bạn có thể chọn hiển thị tiện ích bộ lọc cho câu hỏi của mình, nhưng ngay cả khi bạn không, giờ đây bạn có thể ánh xạ biến Bộ lọc trường vào bộ lọc bảng điều khiển khi thêm câu hỏi này vào bảng điều khiển. Bộ lọc trường nên được sử dụng bên trong mệnh đề \\ \"WHERE \"."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:130
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
 msgstr "Điều khoản tùy chọn"
 
@@ -5503,59 +5517,61 @@ msgstr "Điều khoản tùy chọn"
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
 msgstr "dấu ngoặc quanh {0} tạo mệnh đề tùy chọn trong mẫu. Nếu \\ \"biến \" được đặt, thì toàn bộ mệnh đề được đặt vào mẫu. Nếu không, thì toàn bộ mệnh đề được bỏ qua."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:142
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
 msgstr "Để sử dụng nhiều mệnh đề tùy chọn, bạn có thể bao gồm ít nhất một mệnh đề WHERE không tùy chọn, theo sau là các mệnh đề tùy chọn bắt đầu bằng \\ \"AND \"."
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
 msgstr "Đọc tài liệu đầy đủ"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:127
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
 msgstr "Nhãn bộ lọc"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:139
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
 msgstr "Loại biến"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:143
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
 msgstr "Bản văn"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:150
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:119
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
 msgstr "Ngày"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
 msgstr "Bộ lọc trường"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:157
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
 msgstr "Trường để ánh xạ tới"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
 msgstr "Loại bộ lọc"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:201
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
 msgstr "Cần thiết?"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:211
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
 msgstr "Giá trị widget bộ lọc mặc định"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:46
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
 msgstr "Lưu trữ câu hỏi này?"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:57
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "Câu hỏi này sẽ bị xóa khỏi bất kỳ bảng điều khiển hoặc xung sử dụng nó."
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:136
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
 msgstr "Câu hỏi"
 
@@ -5572,21 +5588,21 @@ msgstr "Bạn đang chỉnh sửa trang này"
 msgid "See this {0}"
 msgstr "Xem {0}"
 
-#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:120
+#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
 msgstr "Một tập hợp con của"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:68
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
 msgstr "Chọn một kiểu trường"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:57
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
 msgstr "Không có kiểu trường"
 
@@ -5595,16 +5611,16 @@ msgid "by"
 msgstr "bởi"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
-#: frontend/src/metabase/reference/databases/FieldList.jsx:152
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
+#: frontend/src/metabase/reference/databases/FieldList.jsx:155
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
 msgstr "Kiểu trường"
 
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:72
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
 msgstr "Chọn một chìa khóa nước ngoài"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:53
+#: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
 msgstr "Xem công thức {0}"
 
@@ -5621,12 +5637,12 @@ msgid "Nothing important yet"
 msgstr "Không có gì quan trọng hết"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:168
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:233
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:211
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:215
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:219
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:229
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:236
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:214
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
 msgstr "Không có gì thú vị hết"
 
@@ -5635,12 +5651,12 @@ msgid "Things to be aware of about this {0}"
 msgstr "Những điều cần biết về điều này {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:178
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:243
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:221
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:225
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:229
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:239
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:246
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:224
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
 msgstr "Không có gì cần biết"
 
@@ -5702,15 +5718,15 @@ msgstr "Lí do cho thay đổi"
 msgid "Leave a note to explain what changes you made and why they were required"
 msgstr "Để lại chú thích để giải thích những thay đổi bạn vừa tạo và tại sao chúng cần thiết."
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:166
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
 msgstr "Tại sao cơ sở dữ liệu này thú vị"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:176
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
 msgstr "Những điều cần lưu ý về cơ sở dữ liệu này"
 
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:46
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
 msgstr "Cơ sở dữ liệu và bảng"
@@ -5718,42 +5734,42 @@ msgstr "Cơ sở dữ liệu và bảng"
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:41
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:170
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:173
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:34
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:184
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:187
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:30
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:188
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:187
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:191
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:190
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
 msgstr "Chi tiết"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
-#: frontend/src/metabase/reference/databases/TableList.jsx:111
+#: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
 msgstr "Bảng trong {0}"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:222
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:200
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:218
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:203
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
 msgstr "Tên thực trong cơ sở dữ liệu"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:231
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:227
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
 msgstr "Tại sao trường này thú vị"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:241
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:237
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
 msgstr "Những điều cần lưu ý về trường này"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:253
-#: frontend/src/metabase/reference/databases/FieldList.jsx:155
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:249
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
+#: frontend/src/metabase/reference/databases/FieldList.jsx:158
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
 msgstr "Kiểu dữ liệu"
 
@@ -5762,13 +5778,13 @@ msgstr "Kiểu dữ liệu"
 msgid "Fields in this table will appear here as they're added"
 msgstr "Các trường trong bảng này sẽ xuất hiện tại đây khi chúng được thêm vào"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:134
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:135
+#: frontend/src/metabase/reference/databases/FieldList.jsx:137
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
 msgstr "Các trường trong {0}"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:149
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:150
+#: frontend/src/metabase/reference/databases/FieldList.jsx:152
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
 msgstr "Tên trường"
 
@@ -5792,7 +5808,10 @@ msgstr "Cơ sở dữ liệu sẽ xuất hiện ở đây ngay khi quản trị 
 msgid "Connect a database"
 msgstr "Kết nối một cơ sở dữ liệu"
 
+#. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
+#. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
+#: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
 msgstr "Số đếm của {0}"
 
@@ -5800,11 +5819,11 @@ msgstr "Số đếm của {0}"
 msgid "See raw data for {0}"
 msgstr "Xem dữ liệu thô cho {0}"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:209
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
 msgstr "Tại sao bảng này thú vị"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:219
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
 msgstr "Những điều cần lưu ý về bảng này"
 
@@ -5816,16 +5835,16 @@ msgstr "Các bảng trong cơ sở dữ liệu này sẽ xuất hiện tại đ�
 msgid "Questions about this table will appear here as they're added"
 msgstr "Các câu hỏi về bảng này sẽ xuất hiện tại đây khi chúng được thêm vào"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:71
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:75
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:74
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
 msgstr "Các câu hỏi về {0}"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
 msgstr "Đã tạo {0} bởi {1}"
 
@@ -5837,151 +5856,152 @@ msgstr "Các trường trong bảng này"
 msgid "Questions about this table"
 msgstr "Các câu hỏi về bảng này"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:157
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
 msgstr "Giúp nhóm của bạn bắt đầu với dữ liệu của bạn"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:159
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
 msgstr "Hiển thị cho nhóm của bạn cái gì quan trọng nhất bằng cách chọn bảng điều khiển, số liệu và phân đoạn hàng đầu"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:165
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
 msgstr "Bắt đầu"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:173
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
 msgstr "Bảng điều khiển quan trọng nhất của chúng tôi"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:188
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
 msgstr "Các con số mà chúng tôi chú ý"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:213
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
 msgstr "Số liệu là các con số quan trọng mà công ty bạn quan tâm. Chúng thường đại diện một chỉ số cốt lõi của cách mà doanh nghiệp đang thể hiện"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:221
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
 msgstr "Xem tất cả số liệu"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:235
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
 msgstr "Phân đoạn và bảng"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
+#: frontend/src/metabase/home/containers/SearchApp.jsx:83
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
 msgstr "Các bảng"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:262
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
 msgstr "Phân đoạn và bảng là các khối xây dựng dữ liệu của công ty bạn. Bảng là tập hợp các thông tin thô trong khi các phân đoạn là các lát cụ thể với ý nghĩa cụ thể, như {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:267
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
 msgstr "Bảng là các khối xây dựng dữ liệu của công ty bạn."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:277
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
 msgstr "Xem tất cả phân đoạn"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:293
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
 msgstr "Xem tất cả bảng"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:301
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
 msgstr "Những điều khác cần biết về dữ liệu của chúng tôi \""
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
 msgstr "Tìm hiểu thêm"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:307
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
 msgstr "Một cách tốt để biết dữ liệu của bạn là dành một chút thời gian để khám phá các bảng khác nhau và thông tin khác có sẵn cho bạn. Có thể mất một lúc, nhưng bạn sẽ bắt đầu nhận ra tên và ý nghĩa theo thời gian."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:313
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
 msgstr "Khám phá dữ liệu của chúng tôi"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:321
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
 msgstr "Có câu hỏi?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:326
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
 msgstr "Liên hệ {0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:248
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
 msgstr "Giúp người dùng Metabase mới tìm đường "
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:251
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
 msgstr "Hướng dẫn Bắt đầu làm nổi bật bảng điều khiển, số liệu, phân đoạn và bảng quan trọng nhất và thông báo cho người dùng của bạn về những điều quan trọng họ nên biết trước khi đào sâu vào dữ liệu."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:258
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
 msgstr "Có bảng điều khiển nào quan trọng cho team của bạn không?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:260
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
 msgstr "Tạo một bảng điều khiển bây giờ"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:266
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
 msgstr "Bảng điều khiển quan trọng nhất của bạn là gì?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:285
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
 msgstr "Bạn có số liệu tham khảo chung nào không?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:287
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
 msgstr "Tìm hiểu cách định nghĩa một số liệu"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:300
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
 msgstr "3-5 số liệu tham khảo thông thường nhất của bạn là gì?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:344
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
 msgstr "Thêm một số liệu khác"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:357
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
 msgstr "Bạn có bất cứ phân đoạn hoặc bảng tham khảo thông thường nào không?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:359
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
 msgstr "Tìm hiểu cách tạo một phân đoạn"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:372
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
 msgstr "3-5 phân đoạn hoặc bảng thường được tham chiếu sẽ hữu ích cho đối tượng này là gì?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:418
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
 msgstr "Thêm phân đoạn hoặc bảng khác"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:427
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
 msgstr "Có bất cứ điều gì người dùng của bạn nên hiểu hoặc biết trước khi họ bắt đầu truy cập dữ liệu không? \" "
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:433
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
 msgstr "Người dùng của dữ liệu này nên biết gì trước khi họ bắt đầu truy cập nó?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:437
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
 msgstr "Ví dụ: những kỳ vọng xung quanh quyền riêng tư và sử dụng dữ liệu, những cạm bẫy hoặc hiểu lầm phổ biến, thông tin về hiệu suất kho dữ liệu, thông báo pháp lý, v.v."
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
 msgstr "Có ai đó mà người dùng của bạn có thể liên hệ để được giúp đỡ nếu họ bối rối về hướng dẫn này?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:457
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
 msgstr "Người dùng nên liên hệ với ai để được giúp đỡ nếu họ bối rối về dữ liệu này?"
 
@@ -5990,39 +6010,39 @@ msgstr "Người dùng nên liên hệ với ai để được giúp đỡ nếu
 msgid "Please enter a revision message"
 msgstr "Vui lòng nhập tin nhắn sửa đổi"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:213
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
 msgstr "Tại sao số liệu này thú vị"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:223
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
 msgstr "Những điều cần biết về số liệu này"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:233
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
 msgstr "Số liệu này được tính toán thế nào"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:235
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
 msgstr "Chưa có gì về cách tính toán"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:293
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
 msgstr "Các trường khác bạn có thể nhóm dữ liệu này theo"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:294
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
 msgstr "Các trường bạn có thể nhóm dữ liệu này theo"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:23
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "Số liệu là các con số chính thức mà nhóm của bạn quan tâm"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
 msgstr "Số liệu sẽ xuất hiện tại đây ngay khi các quản trị viên của bạn tạo"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
 msgstr "Tìm hiều cách tạo số liệu"
 
@@ -6034,9 +6054,9 @@ msgstr "Các câu hỏi về số liệu này sẽ xuất hiện tại đây khi
 msgid "There are no revisions for this metric"
 msgstr "Không có sửa đổi cho số liệu này"
 
-#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:88
-#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
-#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:88
+#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
+#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
+#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
 msgstr "Lịch sử sửa đổi cho {0}"
 
@@ -6044,27 +6064,27 @@ msgstr "Lịch sử sửa đổi cho {0}"
 msgid "X-ray this metric"
 msgstr "X quang số liệu này"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:217
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
 msgstr "Tại sao phân đoạn này thú vị"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:227
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
 msgstr "Những điều cần lưu ý về phân đoạn này"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
 msgstr "Phân đoạn là tập con thú vị của bảng"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "Xác định các phân khúc phổ biến cho nhóm của bạn giúp đặt câu hỏi dễ dàng hơn"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
 msgstr "Phân khúc sẽ xuất hiện ở đây khi quản lý của bạn thiết lập "
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
 msgstr "Học cách thiết lập phân khúc"
 
@@ -6092,7 +6112,7 @@ msgstr "X-ray phân khúc này"
 msgid "Login"
 msgstr "Đăng nhập"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:130
+#: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
 msgstr "Tìm kiếm"
@@ -6109,99 +6129,99 @@ msgstr "Câu hỏi mới"
 msgid "Select the type of Database you use"
 msgstr "Chọn loại cơ sở dữ liệu bạn sử dụng"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:141
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
 msgstr "Thêm dữ liệu"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:145
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
 msgstr "Tôi sẽ thêm dữ liệu riêng sau"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
 msgstr "Đang kết nối đến {0}"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:165
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
 msgstr "Bạn sẽ cần vài thông tin về cơ sở dữ liệu của mình, như tên đăng nhập và mật khẩu. Nếu bạn không có thông tin đó bây giờ, Metabase sẽ đưa ra thông tin mẫu để bạn có thể bắt đầu "
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:196
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
 msgstr "Tôi sẽ bổ sung dữ liệu sau"
 
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:41
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
 msgstr "Điều khiển scan tự động"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:53
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
 msgstr "Tùy chọn dữ liệu sử dụng"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
 msgstr "Cảm ơn đã giúp chúng tôi cải tiến"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:57
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
 msgstr "Chúng tôi sẽ không thu tập sự kiện được sử dụng"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:76
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "Với mục đích cải tiến Metabase, chúng tôi muốn thu thập dữ liệu sử dụng hiện tại qua Google Analytics "
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
 msgstr "Đây là danh sách đầy đủ những gì chúng tôi theo dõi và tại sao"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:98
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "Cho phép Metabase thu thập sự kiện được sử dụng ẩn danh"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase {0} thu thập mọi thứ về dữ liệu hay kết quả câu hỏi của bạn"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:106
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
 msgstr "không bao giờ"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
 msgstr "Tất cả bộ sưu tập đều hoàn toàn ẩn danh"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "Có thể tắt bộ sưu tập bất cứ lúc nào trong phần cài đặt quản trị của bạn"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:45
+#: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
 msgstr "Nếu bạn cảm thấy bế tắc"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:52
+#: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
 msgstr "Hướng dẫn khởi động của chúng tôi"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:53
+#: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
 msgstr "Chỉ một click nữa"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:95
+#: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
 msgstr "Chào mừng đến Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:96
+#: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "Có vẻ mọi thứ đang hoạt động. Giờ để hiểu về bạn, hãy kết nối dữ liệu của bạn, và bắt đầu tìm kiếm cho bạn vài câu trả lời"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:100
+#: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
 msgstr "Cùng bắt đầu"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:145
+#: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
 msgstr "Bạn đã được trang bị đầy đủ"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:156
+#: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
 msgstr "Đưa tôi đến Metabase"
 
@@ -6218,7 +6238,7 @@ msgid "Create a password"
 msgstr "Thiết lập mật khẩu"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:116
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
 msgstr "Shhh..."
 
@@ -6411,11 +6431,11 @@ msgstr "Đăng nhập bằng địa chỉ Google Email"
 msgid "User Details"
 msgstr "Thông tin người sử dụng"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:275
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
 msgstr "Đặt lại về mặc định"
 
-#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:133
+#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
 msgstr "Bản đồ không rõ"
 
@@ -6427,24 +6447,24 @@ msgstr "Bản đồ lưới yêu cầu kinh độ / vĩ độ."
 msgid "more"
 msgstr "Thêm"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:101
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
 msgstr "Những trường nào bạn muốn sử dụng cho trục X và Y"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:103
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:60
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
 msgstr "Chọn trường"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:204
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
 msgstr "Lưu làm mặc định"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
 msgstr "Vẽ hộp để lọc"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
 msgstr "Hủy lọc"
 
@@ -6452,7 +6472,7 @@ msgstr "Hủy lọc"
 msgid "Pin Map"
 msgstr "Gắn bản đồ"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:303
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
 msgstr "Không đặt"
 
@@ -6460,31 +6480,31 @@ msgstr "Không đặt"
 msgid "Rows {0}-{1} of {2}"
 msgstr "Hàng {0} - {1} trong số {2}"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:189
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
 msgstr "Dữ liệu bị cắt ngắn thành {0} hàng"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:364
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
 msgstr "Không thể tìm thấy trực quan"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:371
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
 msgstr "Không thể hiển thị biểu đồ này với dữ liệu này"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:469
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
 msgstr "Không có kết quả"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:490
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
 msgstr "Đang chờ..."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:493
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
 msgstr "Điều này thường mất trung bình {0}."
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:499
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
 msgstr "(Đây là một chút dài cho một bảng điều khiển)"
 
@@ -6500,11 +6520,11 @@ msgstr "Chọn một trường"
 msgid "error"
 msgstr "lỗi"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:126
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
 msgstr "Nhấp và kéo để thay đổi thứ tự của họ"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:139
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
 msgstr "Thêm các trường từ danh sách dưới đây"
 
@@ -6594,7 +6614,7 @@ msgid "Highlight the whole row"
 msgstr "Đánh dấu toàn bộ hàng"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:98
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "Màu"
 
@@ -6659,20 +6679,20 @@ msgstr "Hình dung với định danh đó đã được đăng ký:"
 msgid "No visualization for {0}"
 msgstr "Không trực quan hóa cho {0}"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:75
+#: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
 msgstr "\\ \"{0} \" là trường không kết hợp: nếu nó có nhiều hơn một giá trị tại một điểm trên trục x, các giá trị sẽ được tính tổng."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:91
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
 msgstr "Loại biểu đồ này yêu cầu ít nhất 2 cột."
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:96
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
 msgstr "Loại biểu đồ này không hỗ trợ nhiều hơn {0} chuỗi dữ liệu."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:51
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:297
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
 msgstr "Mục đích"
 
@@ -6710,25 +6730,25 @@ msgstr "Thay đổi cài đặt"
 msgid "xValues missing!"
 msgstr "Giá trị thiếu"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:114
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "Trục X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:140
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
 msgstr "Thêm chuỗi"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:153
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "trục Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:178
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
 msgstr "Thêm chuỗi khác..."
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:195
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
 msgstr "Kích thước bong bóng"
 
@@ -6742,7 +6762,7 @@ msgid "Curve"
 msgstr "Đường cong"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:69
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
 msgstr "Bước"
 
@@ -6750,27 +6770,27 @@ msgstr "Bước"
 msgid "Show point markers on lines"
 msgstr "Hiển thị điểm đánh dấu trên đường"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:235
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
 msgstr "Đang xếp chồng"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:239
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
 msgstr "Không xếp chồng"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:240
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
 msgstr "Xếp chồng"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:241
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
 msgstr "Xếp chồng - 100%"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:300
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
 msgstr "Hiển thị đích"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:306
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
 msgstr "Giá trị đích"
 
@@ -6790,126 +6810,126 @@ msgstr "Không có gì"
 msgid "Linear Interpolated"
 msgstr "Nội suy tuyến tính"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:371
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
 msgstr "Kích thước trục X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
 msgstr "Dòng thời gian"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:391
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:409
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:381
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
 msgstr "Tuyến tính"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:410
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:383
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
 msgstr "Nguồn"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:384
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
 msgstr "Khóa"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:396
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
 msgstr "Biểu đồ"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:398
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
 msgstr "Bình thường"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:404
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
 msgstr "Kích thước trục Y"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:417
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
 msgstr "Hiển thị dòng trục x và điểm"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:423
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
 msgstr "Gọn nhẹ"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:424
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
 msgstr "Xoay 45 độ"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
 msgstr "Xoay 90 độ"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
 msgstr "Hiển thị dòng trục y và điểm"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
 msgstr "Tự động phạm vi trục y "
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
 msgstr "Dùng trục Y xoay khi cần thiết"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
 msgstr "Hiển thị nhãn trên trục X"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:501
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
 msgstr "Nhãn trục "
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:510
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
 msgstr "Thể hiện nhãn trên trục "
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:516
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
 msgstr "Hiển thị nhãn trên trục Y"
 
-#: frontend/src/metabase/visualizations/lib/utils.js:129
+#: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
 msgstr "Độ lệch chuẩn"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:275
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:17
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:256
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
 msgstr "Vùng"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
 msgstr "biểu đồ khu vực"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:276
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:16
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:257
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
 msgstr "Thanh"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
 msgstr "biểu đồ thanh"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
 msgstr "Những lĩnh vực nào bạn muốn sử dụng"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
 msgstr "Phễu"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:76
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:76
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "Đo lường"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
 msgstr "Loại phễu"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:88
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
 msgstr "Biểu đồ cột"
 
@@ -6917,141 +6937,141 @@ msgstr "Biểu đồ cột"
 msgid "line chart"
 msgstr "biểu đồ đường"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:224
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "Vui lòng chọn các cột kinh độ và vĩ độ trong cài đặt biểu đồ."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
 msgstr "Vui lòng chọn một bản đồ khu vực."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 msgid "Please select region and metric columns in the chart settings."
 msgstr "Vui lòng chọn các cột khu vực và số liệu trong cài đặt biểu đồ."
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:38
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "Bản đồ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:53
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
 msgstr "Loại bản đồ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:57
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:149
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
 msgstr "Vùng trên bản đồ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
 msgstr "Đánh dấu trên bản đồ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
 msgstr "Loại đánh dấu"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
 msgstr "Ngói"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
 msgstr "Dấu"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
 msgstr "Trường vĩ độ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
 msgstr "Trường kinh độ"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:142
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:168
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
 msgstr "Trường số liệu"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
 msgstr "Trường vùng"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
 msgstr "Bán kính"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:198
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
 msgstr "Làm nhòe"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
 msgstr "Độ mờ tối thiểu"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
 msgstr "Thu phóng tối đa"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:175
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
 msgstr "Không tìm thấy quan hệ"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:213
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
 msgstr "thông qua {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:290
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
 msgstr " {0} này được liên kết đến:"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:47
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
 msgstr "Chi tiết đối tượng"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
 msgstr "đối tượng"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
 msgstr "Tổng"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "Cột bạn muốn sử dụng"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:44
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "Bánh"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "Kích thước"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:81
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "Hiển thị huyền thoại"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:86
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "Hiển thị phần trăm trong huyền thoại"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:92
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "Tỉ lệ phần trăm tối thiểu"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:146
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
 msgstr "Đạt được mục tiêu"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:148
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
 msgstr "Vượt quá mục tiêu"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
 msgstr "Mục tiêu {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
 msgstr "Hình dung tiến độ đòi hỏi một số"
 
@@ -7059,9 +7079,9 @@ msgstr "Hình dung tiến độ đòi hỏi một số"
 msgid "Progress"
 msgstr "Đang thực hiện"
 
-#: frontend/src/metabase/entities/collections.js:108
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:176
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:57
+#: frontend/src/metabase/entities/collections.js:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "Màu"
 
@@ -7073,7 +7093,7 @@ msgstr "Biểu đồ hàng"
 msgid "row chart"
 msgstr "biểu đồ hàng"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:357
+#: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
 msgstr "Kiểu tách"
 
@@ -7081,15 +7101,15 @@ msgstr "Kiểu tách"
 msgid "Number of decimal places"
 msgstr "Số vị thập phân"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:381
+#: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
 msgstr "Thêm một tiền tố"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:385
+#: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
 msgstr "Thêm một hậu tố"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:374
+#: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
 msgstr "Nhân với một số"
 
@@ -7101,7 +7121,7 @@ msgstr "Tiêu tan"
 msgid "scatter plot"
 msgstr "phân tán âm mưu"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:78
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
 msgstr "Xoay bảng"
 
@@ -7110,7 +7130,8 @@ msgid "Visible fields"
 msgstr "Các trường nhìn thấy được"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-msgid "Write here, and use Markdown if you''d like"
+#, fuzzy
+msgid "Write here, and use Markdown if you'd like"
 msgstr "Viết ở đây và sử dụng Markdown nếu bạn muốn"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
@@ -7151,12 +7172,12 @@ msgstr "Phải"
 msgid "Show background"
 msgstr "Hiển thị nền"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:553
+#: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "ngăn"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:559
+#: frontend/src/metabase-lib/lib/Dimension.js:731
 msgid "Auto binned"
 msgstr "tự động ngăn"
 
@@ -7424,24 +7445,24 @@ msgstr "Tự động ngăn"
 msgid "Don''t bin"
 msgstr "Không ngăn"
 
-#: frontend/src/metabase/lib/query_time.js:193 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "ngày"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
-#: frontend/src/metabase/lib/query_time.js:189 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "Phút"
 
-#: frontend/src/metabase/lib/query_time.js:191 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "giờ"
 
 #. Quý
-#: frontend/src/metabase/lib/query_time.js:199 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 #, fuzzy
 msgid "Quarter"
 msgid_plural "Quarters"
@@ -7508,7 +7529,7 @@ msgid "Bin every 20 degrees"
 msgstr "Ngăn mỗi 20 độ"
 
 #. returns `true` if successful -- see JavaDoc
-#: src/metabase/api/tiles.clj src/metabase/pulse/render.clj
+#: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
 msgstr "Không tìm thấy nhà văn hình ảnh thích hợp!"
 
@@ -7580,10 +7601,12 @@ msgstr "tổng tích lũy"
 msgid "{0} and {1}"
 msgstr "{0} và {1}"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} của {1}"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
 msgstr "{0} bởi {1}"
@@ -7596,9 +7619,11 @@ msgstr "{0} trong phân đoạn {1}"
 msgid "{0} segment"
 msgstr "Phân đoạn {0}"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
-msgstr "{0} số liệu"
+msgid_plural "{0} metrics"
+msgstr[0] "{0} số liệu"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
@@ -8179,6 +8204,7 @@ msgid "Cannot save Question: source query has circular references."
 msgstr "Không thể lưu Câu hỏi: truy vấn nguồn có tham chiếu vòng tròn."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
+#: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
 msgstr "Thẻ {0} không tồn tại."
@@ -8580,7 +8606,7 @@ msgstr "Loại kênh không được nhận dạng {0}"
 msgid "Error sending notification!"
 msgstr "Lỗi gửi thông báo!"
 
-#: src/metabase/pulse/color.clj
+#: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
 msgstr "Không thể tìm thấy bộ chọn màu JS tại '' {0} ''"
 
@@ -8887,43 +8913,43 @@ msgstr "Quyền dữ liệu"
 msgid "Collection permissions"
 msgstr "Quyền thu thập"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:56
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
 msgstr "Xem tất cả các quyền thu thập"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:25
+#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
 msgstr "Đồng thời thay đổi bộ sưu tập phụ"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:282
+#: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
 msgstr "Có thể chỉnh sửa bộ sưu tập này và nội dung của nó"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:289
+#: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
 msgstr "Có thể xem các mục trong bộ sưu tập này"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:749
+#: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
 msgstr "Có thể xem các mục trong bộ sưu tập này"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:825
+#: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "Nhóm này có quyền xem ít nhất một bộ sưu tập của bộ sưu tập này."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:830
+#: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "Nhóm này có quyền chỉnh sửa ít nhất một bộ sưu tập con của bộ sưu tập này."
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
 msgstr "Xem các bộ sưu tập phụ "
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:211
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
 msgstr "Nhớ tôi"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:95
+#: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
 msgstr "X-quang lược đồ này"
 
@@ -8955,31 +8981,32 @@ msgstr "Lưu bảng điều khiển, câu hỏi và bộ sưu tập trong \\ \"{
 msgid "Access dashboards, questions, and collections in \"{0}\""
 msgstr "Truy cập bảng điều khiển, câu hỏi và bộ sưu tập trong \\ \"{0} \""
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:221
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
 msgstr "So sánh"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:229
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
 msgstr "Thu nhỏ"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:233
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
 msgstr "Liên quan"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:293
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
 msgstr "Thêm tia X"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:46
+#: frontend/src/metabase/home/containers/SearchApp.jsx:40
+#: src/metabase/pulse/render/body.clj
 msgid "No results"
 msgstr "Không có kết quả"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:47
+#: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
 msgstr "Metabase không thể tìm thấy bất kỳ kết quả nào cho tìm kiếm của bạn. "
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:111
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
 msgstr "Không có số liệu"
 
@@ -9021,7 +9048,7 @@ msgstr "Không thể cấp quyền: {0}"
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
 msgstr "Không thể giải mã chuỗi mã hóa. Bạn đã thay đổi hoặc quên đặt MB_ENCRYPTION_SECRET_KEY?"
 
-#: frontend/src/metabase/entities/collections.js:164
+#: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
 msgstr "Tất cả các bộ sưu tập cá nhân"
 
@@ -9185,18 +9212,18 @@ msgstr "Không có"
 msgid "Windows domain"
 msgstr "Tên miền Windows"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:509
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:515
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:490
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:499
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
 msgstr "Nhãn"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:329
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
 msgstr "Thêm thành viên"
 
-#: frontend/src/metabase/entities/collections.js:115
+#: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
 msgstr "Bộ sưu tập đã được lưu trongBộ sưu tập đã được lưu trong"
 
@@ -9217,39 +9244,39 @@ msgid "Sharing"
 msgstr "Chia sẻ"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:234
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:270
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:299
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:305
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:313
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:321
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:218
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:251
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:280
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:286
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:294
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:302
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:80
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:85
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:91
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:97
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:50
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:56
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
 msgstr "Hiển thị"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:370
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:416
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:431
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:487
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:358
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:406
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:447
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
 msgstr "Trục"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:222
-#: frontend/src/metabase/admin/settings/selectors.js:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
+#: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
@@ -9283,21 +9310,21 @@ msgstr "tia X"
 msgid "Compare to the rest"
 msgstr "So sánh với phần còn lại"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:244
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "Sử dụng múi giờ của Máy ảo Java (JVM)"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
 msgstr "Chúng tôi khuyên bạn nên bỏ qua điều này trừ khi bạn thực hiện truyền múi giờ thủ công trong\n"
 "\"\"nhiều hoặc hầu hết các truy vấn của bạn với dữ liệu này."
 
-#: frontend/src/metabase/containers/Overworld.jsx:310
+#: frontend/src/metabase/containers/Overworld.jsx:312
 msgid "Your team's most important dashboards go here"
 msgstr "Bảng điều khiển quan trọng nhất của nhóm của bạn ở đây"
 
-#: frontend/src/metabase/containers/Overworld.jsx:311
+#: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
 msgstr "Ghim bảng điều khiển trong {0} để chúng xuất hiện trong không gian này cho mọi người"
 
@@ -9313,32 +9340,32 @@ msgstr "Sử dụng múi giờ JVM"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "Chúng tôi hiện đang phân tích các bảng và trường để giúp bạn khám phá dữ liệu của mình. "
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
 msgstr "Mẹo"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:258
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
 msgstr "Chọn một loại tiền tệ"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:318
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
 msgstr "Loại lĩnh vực"
 
 #: frontend/src/metabase/admin/routes.jsx:109
-#: frontend/src/metabase/nav/containers/Navbar.jsx:224
+#: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
 msgstr "Xử lý sự cố"
 
-#: frontend/src/metabase/admin/settings/selectors.js:96
+#: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
 msgstr "Kích hoạt tính năng X-quang"
 
-#: frontend/src/metabase/admin/settings/selectors.js:323
+#: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
 msgstr "Tùy chọn định dạng"
 
-#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:19
+#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
 msgstr "Chi tiết tác vụ"
 
@@ -9378,7 +9405,7 @@ msgstr "Tiền tệ"
 msgid "Pick a user or channel..."
 msgstr "Chọn người dùng hoặc kênh ..."
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
+#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
 msgstr "Không có cài đặt định dạng"
 
@@ -9486,31 +9513,31 @@ msgstr "HH:MM:SS.MS"
 msgid "Time style"
 msgstr "Kiểu thời gian"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:299
+#: frontend/src/metabase/visualizations/lib/settings/column.js:300
 msgid "Unit of currency"
 msgstr "Đơn vị tiền tệ"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:319
+#: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
 msgstr "Kiểu nhãn tiền tệ"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:337
+#: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
 msgstr "Nơi hiển thị đơn vị tiền tệ"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:370
+#: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
 msgstr "Số lượng thập phân tối thiểu"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:271
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
 msgstr "Loại biểu đồ xếp chồng"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:314
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
 msgstr "Nhãn mục tiêu"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:322
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
 msgstr "Hiển thị đường xu hướng"
 
@@ -9539,7 +9566,7 @@ msgstr "Dòng + Cột"
 msgid "line and bar chart"
 msgstr "biểu đồ đường và biểu đồ cột"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:72
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
 msgstr "Đo trực quan đòi hỏi một số."
 
@@ -9547,75 +9574,75 @@ msgstr "Đo trực quan đòi hỏi một số."
 msgid "Gauge"
 msgstr "Máy đo"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
 msgstr "Phạm vi đo"
 
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
 msgstr "Lĩnh vực để hiển thị"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
 msgstr "cuối {0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:185
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
 msgstr "{0} là {1} {2}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:52
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
 msgstr "Nhóm theo trường thời gian để xem điều này đã thay đổi theo thời gian như thế nào"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
 msgstr "Chuyển màu dương / âm?"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
 msgstr "Cột xoay"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:107
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
 msgstr "Cột di động"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:123
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
 msgstr "Cột có thể nhìn thấy"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:143
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
 msgstr "Định dạng có điều kiện"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
 msgstr "Tiêu đề cột"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
 msgstr "Hiển thị biểu đồ cột nhỏ"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:183
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
 msgstr "Liên kết"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:187
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
 msgstr "Liên kết email"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
 msgstr "Hình ảnh"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:195
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
 msgstr "Tự động"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:200
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
 msgstr "Xem dưới dạng liên kết hoặc hình ảnh"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
 msgstr "văn bản liên kết"
 
@@ -9879,7 +9906,7 @@ msgstr "Lỗi truy vấn tiền xử lý"
 msgid "No native form returned."
 msgstr "Không có hình thức bản địa trở lại."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
 msgstr "Phản hồi không hợp lệ từ trình điều khiển cơ sở dữ liệu. Không: tình trạng được cung cấp."
 
@@ -11245,7 +11272,7 @@ msgstr "Lõi cài đặt `query-caching-max-kb` thành {0}"
 msgid "Values greater than {1} are not allowed."
 msgstr "Các giá trị lớn hơn {1} không được phép."
 
-#: src/metabase/query_processor/middleware/resolve_database.clj
+#: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
 msgstr "Cơ sở dữ liệu {0} không tồn tại."
 
@@ -11294,7 +11321,7 @@ msgstr "Triggers"
 msgid "View triggers"
 msgstr "Xem triggers"
 
-#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:82
+#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
 msgstr "Thông tin Scheduler"
 
@@ -11326,7 +11353,7 @@ msgstr "Thời gian chạy cuối cùng"
 msgid "May Fire Again?"
 msgstr "Có thể chạy tiếp?"
 
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:75
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
 msgstr "Triggers cho {0}"
 
@@ -11338,19 +11365,19 @@ msgstr "Tác vụ"
 msgid "Jobs"
 msgstr "Jobs"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
 msgstr "Đã tạo bản sao {0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:55
+#: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
 msgstr "Tạo bản sao"
 
-#: frontend/src/metabase/components/EntityItem.jsx:61
+#: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
 msgstr "Lưu trữ item này"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:330
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
 msgstr "Đã tạo bản sao"
 
@@ -11400,54 +11427,55 @@ msgstr "{0} {1} trước"
 msgid "{0} {1} from now"
 msgstr "{0} {1} từ nay"
 
-#: frontend/src/metabase/lib/query_time.js:187
+#: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
 msgstr[0] "Khoảng mặc định"
 
-#: frontend/src/metabase/lib/query_time.js:203
+#: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
 msgstr[0] "phút mỗi giờ"
 
-#: frontend/src/metabase/lib/query_time.js:205
+#: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
 msgstr[0] "giờ mỗi ngày"
 
-#: frontend/src/metabase/lib/query_time.js:207
+#: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
 msgstr[0] "ngày mỗi tuần"
 
-#: frontend/src/metabase/lib/query_time.js:209
+#: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
 msgstr[0] "ngày mỗi tháng"
 
-#: frontend/src/metabase/lib/query_time.js:211
+#: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
 msgstr[0] "ngày mỗi năm"
 
-#: frontend/src/metabase/lib/query_time.js:213
+#: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
 msgstr[0] "tuần mỗi năm"
 
-#: frontend/src/metabase/lib/query_time.js:215
+#: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
 msgstr[0] "tháng mỗi năm"
 
-#: frontend/src/metabase/lib/query_time.js:217
+#: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] "quý mỗi năm"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:79
+#: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] "lựa chọn"
@@ -11460,20 +11488,20 @@ msgstr "[Q]Q"
 msgid "This"
 msgstr "Cái này"
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:64
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
 msgstr "Không phù hợp"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:147
+#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
 msgstr "Thêm thời gian"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:170
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
 msgstr "Không có gì để so sánh với {0}."
 
-#: frontend/src/metabase-lib/lib/Dimension.js:517
+#: frontend/src/metabase-lib/lib/Dimension.js:678
 msgid "by {0}"
 msgstr "bởi {0}"
 
@@ -11767,35 +11795,35 @@ msgstr "Đăng ký driver chậm chạp {0} ..."
 msgid "Error running query for Card {0}"
 msgstr "Lỗi khi chạy truy vấn cho Thẻ {0}"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
 msgstr "Tuần trước"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This week"
 msgstr "Tuần này"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
 msgstr "Tháng trước"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This month"
 msgstr "Tháng này"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
 msgstr "Quý trước"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
 msgstr "Quý này"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
 msgstr "Năm ngoái"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This year"
 msgstr "Năm nay"
 
@@ -12042,7 +12070,7 @@ msgid "[[CreateDate]] by quarter of the year"
 msgstr "[[CreatDate]] theo quý trong năm"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:200
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
 msgstr "Chỉnh sửa người dùng"
 
@@ -12050,12 +12078,12 @@ msgstr "Chỉnh sửa người dùng"
 msgid "New user"
 msgstr "Người dùng mới"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
 msgstr "Đặt lại mật khẩu"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:209
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
 msgstr "Vô hiệu hóa người dùng"
 
@@ -12067,40 +12095,40 @@ msgstr "Kích hoạt lại {0}?"
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
 msgstr "Chúng tôi không thể gửi cho họ lời mời qua email, vì vậy hãy yêu cầu họ đăng nhập bằng {0} và mật khẩu này mà chúng tôi đã tạo cho họ:"
 
-#: frontend/src/metabase/entities/collections.js:21
+#: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
 msgstr "bộ sưu tập"
 
-#: frontend/src/metabase/entities/collections.js:22
+#: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
 msgstr "bộ sưu tập"
 
-#: frontend/src/metabase/entities/dashboards.js:29
+#: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
 msgstr "bảng điều khiển"
 
-#: frontend/src/metabase/entities/dashboards.js:30
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
 msgstr "bảng điều khiển"
 
-#: frontend/src/metabase/entities/users.js:125
+#: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
 msgstr "Tên là bắt buộc"
 
-#: frontend/src/metabase/entities/users.js:126
-#: frontend/src/metabase/entities/users.js:133
+#: frontend/src/metabase/entities/users.js:38
+#: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
 msgstr "Phải từ 100 ký tự trở xuống"
 
-#: frontend/src/metabase/entities/users.js:132
+#: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
 msgstr "Họ là bắt buộc"
 
-#: frontend/src/metabase/entities/users.js:138
+#: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
 msgstr "Email là bắt buộc"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:90
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
 msgstr "Các mục bạn lưu trữ sẽ xuất hiện ở đây."
 
@@ -12108,11 +12136,11 @@ msgstr "Các mục bạn lưu trữ sẽ xuất hiện ở đây."
 msgid "No description"
 msgstr "Không có mô tả"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:175
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
 msgstr "Tổng tất cả các giá trị"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:183
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
 msgstr "Xem tất cả các giá trị riêng biệt"
 
@@ -12312,15 +12340,774 @@ msgstr "Thêm người dùng {0} vào nhóm Tất cả người dùng ..."
 msgid "Adding User {0} to Admin permissions group..."
 msgstr "Thêm người dùng {0} vào nhóm Quản trị viên ..."
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
 msgstr "Truy vấn thất bại"
 
-#: src/metabase/query_processor/async.clj
+#: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
 msgstr "Số lượng truy vấn đồng thời tối đa để cho phép trên mỗi Cơ sở dữ liệu được kết nối."
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
 msgstr "Đã hết thời gian sau {0} mili giây."
+
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
+msgid "Misfire Instruction"
+msgstr ""
+
+#: frontend/src/metabase/components/ArchiveModal.jsx:31
+msgid "Archive this?"
+msgstr ""
+
+#: frontend/src/metabase/components/BrowseApp.jsx:244
+msgid "Learn about our data"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
+msgid "Use DNS SRV when connecting"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
+msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
+"an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
+"leave this disabled."
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
+msgid "Automatically run queries when doing simple filtering and summarizing"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr ""
+
+#: frontend/src/metabase/containers/Overworld.jsx:247
+msgid "Learn about this database"
+msgstr ""
+
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+msgid "Archive this dashboard?"
+msgstr ""
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:113
+msgid "All results"
+msgstr "Tất cả kết quả"
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:180
+msgid "Our Analytics"
+msgstr ""
+
+#: frontend/src/metabase/lib/schema_metadata.js:500
+msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
+msgstr ""
+
+#: frontend/src/metabase/lib/schema_metadata.js:508
+msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
+msgstr ""
+
+#: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
+msgid "Filter"
+msgstr "Lọc"
+
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+msgid "record"
+msgid_plural "records"
+msgstr[0] ""
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:346
+msgid "Browse Data"
+msgstr ""
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:376
+msgid "Write SQL"
+msgstr "Viết truy vấn SQL"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
+msgid "Simple question"
+msgstr "Câu hỏi đơn giản"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
+msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
+msgid "Custom question"
+msgstr "Câu hỏi tuỳ chỉnh"
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
+msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+msgid "Basic Metrics"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+msgid "Custom…"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
+msgid "Add grouping"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
+msgid "Pick a limit"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
+msgid "Show maximum"
+msgstr "Hiển thị tối đa"
+
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
+msgid "Get Preview"
+msgstr "Xem trước"
+
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
+msgid "Back to previous results"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
+msgid "Sample values"
+msgstr "Giá trị mẫu"
+
+#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
+msgid "Visualize"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
+msgid "Join data"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
+msgid "Custom column"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
+msgid "Summarize"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
+msgid "Aggregate"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
+msgid "Breakout"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
+msgid "Pick the metric you want to see"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
+#: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
+msgid "Pick a column to group by"
+msgstr "Chọn một cột để gom nhóm"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
+msgid "Pick your starting data"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select None"
+msgstr "Không chọn gì"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select All"
+msgstr "Chọn tất cả"
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
+msgid "Pick a table..."
+msgstr "Chọn một bảng..."
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
+msgid "Enter a limit"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
+msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
+msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
+msgid "View the native query"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
+msgid "Native query for this question"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
+msgid "Convert this question to a native query"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
+msgid "SQL for this question"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
+msgid "Convert this question to SQL"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
+msgid "Get alerts"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
+msgid "{0} breakout"
+msgid_plural "{0} breakouts"
+msgstr[0] ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
+msgid "Hide filters"
+msgstr "Ẩn bộ lọc"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
+msgid "Show filters"
+msgstr "Hiện bộ lọc"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
+msgid "Started from"
+msgstr "Bắt đầu từ"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
+msgid "{0} row"
+msgid_plural "{0} rows"
+msgstr[0] ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
+msgid "Show all rows"
+msgstr "Hiển thị tất cả các hàng"
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
+msgid "Show {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
+msgid "Showing first {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
+msgid "Showing {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
+msgid "Summarized"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Hide editor"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Show editor"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
+msgid "Pick the metric you'd like to see"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
+msgid "{0} options"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
+msgid "Choose a visualization"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
+msgid "Filter by"
+msgstr "Lọc theo"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+msgid "Summarize by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+msgid "Group by"
+msgstr "Nhóm theo"
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+msgid "Add a metric"
+msgstr ""
+
+#: frontend/src/metabase/user/components/UserSettings.jsx:57
+msgid "Profile"
+msgstr "Hồ sơ"
+
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:548
+msgid "This is usually pretty fast but seems to be taking a while right now."
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
+msgid "Combo"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
+msgid "Row"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
+msgid "Trend"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:129
+msgid "Boolean"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+msgid "Unknown Segment"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+msgid "Unknown Filter"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
+msgid "Left outer join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
+msgid "Right outer join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
+msgid "Inner join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
+msgid "Full outer join"
+msgstr ""
+
+#: src/metabase/api/card.clj
+msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
+msgstr ""
+
+#: src/metabase/api/session.clj
+msgid "Problem connecting to LDAP server, will fall back to local authentication"
+msgstr ""
+
+#: src/metabase/api/setup.clj
+msgid "Cannot create Database: cannot find driver {0}."
+msgstr ""
+
+#: src/metabase/api/tiles.clj
+msgid "Query failed"
+msgstr "Truy vấn thất bại"
+
+#: src/metabase/async/util.clj
+msgid "Warning: {0} returned `nil`"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing result to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing exception to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Request canceled, canceling future."
+msgstr ""
+
+#: src/metabase/cmd/load_from_h2.clj
+msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "Application database setup"
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Could not find {0} driver."
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Abstract drivers cannot derive from concrete parent drivers."
+msgstr ""
+
+#: src/metabase/driver/mysql.clj
+msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifer."
+msgstr ""
+
+#: src/metabase/driver/sql_jdbc/execute.clj
+msgid "Client closed connection, canceling query"
+msgstr ""
+
+#: src/metabase/integrations/ldap.clj
+msgid "{0} is not a valid DN."
+msgstr ""
+
+#: src/metabase/middleware/log.clj
+msgid "Error logging API request"
+msgstr ""
+
+#: src/metabase/middleware/misc.clj
+msgid "Failed to set site-url"
+msgstr ""
+
+#: src/metabase/models/database.clj
+msgid "Error destroying thread pool for DB."
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/models/task_history.clj src/metabase/sync/util.clj
+msgid "Error saving task history"
+msgstr ""
+
+#: src/metabase/plugins.clj
+msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
+msgstr ""
+
+#: src/metabase/plugins/classloader.clj
+msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
+msgstr ""
+
+#: src/metabase/plugins/files.clj
+msgid "Failed to copy file"
+msgstr ""
+
+#: src/metabase/public_settings.clj
+msgid "Invalid site URL: {0}"
+msgstr ""
+
+#: src/metabase/public_settings.clj
+msgid "site-url is invalid; returning nil for now. Will be reset on next request."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "More results have been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "This question has been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "We were unable to display this Pulse."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "Please view this card in Metabase."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "An error occurred while displaying this card."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Can only determine expected columns for MBQL queries."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "No columns returned."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot find Table ID for {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "No matching info found."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Could not resolve {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Invalid fk-> clause: nowhere to add corresponding join."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "{0} driver does not support foreign keys."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Query processor error: number of columns returned by driver does not match results."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Expected {0} columns, but first row of resuls has {1} columns."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "No expression named {0} found. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Distinct values of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Average of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "SD of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Min of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Max of {0}"
+msgstr ""
+
+#. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0} matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Share of rows matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Count of rows matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Request already canceled, will not run synchronous QP code."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unexpectedly got `nil` Query Processor response."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Got InterruptedException. Canceling query."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Query timed out after %s"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Creating new query thread pool for Database {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Destroying query thread pool for Database {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Request canceled, canceling pending query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: query is missing source-metadata"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Using query processor cache backend: {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/expand_macros.clj
+msgid "Invalid metric: {0} reason: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unknown error"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unexpected nil response from query processor."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Query canceled"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: Database {0} does not exist."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_source_table.clj
+msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Cannot store Tables or Fields before Database is stored."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Attempting to fetch second Database. Queries can only reference one Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
+msgstr ""
+
+#: src/metabase/routes/index.clj
+msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Sample dataset DB file ''{0}'' cannot be found."
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Loading sample dataset..."
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Failed to load sample dataset"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Found new tables:"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Marking tables as inactive:"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Updating description for tables:"
+msgstr ""
+
+#: src/metabase/task.clj
+msgid "Rescheduling job {0}"
+msgstr ""
+
+#: src/metabase/task.clj
+msgid "Error rescheduling job"
+msgstr ""
+
+#: src/metabase/task/send_pulses.clj
+msgid "Starting Pulse Execution: {0}"
+msgstr ""
+
+#: src/metabase/task/send_pulses.clj
+msgid "Finished Pulse Execution: {0}"
+msgstr ""
+
+#: src/metabase/task/sync_databases.clj
+msgid "Failed to schedule tasks for Database {0}"
+msgstr ""
+
+#: src/metabase/util/schema.clj
+msgid "All elements must be distinct."
+msgstr ""
+
+#: 
+msgctxt "Modal for selecting columns in source data or when doing a join."
+msgid "Pick the columns you want to include"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
+msgid "Change join type"
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifier."
+msgstr ""
+
+#: src/metabase/integrations/common.clj
+msgid "Error adding User {0} to Group {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Infinite loop detected: recursively preprocessed query {0} times."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Error determining expected columns for query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
+msgstr ""
 

--- a/locales/zh.po
+++ b/locales/zh.po
@@ -28,19 +28,21 @@ msgstr "探索数据"
 msgid "Select a database type"
 msgstr "选择数据库类型"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:75
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:401
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:71
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:182
+#: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:410
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:74
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:203
 #: frontend/src/metabase/components/ActionButton.jsx:51
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:7
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:180
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:197
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:170
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:15
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:193
 #: frontend/src/metabase/reference/components/EditHeader.jsx:54
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:171
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:180
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:164
+#, fuzzy
 msgid "Save"
 msgstr "保存"
 
@@ -59,7 +61,8 @@ msgid "This is a lightweight process that checks for\n"
 msgstr "这是一个检查数据库模式变化的轻量级的过程，大部分情况下，你可以使用每小时同步。"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:184
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
+#, fuzzy
 msgid "Scan"
 msgstr "扫描"
 
@@ -74,126 +77,128 @@ msgid "Metabase can scan the values present in each\n"
 "database."
 msgstr "Metabase可以扫描数据库中每个字段的值来启用选择框过滤器。这是一个资源密集型的过程，尤其当你有一个很大的数据库"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:159
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
 msgstr "Metabase应该在什么时候自动扫描缓存的字段值"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:164
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
 msgstr "根据排程，周期性地进行"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:195
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
 msgstr "只有当你在添加一个新的过滤控件时"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:199
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
 msgstr "当用户向仪表盘或SQL查询添加一个新的过滤器，Metabase会扫描过滤器对应的字段来显示一个可选值列表。"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:210
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
 msgid "Never, I'll do this manually if I need to"
 msgstr "不用，如果需要我会手动执行"
 
-#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:222
+#: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:222
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:426
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
 msgid "Saving..."
 msgstr "保存中......"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:39
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:144
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
 msgid "Server error encountered"
 msgstr "服务器碰到错误"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:58
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
 msgstr "是否要删除这个数据库？"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
 msgstr "所有依赖这个数据库保存的问题，指标，数据段将要丢失。"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:67
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
 msgstr "此操作无法撤销。"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
 msgstr "如果确认，请输入。"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:53
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:70
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
 msgstr "删除"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:71
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
 msgstr "在这个框里:"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:82
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:50
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:87
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:93
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:84
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:86
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:27
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:49
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:52
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:58
-#: frontend/src/metabase/admin/permissions/selectors.js:160
-#: frontend/src/metabase/admin/permissions/selectors.js:170
-#: frontend/src/metabase/admin/permissions/selectors.js:185
-#: frontend/src/metabase/admin/permissions/selectors.js:224
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:355
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:181
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:247
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:61
+#: frontend/src/metabase/admin/permissions/selectors.js:163
+#: frontend/src/metabase/admin/permissions/selectors.js:173
+#: frontend/src/metabase/admin/permissions/selectors.js:188
+#: frontend/src/metabase/admin/permissions/selectors.js:227
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:357
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:202
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:268
+#: frontend/src/metabase/components/ArchiveModal.jsx:35
 #: frontend/src/metabase/components/ConfirmContent.jsx:18
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:72
 #: frontend/src/metabase/components/HeaderModal.jsx:49
-#: frontend/src/metabase/components/form/StandardForm.jsx:61
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:196
+#: frontend/src/metabase/components/form/StandardForm.jsx:62
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:198
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:289
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:162
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:153
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:38
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:189
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:191
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:354
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:24
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:83
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:48
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:41
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:92
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 #: frontend/src/metabase/reference/components/EditHeader.jsx:34
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:52
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:259
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
 msgstr "取消"
 
-#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:88
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:121
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:132
+#: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
 msgstr "删除"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:128
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:74
-#: frontend/src/metabase/admin/permissions/selectors.js:320
-#: frontend/src/metabase/admin/permissions/selectors.js:327
-#: frontend/src/metabase/admin/permissions/selectors.js:423
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
+#: frontend/src/metabase/admin/permissions/selectors.js:323
+#: frontend/src/metabase/admin/permissions/selectors.js:330
+#: frontend/src/metabase/admin/permissions/selectors.js:426
 #: frontend/src/metabase/admin/routes.jsx:53
-#: frontend/src/metabase/nav/containers/Navbar.jsx:214
+#: frontend/src/metabase/nav/containers/Navbar.jsx:243
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
 msgstr "数据库"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:129
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
 msgstr "添加数据库"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
 msgstr "连接"
@@ -202,107 +207,107 @@ msgstr "连接"
 msgid "Scheduling"
 msgstr "调度"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:170
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:78
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:84
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:26
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:221
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
 msgstr "保存修改"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:185
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:38
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:38
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
 msgstr "动作"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:193
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
 msgstr "开始同步数据库模式"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:194
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:206
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:15
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:23
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:109
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
 msgstr "开始..."
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:195
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
 msgstr "同步失败"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
 msgstr "同步触发！"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:205
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
 msgstr "现在重新扫描字段值"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:207
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
 msgstr "无法开始扫描"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
 msgstr "扫描已触发！"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:215
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:401
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
 msgstr "危险操作"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:221
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
 msgstr "放弃保存的字段值"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:239
+#: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
 msgstr "删除数据库"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:73
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
 msgstr "添加数据库"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:85
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:36
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:36
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:122
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:32
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:123
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:183
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:91
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:399
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:446
 #: frontend/src/metabase/containers/EntitySearch.jsx:26
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:218
-#: frontend/src/metabase/entities/collections.js:93
-#: frontend/src/metabase/entities/dashboards.js:145
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:461
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:81
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:220
+#: frontend/src/metabase/entities/collections.js:94
+#: frontend/src/metabase/entities/dashboards.js:142
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
 msgstr "名字"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:86
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
 msgstr "引擎"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:115
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
 msgstr "删除中。。。"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:145
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
 msgstr "加载中。。。"
 
-#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:161
+#: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
 msgstr "恢复样本数据集"
 
@@ -319,9 +324,9 @@ msgid "Successfully saved!"
 msgstr "保存成功！"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:177
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:197
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:189
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
 msgstr "编辑"
@@ -330,86 +335,90 @@ msgstr "编辑"
 msgid "Revision History"
 msgstr "修订记录"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
 msgstr "作废{0}？"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
 msgstr "保存的问题和依赖于此{0}的其他内容将继续有效，但不再可以从查询构建器中选择此{1}。"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:39
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
 msgstr "如果您确定要让此{0}退役，请解释一下原因："
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
 msgstr "这将显示在活动信息和电子邮件中，该电子邮件将发送给您团队中创建使用此{0}内容的任何人。"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
 msgstr "作废"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
 msgstr "正在作废……"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
 msgstr "失败"
 
-#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:61
+#: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
 msgstr "成功"
 
-#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:118
+#: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:91
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
+#: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
 msgstr "预览"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:99
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
 msgstr "暂无字段描述"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:135
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
 msgstr "选择字段可见性"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:210
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
 msgstr "指定的类型不存在"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:211
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:148
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:34
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
 msgstr "其他"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:231
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
 msgstr "请选择一个指定类型"
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:277
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
 msgstr "选择目标"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:77
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:89
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:106
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:122
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
 msgstr "字段"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
 msgstr "字段"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:121
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:306
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
 msgstr "可见性"
 
@@ -417,52 +426,52 @@ msgstr "可见性"
 msgid "Type"
 msgstr "类型"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
 msgstr "当前数据库"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:92
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
 msgstr "查看原始格式"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:45
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
 msgstr "数据类型"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
 msgstr "附加信息"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:44
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
 msgstr "查找数据库模式"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:51
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
 msgstr[0] "{0} 结构"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:82
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
 msgstr "隐藏原因"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:83
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
 msgstr "日志数据"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:84
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
 msgstr "不相关"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:90
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
 msgid "Queryable"
 msgstr "可查询"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:91
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
 msgstr "已隐藏"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:117
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
 msgstr "暂无表格描述"
 
@@ -470,63 +479,65 @@ msgstr "暂无表格描述"
 msgid "Metadata Strength"
 msgstr "元数据完整度"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:87
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
 msgstr[0] "{0}可查询表格"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:96
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
 msgstr[0] "{0}隐藏表格"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:113
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
 msgstr "查找表格"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:126
+#: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
 msgstr "表结构"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:24
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:137
+#: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:68
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:33
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:27
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:56
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:190
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:63
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
 msgstr "指标"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
 msgstr "添加指标"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:37
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
 msgstr "定义"
 
-#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
 msgstr "创建指标并添加到查询设计器的视图下拉列表"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:24
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:930
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
+#: frontend/src/metabase/home/containers/SearchApp.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:952
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:33
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:19
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:56
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
 msgstr "过滤器"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:30
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
 msgstr "添加过滤器"
 
-#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:54
+#: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
 msgstr "创建过滤器并添加到查询设计器的筛选下拉列表"
 
@@ -554,53 +565,53 @@ msgstr "编辑"
 msgid "made some changes"
 msgstr "做了一些改动"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:46
-#: frontend/src/metabase/home/components/Activity.jsx:80
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:332
+#: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
+#: frontend/src/metabase/home/components/Activity.jsx:82
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
 msgstr "您"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:37
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
 msgstr "数据模型"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:43
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
 msgstr "历史"
 
-#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:48
+#: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
 msgstr "历史版本"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:239
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
 msgstr "{0} - 字段设置"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:307
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
 msgstr "这些字段将在哪里显示？"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:329
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
 msgstr "字段过滤"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:330
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
 msgstr "当在过滤器中使用此字段时，人们应该使用什么形式输入他们想要过滤的值?"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:453
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
 msgstr "暂无筛选条件描述"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:379
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
 msgstr "原始值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:380
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
 msgid "Mapped value"
 msgstr "映射值"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:423
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
 msgstr "输入值"
 
@@ -617,7 +628,7 @@ msgid "Custom mapping"
 msgstr "自定义映射"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:155
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
 msgid "Unrecognized mapping type"
 msgstr "无法识别对应类型"
 
@@ -625,23 +636,23 @@ msgstr "无法识别对应类型"
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
 msgstr "当前字段不是外键或者缺少外键关联表元数据"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:187
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
 msgstr "选中的字段不是外键"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:347
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
 msgstr "显示值"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:348
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
 msgstr "选择显示数据库中的原始值，或者显示此字段的关联或自定义信息。"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:268
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
 msgstr "选择字段"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:289
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
 msgstr "请选择显示字段"
 
@@ -649,16 +660,16 @@ msgstr "请选择显示字段"
 msgid "Tip:"
 msgstr "提示："
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:433
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
 msgstr "你可能想要更新这个字段的名称来确保它基于你的重新映射选择时仍然有意义"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:364
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:102
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
 msgstr "缓存字段值"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:365
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
 msgstr "Metabase 通过扫描该字段，以启用仪表盘和问题的多选框筛选。"
 
@@ -667,167 +678,168 @@ msgid "Re-scan this field"
 msgstr "重新扫描该字段"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
 msgstr "丢弃字段缓存"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:118
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
 msgstr "丢弃字段值失败"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:119
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard triggered!"
 msgstr "丢弃处理已经触发！"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:105
+#: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
 msgstr "选择任意表单来显示它的所有模式并且添加或删除元数据"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:37
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:34
-#: frontend/src/metabase/entities/collections.js:96
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
+#: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
 msgstr "名称必填"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:40
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:37
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
 msgstr "描述必填"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:44
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:41
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
 msgstr "调整信息必填"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:50
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
 msgstr "聚合信息必填"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:110
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
 msgstr "编辑指标"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:111
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
 msgstr "创建指标"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:115
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
 msgstr "修改指标并留下简要说明。"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
 msgstr "你能够创造已存储的指标来添加一个已经命名的指标选项到这个表单。存储刻度包括你添加的聚合类型，聚合字段和可选的任何筛选项。举个例子，你可能使用这个来为一个订单表单创造一些像是“平均价”的官方计算方法，"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
 msgstr "结果："
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:157
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
 msgstr "命名指标"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
 msgstr "为指标命名，方便其他人查找。"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:162
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
 msgstr "简短的描述"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:166
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
 msgstr "描述指标"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
 msgstr "描述指标，方便其他人理解。"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
 msgstr "在这里详细描述指标，比如不太明显的规则"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:175
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:179
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
 msgstr "更改原因"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:177
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
 msgstr "留言以说明您所做的更改以及为何需要这些更改。"
 
-#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:181
+#: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
 msgstr "这将显示在此指标的修订历史记录中，以帮助每个人记住事情发生变化的原因"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:49
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
 msgstr "至少需要一个筛选条件"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:116
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
 msgstr "编辑划分"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:117
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
 msgstr "创建划分"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:121
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
 msgstr "更改划分，并描述变动内容。"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:122
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
 msgstr "选择并添加筛选条件以为{0}表创建新段"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:161
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
 msgstr "命名划分"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:162
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
 msgstr "命名划分方便其他人查找"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:170
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
 msgstr "描述划分"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:171
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
 msgid "Give your segment a description to help others understand what it's about."
 msgstr "描述划分，方便其他人理解。"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:175
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
 msgstr "在这里详细描述划分，比如不太明显的规则"
 
-#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:185
+#: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
 msgstr "这将显示在过滤器的修订历史记录中，以帮助每个人记住事情发生变化的原因"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:266
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:87
-#: frontend/src/metabase/nav/containers/Navbar.jsx:199
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:269
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:91
+#: frontend/src/metabase/nav/containers/Navbar.jsx:228
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
 msgstr "设置"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:103
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
 msgstr "Metabase扫描此表中的值以启用仪表板和问题中的复选框过滤器。"
 
-#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:108
+#: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
 msgstr "刷新表格"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:253
-#: frontend/src/metabase/dashboard/components/DashCard.jsx:278
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
+#: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
 msgstr "添加"
 
@@ -836,20 +848,22 @@ msgstr "添加"
 msgid "Not a valid formatted email address"
 msgstr "非法的email地址"
 
+#: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:100
 msgid "First name"
 msgstr "名"
 
+#: frontend/src/metabase/entities/users.js:42
 #: frontend/src/metabase/setup/components/UserStep.jsx:203
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:117
 msgid "Last name"
 msgstr "姓"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:77
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:158
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:161
 #: frontend/src/metabase/components/NewsletterForm.jsx:94
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:470
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:481
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
@@ -863,34 +877,35 @@ msgstr "组权限"
 msgid "Make this user an admin"
 msgstr "设为管理员"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:32
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
 msgstr "所有属于这个{0}群组的用户，并且不能从这个群组中被移除。为这个群组设置许可权限是一个确保你知道Metabase新用户将会能够看到什么的好办法。"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:41
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
 msgstr "这是一个特殊的组，其成员可以查看Metabase实例中的所有内容，可以访问和更改管理面板中的设置，包括更改权限！ 因此，小心地将人员添加到该组。"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:45
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
 msgstr "为了确保你不会被Metabase锁在外面，必须需要至少一个用户在这个群组里。"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
 msgstr "组员"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:177
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:124
-#: frontend/src/metabase/admin/settings/selectors.js:113
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
+#: frontend/src/metabase/admin/settings/selectors.js:110
+#: frontend/src/metabase/entities/users.js:50
 #: frontend/src/metabase/lib/core.js:55
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
 msgstr "邮箱"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:203
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
 msgstr "组内成员权限一致"
 
@@ -901,8 +916,8 @@ msgid "Admin"
 msgstr "管理员"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:237
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:290
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
 msgstr "和"
 
@@ -930,13 +945,13 @@ msgid "Are you sure? All members of this group will lose any permissions setting
 msgstr "确定吗？该组所有成员都将丢失该组下的权限设置。此操作不可逆。"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
 msgstr "是"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:42
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
 msgstr "否"
 
@@ -955,10 +970,11 @@ msgstr "移除分组"
 #: frontend/src/metabase/components/HeaderModal.jsx:43
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:282
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:107
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:327
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:395
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:193
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:265
+#: frontend/src/metabase/query_builder/components/SidebarContent.jsx:17
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
 msgstr "完成"
 
@@ -968,9 +984,9 @@ msgstr "分组名称"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:131
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
 #: frontend/src/metabase/admin/routes.jsx:88
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
 msgstr "分组"
 
@@ -999,9 +1015,9 @@ msgid "Deactivate"
 msgstr "停用"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:93
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
-#: frontend/src/metabase/nav/containers/Navbar.jsx:204
+#: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
 msgstr "人员管理"
 
@@ -1041,7 +1057,6 @@ msgid "We've re-sent {0}'s invite"
 msgstr "我们已重新发送{0}的邀请邮件"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
-#: frontend/src/metabase/tutorial/Tutorial.jsx:253
 msgid "Okay"
 msgstr "好的"
 
@@ -1073,13 +1088,13 @@ msgstr "他们将能够再次登录，并且将被放回到帐户被停用之前
 msgid "Reset {0}'s password?"
 msgstr "重置{0}的密码"
 
-#: frontend/src/metabase/components/form/StandardForm.jsx:77
+#: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
 msgstr "重置"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
-#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:44
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
 msgstr "是否确认执行此操作？"
 
@@ -1095,76 +1110,78 @@ msgstr "这是系统提供的用于登录的临时密码，登录成功后请修
 msgid "We've sent them an email with instructions for creating a new password."
 msgstr "我们已向他们发送了一封电子邮件，其中包含创建新密码的说明。"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:101
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
 msgstr "激活"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:127
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
 msgstr "已停用"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:115
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
 msgstr "邀请其他人"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:132
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
 msgstr "上次登录"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:153
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
 msgstr "用谷歌账号登录"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:158
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
 msgstr "用LDAP账号登录"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:170
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
 msgstr "重启账号"
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:193
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
 msgstr "永不"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:27
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
 msgstr[0] "表格 {0}\n"
 "Plural: {0} 张表格"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:45
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
 msgstr "将会"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:48
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
 msgstr "已经被赋予权限连接至"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:53
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
 msgstr "和"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:56
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
 msgstr "拒绝访问"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:70
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
 msgstr "将不再能够"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:71
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
 msgstr "现在将能够"
 
-#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:79
+#: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
 msgstr "本地查询"
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
-#: frontend/src/metabase/nav/containers/Navbar.jsx:219
+#: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
 msgstr "权限"
 
@@ -1189,15 +1206,15 @@ msgstr "权限无更改。"
 msgid "You've made changes to permissions."
 msgstr "权限被更改。"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:52
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
 msgstr "这个集合的权限"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:53
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
 msgstr "有变更未保存"
 
-#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:54
+#: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
 msgstr "页面上有未保存的变革，你想离开吗？"
 
@@ -1217,119 +1234,119 @@ msgstr "每个Metabase用户都属于“所有用户”组。如果要限制一�
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
 msgstr "MetaBot是Metabase的Slack机器人。您可以在此处选择访问权限。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:119
+#: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
 msgstr "“{0}”组可以访问与该组不同的{1}，这可以为该组提供对某些{2}的额外访问权限。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:124
+#: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
 msgstr "“{0}”组具有比此更高的访问级别，并将覆盖此设置。您应该限制或撤消“{1}”组对此项目的访问权限。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
 msgstr "限制"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:154
+#: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
 msgstr "撤销"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:156
+#: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
 msgstr "即使{0}有更高权限？"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:258
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
 msgstr "部分权限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:159
-#: frontend/src/metabase/admin/permissions/selectors.js:223
-#: frontend/src/metabase/admin/permissions/selectors.js:266
+#: frontend/src/metabase/admin/permissions/selectors.js:162
+#: frontend/src/metabase/admin/permissions/selectors.js:226
+#: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
 msgstr "取消权限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:168
+#: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
 msgstr "更改权限为受限权限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:169
+#: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
 msgstr "更改"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:182
+#: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
 msgstr "允许原始查询语句写作？"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:183
+#: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
 msgstr "这也将更改此组对此数据库的“不受限制的”访问权限。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:184
+#: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
 msgstr "允许"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:221
+#: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
 msgstr "取消所有表的权限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:222
+#: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
 msgstr "这也将撤消此组对该数据库的原始查询的访问权限。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:251
+#: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
 msgstr "授予不受限制的访问权限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:252
+#: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
 msgstr "不受限制的权限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:259
+#: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
 msgstr "受限制的权限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:267
+#: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
 msgstr "没有权限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:273
+#: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
 msgstr "写原始查询语句"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:274
+#: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
 msgstr "能够写原始查询语句"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:281
+#: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
 msgstr "修改集合"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:288
+#: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
 msgstr "查看集合"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:331
-#: frontend/src/metabase/admin/permissions/selectors.js:427
-#: frontend/src/metabase/admin/permissions/selectors.js:524
+#: frontend/src/metabase/admin/permissions/selectors.js:334
+#: frontend/src/metabase/admin/permissions/selectors.js:430
+#: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
 msgstr "允许访问数据"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:492
-#: frontend/src/metabase/admin/permissions/selectors.js:649
-#: frontend/src/metabase/admin/permissions/selectors.js:654
+#: frontend/src/metabase/admin/permissions/selectors.js:495
+#: frontend/src/metabase/admin/permissions/selectors.js:652
+#: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
 msgstr "查看表格"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:590
+#: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
 msgstr "SQL查询"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:660
+#: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
 msgstr "查看架构"
 
 #: frontend/src/metabase/admin/routes.jsx:59
-#: frontend/src/metabase/nav/containers/Navbar.jsx:209
+#: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
 msgstr "数据模型"
 
@@ -1338,30 +1355,30 @@ msgstr "数据模型"
 msgid "Sign in with Google"
 msgstr "Google账号登录"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:13
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
 msgstr "允许拥有Metabase帐户的用户使用与其电子邮件地址匹配的Google帐户以及其Metabase用户名和密码进行登录。"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:17
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:29
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
 msgstr "配置"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
-#: frontend/src/metabase/admin/settings/selectors.js:207
+#: frontend/src/metabase/admin/settings/selectors.js:204
 msgid "LDAP"
 msgstr "联机分析处理"
 
-#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:25
+#: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
 msgstr "允许用户在没有你的LDAP字典的情况下使用他们的LDAP证书来登录到Metabase，并且允许自动LDAP群组的自动同步到Metabase的群组"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
-#: frontend/src/metabase/admin/settings/selectors.js:160
+#: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
 msgstr "这不是有效的电子邮件地址"
 
@@ -1399,7 +1416,7 @@ msgstr "完成"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
-#: frontend/src/metabase/admin/settings/selectors.js:202
+#: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
 msgstr "认证"
 
@@ -1463,21 +1480,21 @@ msgstr "为MetaBot创建一个Slack Bot用户"
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
 msgstr "进入后，请为其命名并单击{0}。然后将Bot API令牌复制并粘贴到下面的字段中。完成后，在Slack中创建“metabase_files”通道。Metabase需要这个来上传图表。"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:90
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
 msgstr "你正在运行的Metabase {0}是最新版本的。"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:99
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
 msgstr "Metabase {0}可更新。你正在运行是{1}"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:112
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:96
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
 msgstr "更新"
 
-#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:116
+#: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
 msgstr "更新内容"
 
@@ -1490,80 +1507,80 @@ msgstr "添加一个地图"
 msgid "URL"
 msgstr "链接"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:199
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
 msgstr "删除自定义地图"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:327
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:40
-#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:181
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:104
+#: frontend/src/metabase/parameters/components/ParameterWidget.jsx:193
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
 msgstr "删除"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:226
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:187
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:241
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:145
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:187
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:246
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
 msgstr "选择"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:241
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
 msgstr "样例值"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
 msgstr "添加新地图"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:279
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
 msgstr "编辑地图"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:280
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
 msgstr "这个地图叫什么"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:285
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
 msgstr "比如，英国、巴西、火星"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:292
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
 msgstr "你想使用的GeoJSON文件URL"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:298
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
 msgstr "例如 https://my-mb-server.com/maps/my-map.json"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:33
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
 msgstr "刷新"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:309
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
 msgstr "加载"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:315
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
 msgstr "哪个属性指定了区域的标识符？"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:324
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
 msgstr "哪个属性指定了区域的显示名称？"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:345
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
 msgstr "读取一个 GeoJSON 文件来预览"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
 msgstr "保存地图"
 
-#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:363
+#: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
 msgstr "添加地图"
 
@@ -1575,11 +1592,11 @@ msgstr "使用嵌入式"
 msgid "By enabling embedding you're agreeing to the embedding license located at"
 msgstr "启用嵌入即表示您同意嵌入许可，该许可位于"
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:19
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
 msgstr "简单来说，当您在自己的应用程序中嵌入Metabase的图表或仪表板时，只要您保留Metabase徽标和“Powered by Metabase”，该应用程序就不受涵盖Metabase其余部分的Affero通用公共许可证的约束。但是，您应该阅读上面链接的许可文本，因为这是您将通过启用此功能同意的实际许可。"
 
-#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:32
+#: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
 msgstr "启用"
 
@@ -1603,25 +1620,25 @@ msgstr "购买 token"
 msgid "Enter a token"
 msgstr "输入 token"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:134
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
 msgstr "编辑映射"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:140
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
 msgstr "分组映射"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:147
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
 msgstr "创建映射"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
 msgstr "映射允许Metabase根据目录服务器提供的成员资格信息自动添加和删除组中的用户。Admin组的成员身份可以通过映射授予，但作为故障保护措施并不会被自动删除。"
 
-#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:154
+#: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
 msgstr "专有名字"
 
@@ -1633,43 +1650,43 @@ msgstr "公开链接"
 msgid "Revoke Link"
 msgstr "撤销链接"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:121
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
 msgstr "禁用这个链接吗？"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:122
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
 msgstr "它们将不会工作了，并且不能被重新存储，但是你能够创建新的链接。"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:149
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
 msgstr "公共仪表盘列表"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:152
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
 msgstr "还没有公开分享的仪表盘。"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:160
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
 msgstr "公共卡片列表"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:163
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
 msgstr "还没有公开分享任何问题。"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:172
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
 msgstr "嵌入的仪表板列表"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:173
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
 msgstr "还没有仪表盘被嵌入。"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:183
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
 msgstr "嵌入的卡片列表"
 
-#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:184
+#: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
 msgstr "还没有提问被嵌入"
 
@@ -1690,18 +1707,17 @@ msgid "Generate Key"
 msgstr "生成秘钥"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:78
-#: frontend/src/metabase/admin/settings/selectors.js:87
+#: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
 msgstr "生效"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
-#: frontend/src/metabase/admin/settings/selectors.js:83
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:103
+#: frontend/src/metabase/admin/settings/selectors.js:82
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
 msgstr "取消"
 
-#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:116
+#: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
 msgstr "未知设置{0}"
 
@@ -1709,7 +1725,7 @@ msgstr "未知设置{0}"
 msgid "Setup"
 msgstr "初始化"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:217
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
 msgstr "基本设置"
@@ -1738,11 +1754,11 @@ msgstr "数据源默认时区"
 msgid "Select a timezone"
 msgstr "选择时区"
 
-#: frontend/src/metabase/admin/settings/selectors.js:55
+#: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
 msgstr "并非所有数据库支持时区，部分设置无法生效。"
 
-#: frontend/src/metabase/admin/settings/selectors.js:60
+#: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
 msgstr "语言"
 
@@ -1750,202 +1766,202 @@ msgstr "语言"
 msgid "Select a language"
 msgstr "选择语言"
 
-#: frontend/src/metabase/admin/settings/selectors.js:70
+#: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
 msgstr "匿名跟踪"
 
-#: frontend/src/metabase/admin/settings/selectors.js:75
+#: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
 msgstr "友好的表单和字段名称"
 
-#: frontend/src/metabase/admin/settings/selectors.js:81
+#: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
 msgstr "仅用空格替换下划线和短划线"
 
-#: frontend/src/metabase/admin/settings/selectors.js:91
+#: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
 msgstr "启用网状查询"
 
-#: frontend/src/metabase/admin/settings/selectors.js:102
+#: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
 msgstr "更新"
 
-#: frontend/src/metabase/admin/settings/selectors.js:107
+#: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
 msgstr "检查更新"
 
-#: frontend/src/metabase/admin/settings/selectors.js:118
+#: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
 msgstr "SMTP地址"
 
-#: frontend/src/metabase/admin/settings/selectors.js:126
+#: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
 msgstr "SMTP端口"
 
-#: frontend/src/metabase/admin/settings/selectors.js:130
-#: frontend/src/metabase/admin/settings/selectors.js:230
+#: frontend/src/metabase/admin/settings/selectors.js:127
+#: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
 msgstr "不是有效的端口"
 
-#: frontend/src/metabase/admin/settings/selectors.js:134
+#: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
 msgstr "SMTP安全"
 
-#: frontend/src/metabase/admin/settings/selectors.js:142
+#: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
 msgstr "SMTP用户名"
 
-#: frontend/src/metabase/admin/settings/selectors.js:149
+#: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
 msgstr "SMTP密码"
 
-#: frontend/src/metabase/admin/settings/selectors.js:156
+#: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
 msgstr "选择地址"
 
-#: frontend/src/metabase/admin/settings/selectors.js:170
+#: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
 msgstr "Slack API令牌"
 
-#: frontend/src/metabase/admin/settings/selectors.js:172
+#: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
 msgstr "输入您从Slack收到的令牌"
 
-#: frontend/src/metabase/admin/settings/selectors.js:189
+#: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
 msgstr "单点登录"
 
-#: frontend/src/metabase/admin/settings/selectors.js:213
+#: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
 msgstr "LDAP身份验证"
 
-#: frontend/src/metabase/admin/settings/selectors.js:219
+#: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
 msgstr "LDAP主机"
 
-#: frontend/src/metabase/admin/settings/selectors.js:227
+#: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
 msgstr "LDAP端口"
 
-#: frontend/src/metabase/admin/settings/selectors.js:234
+#: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
 msgstr "LDAP安全性"
 
-#: frontend/src/metabase/admin/settings/selectors.js:242
+#: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
 msgstr "用户名或DN"
 
-#: frontend/src/metabase/admin/settings/selectors.js:247
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:188
-#: frontend/src/metabase/user/components/UserSettings.jsx:72
+#: frontend/src/metabase/admin/settings/selectors.js:244
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:191
+#: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
 msgstr "密码"
 
-#: frontend/src/metabase/admin/settings/selectors.js:252
+#: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "User search base"
 msgstr "用户搜索库"
 
-#: frontend/src/metabase/admin/settings/selectors.js:258
+#: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
 msgstr "用户筛选"
 
-#: frontend/src/metabase/admin/settings/selectors.js:264
+#: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
 msgstr "检查括号"
 
-#: frontend/src/metabase/admin/settings/selectors.js:270
+#: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
 msgstr "电子邮件属性"
 
-#: frontend/src/metabase/admin/settings/selectors.js:275
+#: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
 msgstr "名字属性"
 
-#: frontend/src/metabase/admin/settings/selectors.js:280
+#: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
 msgstr "姓氏属性"
 
-#: frontend/src/metabase/admin/settings/selectors.js:285
+#: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
 msgstr "同步组成员"
 
-#: frontend/src/metabase/admin/settings/selectors.js:291
+#: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
 msgstr "用户组搜索库"
 
-#: frontend/src/metabase/admin/settings/selectors.js:300
+#: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
 msgstr "地图"
 
-#: frontend/src/metabase/admin/settings/selectors.js:305
+#: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
 msgstr "地图贴片服务器URL"
 
-#: frontend/src/metabase/admin/settings/selectors.js:306
+#: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
 msgstr "Metabase默认使用PoenStreet地图"
 
-#: frontend/src/metabase/admin/settings/selectors.js:311
+#: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
 msgstr "自定义地图"
 
-#: frontend/src/metabase/admin/settings/selectors.js:312
+#: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
 msgstr "添加您自己的GeoJSON文件以启用不同的区域地图可视化"
 
-#: frontend/src/metabase/admin/settings/selectors.js:331
+#: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
 msgstr "公开分享"
 
-#: frontend/src/metabase/admin/settings/selectors.js:336
+#: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
 msgstr "开启公开共享"
 
-#: frontend/src/metabase/admin/settings/selectors.js:341
+#: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
 msgstr "已共享仪表盘"
 
-#: frontend/src/metabase/admin/settings/selectors.js:347
+#: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
 msgstr "已共享提问"
 
-#: frontend/src/metabase/admin/settings/selectors.js:354
+#: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
 msgstr "嵌入在其他的应用中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:381
+#: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
 msgstr "启用将Metabase嵌入到其他应用中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:391
+#: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
 msgstr "嵌入秘钥"
 
-#: frontend/src/metabase/admin/settings/selectors.js:397
+#: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
 msgstr "嵌入的仪表板"
 
-#: frontend/src/metabase/admin/settings/selectors.js:403
+#: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
 msgstr "嵌入的问题"
 
-#: frontend/src/metabase/admin/settings/selectors.js:410
+#: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
 msgstr "缓存中"
 
-#: frontend/src/metabase/admin/settings/selectors.js:415
+#: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
 msgstr "启用缓存"
 
-#: frontend/src/metabase/admin/settings/selectors.js:420
+#: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
 msgstr "最小查询周期"
 
-#: frontend/src/metabase/admin/settings/selectors.js:427
+#: frontend/src/metabase/admin/settings/selectors.js:424
 msgid "Cache Time-To-Live (TTL) multiplier"
 msgstr "缓存生存时间（TTL）乘数"
 
-#: frontend/src/metabase/admin/settings/selectors.js:434
+#: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
 msgstr "最大缓存允许大小"
 
@@ -1961,11 +1977,11 @@ msgstr "你的警报已经更新了"
 msgid "The alert was successfully deleted."
 msgstr "警报成功删除了"
 
-#: frontend/src/metabase/auth/auth.js:33
+#: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
 msgstr "请输入有效格式的Email地址"
 
-#: frontend/src/metabase/auth/auth.js:116
+#: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
@@ -2007,90 +2023,87 @@ msgstr "发送账号重置邮件"
 msgid "Check your email for instructions on how to reset your password."
 msgstr "检查你的邮件来获取重置密码说明"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:128
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
 msgstr "登录Metabase"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:138
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
 msgstr "或者"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:157
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
 msgstr "用户名或者邮箱地址"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:217
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
 msgstr "登录"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:230
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
 msgstr "我似乎忘记了我的密码"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:102
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
 msgstr "发送一个新的重置email邮件"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:120
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
 msgstr "噢，那是个过期的链接"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:122
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
 msgstr "于安全原因，密码重置链接会在一段时间后过期。如果您仍需要重置密码，可以{0}。"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:147
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
 msgstr "新密码"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:149
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
 msgstr "为了确保您的数据安全，密码{0}"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:163
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
 msgstr "创建新密码"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:170
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:141
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
 msgstr "确保它的安全性像上方说明中一样"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:184
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:150
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
 msgstr "确认新密码"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:191
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:159
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
 msgstr "确认它和你刚刚输入的一致"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:216
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
 msgstr "你的密码已经被重置"
 
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:222
-#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:227
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
+#: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
 msgstr "用你的新密码登录"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:182
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:251
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
 msgstr "保存失败"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:183
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:129
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:225
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:252
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:173
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
 msgstr "已保存"
 
@@ -2098,24 +2111,22 @@ msgstr "已保存"
 msgid "Ok"
 msgstr "好"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:38
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
 msgstr "归档集合"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:43
+#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
 msgstr "此集合中的仪表板，集合和定时通知也将被归档。"
 
-#: frontend/src/metabase/components/ArchiveCollectionModal.jsx:47
-#: frontend/src/metabase/components/CollectionLanding.jsx:624
+#: frontend/src/metabase/components/ArchiveModal.jsx:38
+#: frontend/src/metabase/components/CollectionLanding.jsx:620
 #: frontend/src/metabase/components/EntityMenu.info.js:31
 #: frontend/src/metabase/components/EntityMenu.info.js:87
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:47
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:195
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:200
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:50
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:196
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:201
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:40
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:53
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
 msgstr "归档"
@@ -2124,28 +2135,27 @@ msgstr "归档"
 msgid "This {0} has been archived"
 msgstr "此{0}已归档。"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:715
+#: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
 msgstr "查看归档"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:43
+#: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
 msgstr "取消归档此{0}"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:70
-#: frontend/src/metabase/components/BrowseApp.jsx:132
-#: frontend/src/metabase/components/BrowseApp.jsx:225
+#: frontend/src/metabase/components/BrowseApp.jsx:39
+#: frontend/src/metabase/components/BrowseApp.jsx:102
+#: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
 msgstr "我们的数据"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:169
+#: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
 msgstr "透视这个数据表单"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:183
-#: frontend/src/metabase/containers/Overworld.jsx:246
+#: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
 msgstr "了解这张数据表"
 
@@ -2163,31 +2173,31 @@ msgstr "已保存！"
 msgid "Saving failed."
 msgstr "保存失败"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
 msgstr "日"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
 msgstr "一"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
 msgstr "二"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
 msgstr "三"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
 msgstr "四"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
 msgstr "五"
 
-#: frontend/src/metabase/components/Calendar.jsx:118
+#: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
 msgstr "六"
 
@@ -2232,60 +2242,60 @@ msgstr "定时通知允许您通过电子邮件或Slack向团队发送最新数�
 msgid "Questions are a saved look at your data."
 msgstr "问题是对保存的数据查看。"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:287
+#: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
 msgstr "固定"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:341
+#: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
 msgstr "把东西拖到这里将它固定在顶部"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:737
-#: frontend/src/metabase/components/CollectionLanding.jsx:353
-#: frontend/src/metabase/home/containers/SearchApp.jsx:35
-#: frontend/src/metabase/home/containers/SearchApp.jsx:92
+#: frontend/src/metabase/admin/permissions/selectors.js:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:352
+#: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
 msgstr "集合"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:432
-#: frontend/src/metabase/components/CollectionLanding.jsx:455
+#: frontend/src/metabase/components/CollectionLanding.jsx:431
+#: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
 msgstr "拖到这里取消固定"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:490
+#: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
 msgstr[0] "已选择{0}项"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:522
+#: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
 msgstr "移动{0}项？"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:523
+#: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
 msgstr "移动“{0}”？"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:631
+#: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
 msgstr "移动"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:692
+#: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
 msgstr "修改集合"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:700
+#: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
 msgstr "归档集合"
 
-#: frontend/src/metabase/components/CollectionList.jsx:64
-#: frontend/src/metabase/entities/collections.js:155
+#: frontend/src/metabase/components/CollectionList.jsx:67
+#: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
 msgstr "我的个人集合"
 
-#: frontend/src/metabase/components/CollectionList.jsx:106
+#: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
 msgstr "新建集合"
 
@@ -2293,11 +2303,11 @@ msgstr "新建集合"
 msgid "Copied!"
 msgstr "已复制！"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:216
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
 msgstr "为Metabse连接使用SSH通道"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
@@ -2305,75 +2315,76 @@ msgstr "一些数据库安装只有通过SSH通道访问的服务器有权访问
 "当VPN不可用时，这个选项也提供了一个额外的安全层。\n"
 "启用这个选项，通常比直接连接速度更慢。"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:271
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
 msgstr "这是一个大型数据库，让我选择Metabase同步和扫描的时间"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:273
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
 msgstr "默认情况下，Metabase每小时执行一次轻量级同步，每天执行一次密集扫描。\n"
 "如果您有一个大型数据库，我们建议启用此功能并查看字段值扫描的发生时间和频率。"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:289
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
 msgstr "{0}为您的项目生成客户端ID和客户端密钥。"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:291
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:353
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
 msgstr "点击这里"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
 msgstr "选择“其他”作为应用程序类型。把它命名为你想要的任何东西。"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:316
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
 msgstr "{0}获取身份验证代码"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:328
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
 msgstr "使用Google Driver权限"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:348
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
 msgstr "要将Metabase用于此数据，您必须在Google Developers Console中启用API访问权限。"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:351
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
 msgstr "如果您还没有这样做，请转到控制台{0}。"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
 msgstr "您想如何使用这个数据库？"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:427
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:237
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:188
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:74
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:116
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:236
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:194
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:79
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
 msgstr "下一步"
 
-#: frontend/src/metabase/components/ArchivedItem.jsx:52
+#: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
 msgstr "删除这个{0}"
 
-#: frontend/src/metabase/components/EntityItem.jsx:43
+#: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
 msgstr "标记这个项目"
 
-#: frontend/src/metabase/components/EntityItem.jsx:49
+#: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
 msgstr "移动这个项目"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
 msgstr "编辑这个提问"
 
@@ -2386,6 +2397,7 @@ msgstr "行为的类型"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
 msgstr "查看修订历史"
 
@@ -2401,8 +2413,7 @@ msgstr "档案行为"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:329
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:342
+#: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
 msgstr "添加到仪表盘"
 
@@ -2426,13 +2437,12 @@ msgstr "另一个行为类型"
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:449
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:454
 msgid "Get alerts about this"
 msgstr "获得关于这个的警报"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
 msgstr "查看SQL语句"
 
@@ -2452,43 +2462,43 @@ msgstr "这里是全部的错误信息"
 msgid "Hi, Metabot here."
 msgstr "你好，我是Meta机器人"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:95
+#: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
 msgstr "基于这个模式"
 
-#: frontend/src/metabase/components/ExplorePane.jsx:174
+#: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
 msgstr "看看您的"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:234
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
 msgstr "查找列表"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:238
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
 msgstr "用{0}搜索"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:240
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
 msgstr "或者输入一个ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:244
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
 msgstr "输入一个ID"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:246
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
 msgstr "输入一个数字"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:248
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
 msgstr "输入一些文本"
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:355
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
 msgstr "没有找到匹配的{0} "
 
-#: frontend/src/metabase/components/FieldValuesWidget.jsx:363
+#: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
 msgstr "包括每个选项在你的过滤器中很可能将不会起很大作用……"
 
@@ -2504,17 +2514,17 @@ msgstr "我们运行中出现了一个错误，你可以尝试刷新这个页面
 #: frontend/src/metabase/components/HeaderBar.jsx:45
 #: frontend/src/metabase/components/ListItem.jsx:37
 #: frontend/src/metabase/reference/components/Detail.jsx:47
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:158
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:213
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:191
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:205
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:209
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:209
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:161
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:216
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:194
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:208
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
 msgstr "暂无描述"
 
 #: frontend/src/metabase/components/Header.jsx:112
-#: frontend/src/metabase/entities/containers/EntityForm.jsx:43
+#: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
 msgstr "新的"
 
@@ -2522,54 +2532,53 @@ msgstr "新的"
 msgid "Asked by {0}"
 msgstr "被{0}发起的提问"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:13
+#: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
 msgstr "今天"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:15
+#: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
 msgstr "昨天"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:68
+#: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
 msgstr "第一次修订。"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:70
+#: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
 msgstr "回滚到一个更早的调整并且{0}"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:82
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:289
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:379
-#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:58
+#: frontend/src/metabase/components/HistoryModal.jsx:42
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
+#: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
 msgstr "调整记录"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:90
+#: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
 msgstr "什么时候"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:91
+#: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
 msgstr "谁"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:92
+#: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
 msgstr "什么"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:113
+#: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
 msgstr "恢复"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:114
+#: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
 msgstr "恢复中……"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:115
+#: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
 msgstr "恢复失败"
 
-#: frontend/src/metabase/components/HistoryModal.jsx:116
+#: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
 msgstr "已恢复"
 
@@ -2578,26 +2587,24 @@ msgid "Everything"
 msgstr "所有的"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
-#: frontend/src/metabase/home/containers/SearchApp.jsx:69
 msgid "Dashboards"
 msgstr "仪表盘"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
-#: frontend/src/metabase/home/containers/SearchApp.jsx:115
 msgid "Questions"
 msgstr "报表"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
-#: frontend/src/metabase/routes.jsx:321
+#: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
 msgstr "定时任务"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
-#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:103
+#: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
 msgstr "后退"
 
-#: frontend/src/metabase/components/ListSearchField.jsx:18
+#: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
 msgstr "查找……"
 
@@ -2634,14 +2641,14 @@ msgid "Temporary Password"
 msgstr "临时密码"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:436
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
 msgstr "隐藏"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:437
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:412
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
 msgstr "显示"
 
@@ -2706,7 +2713,7 @@ msgstr "第十五个（中位数）"
 msgid "Calendar Day"
 msgstr "日历日"
 
-#: frontend/src/metabase/components/SchedulePicker.jsx:210
+#: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
 msgstr "你的Metabase时区"
 
@@ -2735,11 +2742,11 @@ msgid "A component used to make a selection"
 msgstr "一个用来做出选择的组件"
 
 #: frontend/src/metabase/components/Select.info.js:20
-#: frontend/src/metabase/components/Select.info.js:28
+#: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
 msgstr "已选择"
 
-#: frontend/src/metabase/components/Select.jsx:297
+#: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
 msgstr "暂无结果"
 
@@ -2752,7 +2759,7 @@ msgid "Unknown error encountered"
 msgstr "未知错误发生了"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
-#: frontend/src/metabase/nav/containers/Navbar.jsx:304
+#: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
 msgstr "创建"
 
@@ -2761,13 +2768,11 @@ msgid "Create dashboard"
 msgstr "创建仪表盘"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:331
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:60
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
 msgstr "表格"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:306
 msgid "Database"
 msgstr "数据库"
 
@@ -2775,22 +2780,20 @@ msgstr "数据库"
 msgid "Creator"
 msgstr "创造者"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:238
+#: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
 msgstr "未找到结果"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:239
+#: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
 msgstr "尝试调整过滤器以找到您要查找的内容。"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:258
+#: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
 msgstr "查看方式"
 
-#: frontend/src/metabase/containers/EntitySearch.jsx:494
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:84
-#: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:69
-#: frontend/src/metabase/tutorial/TutorialModal.jsx:34
+#: frontend/src/metabase/containers/EntitySearch.jsx:495
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
 msgstr "的"
 
@@ -2803,13 +2806,13 @@ msgid "Once you connect your own data, I can show you some automatic exploration
 msgstr "一旦连接了自己的数据，我就可以向您展示一些称为透视的自动探索。以下是一些基于示例数据的例子。"
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
-#: frontend/src/metabase/containers/Overworld.jsx:299
+#: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
 msgstr "从这里开始"
 
-#: frontend/src/metabase/containers/Overworld.jsx:294
-#: frontend/src/metabase/entities/collections.js:147
+#: frontend/src/metabase/containers/Overworld.jsx:296
+#: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
 msgstr "分析"
@@ -2818,53 +2821,53 @@ msgstr "分析"
 msgid "Browse all items"
 msgstr "浏览所有"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:165
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
 msgstr "替换还是保存为新的？"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:173
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
 msgstr "替换原始问题“{0}”"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:178
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
 msgstr "保存为新问题"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:187
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
 msgstr "首先，保存您的问题"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:188
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
 msgstr "保存问题"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:224
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
 msgstr "这个卡片叫什么名字？"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:232
-#: frontend/src/metabase/entities/collections.js:101
-#: frontend/src/metabase/entities/dashboards.js:151
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:234
+#: frontend/src/metabase/entities/collections.js:102
+#: frontend/src/metabase/entities/dashboards.js:148
 #: frontend/src/metabase/lib/core.js:50 frontend/src/metabase/lib/core.js:205
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:156
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:211
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:189
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:203
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:207
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:207
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:24
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:159
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:214
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:192
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:206
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:210
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
 msgstr "描述"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:238
-#: frontend/src/metabase/entities/dashboards.js:153
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
+#: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
 msgstr "这是可选的，但非常有帮助"
 
-#: frontend/src/metabase/containers/SaveQuestionModal.jsx:245
-#: frontend/src/metabase/entities/dashboards.js:157
+#: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
+#: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
 msgstr "将这个放到哪个集合中？"
 
@@ -2876,7 +2879,7 @@ msgstr "已修改"
 msgid "item"
 msgstr "项"
 
-#: frontend/src/metabase/containers/UndoListing.jsx:81
+#: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
 msgstr "撤销"
 
@@ -2900,15 +2903,15 @@ msgstr "我们不确定这个提问是否兼容"
 msgid "Archive Dashboard"
 msgstr "文档仪表盘"
 
-#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:20
+#: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
 msgstr "确保为每个系列都做出了选择，不然筛选将不会在这个卡片上起作用"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:300
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
 msgstr "这个仪表盘看起来是空的"
 
-#: frontend/src/metabase/dashboard/components/Dashboard.jsx:301
+#: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
 msgstr "添加一个疑问来让它变得有用"
 
@@ -2928,59 +2931,58 @@ msgstr "退出全屏"
 msgid "Enter fullscreen"
 msgstr "进入全屏"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:181
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:183
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:250
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
 msgstr "保存中"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:216
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
 msgstr "添加报表"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:219
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
 msgstr "添加报表到仪表盘"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:248
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
 msgstr "添加筛选"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:254
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:78
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
 msgstr "参数"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:275
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:279
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
 msgstr "添加文本框"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
 msgstr "移动仪表盘"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:302
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
 msgstr "编辑仪表盘"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:306
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
 msgstr "编辑仪表盘展示"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:369
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
 msgstr "正在编辑仪表盘"
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:374
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
 msgstr "选择应该在每个卡片中都应该被过滤的字段"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:28
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
 msgstr "移动仪表盘到……"
 
-#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:52
+#: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
 msgstr "仪表盘移动到{0}"
 
@@ -2995,7 +2997,7 @@ msgstr "什么类型的筛选"
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:179
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
 msgstr "关闭"
 
@@ -3035,174 +3037,174 @@ msgstr "刷新于"
 msgid "Remove this question?"
 msgstr "移除这个疑问？"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:71
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
 msgstr "你的仪表盘已经保存"
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:745
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:76
+#: frontend/src/metabase/components/CollectionLanding.jsx:744
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
 msgstr "查看它"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:137
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
 msgstr "把这个保存"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:170
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
 msgstr "展示更多"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:140
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
 msgstr "此卡没有可以映射到此参数类型的任何字段或参数。"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:142
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
 msgstr "此字段中的值不会与您选择的任何其他字段的值重叠。"
 
-#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:186
+#: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
 msgstr "无可用字段"
 
-#: frontend/src/metabase/entities/collections.js:97
+#: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
 msgstr "名称不能超过100个字符"
 
-#: frontend/src/metabase/entities/collections.js:111
+#: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
 msgstr "颜色是必需的"
 
-#: frontend/src/metabase/entities/dashboards.js:146
+#: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
 msgstr "你的仪表盘叫什么名字？"
 
-#: frontend/src/metabase/home/components/Activity.jsx:92
+#: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
 msgstr "是否有一些超棒的东西很难描述"
 
-#: frontend/src/metabase/home/components/Activity.jsx:101
-#: frontend/src/metabase/home/components/Activity.jsx:116
+#: frontend/src/metabase/home/components/Activity.jsx:103
+#: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
 msgstr "创建一个关于……警报"
 
-#: frontend/src/metabase/home/components/Activity.jsx:126
-#: frontend/src/metabase/home/components/Activity.jsx:141
+#: frontend/src/metabase/home/components/Activity.jsx:128
+#: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
 msgstr "删除一个关于……的警报"
 
-#: frontend/src/metabase/home/components/Activity.jsx:152
+#: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
 msgstr "保存一个关于……的疑问"
 
-#: frontend/src/metabase/home/components/Activity.jsx:165
+#: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
 msgstr "存储一个疑问"
 
-#: frontend/src/metabase/home/components/Activity.jsx:169
+#: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
 msgstr "删除一个疑问"
 
-#: frontend/src/metabase/home/components/Activity.jsx:172
+#: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
 msgstr "创建一个仪表盘"
 
-#: frontend/src/metabase/home/components/Activity.jsx:175
+#: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
 msgstr "删除一个仪表盘"
 
-#: frontend/src/metabase/home/components/Activity.jsx:181
-#: frontend/src/metabase/home/components/Activity.jsx:196
+#: frontend/src/metabase/home/components/Activity.jsx:183
+#: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
 msgstr "添加一个疑问到仪表盘"
 
-#: frontend/src/metabase/home/components/Activity.jsx:206
-#: frontend/src/metabase/home/components/Activity.jsx:221
+#: frontend/src/metabase/home/components/Activity.jsx:208
+#: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
 msgstr "从仪表盘中移除一个问题"
 
-#: frontend/src/metabase/home/components/Activity.jsx:231
-#: frontend/src/metabase/home/components/Activity.jsx:238
+#: frontend/src/metabase/home/components/Activity.jsx:233
+#: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
 msgstr "接收最新的数据来自"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:621
-#: frontend/src/metabase/home/components/Activity.jsx:244
+#: frontend/src/metabase-lib/lib/Dimension.js:814
+#: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:273
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
 msgstr "未知"
 
-#: frontend/src/metabase/home/components/Activity.jsx:251
+#: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
 msgstr "Hello World!"
 
-#: frontend/src/metabase/home/components/Activity.jsx:252
+#: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
 msgstr "Metabase正在运行"
 
-#: frontend/src/metabase/home/components/Activity.jsx:258
-#: frontend/src/metabase/home/components/Activity.jsx:288
+#: frontend/src/metabase/home/components/Activity.jsx:260
+#: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
 msgstr "添加指标"
 
-#: frontend/src/metabase/home/components/Activity.jsx:272
-#: frontend/src/metabase/home/components/Activity.jsx:362
+#: frontend/src/metabase/home/components/Activity.jsx:274
+#: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
 msgstr "到"
 
-#: frontend/src/metabase/home/components/Activity.jsx:282
-#: frontend/src/metabase/home/components/Activity.jsx:322
-#: frontend/src/metabase/home/components/Activity.jsx:372
-#: frontend/src/metabase/home/components/Activity.jsx:413
+#: frontend/src/metabase/home/components/Activity.jsx:284
+#: frontend/src/metabase/home/components/Activity.jsx:324
+#: frontend/src/metabase/home/components/Activity.jsx:374
+#: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
 msgstr "表单"
 
-#: frontend/src/metabase/home/components/Activity.jsx:298
-#: frontend/src/metabase/home/components/Activity.jsx:328
+#: frontend/src/metabase/home/components/Activity.jsx:300
+#: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
 msgstr "指标已经被修改"
 
-#: frontend/src/metabase/home/components/Activity.jsx:312
-#: frontend/src/metabase/home/components/Activity.jsx:403
+#: frontend/src/metabase/home/components/Activity.jsx:314
+#: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
 msgstr "在……里面"
 
-#: frontend/src/metabase/home/components/Activity.jsx:335
+#: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
 msgstr "移除指标"
 
-#: frontend/src/metabase/home/components/Activity.jsx:338
+#: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
 msgstr "创建定时通知"
 
-#: frontend/src/metabase/home/components/Activity.jsx:341
+#: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
 msgstr "删除定时通知"
 
-#: frontend/src/metabase/home/components/Activity.jsx:347
-#: frontend/src/metabase/home/components/Activity.jsx:378
+#: frontend/src/metabase/home/components/Activity.jsx:349
+#: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
 msgstr "添加筛选"
 
-#: frontend/src/metabase/home/components/Activity.jsx:388
-#: frontend/src/metabase/home/components/Activity.jsx:419
+#: frontend/src/metabase/home/components/Activity.jsx:390
+#: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
 msgstr "修改筛选"
 
-#: frontend/src/metabase/home/components/Activity.jsx:426
+#: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
 msgstr "移除筛选"
 
-#: frontend/src/metabase/home/components/Activity.jsx:429
+#: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
 msgstr "已加入！"
 
-#: frontend/src/metabase/home/components/Activity.jsx:529
+#: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
 msgstr "嗯……无事发生"
 
-#: frontend/src/metabase/home/components/Activity.jsx:532
+#: frontend/src/metabase/home/components/Activity.jsx:534
 msgid "Save a question and get this baby going!"
 msgstr "存储一个问题并让它运行"
 
@@ -3250,21 +3252,21 @@ msgstr "最近查看"
 msgid "You haven't looked at any dashboards or questions recently"
 msgstr "最近没有查看的仪表盘或者图表"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:99
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
 msgstr "{0}项已选择"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:121
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:172
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
 msgstr "取消归档"
 
-#: frontend/src/metabase/home/containers/HomepageApp.jsx:74
-#: frontend/src/metabase/nav/containers/Navbar.jsx:331
+#: frontend/src/metabase/home/containers/HomepageApp.jsx:77
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
 msgstr "活动"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:28
+#: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
 msgstr "{0}的结果"
 
@@ -3329,6 +3331,7 @@ msgstr "头像图片URL链接"
 msgid "Common"
 msgstr "共同"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
@@ -3365,8 +3368,9 @@ msgstr "纬度"
 msgid "Longitude"
 msgstr "经度"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:149
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
 msgstr "数字"
@@ -3463,7 +3467,7 @@ msgstr "分数"
 
 #: frontend/src/metabase/lib/core.js:210
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
-#: frontend/src/metabase/visualizations/lib/settings/visualization.js:17
+#: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
 msgstr "标题"
 
@@ -3520,8 +3524,9 @@ msgid "Metabase will never retrieve this field. Use this for sensitive or irrele
 msgstr "Metabase永远不会获取此字段。将此用于敏感或不相关的信息。"
 
 #: frontend/src/metabase/lib/expressions/config.js:7
-#: frontend/src/metabase/lib/query.js:614
-#: frontend/src/metabase/visualizations/lib/utils.js:126
+#: frontend/src/metabase/lib/query.js:300
+#: frontend/src/metabase/visualizations/lib/utils.js:130
+#: src/metabase/query_processor/middleware/annotate.clj
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
@@ -3536,7 +3541,7 @@ msgstr "累积计数"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
-#: frontend/src/metabase/visualizations/lib/utils.js:127
+#: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
 msgstr "求和"
 
@@ -3545,7 +3550,7 @@ msgid "CumulativeSum"
 msgstr "累积求和"
 
 #: frontend/src/metabase/lib/expressions/config.js:11
-#: frontend/src/metabase/visualizations/lib/utils.js:128
+#: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
 msgstr "不重复"
 
@@ -3554,34 +3559,34 @@ msgid "StandardDeviation"
 msgstr "标准差"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
-#: frontend/src/metabase/visualizations/lib/utils.js:125
+#: frontend/src/metabase/visualizations/lib/utils.js:129
 msgid "Average"
 msgstr "平均"
 
 #: frontend/src/metabase/lib/expressions/config.js:14
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:25
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:450
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
 msgstr "最小"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:458
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
 msgstr "最大"
 
-#: frontend/src/metabase/lib/expressions/parser.js:384
+#: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
 msgstr "哎呀，出错了"
 
-#: frontend/src/metabase/lib/formatting.js:707
+#: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
 msgid_plural "{0} seconds"
 msgstr[0] "{0}秒"
 
-#: frontend/src/metabase/lib/formatting.js:710
+#: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
 msgstr[0] "{0}分钟"
@@ -3619,222 +3624,224 @@ msgstr "你在想什么？"
 msgid "What do you want to find out?"
 msgstr "你想找出什么？"
 
-#: frontend/src/metabase/lib/query.js:612
-#: frontend/src/metabase/lib/schema_metadata.js:451
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:246
+#: frontend/src/metabase/lib/query.js:298
+#: frontend/src/metabase/lib/schema_metadata.js:458
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
 msgstr "原始数据"
 
-#: frontend/src/metabase/lib/query.js:616
+#: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
 msgstr "累积计数"
 
-#: frontend/src/metabase/lib/query.js:619
+#: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
 msgstr "平均"
 
-#: frontend/src/metabase/lib/query.js:624
+#: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
 msgstr "去重值"
 
-#: frontend/src/metabase/lib/query.js:629
+#: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
 msgstr "标准差"
 
-#: frontend/src/metabase/lib/query.js:634
+#: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
 msgstr "总计"
 
-#: frontend/src/metabase/lib/query.js:639
+#: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
 msgstr "累积和"
 
-#: frontend/src/metabase/lib/query.js:644
+#: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
 msgstr "最大"
 
-#: frontend/src/metabase/lib/query.js:649
+#: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
 msgstr "最小"
 
-#: frontend/src/metabase/lib/query.js:663
+#: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
 msgstr "以……聚合"
 
-#: frontend/src/metabase/lib/query.js:677
+#: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
 msgstr "以……筛选"
 
-#: frontend/src/metabase/lib/query.js:706
+#: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
 msgstr "以……分类"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
 msgstr "真"
 
-#: frontend/src/metabase/lib/schema_metadata.js:221
+#: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
 msgstr "假"
 
-#: frontend/src/metabase/lib/schema_metadata.js:305
+#: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
 msgstr "选择经度字段"
 
-#: frontend/src/metabase/lib/schema_metadata.js:306
+#: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
 msgstr "输入纬度上边届"
 
-#: frontend/src/metabase/lib/schema_metadata.js:307
+#: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
 msgstr "输入经度左边界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:308
+#: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
 msgstr "输入纬度下边界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:309
+#: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
 msgstr "输入经度右边界"
 
-#: frontend/src/metabase/lib/schema_metadata.js:345
-#: frontend/src/metabase/lib/schema_metadata.js:365
-#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase-lib/lib/Dimension.js:505
+#: frontend/src/metabase-lib/lib/Dimension.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:351
+#: frontend/src/metabase/lib/schema_metadata.js:371
 #: frontend/src/metabase/lib/schema_metadata.js:381
-#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/lib/schema_metadata.js:387
 #: frontend/src/metabase/lib/schema_metadata.js:395
-#: frontend/src/metabase/lib/schema_metadata.js:400
+#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
 msgstr "是"
 
-#: frontend/src/metabase/lib/schema_metadata.js:346
-#: frontend/src/metabase/lib/schema_metadata.js:366
-#: frontend/src/metabase/lib/schema_metadata.js:376
-#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/lib/schema_metadata.js:352
+#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:382
 #: frontend/src/metabase/lib/schema_metadata.js:396
+#: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
 msgstr "不是"
 
-#: frontend/src/metabase/lib/schema_metadata.js:347
-#: frontend/src/metabase/lib/schema_metadata.js:361
-#: frontend/src/metabase/lib/schema_metadata.js:369
-#: frontend/src/metabase/lib/schema_metadata.js:377
-#: frontend/src/metabase/lib/schema_metadata.js:385
+#: frontend/src/metabase/lib/schema_metadata.js:353
+#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:375
+#: frontend/src/metabase/lib/schema_metadata.js:383
 #: frontend/src/metabase/lib/schema_metadata.js:391
-#: frontend/src/metabase/lib/schema_metadata.js:401
+#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
 msgstr "为空"
 
-#: frontend/src/metabase/lib/schema_metadata.js:348
-#: frontend/src/metabase/lib/schema_metadata.js:362
-#: frontend/src/metabase/lib/schema_metadata.js:370
-#: frontend/src/metabase/lib/schema_metadata.js:378
-#: frontend/src/metabase/lib/schema_metadata.js:386
+#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:376
+#: frontend/src/metabase/lib/schema_metadata.js:384
 #: frontend/src/metabase/lib/schema_metadata.js:392
-#: frontend/src/metabase/lib/schema_metadata.js:402
+#: frontend/src/metabase/lib/schema_metadata.js:398
+#: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
 msgstr "不为空"
 
-#: frontend/src/metabase/lib/schema_metadata.js:354
+#: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
 msgstr "等于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:355
+#: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
 msgstr "不等于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:356
+#: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
 msgstr "大于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:357
+#: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
 msgstr "小于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:358
-#: frontend/src/metabase/lib/schema_metadata.js:384
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:285
+#: frontend/src/metabase/lib/schema_metadata.js:364
+#: frontend/src/metabase/lib/schema_metadata.js:390
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
 msgstr "介于之间"
 
-#: frontend/src/metabase/lib/schema_metadata.js:359
+#: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
 msgstr "大于或等于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:360
+#: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
 msgstr "小于或等于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:367
+#: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
 msgstr "包含"
 
-#: frontend/src/metabase/lib/schema_metadata.js:368
+#: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
 msgstr "不包含"
 
-#: frontend/src/metabase/lib/schema_metadata.js:371
+#: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
 msgstr "以…开始"
 
-#: frontend/src/metabase/lib/schema_metadata.js:372
+#: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
 msgstr "以…结束"
 
-#: frontend/src/metabase/lib/schema_metadata.js:382
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:264
+#: frontend/src/metabase/lib/schema_metadata.js:388
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
 msgstr "早于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:383
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:271
+#: frontend/src/metabase/lib/schema_metadata.js:389
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
 msgstr "晚于"
 
-#: frontend/src/metabase/lib/schema_metadata.js:397
+#: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
 msgstr "介于中间"
 
-#: frontend/src/metabase/lib/schema_metadata.js:453
+#: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
 msgstr "只是一个包含数据行的表格，没有其他操作。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:459
+#: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
 msgstr "总行数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:461
+#: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
 msgstr "总的数据行数。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:467
+#: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
 msgstr "总和"
 
-#: frontend/src/metabase/lib/schema_metadata.js:469
+#: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
 msgstr "一个字段所有数值的总和。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:475
+#: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
 msgstr "平均值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:477
+#: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
 msgstr "一个字段所有数值的平均值。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:483
+#: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
 msgstr "不重复值的总数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:485
+#: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
 msgstr "一个字段所有互不重复的值的总数"
 
-#: frontend/src/metabase/lib/schema_metadata.js:491
+#: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
 msgstr "累积求和"
 
@@ -3842,7 +3849,7 @@ msgstr "累积求和"
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
 msgstr "一个字段所有数值的累积加和。\\\\n比如：随着时间推移的总收入。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:499
+#: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
 msgstr "累积行数"
 
@@ -3850,105 +3857,105 @@ msgstr "累积行数"
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
 msgstr "累积的数据行数。\\\\ n比如：随着时间的推移销售数量。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:507
+#: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
 msgstr "标准差"
 
-#: frontend/src/metabase/lib/schema_metadata.js:509
+#: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
 msgstr "一个字段所有数值的标准差。"
 
-#: frontend/src/metabase/lib/schema_metadata.js:515
+#: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
 msgstr "最小值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:517
+#: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
 msgstr "一个字段的最小值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:523
+#: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
 msgstr "最大值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:525
+#: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
 msgstr "一个字段的最大值"
 
-#: frontend/src/metabase/lib/schema_metadata.js:533
+#: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
 msgstr "按维度划分"
 
-#: frontend/src/metabase/lib/settings.js:93
+#: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
 msgstr "小写字母"
 
-#: frontend/src/metabase/lib/settings.js:95
+#: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
 msgstr "大写字母"
 
-#: frontend/src/metabase/lib/settings.js:97
+#: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
 msgstr "个数"
 
-#: frontend/src/metabase/lib/settings.js:99
+#: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
 msgstr "特殊字符"
 
-#: frontend/src/metabase/lib/settings.js:105
+#: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
 msgstr "必须"
 
-#: frontend/src/metabase/lib/settings.js:105
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:120
+#: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
 msgstr "长字符"
 
-#: frontend/src/metabase/lib/settings.js:106
+#: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
 msgstr "必须"
 
-#: frontend/src/metabase/lib/settings.js:122
+#: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
 msgstr "包含"
 
-#: frontend/src/metabase/lib/utils.js:92
+#: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
 msgstr "0"
 
-#: frontend/src/metabase/lib/utils.js:93
+#: frontend/src/metabase/lib/utils.js:86
 msgid "one"
 msgstr "1"
 
-#: frontend/src/metabase/lib/utils.js:94
+#: frontend/src/metabase/lib/utils.js:87
 msgid "two"
 msgstr "2"
 
-#: frontend/src/metabase/lib/utils.js:95
+#: frontend/src/metabase/lib/utils.js:88
 msgid "three"
 msgstr "3"
 
-#: frontend/src/metabase/lib/utils.js:96
+#: frontend/src/metabase/lib/utils.js:89
 msgid "four"
 msgstr "4"
 
-#: frontend/src/metabase/lib/utils.js:97
+#: frontend/src/metabase/lib/utils.js:90
 msgid "five"
 msgstr "5"
 
-#: frontend/src/metabase/lib/utils.js:98
+#: frontend/src/metabase/lib/utils.js:91
 msgid "six"
 msgstr "6"
 
-#: frontend/src/metabase/lib/utils.js:99
+#: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
 msgstr "7"
 
-#: frontend/src/metabase/lib/utils.js:100
+#: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
 msgstr "8"
 
-#: frontend/src/metabase/lib/utils.js:101
+#: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
 msgstr "9"
 
@@ -4022,6 +4029,7 @@ msgstr "时间"
 msgid "Date range, relative date, time of day, etc."
 msgstr "日期范围,相关日期，一天中的时间，等等"
 
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
@@ -4044,7 +4052,7 @@ msgid "Category, Type, Model, Rating, etc."
 msgstr "类别、类型、模型、评分等"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
-#: frontend/src/metabase/user/components/UserSettings.jsx:54
+#: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
 msgstr "账户设置"
 
@@ -4056,56 +4064,56 @@ msgstr "退出管理员"
 msgid "Logs"
 msgstr "日志"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:58
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:64
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
 msgstr "帮助"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:67
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
 msgstr "关于Metabase"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:73
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
 msgstr "注销"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:98
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
 msgstr "谢谢使用"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:102
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
 msgstr "正在使用版本"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:105
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
 msgstr "建立于"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:124
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
 msgstr "是一个……的商标"
 
-#: frontend/src/metabase/nav/components/ProfileLink.jsx:126
+#: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
 msgstr "并且它在加州，旧金山精心被打造"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:194
+#: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
 msgstr "Metabase管理员"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:300
+#: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
 msgstr "创建图表"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:309
+#: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
 msgstr "新仪表盘"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:315
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/nav/containers/Navbar.jsx:361
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
 msgstr "新定时任务"
 
@@ -4113,16 +4121,16 @@ msgstr "新定时任务"
 msgid "Reference"
 msgstr "参考"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:83
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
 msgstr "哪个指标？"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:110
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:24
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
 msgstr "为你的团队定义共同指标，让它甚至简单到可以轻松的提问"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:113
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
 msgstr "如何创建指标"
 
@@ -4134,8 +4142,8 @@ msgstr "按地图、趋势查看时间维度的数据，方便了解趋势变化
 msgid "Custom"
 msgstr "自定义"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:150
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:517
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
 msgstr "新的疑问"
 
@@ -4143,22 +4151,22 @@ msgstr "新的疑问"
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
 msgstr "使用简单的疑问创建器来查看趋势、列表或者事物，或者创建你自己的指标。"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:161
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
 msgstr "原生查询"
 
-#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:162
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
 msgstr "为了回答更多复杂的疑问，你可以写下你自己的SQL语句或者原生查询。"
 
-#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:240
+#: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
 msgstr "选择一个默认值"
 
-#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:149
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
 msgstr "更新过滤器"
 
@@ -4166,14 +4174,14 @@ msgstr "更新过滤器"
 #: frontend/src/metabase/lib/query_time.js:123
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:9
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Today"
 msgstr "今天"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
 msgstr "昨天"
 
@@ -4185,7 +4193,8 @@ msgstr "过去7天"
 msgid "Past 30 days"
 msgstr "过去30天"
 
-#: frontend/src/metabase/lib/query_time.js:195
+#. 周
+#: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:29
 #: src/metabase/api/table.clj
@@ -4193,7 +4202,7 @@ msgid "Week"
 msgid_plural "Weeks"
 msgstr[0] "周"
 
-#: frontend/src/metabase/lib/query_time.js:197
+#: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:30
 #: src/metabase/api/table.clj
@@ -4201,7 +4210,7 @@ msgid "Month"
 msgid_plural "Months"
 msgstr[0] "月"
 
-#: frontend/src/metabase/lib/query_time.js:201
+#: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:31
 #: src/metabase/api/table.clj
@@ -4250,6 +4259,7 @@ msgstr "输入一个值……"
 msgid "Enter a default value..."
 msgstr "输入一个默认值……"
 
+#: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
 msgstr "发生了一个错误"
@@ -4290,24 +4300,24 @@ msgstr "发布"
 msgid "Code"
 msgstr "代码"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:70
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
 msgstr "样式"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
 msgstr "这个嵌套可以使用什么参数？"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:83
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
 msgstr "此{0}尚未配置任何参数。"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
 msgstr "可编辑的"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
 msgstr "锁定的"
 
@@ -4315,19 +4325,19 @@ msgstr "锁定的"
 msgid "Preview Locked Parameters"
 msgstr "预览锁定参数"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:115
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
 msgstr "尝试在此处将一些值传递给锁定的参数。当您使用此服务器时，您的服务器必须提供签名令牌中的实际值。"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
 msgstr "危险区域"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
 msgstr "这将会为这个{0}禁用嵌入功能"
 
-#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:128
+#: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
 msgstr "撤销发布"
 
@@ -4367,64 +4377,64 @@ msgstr "更多{0}"
 msgid "examples on GitHub"
 msgstr "在GitHub上的案例"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:72
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
 msgstr "开启分享"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
 msgstr "禁用这个公共链接？"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:77
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
 msgstr "会取消已存在的链接。可以重新生效，但是链接会变更。"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
 msgstr "公开链接"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:118
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
 msgstr "将{0}通过下面的链接分享那些没有Metabase账号的人。"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:158
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
 msgstr "公开嵌入"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:159
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
 msgstr "将这个代码块粘贴到页面代码，可以在博客或者网页中启用{0}。"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:176
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
 msgstr "在一个应用嵌入这个{0}"
 
-#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:177
+#: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
 msgstr "通过与应用程序服务器代码集成，您可以提供仅限于特定用户，客户，组织等的安全统计信息{0}。"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
 msgstr "移除附件"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:95
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
 msgstr "添加结果文件附件"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
 msgstr "图表会被添加文件附件"
 
-#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:128
+#: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
 msgstr "这个图表不会包含在你的定时任务中"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:92
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
 msgstr "这个定时任务不再发送给{0}{1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:94
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:376
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
 msgstr[0] "{0}地址"
@@ -4433,39 +4443,39 @@ msgstr[0] "{0}地址"
 msgid "Slack channel {0} will no longer get this pulse {1}"
 msgstr "Slack通道{0}将不再接收此定时通知{1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:110
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
 msgstr "{0}不会再收到定时任务{1}"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:127
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
 msgstr "编辑定时任务"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:131
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
 msgstr "什么是定时任务"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:141
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
 msgstr "得到结果了！"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:157
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
 msgstr "这个数据应该去哪？"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:173
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
 msgstr "正在取消归档"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
 msgstr "取消归档失败"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
 msgstr "已取消归档"
 
-#: frontend/src/metabase/pulse/components/PulseEdit.jsx:182
+#: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
 msgstr "创建定时任务"
 
@@ -4475,7 +4485,7 @@ msgstr "附件"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:673
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
 msgstr "小心"
 
@@ -4496,6 +4506,7 @@ msgid "We recommend keeping pulses small and focused to help keep them digestibl
 msgstr "推荐精简定时任务，方便整个团队理解和使用。"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
+#: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
 msgstr "选择你的数据"
 
@@ -4511,47 +4522,47 @@ msgstr "电子邮箱"
 msgid "Slack messages"
 msgstr "Slack消息"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
 msgstr "发送"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:222
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
 msgstr "{0}将会在……被发送"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:224
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
 msgstr "信息"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
 msgstr "现在发送邮件"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:241
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
 msgstr "现在发送邮件给{0}"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
 msgstr "发送中……"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:244
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
 msgstr "发送失败"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
 msgstr "未发送，因为定时任务没有结果。"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:248
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
 msgstr "定时任务已发送。"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:287
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
 msgstr "{0}需要被设置成管理员"
 
-#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:302
+#: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
 msgstr "Slack"
 
@@ -4600,21 +4611,21 @@ msgid "Before {0}"
 msgstr "之前{0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:295
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
 msgstr "是空的"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:301
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
 msgstr "不是空的"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:213
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
 msgstr "所有时间"
 
-#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:154
+#: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
 msgstr "应用"
 
@@ -4680,7 +4691,7 @@ msgstr "分布"
 msgid "View details"
 msgstr "查看细节"
 
-#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:54
+#: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
 msgstr "查看{0}的{1}"
 
@@ -4704,22 +4715,22 @@ msgstr "平均"
 msgid "Distincts"
 msgstr "不重复"
 
-#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:32
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
 msgstr[0] "查看这个{0}\n"
 "Plural:查看这些{0}"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:225
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
 msgstr "放大"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:19
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
 msgstr "自定义表达方式"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:20
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
 msgstr "共同指标"
 
@@ -4727,7 +4738,7 @@ msgstr "共同指标"
 msgid "Metabasics"
 msgstr "基本知識"
 
-#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
 msgstr "名称（可选）"
 
@@ -4739,31 +4750,31 @@ msgstr "选择一个聚合"
 msgid "Set up your own alert"
 msgstr "建立你自己的警报"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:140
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
 msgstr "不可关注……"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:145
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
 msgstr "关注失败"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:204
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
 msgstr "取消关注"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:235
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
 msgstr "没有频道"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:263
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
 msgstr "完成，你已经关注了"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:335
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
 msgstr "你正在接收{0}的警报"
 
-#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
+#: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
 msgstr "{0}设置一个警报"
 
@@ -4819,147 +4830,147 @@ msgstr "编辑提醒"
 msgid "Edit alert"
 msgstr "编辑提醒"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:374
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
 msgstr "提醒不再发送{0}"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:382
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
 msgstr "Slack通道{0}将不再接收此警报。"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:386
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
 msgstr "{0}不再收到这个提醒"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:403
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
 msgstr "删除提醒"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:405
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
 msgstr "停止并删除提醒。无法恢复，请注意！"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:413
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
 msgstr "删除这个警报？"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:497
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
 msgstr "当这个线……时警告我"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:498
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
 msgstr "警告我，当这个进程条……"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
 msgstr "超过目标线"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:501
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
 msgstr "达成目标"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
 msgstr "低于目标线"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:504
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
 msgstr "低于目标"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:512
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
 msgstr "首次超越，还是每次？"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:513
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
 msgstr "是第一次达成目标，还是每一次都是？"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
 msgstr "第一次"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:516
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
 msgstr "每一次"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:619
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
 msgstr "你想发送这些警报到哪里？"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:630
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
 msgstr "电子邮件发送警报到："
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:672
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
 msgstr "{0} 多行图表还不支持基于目标的报警，所以当图标有{1}时，这个报警就会发送。"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
 msgstr "结果"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:679
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
 msgstr "{0}这种类型的警报是最有效果的，当你存储疑问没有"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:680
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
 msgstr "提示"
 
-#: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
+#: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
 msgstr "通常"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:57
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
 msgstr "选择一个区间或者表单"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:73
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
 msgstr "选择一个数据库"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:88
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
 msgstr "选择……"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:128
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
 msgstr "选择一个表单"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:793
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
 msgstr "该数据库未发现表"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:830
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
 msgstr "图表缺失？"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:834
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
 msgstr "了解更多关于嵌套查询"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:868
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
 msgstr "字段"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:946
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
 msgstr "没有划分"
 
-#: frontend/src/metabase/query_builder/components/DataSelector.jsx:969
+#: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
 msgstr "找到一个划分"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:46
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
 msgstr "查看更少"
 
-#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:56
+#: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
 msgstr "查看更多"
 
@@ -4968,60 +4979,65 @@ msgid "Pick a field to sort by"
 msgstr "选择一个字段来排序"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
 msgstr "排序"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
 msgstr "行限制"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:69
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
 msgstr "未知字段"
 
-#: frontend/src/metabase/query_builder/components/FieldName.jsx:72
+#: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
 msgstr "字段"
 
-#: frontend/src/metabase/query_builder/components/Filter.jsx:114
+#: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
 msgstr "匹配"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
+#: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
 msgstr "添加筛选条件来缩小你的答案范围"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:284
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
 msgstr "添加一个聚合"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:322
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:102
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:113
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:152
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:194
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:59
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:68
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:75
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:225
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:231
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:237
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:70
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:75
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:64
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:112
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:89
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:131
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:176
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:63
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:103
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:302
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:308
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:314
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
 msgstr "数据"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:352
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
 msgstr "筛选条件"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:369
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
 msgstr "查看"
 
-#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:386
+#: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
 msgstr "分组条件"
 
@@ -5029,23 +5045,23 @@ msgstr "分组条件"
 msgid "None"
 msgstr "没有"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:345
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
 msgstr "这个疑问已经被写入{0}"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:353
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
 msgstr "隐藏编辑器"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:354
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
 msgstr "隐藏查询"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:359
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
 msgstr "打开编辑器"
 
-#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:360
+#: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
 msgstr "显示查询"
 
@@ -5066,15 +5082,15 @@ msgstr "下载数据"
 msgid "Warning"
 msgstr "警告"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:52
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
 msgstr "数据行太多，需要一段时间才能下载。"
 
-#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:53
+#: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
-msgstr "下载上线是1百万行"
+msgstr "下载上限是1百万行"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:232
+#: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
 msgstr "编辑图表"
 
@@ -5090,17 +5106,17 @@ msgstr "取消"
 msgid "Move question"
 msgstr "移动图表"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:283
+#: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
 msgstr "将这个放到哪个集合中？"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:313
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:110
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
+#: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
 msgstr "变量"
 
-#: frontend/src/metabase/query_builder/components/QueryHeader.jsx:432
+#: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
 msgstr "了解数据集"
 
@@ -5144,11 +5160,11 @@ msgstr "这个图表的{0}"
 msgid "Convert this question to {0}"
 msgstr "转换图表为{0}"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:122
+#: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
 msgstr "这个图表大约需要{0}来刷新"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:131
+#: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
 msgstr "已更新"
 
@@ -5165,11 +5181,11 @@ msgstr "显示第一个{0}{1}中"
 msgid "Showing {0} {1}"
 msgstr "显示{0}{1}中"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:281
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
 msgstr "开始计算"
 
-#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:294
+#: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
 msgstr "如果你给我一些数据我可以展示给你看一些很酷的东西，运行一个查询吧！"
 
@@ -5177,7 +5193,7 @@ msgstr "如果你给我一些数据我可以展示给你看一些很酷的东西
 msgid "How do I use this thing?"
 msgstr "我该如何使用这个？"
 
-#: frontend/src/metabase/query_builder/components/RunButton.jsx:28
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
 msgstr "得到答案"
 
@@ -5205,39 +5221,39 @@ msgstr "对不起，出现问题了。"
 msgid "Group time by"
 msgstr "时间分组"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:46
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
 msgstr "你的疑问花了很长时间"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:47
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
 msgstr "并没有及时从数据库里获取结果，因此停止。可以过段时间再尝试，或者问题依旧存在，可以联系管理员。"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:55
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
 msgstr "我们碰到了服务器问题"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:56
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
 msgstr "等待一两分钟后，再刷新页面。如果问题依旧存在，请联系管理员。"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:88
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
 msgstr "你的疑问有故障"
 
-#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:89
+#: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
 msgstr "大多数情况，是由于无效查询或错误输入值导致。请确认输入值，重新运行脚本。"
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:60
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
 msgstr "这可能是您正在寻找的答案。如果不是，请尝试删除或更改过滤器，使其不那么具体。"
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
 msgstr "你也可以{0}，当有一些结果时。"
 
-#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:68
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
 msgstr "得到一个警报"
 
@@ -5245,11 +5261,11 @@ msgstr "得到一个警报"
 msgid "Back to last run"
 msgstr "返回上一次运行"
 
-#: frontend/src/metabase/query_builder/components/VisualizationSettings.jsx:100
+#: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
 msgstr "可视化"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:96
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
 msgstr "没有设置描述"
 
@@ -5261,7 +5277,7 @@ msgstr "为当前疑问使用"
 msgid "Potentially useful questions"
 msgstr "有潜在价值的疑问"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:166
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
 msgstr "按{0}分组"
 
@@ -5274,14 +5290,14 @@ msgstr "{0}的和"
 msgid "All distinct values of {0}"
 msgstr "{0}的去重值"
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:187
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
 msgstr "按{1}分组的{0}计数"
 
-#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+#: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:30
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:26
@@ -5297,34 +5313,34 @@ msgstr "数据参考"
 msgid "Learn more about your data structure to ask more useful questions"
 msgstr "了解更多关于你的数据结构并提出更多有用的疑问"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:58
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:84
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
 msgstr "在创建一个新的疑问之前不能找到表单元数据"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:80
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
 msgstr "查看{0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:94
+#: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
 msgstr "指标定义"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:118
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
 msgstr "根据{0}筛选"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:127
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
 msgstr "{0}的数字"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
 msgstr "查看所有的{0}"
 
-#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:148
+#: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
 msgstr "区段定义"
 
@@ -5336,7 +5352,7 @@ msgstr "在加载表时发生了一个错误"
 msgid "See the raw data for {0}"
 msgstr "查看{0}的所有原始数据"
 
-#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:180
+#: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
 msgstr "更多"
 
@@ -5348,24 +5364,24 @@ msgstr "不可用的表达式"
 msgid "unknown error"
 msgstr "未知错误"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:46
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
 msgstr "字段公式"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:57
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
 msgstr "这有点像在EXCEL表中编写公式，你可以使用数字，字段，数学符号和一些函数，例如 Subtotal - Cost。"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
 msgstr "了解更多"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:66
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
 msgstr "给它一个名字吧"
 
-#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:72
+#: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
 msgstr "一些超棒的、值得记录的东西"
 
@@ -5417,7 +5433,8 @@ msgstr "正确"
 msgid "false"
 msgstr "错误"
 
-#: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:404
+#: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
 msgstr "添加过滤器"
 
@@ -5425,15 +5442,15 @@ msgstr "添加过滤器"
 msgid "Item"
 msgstr "项"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:221
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
 msgstr "前"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:252
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
 msgstr "当前"
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:278
+#: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
@@ -5444,7 +5461,7 @@ msgid "Enter desired number"
 msgstr "输入期望值"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:100
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
 msgstr "空的"
 
@@ -5468,35 +5485,35 @@ msgstr "可以输入多个值按逗号分隔"
 msgid "Enter desired text"
 msgstr "输入想要的文本"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:83
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
 msgstr "试试看"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:105
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
 msgstr "这是针对于？"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
 msgstr "原生查询中的变量允许使用筛选组件或URL参数来动态替换查询中的值。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:112
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
 msgstr "{0}在此SQL模板中创建一个名为“variable_name”的变量。变量可以在侧面板中给出类型，这会改变它们的行为。除“字段过滤器”之外的所有变量类型都将自动导致过滤器小部件放在此问题上;使用字段过滤器，这是可选的。填充此过滤器窗口小部件时，该值将替换SQL模板中的变量。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:121
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
 msgstr "字段过滤器"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:123
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
 msgstr "为变量提供“字段过滤器”类型将允许您链接SQL卡到仪表盘的过滤组件，或在图表上使用更多类型的过滤组件。 在现有列上添加过滤器时，字段过滤器变量会插入类似于GUI查询构建器生成的SQL。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:126
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
 msgstr "添加“字段过滤器”变量时，您需要将其映射到特定字段。 然后，您可以选择在问题上显示过滤组件，但即使不这样做，现在可以在将此问题添加到仪表板时将“字段过滤器”变量映射到仪表盘过滤器。 字段过滤器应在“WHERE”子句中使用。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:130
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
 msgstr "可选条款"
 
@@ -5504,59 +5521,61 @@ msgstr "可选条款"
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
 msgstr "{0}周围的括号在模板中创建一个可选子句。如果设置了“variable”，则将整个子句放入模板中。否则忽略整个子句。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:142
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
 msgstr "要使用多个可选子句，您可以包含至少一个非可选WHERE子句，接着以“AND”开头的可选子句。"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:154
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
 msgstr "阅读完整文档"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:127
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
 msgstr "过滤标签"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:139
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
 msgstr "多种类型"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:143
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
 msgstr "文本"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:150
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:119
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
 msgstr "日期"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
 msgstr "字段筛选条件"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:157
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
 msgstr "字段映射到"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:179
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
 msgstr "过滤器样式"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:201
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
-msgstr "需要么？"
+msgstr "必填项？"
 
-#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:211
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
 msgstr "过滤器默认值"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:46
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
 msgstr "归档图表？"
 
-#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:57
+#: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
 msgstr "这个图表会从已引用的仪表盘或定时任务中移除"
 
-#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:136
+#: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
 msgstr "疑问"
 
@@ -5573,21 +5592,21 @@ msgstr "你正在编辑这个页面"
 msgid "See this {0}"
 msgstr "查看这个{0}"
 
-#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:120
+#: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
 msgstr "子集"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:68
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
 msgstr "选择一个字段类型"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:57
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
 msgstr "没有字段类型"
 
@@ -5596,16 +5615,16 @@ msgid "by"
 msgstr "通过"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
-#: frontend/src/metabase/reference/databases/FieldList.jsx:152
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
+#: frontend/src/metabase/reference/databases/FieldList.jsx:155
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
 msgstr "字段类型"
 
-#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:72
+#: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
 msgstr "选择一个外键"
 
-#: frontend/src/metabase/reference/components/Formula.jsx:53
+#: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
 msgstr "查看{0}的公式"
 
@@ -5622,12 +5641,12 @@ msgid "Nothing important yet"
 msgstr "还没有什么重要的事情"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:168
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:233
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:211
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:215
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:219
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:229
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:236
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:214
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:218
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
 msgstr "还没有什么有趣的事情"
 
@@ -5636,12 +5655,12 @@ msgid "Things to be aware of about this {0}"
 msgstr "关于{0}的注意事项"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:178
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:243
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:221
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:225
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:229
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:239
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:246
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:224
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:228
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
 msgstr "目前暂无注意项"
 
@@ -5703,15 +5722,15 @@ msgstr "变更的理由"
 msgid "Leave a note to explain what changes you made and why they were required"
 msgstr "对为什么必须做这些修改进行文字记录"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:166
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
 msgstr "为什么这个数据库十分有趣"
 
-#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:176
+#: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
 msgstr "关于这个数据库需要了解的事情"
 
-#: frontend/src/metabase/reference/databases/DatabaseList.jsx:46
+#: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
 msgstr "数据库和报表"
@@ -5719,42 +5738,42 @@ msgstr "数据库和报表"
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:41
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:170
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:173
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:34
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:184
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:187
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:30
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:188
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:187
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:191
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:190
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
 msgstr "细节"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
-#: frontend/src/metabase/reference/databases/TableList.jsx:111
+#: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
 msgstr "{0}中的报表"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:222
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:200
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:218
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:203
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
 msgstr "实际在数据库中的名称"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:231
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:227
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
 msgstr "为什么这个字段有趣"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:241
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:237
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
 msgstr "关于这个字段需要了解的事情"
 
-#: frontend/src/metabase/reference/databases/FieldDetail.jsx:253
-#: frontend/src/metabase/reference/databases/FieldList.jsx:155
-#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:249
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
+#: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
+#: frontend/src/metabase/reference/databases/FieldList.jsx:158
+#: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
 msgstr "数据类型"
 
@@ -5763,13 +5782,13 @@ msgstr "数据类型"
 msgid "Fields in this table will appear here as they're added"
 msgstr "在这个表单中添加字段时，它们将会出现在这里"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:134
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:135
+#: frontend/src/metabase/reference/databases/FieldList.jsx:137
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
 msgstr "在{0}中的字段"
 
-#: frontend/src/metabase/reference/databases/FieldList.jsx:149
-#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:150
+#: frontend/src/metabase/reference/databases/FieldList.jsx:152
+#: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
 msgstr "字段名称"
 
@@ -5793,7 +5812,10 @@ msgstr "一但你的管理员添加了，数据库将会出现在这里"
 msgid "Connect a database"
 msgstr "连接一个数据库"
 
+#. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
+#. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
+#: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
 msgstr "{0}计数"
 
@@ -5801,11 +5823,11 @@ msgstr "{0}计数"
 msgid "See raw data for {0}"
 msgstr "查看{0}的原始数据"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:209
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
 msgstr "为什么这个表单有趣"
 
-#: frontend/src/metabase/reference/databases/TableDetail.jsx:219
+#: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
 msgstr "关于这个表单需要知道的事情"
 
@@ -5817,16 +5839,16 @@ msgstr "当在这个数据库中添加表单时，它们将会出现在这里"
 msgid "Questions about this table will appear here as they're added"
 msgstr "当关于这个表单的疑问被添加时，它们将会出现在这里"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:71
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:75
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:74
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
 msgstr "关于{0}的疑问"
 
-#: frontend/src/metabase/reference/databases/TableQuestions.jsx:95
-#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:99
-#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:98
+#: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
+#: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
+#: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
 msgstr "根据{1}创建{0}"
 
@@ -5838,151 +5860,152 @@ msgstr "在这个表中的字段"
 msgid "Questions about this table"
 msgstr "关于这个表的疑问"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:157
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
 msgstr "帮助团队了解数据"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:159
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
 msgstr "选择TOP仪表盘、指标和划分，向团队展示什么是最重要的。"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:165
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
 msgstr "开始"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:173
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
 msgstr "我们最重要的仪表盘"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:188
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
 msgstr "我们注意的那些数字"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:213
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
 msgstr "指标是贵公司关心的重要数字,它们通常代表业务运营方式的核心指标。"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:221
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
 msgstr "查看所有的指标"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:235
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
 msgstr "划分和表格"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
+#: frontend/src/metabase/home/containers/SearchApp.jsx:83
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
 msgstr "表格"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:262
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
 msgstr "划分和表格是公司数据的构建块。 表格是原始信息的集合，而划分是具有特定含义的切片，如{0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:267
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
 msgstr "表示公司数据组织的基本单元"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:277
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
 msgstr "查看所有的区间"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:293
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
 msgstr "查看所有的表单"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:301
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
 msgstr "关于我们的数据需要了解的其他事情"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
 msgstr "发现更多"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:307
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
 msgstr "了解数据的一个好方法就是花时间去看下不同的表格还有其他可用信息。可能会花一段时间，但是慢慢地会了解很多字段名和含义。"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:313
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
 msgstr "探索我们的数据"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:321
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
 msgstr "有问题吗？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:326
+#: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
 msgstr "联系{0}"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:248
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
 msgstr "帮助新的Metabase用户了解如何使用"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:251
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
 msgstr "“入门指南”重点介绍了仪表盘，指标，划分和表格，并在深入了解数据之前告知用户他们应该了解的重要事项。"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:258
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
 msgstr "这有一个对你们团队来说重要的仪表盘吗？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:260
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
 msgstr "现在创建一个仪表盘"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:266
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
 msgstr "什么是你最重要的仪表盘?"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:285
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
 msgstr "你有常引用的指标么？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:287
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
 msgstr "了解如何定义指标。"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:300
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
 msgstr "你最常引用的3~5个指标是什么？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:344
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
 msgstr "添加另外一个指标"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:357
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
 msgstr "你有常引用的划分或表格么？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:359
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
 msgstr "学习如何创建一个区间"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:372
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
 msgstr "对其他人有用的3~5个常引用的划分或者表格是什么？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:418
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
 msgstr "添加另外一个区间或表单"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:427
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
 msgstr "有什么是你的用户在开始连接到他们的数据库之前应该理解或者知道的吗？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:433
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
 msgstr "这个数据的用户在开始连接之前应该知道什么？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:437
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
 msgstr "例如，对数据隐私和使用的期望，常见的陷阱或误解，有关数据仓库性能的信息，法律声明等。"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
 msgstr "有什么人是你的用户如果对向导感到疑惑，可以联系到并且寻求帮助的吗？"
 
-#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:457
+#: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
 msgstr "用户如果对这个数据感到疑惑，他们应该联系谁寻求帮助？"
 
@@ -5991,39 +6014,39 @@ msgstr "用户如果对这个数据感到疑惑，他们应该联系谁寻求帮
 msgid "Please enter a revision message"
 msgstr "请输入一个调整信息"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:213
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
 msgstr "为什么这个指标有趣"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:223
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
 msgstr "关于这个指标需要注意的事情"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:233
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
 msgstr "这个指标是如何计算的"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:235
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
 msgstr "它是如何计算的里面还没有东西"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:293
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
 msgstr "你可以通过聚合这个指标形成的其他领域"
 
-#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:294
+#: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
 msgstr "你可以通过聚合这个指标得到的领域"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:23
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
 msgstr "指标是你的团队关心的官方数字"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:25
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
 msgstr "一但你的管理员创建了一些指标的话，它们将会出现在这里"
 
-#: frontend/src/metabase/reference/metrics/MetricList.jsx:27
+#: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
 msgstr "了解如何创建指标"
 
@@ -6035,9 +6058,9 @@ msgstr "添加这个指标的图表会在这里显示。"
 msgid "There are no revisions for this metric"
 msgstr "这个指标没有修改历史"
 
-#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:88
-#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:52
-#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:88
+#: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
+#: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
+#: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
 msgstr "{0}的修改历史"
 
@@ -6045,27 +6068,27 @@ msgstr "{0}的修改历史"
 msgid "X-ray this metric"
 msgstr "透视这个指标"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:217
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
 msgstr "为什么这个区段很有意思"
 
-#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:227
+#: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
 msgstr "关于这个区段的注意事项"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:23
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
 msgstr "区段是表格的子集"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:24
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
 msgstr "为你的团队定义公共区段，让它用来提问也十分容易"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:25
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
 msgstr "你的管理员添加后，区段将会出现在这里，"
 
-#: frontend/src/metabase/reference/segments/SegmentList.jsx:27
+#: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
 msgstr "学习如何创建区段"
 
@@ -6093,7 +6116,7 @@ msgstr "透视这个区段"
 msgid "Login"
 msgstr "登录"
 
-#: frontend/src/metabase/nav/containers/Navbar.jsx:130
+#: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
 msgstr "查询"
@@ -6110,99 +6133,99 @@ msgstr "新疑问"
 msgid "Select the type of Database you use"
 msgstr "选择你使用的数据库类型"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:141
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
 msgstr "添加你的数据"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:145
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
 msgstr "我之后将会添加自己的数据"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
 msgstr "连接到{0}"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:165
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
 msgstr "在开始之前需要配置数据库信息（如：用户名、密码）。如果暂时没有这些信息metabase也提供了一个简单数据源供学习使用。"
 
-#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:196
+#: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
 msgstr "我之后再添加数据"
 
-#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:41
+#: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
 msgstr "控制自动化扫描"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:53
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
 msgstr "使用数据引用"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
 msgstr "感谢帮助我们提升"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:57
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
 msgstr "我们不会收集任何使用事件信息"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:76
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
 msgstr "为了提升Metabase的用户体验，可能需要通过Google Analytics收集特定的使用数据。"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:85
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
 msgstr "这个我们所有我们要收集的清单，以及为什么要收集"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:98
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
 msgstr "允许Metabase匿名收集使用事件"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:105
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
 msgstr "Metabase{0}收集任何事情关于你的数据或者提问结果"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:106
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
 msgstr "永不"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:108
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
 msgstr "所有的收集都是匿名的。"
 
-#: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
+#: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
 msgstr "您随时可以在管理设置中关闭信息收集。"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:45
+#: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
 msgstr "如果你不知从何下手"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:52
+#: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
 msgstr "初始化文档"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:53
+#: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
 msgstr "点击一下"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:95
+#: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
 msgstr "欢迎来到Metabase"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:96
+#: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
 msgstr "看起来一切都在正常工作，现在让我们了解你吧，连接到你的数据，并且开始寻找一些属于你的答案！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:100
+#: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
 msgstr "让我们开始吧"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:145
+#: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
 msgstr "你已经设置完毕了！"
 
-#: frontend/src/metabase/setup/components/Setup.jsx:156
+#: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
 msgstr "带我去Metabase"
 
@@ -6219,7 +6242,7 @@ msgid "Create a password"
 msgstr "创建一个密码"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
-#: frontend/src/metabase/user/components/SetUserPassword.jsx:116
+#: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
 msgstr "嘘……"
 
@@ -6412,11 +6435,11 @@ msgstr "用Google邮箱地址登录"
 msgid "User Details"
 msgstr "用户详情"
 
-#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:275
+#: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
 msgstr "恢复默认值"
 
-#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:133
+#: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
 msgstr "未知地图"
 
@@ -6428,24 +6451,24 @@ msgstr "网格地图需要绑定经度/纬度。"
 msgid "more"
 msgstr "更多"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:101
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
 msgstr "横坐标和纵坐标想使用那些字段?"
 
-#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:103
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:60
+#: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
 msgstr "选择字段"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:204
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
 msgstr "作为默认视图存储"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
 msgstr "添加过滤器"
 
-#: frontend/src/metabase/visualizations/components/PinMap.jsx:226
+#: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
 msgstr "取消过滤器"
 
@@ -6453,7 +6476,7 @@ msgstr "取消过滤器"
 msgid "Pin Map"
 msgstr "固定地图"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:303
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
 msgstr "撤销设置"
 
@@ -6461,31 +6484,31 @@ msgstr "撤销设置"
 msgid "Rows {0}-{1} of {2}"
 msgstr "{2}的{0}~{1}行"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:189
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
 msgstr "数据被截断为{0}行。"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:364
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
 msgstr "找不到可视化"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:371
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
 msgstr "无法显示这个图表显示这些数据"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:469
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
 msgstr "没有结果！"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:490
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
 msgstr "仍然在等待……"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:493
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
 msgstr "这将通常取一个{0}的平均数。"
 
-#: frontend/src/metabase/visualizations/components/Visualization.jsx:499
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
 msgstr "（这对于仪表盘来说有点太长了）"
 
@@ -6501,11 +6524,11 @@ msgstr "选择一个字段"
 msgid "error"
 msgstr "错误"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:126
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
 msgstr "点击并且拖拽来改变他们的指令"
 
-#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:139
+#: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
 msgstr "从下方列表中添加字段"
 
@@ -6595,7 +6618,7 @@ msgid "Highlight the whole row"
 msgstr "高亮整行"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:98
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
 msgstr "颜色"
 
@@ -6661,20 +6684,20 @@ msgid "No visualization for {0}"
 msgstr "没有{0}的可视化"
 
 #. 未聚合的字段，如果你没有下一步操作，默认将对这个字段求和。
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:75
+#: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
 msgstr "“{0}”是未聚合的字段，如果它在X轴的点上有多于一个的值，这些值将会被求和。"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:91
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
 msgstr "这种图表需要至少2列"
 
-#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:96
+#: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
 msgstr "这种图表不支持超过{0}种数据"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:316
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:51
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:297
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
 msgstr "目标"
 
@@ -6712,25 +6735,25 @@ msgstr "编辑设置"
 msgid "xValues missing!"
 msgstr "x值丢失！"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:114
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
 msgstr "X轴"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:140
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
 msgstr "添加一系列断点......"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:153
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
 msgstr "Y轴"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:178
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
 msgstr "添加另一个系列……"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:195
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
 msgstr "气泡大小"
 
@@ -6744,7 +6767,7 @@ msgid "Curve"
 msgstr "曲线"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:69
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
 msgstr "步骤"
 
@@ -6752,27 +6775,27 @@ msgstr "步骤"
 msgid "Show point markers on lines"
 msgstr "在线上显示点的标记"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:235
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
 msgstr "正在堆叠"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:239
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
 msgstr "不要堆叠"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:240
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
 msgstr "堆叠"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:241
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
 msgstr "堆叠 - 100%"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:300
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
 msgstr "显示目标"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:306
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
 msgstr "目标值"
 
@@ -6792,126 +6815,126 @@ msgstr "什么也没有"
 msgid "Linear Interpolated"
 msgstr "线性插值平滑"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:371
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
 msgstr "X轴比例"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
 msgstr "时间系列"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:391
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:409
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:381
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
 msgstr "线性"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:410
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:383
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
 msgstr "势"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:411
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:384
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
 msgstr "日志"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:396
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
 msgstr "柱状图"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:398
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
 msgstr "序数"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:404
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
 msgstr "Y轴比例"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:417
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
 msgstr "显示X轴线和标记"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:423
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
 msgstr "压缩"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:424
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
 msgstr "旋转45°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:425
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
 msgstr "旋转90°"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:432
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
 msgstr "显示Y轴线段和标记"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:444
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
 msgstr "自动Y轴范围"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:488
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
 msgstr "当需要时使用一个分离的Y轴"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:495
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
 msgstr "展示标签在X轴上"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:501
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
 msgstr "X轴标签"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:510
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
 msgstr "展示标签在Y轴上"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:516
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
 msgstr "Y轴标签"
 
-#: frontend/src/metabase/visualizations/lib/utils.js:129
+#: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
 msgstr "标准差"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:275
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:17
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:256
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
 msgstr "区域"
 
-#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:20
+#: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
 msgstr "区域图表"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:276
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:16
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:257
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
 msgstr "柱"
 
-#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:19
+#: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
 msgstr "柱形图"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
 msgstr "你想要使用哪个领域？"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:87
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
 msgstr "漏斗"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:76
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:76
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
 msgstr "测量"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:82
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
 msgstr "漏斗类型"
 
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:88
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
 msgstr "柱形图"
 
@@ -6919,141 +6942,141 @@ msgstr "柱形图"
 msgid "line chart"
 msgstr "线段图表"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:224
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
 msgstr "请在图表设置中选择经度和维度的列"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:230
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
 msgstr "请选择一个区域地图"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:236
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 msgid "Please select region and metric columns in the chart settings."
 msgstr "请在图表设置中选择一个区域和指标列"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:38
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
 msgstr "地图"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:53
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
 msgstr "地图类型"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:57
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:149
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
 msgstr "区域地图"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:58
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
 msgstr "固定地图"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
 msgstr "固定类型"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
 msgstr "标题"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:110
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
 msgstr "标记"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:126
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
 msgstr "维度字段"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
 msgstr "经度字段"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:142
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:168
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
 msgstr "指标字段"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
 msgstr "区域字段"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:192
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
 msgstr "半径"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:198
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
 msgstr "模糊"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
 msgstr "最小不透明度"
 
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
 msgstr "放到最大"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:175
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
 msgstr "没有发现关联。"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:213
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
 msgstr "通过{0}"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:290
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
 msgstr "这个{0}连接到"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:47
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
 msgstr "对象细节"
 
-#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:50
+#: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
 msgstr "对象"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:312
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
 msgstr "总计"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
 msgstr "需要用哪些列？"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:44
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
 msgstr "饼图"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:71
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
 msgstr "维度"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:81
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
 msgstr "显示说明"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:86
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
 msgstr "在说明中显示百分比"
 
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:92
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
 msgstr "最小切片百分比"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:146
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
 msgstr "目标达成"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:148
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
 msgstr "突破目标"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:215
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
 msgstr "目标{0}"
 
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
 msgstr "处理可视化需要一个数字。"
 
@@ -7061,9 +7084,9 @@ msgstr "处理可视化需要一个数字。"
 msgid "Progress"
 msgstr "处理"
 
-#: frontend/src/metabase/entities/collections.js:108
-#: frontend/src/metabase/visualizations/visualizations/Map.jsx:176
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:57
+#: frontend/src/metabase/entities/collections.js:109
+#: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
 msgstr "颜色"
 
@@ -7075,7 +7098,7 @@ msgstr "原始图表"
 msgid "row chart"
 msgstr "原始图表"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:357
+#: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
 msgstr "分隔符"
 
@@ -7083,15 +7106,15 @@ msgstr "分隔符"
 msgid "Number of decimal places"
 msgstr "小数位数"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:381
+#: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
 msgstr "添加一个前缀"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:385
+#: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
 msgstr "添加一个后缀"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:374
+#: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
 msgstr "乘以数字"
 
@@ -7103,7 +7126,7 @@ msgstr "分散"
 msgid "scatter plot"
 msgstr "散点图"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:78
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
 msgstr "透视表"
 
@@ -7112,7 +7135,8 @@ msgid "Visible fields"
 msgstr "可见区域"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-msgid "Write here, and use Markdown if you''d like"
+#, fuzzy
+msgid "Write here, and use Markdown if you'd like"
 msgstr "在这里编辑，也可以使用Markdown语法"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
@@ -7153,12 +7177,12 @@ msgstr "右边"
 msgid "Show background"
 msgstr "显示背景"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:553
+#: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
 msgstr[0] "{0} 刻度间隔"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:559
+#: frontend/src/metabase-lib/lib/Dimension.js:731
 msgid "Auto binned"
 msgstr "自动分组"
 
@@ -7426,23 +7450,23 @@ msgstr "自动间隔"
 msgid "Don''t bin"
 msgstr "无间隔"
 
-#: frontend/src/metabase/lib/query_time.js:193 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
 msgstr[0] "天"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
-#: frontend/src/metabase/lib/query_time.js:189 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
 msgstr[0] "分钟"
 
-#: frontend/src/metabase/lib/query_time.js:191 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
 msgstr[0] "小时"
 
-#: frontend/src/metabase/lib/query_time.js:199 src/metabase/api/table.clj
+#: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
 msgstr[0] "季度"
@@ -7508,7 +7532,7 @@ msgid "Bin every 20 degrees"
 msgstr "按20度间隔"
 
 #. returns `true` if successful -- see JavaDoc
-#: src/metabase/api/tiles.clj src/metabase/pulse/render.clj
+#: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
 msgstr "找不到合适的图像写入器！"
 
@@ -7580,10 +7604,12 @@ msgstr "累积总和"
 msgid "{0} and {1}"
 msgstr "{0} 和 {1}"
 
+#: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
 msgstr "{0} 的 {1}"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
 msgstr "{0} by {1}"
@@ -7596,9 +7622,11 @@ msgstr "划分 {1} 中的 {0}"
 msgid "{0} segment"
 msgstr "划分 {0}"
 
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
-msgstr "指标 {0}"
+msgid_plural "{0} metrics"
+msgstr[0] "指标 {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
@@ -8179,6 +8207,7 @@ msgid "Cannot save Question: source query has circular references."
 msgstr "不能保存疑问：源查询拥有循环引用。"
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
+#: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
 msgstr "卡片{0}不存在"
@@ -8580,7 +8609,7 @@ msgstr "无法识别的频道类型(0)"
 msgid "Error sending notification!"
 msgstr "发送提醒错误！"
 
-#: src/metabase/pulse/color.clj
+#: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
 msgstr "在“{0}”中找不到JS颜色选择项"
 
@@ -8887,43 +8916,43 @@ msgstr "数据权限"
 msgid "Collection permissions"
 msgstr "文件夹权限"
 
-#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:56
+#: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
 msgstr "查看所有文件夹权限"
 
-#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:25
+#: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
 msgstr "同时更改子集合"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:282
+#: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
 msgstr "允许修改集合及其内容"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:289
+#: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
 msgstr "允许查看该集合的内容"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:749
+#: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
 msgstr "集合的权限"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:825
+#: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
 msgstr "该组有权查看此集合的至少一个子集合。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:830
+#: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
 msgstr "该组有权编辑此集合的至少一个子集合。"
 
-#: frontend/src/metabase/admin/permissions/selectors.js:843
+#: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
 msgstr "查看子集合"
 
-#: frontend/src/metabase/auth/containers/LoginApp.jsx:211
+#: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
 msgstr "记住我"
 
-#: frontend/src/metabase/components/BrowseApp.jsx:95
+#: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
 msgstr "透视这个图表"
 
@@ -8955,31 +8984,32 @@ msgstr "在“{0}”中保存仪表板，问题和集合"
 msgid "Access dashboards, questions, and collections in \"{0}\""
 msgstr "访问“{0}”中的仪表板，问题和集合"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:221
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
 msgstr "比较"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:229
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
 msgstr "缩小"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:233
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
 msgstr "相关"
 
-#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:293
+#: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
 msgstr "更多透视方法"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:46
+#: frontend/src/metabase/home/containers/SearchApp.jsx:40
+#: src/metabase/pulse/render/body.clj
 msgid "No results"
 msgstr "没有结果"
 
-#: frontend/src/metabase/home/containers/SearchApp.jsx:47
+#: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
 msgstr "Metabase无法找到您的搜索结果。"
 
-#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:111
+#: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
 msgstr "没有指标"
 
@@ -9021,7 +9051,7 @@ msgstr "无法获取权限：{0}"
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
 msgstr "无法解密已加密的字符。你是否忘记设置 MB_ENCRYPTION_SECRET_KEY？"
 
-#: frontend/src/metabase/entities/collections.js:164
+#: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
 msgstr "所有个人集合"
 
@@ -9185,18 +9215,18 @@ msgstr "不适用"
 msgid "Windows domain"
 msgstr "Windows域名"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:494
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:500
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:509
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:515
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:484
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:490
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:499
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
 msgstr "标签"
 
-#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:329
+#: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
 msgstr "添加成员"
 
-#: frontend/src/metabase/entities/collections.js:115
+#: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
 msgstr "集合保存在"
 
@@ -9217,39 +9247,39 @@ msgid "Sharing"
 msgstr "分享"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:234
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:270
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:299
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:305
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:313
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:321
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:218
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:251
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:280
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:286
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:294
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:302
 #: frontend/src/metabase/visualizations/lib/settings/nested.js:126
-#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:83
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:80
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:85
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:91
-#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:97
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:50
-#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:56
+#: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:118
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:114
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:119
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:125
+#: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:131
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:61
+#: frontend/src/metabase/visualizations/visualizations/Progress.jsx:67
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:72
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
 msgstr "显示"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:370
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:403
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:416
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:431
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:443
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:449
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:457
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:487
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:358
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:393
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:406
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:421
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:433
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:439
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:447
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
 msgstr "坐标轴"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:222
-#: frontend/src/metabase/admin/settings/selectors.js:319
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
+#: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
@@ -9283,20 +9313,20 @@ msgstr "透视"
 msgid "Compare to the rest"
 msgstr "和其余的比较"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:244
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
 msgstr "使用Java虚拟机时区"
 
-#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
 msgstr "我们建议你让它关闭，除非你用这些数据在大部分查询中手动调整时区"
 
-#: frontend/src/metabase/containers/Overworld.jsx:310
+#: frontend/src/metabase/containers/Overworld.jsx:312
 msgid "Your team's most important dashboards go here"
 msgstr "你的团队的最重要的仪表盘在这里"
 
-#: frontend/src/metabase/containers/Overworld.jsx:311
+#: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
 msgstr "把面板固定在{0}里，使之对所有人可见"
 
@@ -9312,32 +9342,32 @@ msgstr "使用Java虚拟机时区"
 msgid "We're currently analyzing the tables and fields to help you explore your data."
 msgstr "我们现在正在分析数据表和字段来帮助你探索数据"
 
-#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
+#: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
 msgstr "提示："
 
-#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:258
+#: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
 msgstr "选择一个统用的类型"
 
-#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:318
+#: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
 msgstr "字段类型"
 
 #: frontend/src/metabase/admin/routes.jsx:109
-#: frontend/src/metabase/nav/containers/Navbar.jsx:224
+#: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
 msgstr "错误排查"
 
-#: frontend/src/metabase/admin/settings/selectors.js:96
+#: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
 msgstr "开启 X-ray 功能"
 
-#: frontend/src/metabase/admin/settings/selectors.js:323
+#: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
 msgstr "格式化"
 
-#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:19
+#: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
 msgstr "任务详情"
 
@@ -9377,7 +9407,7 @@ msgstr "货币"
 msgid "Pick a user or channel..."
 msgstr "选择一个用户或频道"
 
-#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:90
+#: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
 msgstr "无格式化设置"
 
@@ -9485,31 +9515,31 @@ msgstr "HH:MM:SS.MS"
 msgid "Time style"
 msgstr "时间格式"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:299
+#: frontend/src/metabase/visualizations/lib/settings/column.js:300
 msgid "Unit of currency"
 msgstr "货币单位"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:319
+#: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
 msgstr "货币标签风格"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:337
+#: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
 msgstr "在哪里显示货币单位"
 
-#: frontend/src/metabase/visualizations/lib/settings/column.js:370
+#: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
 msgstr "最少小数位数"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:271
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
 msgstr "堆叠图表类型"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:314
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
 msgstr "目标标签"
 
-#: frontend/src/metabase/visualizations/lib/settings/graph.js:322
+#: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
 msgstr "显示趋势线"
 
@@ -9538,7 +9568,7 @@ msgstr "线状图+条行图"
 msgid "line and bar chart"
 msgstr "线状图和条型图"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:72
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
 msgstr "标尺可视化需要一个数字"
 
@@ -9546,75 +9576,75 @@ msgstr "标尺可视化需要一个数字"
 msgid "Gauge"
 msgstr "标尺"
 
-#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:104
+#: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
 msgid "Gauge ranges"
 msgstr "标尺范围"
 
-#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:94
+#: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
 msgstr "显示的字段"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:121
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
 msgstr "上一{0}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:185
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
 msgstr "{0}{2} {1}"
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:52
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:39
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
 msgstr "切换正、负颜色"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:90
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
 msgstr "透视列"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:107
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:123
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
 msgstr "可见列"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:143
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
 msgstr "条件格式化"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:165
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
 msgstr "列抬头"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:172
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
 msgstr "显示迷你条形图"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:183
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
 msgstr "连接"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:187
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
 msgstr "Email地址"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
 msgstr "图片"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:195
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
 msgstr "自动"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:200
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
 msgstr "以链接或图片查看"
 
-#: frontend/src/metabase/visualizations/visualizations/Table.jsx:210
+#: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
 msgstr "链接文字"
 
@@ -9727,7 +9757,7 @@ msgstr "HoneySQL 表单:"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Unable to parse date ''{0}''"
-msgstr ""
+msgstr "不能解析日期\"{0}\""
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, cancelling query"
@@ -9878,7 +9908,7 @@ msgstr "预处理查询时出错"
 msgid "No native form returned."
 msgstr "没有返回原生表格。"
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
 msgstr "数据库驱动程序的响应无效。 无 :status 提供。"
 
@@ -10049,7 +10079,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions"
-msgstr ""
+msgstr "会话"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How some of the numbers in [[this]] relate to each other"
@@ -10058,7 +10088,7 @@ msgstr ""
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per country"
-msgstr ""
+msgstr "每个国家的销售额"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by month of the year"
@@ -10119,7 +10149,7 @@ msgstr ""
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per hour of the day"
-msgstr ""
+msgstr "当日每小时事件"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Singleton]]"
@@ -10153,7 +10183,7 @@ msgstr "空值"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Total events"
-msgstr ""
+msgstr "总事件"
 
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "A look at [[GenericTable]] across your [[this]], and how it changes over time."
@@ -11244,7 +11274,7 @@ msgstr "设置参数query-caching-max-kb为{0}失败。"
 msgid "Values greater than {1} are not allowed."
 msgstr "不允许设置大于{1}的值。"
 
-#: src/metabase/query_processor/middleware/resolve_database.clj
+#: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
 msgstr "数据库 {0} 不存在。"
 
@@ -11293,7 +11323,7 @@ msgstr ""
 msgid "View triggers"
 msgstr ""
 
-#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:82
+#: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
 msgstr ""
 
@@ -11325,7 +11355,7 @@ msgstr ""
 msgid "May Fire Again?"
 msgstr ""
 
-#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:75
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
 msgstr ""
 
@@ -11337,19 +11367,19 @@ msgstr ""
 msgid "Jobs"
 msgstr ""
 
-#: frontend/src/metabase/components/CollectionLanding.jsx:740
+#: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
 msgstr ""
 
-#: frontend/src/metabase/components/EntityItem.jsx:55
+#: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
 msgstr ""
 
-#: frontend/src/metabase/components/EntityItem.jsx:61
+#: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
 msgstr ""
 
-#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:330
+#: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
 msgstr ""
 
@@ -11399,54 +11429,55 @@ msgstr ""
 msgid "{0} {1} from now"
 msgstr ""
 
-#: frontend/src/metabase/lib/query_time.js:187
+#: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:203
+#: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:205
+#: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:207
+#: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:209
+#: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:211
+#: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:213
+#: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:215
+#: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
 msgstr[0] ""
 
-#: frontend/src/metabase/lib/query_time.js:217
+#: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
 msgstr[0] ""
 
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
-#: frontend/src/metabase/query_builder/components/Filter.jsx:79
+#: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
 msgstr[0] ""
@@ -11459,20 +11490,20 @@ msgstr ""
 msgid "This"
 msgstr ""
 
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:64
-#: frontend/src/metabase/query_builder/components/AggregationName.jsx:96
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
+#: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
 msgstr ""
 
-#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:147
+#: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
 msgstr ""
 
-#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:170
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
-msgstr ""
+msgstr "无法与前{0}比较"
 
-#: frontend/src/metabase-lib/lib/Dimension.js:517
+#: frontend/src/metabase-lib/lib/Dimension.js:678
 msgid "by {0}"
 msgstr ""
 
@@ -11578,11 +11609,11 @@ msgstr ""
 
 #: src/metabase/driver/util.clj
 msgid "Error loading namespace"
-msgstr ""
+msgstr "加载命名空间失败"
 
 #: src/metabase/events.clj
 msgid "Starting events listener:"
-msgstr ""
+msgstr "开始监听事件"
 
 #: src/metabase/events.clj
 msgid "Unexpected error listening on events"
@@ -11766,37 +11797,37 @@ msgstr ""
 msgid "Error running query for Card {0}"
 msgstr ""
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
-msgstr ""
+msgstr "上周"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This week"
-msgstr ""
+msgstr "这周"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
-msgstr ""
+msgstr "上个月"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This month"
-msgstr ""
+msgstr "这个月"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
-msgstr ""
+msgstr "上季度"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
-msgstr ""
+msgstr "本季度"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
-msgstr ""
+msgstr "去年"
 
-#: src/metabase/pulse/render.clj
+#: src/metabase/pulse/render/datetime.clj
 msgid "This year"
-msgstr ""
+msgstr "今年"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "*driver* is unbound."
@@ -11812,7 +11843,7 @@ msgstr ""
 
 #: src/metabase/sync/sync_metadata/fields/common.clj
 msgid "Field"
-msgstr ""
+msgstr "失败"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error checking if Fields {0} need to be created or reactivated"
@@ -11894,7 +11925,7 @@ msgstr ""
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Cleaning up task history"
-msgstr ""
+msgstr "正在清理任务历史"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were deleted"
@@ -12041,7 +12072,7 @@ msgid "[[CreateDate]] by quarter of the year"
 msgstr ""
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:200
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
 msgstr ""
 
@@ -12049,12 +12080,12 @@ msgstr ""
 msgid "New user"
 msgstr ""
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
 msgstr ""
 
-#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:209
+#: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
 msgstr ""
 
@@ -12066,40 +12097,40 @@ msgstr ""
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
 msgstr ""
 
-#: frontend/src/metabase/entities/collections.js:21
+#: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
 msgstr ""
 
-#: frontend/src/metabase/entities/collections.js:22
+#: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
 msgstr ""
 
-#: frontend/src/metabase/entities/dashboards.js:29
+#: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
 msgstr ""
 
-#: frontend/src/metabase/entities/dashboards.js:30
+#: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
 msgstr ""
 
-#: frontend/src/metabase/entities/users.js:125
+#: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
-msgstr ""
+msgstr "名字是必须的"
 
-#: frontend/src/metabase/entities/users.js:126
-#: frontend/src/metabase/entities/users.js:133
+#: frontend/src/metabase/entities/users.js:38
+#: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
 msgstr ""
 
-#: frontend/src/metabase/entities/users.js:132
+#: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
-msgstr ""
+msgstr "姓是必须的"
 
-#: frontend/src/metabase/entities/users.js:138
+#: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
-msgstr ""
+msgstr "电子邮件是必须的"
 
-#: frontend/src/metabase/home/containers/ArchiveApp.jsx:90
+#: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
 msgstr ""
 
@@ -12107,11 +12138,11 @@ msgstr ""
 msgid "No description"
 msgstr ""
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:175
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
 msgstr ""
 
-#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:183
+#: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
 msgstr ""
 
@@ -12311,15 +12342,774 @@ msgstr ""
 msgid "Adding User {0} to Admin permissions group..."
 msgstr ""
 
-#: src/metabase/query_processor.clj
+#: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
-msgstr ""
+msgstr "查询失败"
 
-#: src/metabase/query_processor/async.clj
+#: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
 msgstr ""
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
+msgstr ""
+
+#: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
+msgid "Misfire Instruction"
+msgstr ""
+
+#: frontend/src/metabase/components/ArchiveModal.jsx:31
+msgid "Archive this?"
+msgstr ""
+
+#: frontend/src/metabase/components/BrowseApp.jsx:244
+msgid "Learn about our data"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
+msgid "Use DNS SRV when connecting"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
+msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
+"an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
+"leave this disabled."
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
+msgid "Automatically run queries when doing simple filtering and summarizing"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr ""
+
+#: frontend/src/metabase/containers/Overworld.jsx:247
+msgid "Learn about this database"
+msgstr ""
+
+#: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
+msgid "Archive this dashboard?"
+msgstr ""
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:113
+msgid "All results"
+msgstr ""
+
+#: frontend/src/metabase/home/containers/SearchApp.jsx:180
+msgid "Our Analytics"
+msgstr ""
+
+#: frontend/src/metabase/lib/schema_metadata.js:500
+msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
+msgstr ""
+
+#: frontend/src/metabase/lib/schema_metadata.js:508
+msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
+msgstr ""
+
+#: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
+msgid "Filter"
+msgstr ""
+
+#: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
+msgid "record"
+msgid_plural "records"
+msgstr[0] ""
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:346
+msgid "Browse Data"
+msgstr ""
+
+#: frontend/src/metabase/nav/containers/Navbar.jsx:376
+msgid "Write SQL"
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
+msgid "Simple question"
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
+msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
+msgid "Custom question"
+msgstr ""
+
+#: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
+msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
+msgid "Basic Metrics"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
+msgid "Custom…"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
+msgid "Add grouping"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
+msgid "Pick a limit"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
+msgid "Show maximum"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/RunButton.jsx:47
+msgid "Get Preview"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
+msgid "Back to previous results"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
+msgid "Sample values"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
+msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
+msgid "Visualize"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
+msgid "Join data"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
+msgid "Custom column"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
+msgid "Summarize"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
+msgid "Aggregate"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
+msgid "Breakout"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
+msgid "Pick the metric you want to see"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
+#: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
+msgid "Pick a column to group by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
+msgid "Pick your starting data"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select None"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
+msgid "Select All"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
+msgid "Pick a table..."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
+msgid "Enter a limit"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
+msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
+msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
+msgid "View the native query"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
+msgid "Native query for this question"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
+msgid "Convert this question to a native query"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
+msgid "SQL for this question"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
+msgid "Convert this question to SQL"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
+msgid "Get alerts"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
+msgid "{0} breakout"
+msgid_plural "{0} breakouts"
+msgstr[0] ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
+msgid "Hide filters"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
+msgid "Show filters"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
+msgid "Started from"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
+msgid "{0} row"
+msgid_plural "{0} rows"
+msgstr[0] ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
+msgid "Show all rows"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
+msgid "Show {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
+msgid "Showing first {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
+msgid "Showing {0}"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
+msgid "Summarized"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Hide editor"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
+msgid "Show editor"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
+msgid "Pick the metric you'd like to see"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
+msgid "{0} options"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
+msgid "Choose a visualization"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
+msgid "Filter by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
+msgid "Summarize by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
+msgid "Group by"
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
+msgid "Add a metric"
+msgstr ""
+
+#: frontend/src/metabase/user/components/UserSettings.jsx:57
+msgid "Profile"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/components/Visualization.jsx:548
+msgid "This is usually pretty fast but seems to be taking a while right now."
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
+msgid "Combo"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
+msgid "Row"
+msgstr ""
+
+#: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
+msgid "Trend"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/DimensionOptions.js:129
+msgid "Boolean"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
+msgid "Unknown Segment"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
+msgid "Unknown Filter"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
+msgid "Left outer join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
+msgid "Right outer join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
+msgid "Inner join"
+msgstr ""
+
+#: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
+msgid "Full outer join"
+msgstr ""
+
+#: src/metabase/api/card.clj
+msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
+msgstr ""
+
+#: src/metabase/api/session.clj
+msgid "Problem connecting to LDAP server, will fall back to local authentication"
+msgstr ""
+
+#: src/metabase/api/setup.clj
+msgid "Cannot create Database: cannot find driver {0}."
+msgstr ""
+
+#: src/metabase/api/tiles.clj
+msgid "Query failed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Warning: {0} returned `nil`"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing result to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Unexpected error writing exception to output channel: already closed"
+msgstr ""
+
+#: src/metabase/async/util.clj
+msgid "Request canceled, canceling future."
+msgstr ""
+
+#: src/metabase/cmd/load_from_h2.clj
+msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
+msgstr ""
+
+#: src/metabase/db.clj
+msgid "Application database setup"
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Could not find {0} driver."
+msgstr ""
+
+#: src/metabase/driver.clj
+msgid "Abstract drivers cannot derive from concrete parent drivers."
+msgstr ""
+
+#: src/metabase/driver/mysql.clj
+msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifer."
+msgstr ""
+
+#: src/metabase/driver/sql_jdbc/execute.clj
+msgid "Client closed connection, canceling query"
+msgstr ""
+
+#: src/metabase/integrations/ldap.clj
+msgid "{0} is not a valid DN."
+msgstr ""
+
+#: src/metabase/middleware/log.clj
+msgid "Error logging API request"
+msgstr ""
+
+#: src/metabase/middleware/misc.clj
+msgid "Failed to set site-url"
+msgstr ""
+
+#: src/metabase/models/database.clj
+msgid "Error destroying thread pool for DB."
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
+msgstr ""
+
+#: src/metabase/models/humanization.clj
+msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/models/task_history.clj src/metabase/sync/util.clj
+msgid "Error saving task history"
+msgstr ""
+
+#: src/metabase/plugins.clj
+msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
+msgstr ""
+
+#: src/metabase/plugins/classloader.clj
+msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
+msgstr ""
+
+#: src/metabase/plugins/files.clj
+msgid "Failed to copy file"
+msgstr ""
+
+#: src/metabase/public_settings.clj
+msgid "Invalid site URL: {0}"
+msgstr ""
+
+#: src/metabase/public_settings.clj
+msgid "site-url is invalid; returning nil for now. Will be reset on next request."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "More results have been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "This question has been included as a file attachment"
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "We were unable to display this Pulse."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "Please view this card in Metabase."
+msgstr ""
+
+#: src/metabase/pulse/render/body.clj
+msgid "An error occurred while displaying this card."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Can only determine expected columns for MBQL queries."
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "No columns returned."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Cannot find Table ID for {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "No matching info found."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Could not resolve {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "Invalid fk-> clause: nowhere to add corresponding join."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_joins.clj
+msgid "{0} driver does not support foreign keys."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Query processor error: number of columns returned by driver does not match results."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Expected {0} columns, but first row of resuls has {1} columns."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "No expression named {0} found. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Distinct values of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Average of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "SD of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Min of {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Max of {0}"
+msgstr ""
+
+#. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Sum of {0} matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Share of rows matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/annotate.clj
+msgid "Count of rows matching condition"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Request already canceled, will not run synchronous QP code."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unexpectedly got `nil` Query Processor response."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Got InterruptedException. Canceling query."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Query timed out after %s"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Creating new query thread pool for Database {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Destroying query thread pool for Database {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async_wait.clj
+msgid "Request canceled, canceling pending query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: query is missing source-metadata"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/binning.clj
+msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/cache.clj
+msgid "Using query processor cache backend: {0}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/expand_macros.clj
+msgid "Invalid metric: {0} reason: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unknown error"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Unexpected nil response from query processor."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/process_userland_query.clj
+msgid "Query canceled"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_driver.clj
+msgid "Unable to resolve driver for query: Database {0} does not exist."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_joins.clj
+msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/resolve_source_table.clj
+msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Cannot store Tables or Fields before Database is stored."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Attempting to fetch second Database. Queries can only reference one Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
+msgstr ""
+
+#: src/metabase/query_processor/store.clj
+msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
+msgstr ""
+
+#: src/metabase/routes/index.clj
+msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Sample dataset DB file ''{0}'' cannot be found."
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Loading sample dataset..."
+msgstr ""
+
+#: src/metabase/sample_data.clj
+msgid "Failed to load sample dataset"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Found new tables:"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Marking tables as inactive:"
+msgstr ""
+
+#: src/metabase/sync/sync_metadata/tables.clj
+msgid "Updating description for tables:"
+msgstr ""
+
+#: src/metabase/task.clj
+msgid "Rescheduling job {0}"
+msgstr ""
+
+#: src/metabase/task.clj
+msgid "Error rescheduling job"
+msgstr ""
+
+#: src/metabase/task/send_pulses.clj
+msgid "Starting Pulse Execution: {0}"
+msgstr ""
+
+#: src/metabase/task/send_pulses.clj
+msgid "Finished Pulse Execution: {0}"
+msgstr ""
+
+#: src/metabase/task/sync_databases.clj
+msgid "Failed to schedule tasks for Database {0}"
+msgstr ""
+
+#: src/metabase/util/schema.clj
+msgid "All elements must be distinct."
+msgstr ""
+
+#: 
+msgctxt "Modal for selecting columns in source data or when doing a join."
+msgid "Pick the columns you want to include"
+msgstr ""
+
+#: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
+msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
+msgstr ""
+
+#: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
+msgid "Change join type"
+msgstr ""
+
+#: src/metabase/driver/sql/util.clj
+msgid "Don't know how to alias {0}, expected an Identifier."
+msgstr ""
+
+#: src/metabase/integrations/common.clj
+msgid "Error adding User {0} to Group {1}"
+msgstr ""
+
+#. now rehumanize all the Tables and Fields using the new strategy.
+#. TODO: Should we do this in a background thread because it is potentially slow?
+#: src/metabase/models/humanization.clj
+msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
+msgstr ""
+
+#: src/metabase/query_processor.clj
+msgid "Infinite loop detected: recursively preprocessed query {0} times."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_implicit_clauses.clj
+msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
+msgstr ""
+
+#: src/metabase/query_processor/middleware/add_source_metadata.clj
+msgid "Error determining expected columns for query"
+msgstr ""
+
+#: src/metabase/query_processor/middleware/async.clj
+msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr ""
 


### PR DESCRIPTION
Dutch (NL) reached 100% on POEditor, so it's being added to 0.33.0.

Of note, some of our previously shipped languages are beginning to dwindle a bit in coverage:
Farsi - fa  (71.14%)
Chinese - zh  (77.14%)
Japanese - ja  (84.47%)
Norwegian Bokmol - nb  (89.68%)
Ukrainian - uk  (92.2%)
Vietnamese - vi  (94.56%)
Turkish - tr  (94.86%)
Italian - it  (94.99%)
German - de  (97.45%)