### PR TITLE
Revert width: 0 on search bar

### DIFF
--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -144,10 +144,10 @@ class SearchBar extends React.Component {
           onClick={() => this.setState({ active: true })}
           active={active}
         >
-          <Icon name="search" ml={2} />
+          <Icon name="search" ml={["10px", 2]} />
           <SearchInput
             py={2}
-            pr={2}
+            pr={[0, 2]}
             pl={1}
             ref={ref => (this.searchInput = ref)}
             value={searchText}

--- a/frontend/src/metabase/nav/containers/Navbar.jsx
+++ b/frontend/src/metabase/nav/containers/Navbar.jsx
@@ -84,7 +84,6 @@ const SearchWrapper = Flex.extend`
 
 const SearchInput = styled.input`
   ${space} background-color: transparent;
-  width: 0;
   border: none;
   color: white;
   font-size: 1em;


### PR DESCRIPTION
This fixes https://github.com/metabase/metabase/issues/10598 but it un-fixes the problem we were seeing on mobile where the gear is getting clipped off screen because of the minimum width of the search's input element. Maybe @kdoh has a better idea how to solve that?

![Screen Shot 2019-08-15 at 3 34 03 PM](https://user-images.githubusercontent.com/2223916/63131395-6567f700-bf72-11e9-8257-d9b2ecdc3126.png)
