### PR TITLE
Fix GA default question applying to new simple/custom questions

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -276,7 +276,7 @@ export default class Question {
     return this.setCard(assoc(this.card(), "display", display));
   }
 
-  setDisplayDefault(): Question {
+  setDefaultDisplay(): Question {
     const query = this.query();
     if (query instanceof StructuredQuery) {
       // TODO: move to StructuredQuery?
@@ -339,6 +339,12 @@ export default class Question {
       }
     }
     return this.setDisplay("table");
+  }
+
+  setDefaultQuery() {
+    return this.query()
+      .setDefaultQuery()
+      .question();
   }
 
   settings(): VisualizationSettings {

--- a/frontend/src/metabase-lib/lib/metadata/Table.js
+++ b/frontend/src/metabase-lib/lib/metadata/Table.js
@@ -39,26 +39,13 @@ export default class Table extends Base {
   }
 
   newQuestion(): Question {
-    let question = Question.create({
+    return Question.create({
       databaseId: this.db.id,
       tableId: this.id,
       metadata: this.metadata,
-    });
-    // NOTE: special case for Google Analytics which doesn't allow raw queries:
-    if (this.entity_type === "entity/GoogleAnalyticsTable") {
-      const dateField = _.findWhere(this.fields, { name: "ga:date" });
-      if (dateField) {
-        question = question
-          .query()
-          .addFilter(["time-interval", ["field-id", dateField.id], -365, "day"])
-          .addAggregation(["metric", "ga:users"])
-          .addAggregation(["metric", "ga:pageviews"])
-          .addBreakout(["datetime-field", ["field-id", dateField.id], "week"])
-          .question()
-          .setDisplay("line");
-      }
-    }
-    return question;
+    })
+      .setDefaultQuery()
+      .setDefaultDisplay();
   }
 
   dimensions(): Dimension[] {

--- a/frontend/src/metabase-lib/lib/queries/Query.js
+++ b/frontend/src/metabase-lib/lib/queries/Query.js
@@ -100,6 +100,10 @@ export default class Query {
     return [];
   }
 
+  setDefaultQuery(): Query {
+    return this;
+  }
+
   /**
    * Helper for updating with functions that expect a DatasetQuery object, or proxy to parent question
    */

--- a/frontend/src/metabase/modes/lib/actions.js
+++ b/frontend/src/metabase/modes/lib/actions.js
@@ -414,7 +414,7 @@ const getLineAreaBarDisplay = (defaultDisplay, existingDisplay) =>
     ? existingDisplay
     : defaultDisplay;
 
-// DEPRECATED: use question.setDisplayDefault()
+// DEPRECATED: use question.setDefaultDisplay()
 export function guessVisualization(
   card: CardObject,
   tableMetadata: Table,

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -767,7 +767,16 @@ export const updateQuestion = (
         newQuestion.query().dependentTableIds(),
       )
     ) {
-      dispatch(loadMetadataForCard(newQuestion.card()));
+      await dispatch(loadMetadataForCard(newQuestion.card()));
+    }
+
+    // setDefaultQuery requires metadata be loaded, need getQuestion to use new metadata
+    const question = getQuestion(getState());
+    const questionWithDefaultQuery = question.setDefaultQuery();
+    if (!questionWithDefaultQuery.isEqual(question)) {
+      await dispatch.action(UPDATE_QUESTION, {
+        card: questionWithDefaultQuery.setDefaultDisplay().card(),
+      });
     }
 
     // run updated query

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.jsx
@@ -27,7 +27,7 @@ export default function Notebook({ className, ...props }) {
           onClick={async () => {
             let cleanQuestion = question.setQuery(question.query().clean());
             if (cleanQuestion.display() === "table") {
-              cleanQuestion = cleanQuestion.setDisplayDefault();
+              cleanQuestion = cleanQuestion.setDefaultDisplay();
             }
             await cleanQuestion.update();
             // switch mode before running otherwise URL update may cause it to switch back to notebook mode

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -15,7 +15,10 @@ function DataStep({ color, query, databases, updateQuery }) {
         selectedDatabaseId={query.databaseId()}
         selectedTableId={query.tableId()}
         setSourceTableFn={tableId =>
-          query.setTableId(tableId).update(updateQuery)
+          query
+            .setTableId(tableId)
+            .setDefaultQuery()
+            .update(updateQuery)
         }
         isInitiallyOpen={!query.tableId()}
         triggerElement={

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector.jsx
@@ -12,7 +12,10 @@ function QuestionDataSelector({ query, databases, triggerElement }) {
       selectedDatabaseId={query.databaseId()}
       selectedTableId={query.tableId()}
       setSourceTableFn={tableId =>
-        query.setTableId(tableId).update(null, { run: true })
+        query
+          .setTableId(tableId)
+          .setDefaultQuery()
+          .update(null, { run: true })
       }
       triggerElement={triggerElement}
       isOpen

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx
@@ -21,7 +21,7 @@ import Icon from "metabase/components/Icon";
 function updateAndRun(query) {
   query
     .question()
-    .setDisplayDefault()
+    .setDefaultDisplay()
     .update(null, { run: true });
 }
 


### PR DESCRIPTION
Resolves #10602

Basically we weren't running the same default query logic we had in `Table.js` for when we changed a query's table. I moved it to `StructuredQuery` so it could be applied to existing query objects. Unfortunately it requires metadata be loaded, so it had to be run as part of the `updateQuestion` action which loads the metadata dependencies.