### PR TITLE
Revert cache busting when autorefreshing a dashboard

### DIFF
--- a/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
@@ -190,7 +190,6 @@ export default (ComposedComponent: ReactClass<any>) =>
           this.props.fetchDashboardCardData({
             reload: true,
             clear: false,
-            ignoreCache: true,
           });
         } else {
           this.setState({ refreshElapsed });


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/10603 as recommended by @tlrobinson.