### PR TITLE
Add refresh button back to SQL editor

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -248,7 +248,7 @@ export class ViewTitleHeader extends React.Component {
           {isRunnable && (
             <RunButtonWithTooltip
               className={cx("text-brand-hover hide", {
-                "sm-show": !isShowingNotebook,
+                "sm-show": !isShowingNotebook || isNative,
                 "text-white-hover": isResultDirty && isRunnable,
               })}
               medium


### PR DESCRIPTION
https://github.com/metabase/metabase/pull/10589 correctly hides the refresh button from the notebook but had the accidental side effect of hiding the refresh button from the SQL editor. This adds it back in.

![image](https://user-images.githubusercontent.com/2223916/63133284-52a4f080-bf79-11e9-8d73-61421d5cc30d.png)
