### PR TITLE
Convert nulls to "(empty)" in row charts and line area bar charts

### DIFF
--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -16,6 +16,8 @@ import {
   colorShades,
 } from "./utils";
 
+import { NULL_DISPLAY_VALUE } from "./constants";
+
 import { minTimeseriesUnit, computeTimeseriesDataInverval } from "./timeseries";
 
 import { computeNumericDataInverval } from "./numeric";
@@ -104,7 +106,7 @@ function getDatas({ settings, series }, warn) {
           : isDimensionNumeric(series)
           ? row[0]
           : row[0] === null
-          ? "(empty)"
+          ? NULL_DISPLAY_VALUE
           : String(row[0]),
         ...row.slice(1),
       ];

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -103,6 +103,8 @@ function getDatas({ settings, series }, warn) {
           ? HACK_parseTimestamp(row[0], s.data.cols[0].unit, warn)
           : isDimensionNumeric(series)
           ? row[0]
+          : row[0] === null
+          ? "(empty)"
           : String(row[0]),
         ...row.slice(1),
       ];

--- a/frontend/src/metabase/visualizations/lib/RowRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/RowRenderer.js
@@ -25,16 +25,20 @@ export default function rowRenderer(
   // disable clicks
   chart.onClick = () => {};
 
-  const formatDimension = row =>
-    formatValue(row[0], { column: cols[0], type: "axis" });
+  const formatDimension = v =>
+    formatValue(v, { column: cols[0], type: "axis" });
 
   // dc.js doesn't give us a way to format the row labels from unformatted data, so we have to
   // do it here then construct a mapping to get the original dimension for tooltipsd/clicks
-  const rows = series[0].data.rows.map(row => [formatDimension(row), row[1]]);
+  const rowsWithFormattedNull = series[0].data.rows.map(([first, ...rest]) => [
+    first === null ? "(empty)" : first,
+    ...rest,
+  ]);
+  const rows = rowsWithFormattedNull.map(([a, b]) => [formatDimension(a), b]);
   const formattedDimensionMap = new Map(
     rows.map(([formattedDimension], index) => [
       formattedDimension,
-      series[0].data.rows[index][0],
+      rowsWithFormattedNull[index][0],
     ]),
   );
 

--- a/frontend/src/metabase/visualizations/lib/RowRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/RowRenderer.js
@@ -9,6 +9,7 @@ import { formatValue } from "metabase/lib/formatting";
 import { initChart, forceSortedGroup, makeIndexMap } from "./renderer_utils";
 import { getFriendlyName } from "./utils";
 import { checkXAxisLabelOverlap } from "./LineAreaBarPostRender";
+import { NULL_DISPLAY_VALUE } from "./constants";
 
 export default function rowRenderer(
   element,
@@ -31,7 +32,7 @@ export default function rowRenderer(
   // dc.js doesn't give us a way to format the row labels from unformatted data, so we have to
   // do it here then construct a mapping to get the original dimension for tooltipsd/clicks
   const rowsWithFormattedNull = series[0].data.rows.map(([first, ...rest]) => [
-    first === null ? "(empty)" : first,
+    first === null ? NULL_DISPLAY_VALUE : first,
     ...rest,
   ]);
   const rows = rowsWithFormattedNull.map(([a, b]) => [formatDimension(a), b]);

--- a/frontend/src/metabase/visualizations/lib/RowRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/RowRenderer.js
@@ -26,16 +26,16 @@ export default function rowRenderer(
   // disable clicks
   chart.onClick = () => {};
 
-  const formatDimension = v =>
-    formatValue(v, { column: cols[0], type: "axis" });
-
   // dc.js doesn't give us a way to format the row labels from unformatted data, so we have to
   // do it here then construct a mapping to get the original dimension for tooltipsd/clicks
   const rowsWithFormattedNull = series[0].data.rows.map(([first, ...rest]) => [
     first === null ? NULL_DISPLAY_VALUE : first,
     ...rest,
   ]);
-  const rows = rowsWithFormattedNull.map(([a, b]) => [formatDimension(a), b]);
+  const rows = rowsWithFormattedNull.map(([a, b]) => [
+    formatValue(a, { column: cols[0], type: "axis" }),
+    b,
+  ]);
   const formattedDimensionMap = new Map(
     rows.map(([formattedDimension], index) => [
       formattedDimension,

--- a/frontend/src/metabase/visualizations/lib/constants.js
+++ b/frontend/src/metabase/visualizations/lib/constants.js
@@ -1,0 +1,3 @@
+import { t } from "ttag";
+
+export const NULL_DISPLAY_VALUE = t`(empty)`;

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer-bar.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer-bar.unit.spec.js
@@ -27,7 +27,7 @@ const DEFAULT_COLUMN_SETTINGS = {
   date_style: "MMMM D, YYYY",
 };
 
-function MainSeries(chartType, settings = {}, value = 1) {
+function MainSeries(chartType, settings = {}, { key = "A", value = 1 } = {}) {
   return {
     card: {
       display: chartType,
@@ -41,7 +41,7 @@ function MainSeries(chartType, settings = {}, value = 1) {
         StringColumn({ display_name: "Category", source: "breakout" }),
         NumberColumn({ display_name: "Sum", source: "aggregation" }),
       ],
-      rows: [["A", value]],
+      rows: [[key, value]],
     },
   };
 }
@@ -184,7 +184,13 @@ describe("LineAreaBarRenderer-bar", () => {
     const onHoverChange = jest.fn();
     renderLineAreaBar(
       element,
-      [MainSeries("bar", { "stackable.stack_type": "normalized" }, 3)],
+      [
+        MainSeries(
+          "bar",
+          { "stackable.stack_type": "normalized" },
+          { value: 3 },
+        ),
+      ],
       { onHoverChange },
     );
 
@@ -217,6 +223,22 @@ describe("LineAreaBarRenderer-bar", () => {
       { key: "Category", value: "A" },
       { key: "Foo", value: 1 },
     ]);
+  });
+
+  it('should render "(empty)" for nulls', () => {
+    const onHoverChange = jest.fn();
+    renderLineAreaBar(element, [MainSeries("bar", {}, { key: null })], {
+      onHoverChange,
+    });
+
+    dispatchUIEvent(qsa(".bar, .dot")[0], "mousemove");
+
+    const { calls } = onHoverChange.mock;
+    const [{ value }] = getDataKeyValues(calls[0][0]);
+    expect(value).toEqual("(empty)");
+
+    const tick = element.querySelector(".axis.x .tick text");
+    expect(tick.textContent).toEqual("(empty)");
   });
 });
 

--- a/frontend/test/metabase/visualizations/components/RowRenderer.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/RowRenderer.unit.spec.js
@@ -30,7 +30,7 @@ describe("RowChart", () => {
     ]);
   });
 
-  it('should render null as "null"', () => {
+  it('should render null as "(empty)"', () => {
     renderChart(rowRenderer, element, [
       {
         card: { display: "row", visualization_settings: {} },

--- a/frontend/test/metabase/visualizations/components/RowRenderer.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/RowRenderer.unit.spec.js
@@ -1,0 +1,43 @@
+import "__support__/mocks";
+
+import {
+  createFixture,
+  cleanupFixture,
+  renderChart,
+  NumberColumn,
+  StringColumn,
+} from "../__support__/visualizations";
+
+import rowRenderer from "metabase/visualizations/lib/RowRenderer";
+
+describe("RowChart", () => {
+  let element;
+
+  beforeEach(function() {
+    element = createFixture();
+  });
+
+  afterEach(function() {
+    cleanupFixture(element);
+  });
+
+  it("should render", () => {
+    renderChart(rowRenderer, element, [
+      {
+        card: { display: "row", visualization_settings: {} },
+        data: { cols: [StringColumn(), NumberColumn()], rows: [["a", 1]] },
+      },
+    ]);
+  });
+
+  it('should render null as "null"', () => {
+    renderChart(rowRenderer, element, [
+      {
+        card: { display: "row", visualization_settings: {} },
+        data: { cols: [StringColumn(), NumberColumn()], rows: [[null, 1]] },
+      },
+    ]);
+
+    expect(element.querySelector("text.row").innerHTML).toBe("(empty)");
+  });
+});


### PR DESCRIPTION
Resolves #10580

Crossfilter doesn't allow null, undefined, or NaN in dimensions. The nulls were getting merged and summed with adjacent rows.

The fix is to explicitly convert nulls to "null". A side effect is that this will merge actual nulls with the string "null" if that distinction matters in a report. Though, that use case was already broken so I'm not particularly worried about it.

This `null` => `"null"` conversion already happens in LineAreaBarCharts [here](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js#L106).