### PR TITLE
Fix docs links, small text changes

### DIFF
--- a/docs/administration-guide/13-embedding.md
+++ b/docs/administration-guide/13-embedding.md
@@ -13,7 +13,7 @@ SQL based questions with template variables can also accept parameters for each 
 ```
 SELECT count(*)
 FROM orders
-WHERE product_id = {{productID}}
+WHERE product_id = {% raw %}{{productID}}{% endraw %}
 ```
 you could specify a specific productID when embedding the question.
 

--- a/docs/administration-guide/start.md
+++ b/docs/administration-guide/start.md
@@ -27,6 +27,6 @@ Are you in charge of managing Metabase for your organization? Then you're in the
 * [Sharing dashboards and questions with public links](12-public-links.md)
 * [Embedding Metabase in other Applications](13-embedding.md)
 
-First things first, you'll need to install Metabase. If you haven’t done that yet, our [Installation Guide](../operations-guide/start.html#installing-and-running-metabase) will help you through the process.
+First things first, you'll need to install Metabase. If you haven’t done that yet, our [Installation Guide](../operations-guide/installing-metabase.md) will help you through the process.
 
 Already done with that? Then let’s start by going over how to [connect Metabase to your database](01-managing-databases.md).

--- a/docs/enterprise-guide/authenticating-with-saml.md
+++ b/docs/enterprise-guide/authenticating-with-saml.md
@@ -1,5 +1,5 @@
 ## Authenticating with SAML
-The open source edition of Metabase includes the option to [set up SSO with Google Sign-in or LDAP](https://metabase.com/docs/latest/administration-guide/10-single-sign-on.html), but the Enterprise edition of Metabase additionally lets you connect your SAML- or JWT-based SSO. Integrating your SSO with Metabase allows you to:
+The open source edition of Metabase includes the option to [set up SSO with Google Sign-in or LDAP](../administration-guide/10-single-sign-on.md), but the Enterprise edition of Metabase additionally lets you connect your SAML- or JWT-based SSO. Integrating your SSO with Metabase allows you to:
 
 * automatically pass user attributes from your SSO to Metabase in order to power data sandboxes
 * let your users access Metabase without re-authenticating.

--- a/docs/enterprise-guide/customizing-drill-through.md
+++ b/docs/enterprise-guide/customizing-drill-through.md
@@ -19,9 +19,9 @@ Click on the `Drill-through` tab at the top and you’ll see two options for wha
 
 ![Settings](./images/customizing-drill-through/chart-link-template.png)
 
-What we need to do here is to type in the full URL of where a user should go when they click on a bar in the chart. But the really powerful thing we can do is to use a variable in the URL which can insert the value of the clicked bar. For example, we could type a URL like this `https://www.google.com/search?q={{STATE}}`.
+What we need to do here is to type in the full URL of where a user should go when they click on a bar in the chart. But the really powerful thing we can do is to use a variable in the URL which can insert the value of the clicked bar. For example, we could type a URL like this `https://www.google.com/search?q={% raw %}{{STATE}}{% endraw %}`.
 
-The important part is the `{{STATE}}` bit — what we’re doing here is referring to the `STATE` column in our query’s result (which we’re using for our x-axis in this case). So if a user was to click on the `TX` (Texas) bar in our chart, the value of the `STATE` column for that bar would be inserted into our URL, so it would look like this: `https://www.google.com/search?q=TX`. If you click on the blue `Columns` link below the input box here, you’ll see the full list of all the columns you can refer to. Your URL can use as many column variables you want; you can even refer to the same column multiple times in different parts of the URL.
+The important part is the `{% raw %}{{STATE}}{% endraw %}` bit — what we’re doing here is referring to the `STATE` column in our query’s result (which we’re using for our x-axis in this case). So if a user was to click on the `TX` (Texas) bar in our chart, the value of the `STATE` column for that bar would be inserted into our URL, so it would look like this: `https://www.google.com/search?q=TX`. If you click on the blue `Columns` link below the input box here, you’ll see the full list of all the columns you can refer to. Your URL can use as many column variables you want; you can even refer to the same column multiple times in different parts of the URL.
 
 Next we’ll click `Done`, then save our dashboard. Now when we click our chart, instead of seeing the actions menu, we’ll be taken to the URL that we entered above, with the value of the clicked bar inserted into the URL. These links will be opened in a new tab or window unless they link to another chart or dashboard within Metabase.
 
@@ -37,13 +37,13 @@ Continuing with our example chart from above, let's say that we have another das
 
 What's really cool now is that we can use a custom link on the bar chart in our first dashboard to automatically pick a value for the State filter in our detail dashboard based on which bar is clicked. To do that, we'll go back to the chart on our first dashboard and go to the `Drill-through` tab in its settings.
 
-In the Link Template input box, we'll put in the full URL of the dashboard that we want to link to, with a variable in it to populate the dashboard's filter. Dashboard URLs in Metabase look like this: `http://YOUR-METABASE-LOCATION.com/dashboard/5`. When you make a selection for a filter on a dashboard, you'll notice some additional text gets added to the end of the URL, like this: `http://YOUR-METABASE-LOCATION.com/dashboard/5?state=DE` In this example, `state` is the name of a filter on our dashboard, and `DE` is the current value of the filter (DE for Delaware). So in our input box, we're going to enter a template that looks like that, but with our `{{STATE}}` column variable in the spot where the filter's value goes: `http://YOUR-METABASE-LOCATION.com/dashboard/5?state={{STATE}}`. Once we save our changes, whenever someone clicks on a bar in this chart, it will take them to our second dashboard with the State filter on that dashboard filled in with the State value of the bar that was clicked.
+In the Link Template input box, we'll put in the full URL of the dashboard that we want to link to, with a variable in it to populate the dashboard's filter. Dashboard URLs in Metabase look like this: `http://YOUR-METABASE-LOCATION.com/dashboard/5`. When you make a selection for a filter on a dashboard, you'll notice some additional text gets added to the end of the URL, like this: `http://YOUR-METABASE-LOCATION.com/dashboard/5?state=DE` In this example, `state` is the name of a filter on our dashboard, and `DE` is the current value of the filter (DE for Delaware). So in our input box, we're going to enter a template that looks like that, but with our `{% raw %}{{STATE}}{% endraw %}` column variable in the spot where the filter's value goes: `http://YOUR-METABASE-LOCATION.com/dashboard/5?state={% raw %}{{STATE}}{% endraw %}`. Once we save our changes, whenever someone clicks on a bar in this chart, it will take them to our second dashboard with the State filter on that dashboard filled in with the State value of the bar that was clicked.
 
 ![Dashboard link template](./images/customizing-drill-through/dashboard-link-template.png)
 
-Keep in mind that your link needs to use the name you've given to the filter, but with underscores in place of any spaces. So if your filter is called `Customer Name`, the part after the question mark in your link should look like `customer_name={{COLUMN}}`.
+Keep in mind that your link needs to use the name you've given to the filter, but with underscores in place of any spaces. So if your filter is called `Customer Name`, the part after the question mark in your link should look like `customer_name={% raw %}{{COLUMN}}{% endraw %}`.
 
-If you want to link to a saved SQL question that has filter widgets in it, you'll follow the exact same process as for a dashboard. Your link template will just look more like this: `http://YOUR-METABASE-LOCATION.com/question/17?filter={{COLUMN}}`. You can also have your link templates go to saved questions built with the graphical editor, but you can't currently pass any variable values to them to fill filters.
+If you want to link to a saved SQL question that has filter widgets in it, you'll follow the exact same process as for a dashboard. Your link template will just look more like this: `http://YOUR-METABASE-LOCATION.com/question/17?filter={% raw %}{{COLUMN}}{% endraw %}`. You can also have your link templates go to saved questions built with the graphical editor, but you can't currently pass any variable values to them to fill filters.
 
 
 ### Customizing drill-through for a column in a table
@@ -60,7 +60,7 @@ Then we'll find the `Display as link` setting. This dropdown will be slightly di
 
 ![Link option](./images/customizing-drill-through/link-option.png)
 
-We'll now see the same link template input box as with the chart example above. Just as before, we can use the double braces syntax, like `{{PRODUCT_ID}}`, in our URL to refer to a column name to insert the clicked cell's value at that point in the URL.
+We'll now see the same link template input box as with the chart example above. Just as before, we can use the double braces syntax, like `{% raw %}{{PRODUCT_ID}}{% endraw %}`, in our URL to refer to a column name to insert the clicked cell's value at that point in the URL.
 
 ![Link option](./images/customizing-drill-through/table-options-filled.png)
 
@@ -68,11 +68,11 @@ We'll now see the same link template input box as with the chart example above. 
 
 Note that you can refer to *any* column in the table here, not just the column whose drill-through behavior you're customizing. When you click on a cell, it will insert the value of all referenced columns *in that same row* into your URL. This could let us do things like make clicking on a product's *name* go to a custom destination, but reference the product's *ID* in the URL.
 
-This comes in handy when linking to a dashboard or question with multiple filters: your link template could for example reference two values for two filters in the dashboard you're linking to, like this so, `http://YOUR-METABASE-LOCATION.com/dashboard/5?name={{NAME}}&id={{ID}}`, where `name` and `id` are the filters. Note the ampersand `&` between the two filters in the link; you can string together any number of filters in your link templates by putting an ampersand between them.
+This comes in handy when linking to a dashboard or question with multiple filters: your link template could for example reference two values for two filters in the dashboard you're linking to, like this so, `http://YOUR-METABASE-LOCATION.com/dashboard/5?name={% raw %}{{NAME}}{% endraw %}&id={% raw %}{{ID}}{% endraw %}`, where `name` and `id` are the filters. Note the ampersand `&` between the two filters in the link; you can string together any number of filters in your link templates by putting an ampersand between them.
 
 **Customizing link text**
 
-You can also optionally customize what text should be displayed in each cell of this column. You can also use the double braces variable syntax here. The way we've used this in the example above is to refer to the value of our `Product ID` column in a sentence that makes it clearer what will happen when the cell is clicked. So `Look up {{PRODUCT_ID}} in our catalog` gets turned into `Look up Awesome Concrete Shoes in our catalog` in the corresponding cell.
+You can also optionally customize what text should be displayed in each cell of this column. You can also use the double braces variable syntax here. The way we've used this in the example above is to refer to the value of our `Product ID` column in a sentence that makes it clearer what will happen when the cell is clicked. So `Look up {% raw %}{{PRODUCT_ID}}{% endraw %} in our catalog` gets turned into `Look up Awesome Concrete Shoes in our catalog` in the corresponding cell.
 
 ---
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -21,26 +21,26 @@ When you need to share dashboards or pulses with others, we *strongly* recommend
 ## Asking questions and running queries
 
 ### Can I use SQL with Metabase?
-[Yes](https://metabase.com/docs/latest/users-guide/04-asking-questions.html#using-sql).
+[Yes](users-guide/writing-sql.md).
 
 ### Do I need to know SQL to use Metabase?
-[No](https://metabase.com/docs/latest/users-guide/04-asking-questions.html)
+[No](users-guide/04-asking-questions.md)
 
 ### Does Metabase support SQL Joins?
 
-Metabase does not expose a "Join" operator, but we do provide ways for non-SQL-proficient users to perform the tasks that joins are used for such as filtering or grouping by columns in other tables, etc.
+Yes. Joins were introduced in Metabase version 0.33 and can be used in the [Notebook-editor](users-guide/custom-questions.md).
 
-For more info see our [blog post on the subject](https://metabase.com/blog/Joins)
+For older versions, please see our [blog post on the subject](https://metabase.com/blog/Joins)
 
 ### Why can't I do X in the Query Builder?
 
-The primary audience of the GUI querying interface is a non-technical user who doesn't SQL. Advanced users can always [use SQL](https://metabase.com/docs/latest/users-guide/04-asking-questions.html#using-sql).
+The primary audience of the GUI querying interface is a non-technical user who doesn't SQL. Advanced users can always [use SQL](users-guide/writing-sql.md).
 
 We're constantly trying to walk the line between putting more functionality into the GUI interface and creating a confusing mess. You can expect it to improve and change with time, but in the meantime, you can always lean on SQL directly for the complicated matters.
 
 ### Why can't I seem to use drill-through or question actions?
 
-Metabase allows you to [click on your charts or tables to explore or zoom in](https://metabase.com/docs/latest/users-guide/03-basic-exploration.html), but these features don't currently work with SQL/native queries (this is because Metabase doesn't currently parse these kinds of queries). The same is true of the question actions menu in the bottom-right of the question detail page.
+Metabase allows you to [click on your charts or tables to explore or zoom in](users-guide/03-basic-exploration.md), but these features don't currently work with SQL/native queries (this is because Metabase doesn't currently parse these kinds of queries). The same is true of the question actions menu in the bottom-right of the question detail page.
 
 However, in [Metabase version 0.25 we introduced nested queries](https://metabase.com/blog/Metabase-0.25#nested-questions), a feature that lets you use the results of SQL/native queries as the starting table for GUI-based questions. This means you'll be able to use sophisticated SQL/native queries to create the exact segments you need, and you and your team will be able to use drill-through and actions if you create GUI-based questions from those segments.
 
@@ -53,7 +53,7 @@ To manually fix field or table names if they still look wrong, you can go to the
 ## Dashboards
 
 ### Can I add headings, free text, section dividers, or images to my dashboards?
-Not currently, but these are all enhancements that we're considering.
+Yes, by using [text cards](users-guide/07-dashboards.md#adding-headings-or-descriptions-with-text-cards).
 
 ### Why do my cards fade out when I use dashboard filters?
 When one or more dashboard filters are active, any card on that dashboard that isn't connected to *every currently active filter* will fade out a bit to clarify that they are not being affected by all active filters. We understand this behavior is contentious, so we're [actively discussing it on GitHub](https://github.com/metabase/metabase/issues/4220).
@@ -74,12 +74,6 @@ In an effort to make sure that dashboards are legible, Metabase changes the way 
 Metabase automatically changes the visualization type of saved questions you put in Pulses so that they fit better in emails and Slack. Here is [an inventory of how charts get changed](https://github.com/metabase/metabase/issues/5493#issuecomment-318198816), and here is [the logic for how this works](https://github.com/metabase/metabase/blob/8f1a287496899250d89a20ec57ac8477cd20bce5/src/metabase/pulse/render.clj#L385-L397).
 
 We understand this behavior isn't expected, and are currently exploring ways to handle this better.
-
-### Why can't I send tables?
-Metabase currently has a limit on how many columns and rows can be included in a Pulse as a safeguard against massive tables getting plopped in users' inboxes, but this is [an issue we're actively discussing changing](https://github.com/metabase/metabase/issues/3894).
-
-### Can I attach files like CSVs to a Pulse?
-Not yet, but [the community is working on it](https://github.com/metabase/metabase/pull/5502)!
 
 ### Can I set more specific or granular schedules for Pulses?
 Not yet, but [we'd love your help](https://github.com/metabase/metabase/issues/3846#issuecomment-318516189) working on implementing designs for this feature.
@@ -132,18 +126,18 @@ Not exactly. Metabase provides access to data you have in an existing database y
 
 Yes, to the extent that we are able to and have time.
 
-If you're sure you've found a bug, please [open an issue](https://github.com/metabase/metabase/issues/new). Otherwise, try checking out the [troubleshooting guide](https://metabase.com/troubleshooting/) first to see if the answer to your problem is there.
+If you're sure you've found a bug, please [open an issue](https://github.com/metabase/metabase/issues/new/choose). Otherwise, try checking out the [troubleshooting guide](troubleshooting/start.md) first to see if the answer to your problem is there.
 
 If you're still having trouble, please start a conversation at our [discussion forum](https://discourse.metabase.com/) and check out the other threads. Someone else might have experienced the same problem.
 
 ### Do you offer paid support?
 
-We are experimenting with offering paid support to a limited number of companies. [Contact us](https://metabase.com/services/) if you want more information.
+We are experimenting with offering paid support to a limited number of companies. [Contact us](https://metabase.com/contact/) if you want more information.
 
 ## Embedding
 
 ### Can I embed charts or dashboards in another application?
 
 Yes, Metabase offers two solutions for sharing charts and dashboards:
-- [Public links](https://metabase.com/docs/latest/administration-guide/12-public-links.html) let you share or embed charts with simplicity.
-- A powerful [application embedding](https://metabase.com/docs/latest/administration-guide/13-embedding.html) let you to embed and customize charts in your own web applications.
+- [Public links](administration-guide/12-public-links.md) let you share or embed charts with simplicity.
+- A powerful [application embedding](administration-guide/13-embedding.md) let you to embed and customize charts in your own web applications.

--- a/docs/information-collection.md
+++ b/docs/information-collection.md
@@ -46,7 +46,7 @@ NOTE: we never capture any specific details in any of our tracking methodology s
 ### Google Analytics Events
 
 | Category | Action | Why we collect this |
-|---------|--------|--------------------|
+|----------|--------|---------------------|
 | Links and Page Views | General website tracking of what pages are most used | This provides better understanding of what parts of the application are liked and used by customers so we know what's popular and potentially what needs more improvement. |
 | Dashboards | When the dashboard dropdown is used, when dashboards are created and updated, what types of edits occur such as adding/removing cards and repositioning. | We use this information to understand how dashboards are being used and what types of activities users most commonly do on their dashboards. |
 | Pulses | When pulses are created and updated, what types of pulses are created, and how many cards typically go in a pulse. | This is used to have a sense for how teams are structuring their push based communication.  When and where is information most often sent and how much information allows Metabase to continue improving features around push based data interactions. |
@@ -58,29 +58,28 @@ NOTE: we never capture any specific details in any of our tracking methodology s
 
 
 ### Server-side Analytics
-| Metric |  An example of why we collect this |
-|---------|--------|
-| Number of Users/Admins and whether SSO is enabled | To understand which auth methods are being used, and whether to prioritize features that scale with # of users. |
+| Metric | An example of why we collect this |
+|--------|-----------------------------------|
+| Number of Users/Admins and whether SSO is enabled | To understand which auth methods are being used, and whether to prioritize features that scale with number of users. |
 | Number of user groups | To understand how complicated a permissions model most of our users have, and to make sure that we don't over-simplify our designs. |
-| Number of Dashboards |  Whether we need to provide ways to organize dashboards. |
-| Number of Cards per Dashboards | Do we need to provide more structure to make long dashboards easier to parse?|
-| Number of Dashboards per Card |  Are our users only creating a card to put it in a dashboard or are they used in many places? |
-| Types of Databases |  Which database driver bugs to prioritize |
+| Number of Dashboards | Whether we need to provide ways to organize dashboards. |
+| Number of Cards per Dashboards | Do we need to provide more structure to make long dashboards easier to parse? |
+| Number of Dashboards per Card | Are our users only creating a card to put it in a dashboard or are they used in many places? |
+| Types of Databases | Which database driver bugs to prioritize |
 | Number of pulses with attachments | Are people using attachments? |
-| Number of alerts | Are people using alerts? Do they typically have a few or does each user have them?|
-| Number of Collections |  Do we need to add additional organization tools? |
-| Number of Databases |  Are users using a single DB or many? How large should the icons for a database in the databrowser be? |
-| Number of Schema |  Are users actively using namespaces on redshift? Do we actually need to design for 100s of schemas or is that just a small percentage of our users? |
-| Number of Tables |  What kind of data models are people using? Do we need table search?|
-| Number of Fields |  Can we pre-fetch all the fields in our metadata api to improve performance for most usres, or should we fetch them per table to scale more efficiently? |
+| Number of alerts | Are people using alerts? Do they typically have a few or does each user have them? |
+| Number of Collections | Do we need to add additional organization tools? |
+| Number of Databases | Are users using a single DB or many? How large should the icons for a database in the databrowser be? |
+| Number of Schema | Are users actively using namespaces on redshift? Do we actually need to design for 100s of schemas or is that just a small percentage of our users? |
+| Number of Tables | What kind of data models are people using? Do we need table search? |
+| Number of Fields | Can we pre-fetch all the fields in our metadata api to improve performance for most usres, or should we fetch them per table to scale more efficiently? |
 | Number of Segments | Are people using segments widely? If so, should we surface them up higher in the UI? |
-| Number of Metrics |  Are metrics common? If not, should we remove the "Metrics" option in the New Question Flow|
+| Number of Metrics | Are metrics common? If not, should we remove the Metrics option in the New Question Flow |
 | Number of Queries Run | How many queries do our most active instances run per day? Do we need to improve caching? |
 | Number of Query Errors | Do we need to change how we display errors in the logs? Are they being spammed? |
-| Query Latencies |  What percentage of our user base runs queries that allow for iterative querying (<1second) |
-| Timezone |  We have a bug in a certain timezone, how many users are in that timezone?  |
-| Language |  How many non-english speaking users do we have? How fast should we be pushing internationalization?|
-| OS + JVM Version | Can we deprecate Java 7 already? |
+| Query Latencies | What percentage of our user base runs queries that allow for iterative querying (<1second) |
+| Timezone | We have a bug in a certain timezone, how many users are in that timezone? |
+| Language | How many non-english speaking users do we have? How fast should we be pushing internationalization? |
+| OS and JVM Version | Can we deprecate Java 7 already? |
 
-Note this is meant to be representative, an exact (as in the actual code that is running to generate this can be audited at https://github.com/metabase/metabase/blob/master/src/metabase/util/stats.clj)
-
+Note this is meant to be representative. The actual code that is running to generate this can be audited at [https://github.com/metabase/metabase/blob/master/src/metabase/util/stats.clj](https://github.com/metabase/metabase/blob/master/src/metabase/util/stats.clj).

--- a/docs/operations-guide/configuring-application-database.md
+++ b/docs/operations-guide/configuring-application-database.md
@@ -11,8 +11,7 @@ data needed to run the application. The default settings use an embedded H2 data
 *  You cannot change the application database while the application is running. Connection configuration information is
    read only once when the application starts up and will remain constant throughout the running of the application.
 *  Metabase provides limited support for migrating from H2 to Postgres or MySQL if you decide to upgrade to a more
-   production-ready database. See [Migrating from H2 to MySQL or
-   Postgres](#migrating-from-using-the-h2-database-to-mysql-or-postgres) for more details.
+   production-ready database. See [Migrating from H2 to MySQL or Postgres](migrating-from-h2.md) for more details.
 
 
 #### [H2](http://www.h2database.com/) (default)

--- a/docs/operations-guide/migrating-from-h2.md
+++ b/docs/operations-guide/migrating-from-h2.md
@@ -5,8 +5,8 @@ If you decide to use the default application database (H2) when you initially st
 Metabase provides a custom migration command for upgrading H2 application database files by copying their data to a new database. Here's what you'll want to do:
 
 1. Shutdown your Metabase instance so that it's not running. This ensures no accidental data gets written to the db while migrating.
-2. Make a backup copy of your H2 application database by following the instructions in [Backing up Metabase Application Data](#backing-up-metabase-application-data). Safety first!
-3. Run the Metabase data migration command using the appropriate environment variables for the target database you want to migrate to.  You can find details about specifying MySQL and Postgres databases at [Configuring the application database](#configuring-the-metabase-application-database). Here's an example of migrating to Postgres:
+2. Make a backup copy of your H2 application database by following the instructions in [Backing up Metabase Application Data](backing-up-metabase-application-data.md). Safety first!
+3. Run the Metabase data migration command using the appropriate environment variables for the target database you want to migrate to.  You can find details about specifying MySQL and Postgres databases at [Configuring the application database](configuring-application-database.md). Here's an example of migrating to Postgres:
 
 ```
 export MB_DB_TYPE=postgres
@@ -22,6 +22,7 @@ It is expected that you will run the command against a brand-new (empty!) databa
 
 ###### Notes
 
+*  Avoid upgrading and migrating at the same time, since it can cause problems with one of database schemas not matching.
 *  It is required that you can connect to the target MySQL or Postgres database in whatever environment you are running this migration command in. So, if you are attempting to move the data to a cloud database, make sure you take that into consideration.
 *  The code that handles these migrations uses a Postgres SQL command that is only available in Postgres 9.4 or newer versions. Please make sure you Postgres database is version 9.4 or newer.
 *  H2 automatically adds a `.h2.db` or `.mv.db` extension to the database path you specify, so make sure the path to the DB file you pass to the command *does not* include it. For example, if you have a file named `/path/to/metabase.db.h2.db`, call the command with `load-from-h2 /path/to/metabase.db`.

--- a/docs/operations-guide/running-metabase-on-docker.md
+++ b/docs/operations-guide/running-metabase-on-docker.md
@@ -2,7 +2,7 @@
 
 Metabase provides an official Docker image via Dockerhub that can be used for deployments on any system that is running Docker.
 
-If you're trying to upgrade your Metabase version on Docker, check out these [upgrading instructions](./start.html#upgrading-metabase).
+If you're trying to upgrade your Metabase version on Docker, check out these [upgrading instructions](upgrading-metabase.md).
 
 ### Launching Metabase on a new container
 
@@ -73,7 +73,7 @@ Keep in mind that Metabase will be connecting from within your docker container,
 
 ### Migrating from H2 to Postgres as the Metabase application database
 
-For general information, see instructions for [migrating from H2 to MySQL or Postgres](./start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres).
+For general information, see instructions for [migrating from H2 to MySQL or Postgres](migrating-from-h2.md).
 
 To migrate an existing Metabase container from an H2 application database to another database container (e.g. Postgres, MySQL), there are a few considerations to keep in mind:
 
@@ -112,7 +112,7 @@ It's best to set your Java timezone to match the timezone you'd like all your re
 
 ### Additional custom settings
 
-While running Metabase on docker you can use any of the custom settings from [Customizing the Metabase Jetty Webserver](./start.html#customizing-the-metabase-jetty-webserver) by setting environment variables on your docker run command.
+While running Metabase on docker you can use any of the custom settings from [Customizing the Metabase Jetty Webserver](customizing-jetty-webserver.md) by setting environment variables on your docker run command.
 
 In addition to the standard custom settings there are two docker specific environment variables `MUID` and `MGID` which are used to set the user and group IDs used by metabase when running in a docker container. These settings make it possible to match file permissions when files, such as the application database, are shared between the host and the container.
 

--- a/docs/operations-guide/running-metabase-on-elastic-beanstalk.md
+++ b/docs/operations-guide/running-metabase-on-elastic-beanstalk.md
@@ -18,7 +18,7 @@ The Metabase team runs a number of production installations on AWS using Elastic
 
 Metabase provides an Elastic Beanstalk pre-configured launch url to help new installations getting started.  If you are starting fresh we recommend you follow this link to begin creating the Elastic Beanstalk deployment with a few choices pre-filled.
 
-[Launch Metabase on Elastic Beanstalk](https://downloads.metabase.com/{{site.latest_version}}/launch-aws-eb.html)
+[Launch Metabase on Elastic Beanstalk](https://downloads.metabase.com/{{ site.latest_version }}/launch-aws-eb.html)
 
 The rest of this guide will follow each phase of the Elastic Beanstalk setup step-by-step.
 

--- a/docs/operations-guide/running-metabase-on-heroku.md
+++ b/docs/operations-guide/running-metabase-on-heroku.md
@@ -37,7 +37,7 @@ Now that you’ve installed Metabase, it’s time to [set it up and connect it t
 ### Troubleshooting
 
 * If your Metabase instance is getting stuck part way through the initialization process and only every shows roughly 30% completion on the loading progress.
-    * The most likely culprit here is a stale database migrations lock that was not cleared.  This can happen if for some reason Heroku kills your Metabase dyno at the wrong time during startup.  __To fix it:__ you can either clear the lock using the built-in [release-locks](start.html#metabase-fails-to-startup) command line function, or if needed you can login to your Metabase application database directly and delete the row in the `DATABASECHANGELOGLOCK` table.  Then just restart Metabase.
+    * The most likely culprit here is a stale database migrations lock that was not cleared.  This can happen if for some reason Heroku kills your Metabase dyno at the wrong time during startup.  __To fix it:__ you can either clear the lock using the built-in [release-locks](../troubleshooting-guide/application-database.md) command line function, or if needed you can login to your Metabase application database directly and delete the row in the `DATABASECHANGELOGLOCK` table.  Then just restart Metabase.
 
 
 # Deploying New Versions of Metabase

--- a/docs/operations-guide/upgrading-metabase.md
+++ b/docs/operations-guide/upgrading-metabase.md
@@ -23,8 +23,8 @@ If you are using the Metabase macOS app, you will be notified when there is a ne
 
 ![Autoupdate Confirmation Dialog](images/AutoupdateScreenshot.png)
 
-#### [Upgrading AWS Elastic Beanstalk deployments](running-metabase-on-elastic-beanstalk.html#deploying-new-versions-of-metabase)
+#### [Upgrading AWS Elastic Beanstalk deployments](running-metabase-on-elastic-beanstalk.md#deploying-new-versions-of-metabase)
 Step-by-step instructions on how to upgrade Metabase running on Elastic Beanstalk using RDS.
 
-#### [Upgrading Heroku deployments](running-metabase-on-heroku.html#deploying-new-versions-of-metabase)
+#### [Upgrading Heroku deployments](running-metabase-on-heroku.md#deploying-new-versions-of-metabase)
 Step-by-step instructions on how to upgrade Metabase running on Heroku.

--- a/docs/troubleshooting-guide/docker.md
+++ b/docs/troubleshooting-guide/docker.md
@@ -62,7 +62,7 @@ will let you see the logs as they are printed.
 
 If the container is being killed before it finished starting it could be a health check timeout in the orchestration service used to start the container, such as Docker Cloud, or Elastic Beanstalk.
 
-If the container is not being killed from the outside, and is failing to start anyway, this problem is probably not specific to Docker. If you are using a Metabase-supplied image, you should [open a GitHub issue](https://github.com/metabase/metabase/issues/new).
+If the container is not being killed from the outside, and is failing to start anyway, this problem is probably not specific to Docker. If you are using a Metabase-supplied image, you should [open a GitHub issue](https://github.com/metabase/metabase/issues/new/choose).
 
 
 ### Not connecting to a remote application database
@@ -80,7 +80,7 @@ If this is a new Metabase instance, then the database you specified via the envi
 Double check you are passing environments to Docker in the correct way.
 You can list the environment variables for a container with this command:
 
-`docker inspect some-postgres -f '{{ .Config.Env }}'`
+`docker inspect some-postgres -f '{% raw %}{{ .Config.Env }}{% endraw %}'`
 
 
 ### The Metabase server isn’t able to connect to a MySQL or PostgreSQL database
@@ -88,7 +88,7 @@ You can list the environment variables for a container with this command:
 The logs for the Docker container return an error message after the “Verifying Database Connection” line.
 
 #### How to fix this:
-Try to connect with `mysql` or `psql` commands with the connection string parameters you are passing in via the environment variables: https://metabase.com/docs/latest/operations-guide/start.html#configuring-the-metabase-application-database
+Try to connect with `mysql` or `psql` commands with the connection string parameters you are passing in [via the environment variables](../operations-guide/configuring-application-database.md).
 
 If you can’t connect to the database, the problem is due to either the credentials or connectivity. Verify that the credentials are correct. If you are able to log in with those credentials from another machine then try to make the same connection from the host running the Docker container.
 
@@ -112,7 +112,7 @@ This will make it clear if this is a network or authentication problem.
 This occurs if you get the Setup screen every time you start the application. The most common root cause is not giving the Docker container a persistent filesystem mount to put the application database in.
 
 #### How to fix this:
-Make sure you are giving the container a persistent volume as described here: https://metabase.com/docs/latest/operations-guide/running-metabase-on-docker.html#mounting-a-mapped-file-storage-volume
+Make sure you are giving the container a [persistent volume](../operations-guide/running-metabase-on-docker.md#mounting-a-mapped-file-storage-volume)
 
 ### The internal port isn’t being remapped correctly
 

--- a/docs/users-guide/04-asking-questions.md
+++ b/docs/users-guide/04-asking-questions.md
@@ -69,9 +69,9 @@ The first dropdown menu in the question builder is where you’ll choose the dat
 
 ##### Using saved questions as source data
 
-If you've [saved some questions](06-sharing-answers.html), in the Data menu you'll see the option to use one of your saved questions as source data. What this means in practice is that you can do things like use complex SQL queries to create new tables that can be used in a question just like any other table in your database.
+If you've [saved some questions](06-sharing-answers.md), in the Data menu you'll see the option to use one of your saved questions as source data. What this means in practice is that you can do things like use complex SQL queries to create new tables that can be used in a question just like any other table in your database.
 
-You can use most saved questions as source data, provided you have [permission](../administration-guide/05-setting-permissions.html) to view that question. You can even use questions that were saved as a chart rather than a table.
+You can use most saved questions as source data, provided you have [permission](../administration-guide/05-setting-permissions.md) to view that question. You can even use questions that were saved as a chart rather than a table.
 
 **Note:** there are some kinds of saved questions that can't be used as source data:
 - Druid questions

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -107,7 +107,8 @@
            " "
            (trs "If you decide to continue to use H2, please be sure to back up the database file regularly.")
            " "
-           (trs "See https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres for more information.")))))
+           (trs "For more information, see")
+           "https://metabase.com/docs/latest/operations-guide/migrating-from-h2.html"))))
    (or @connection-string-details
        (case (db-type)
          :h2       {:type     :h2 ; TODO - we probably don't need to specifc `:type` here since we can just call (db-type)

--- a/src/metabase/util/encryption.clj
+++ b/src/metabase/util/encryption.clj
@@ -39,7 +39,7 @@
    (u/emoji (if default-secret-key "🔐" "🔓"))
    "\n"
    (trs "For more information, see")
-   "https://metabase.com/docs/latest/operations-guide/start.html#encrypting-your-database-connection-details-at-rest"))
+   "https://metabase.com/docs/latest/operations-guide/encrypting-database-details-at-rest.html"))
 
 (defn encrypt
   "Encrypt string `s` as hex bytes using a `secret-key` (a 64-byte byte array), by default the hashed value of


### PR DESCRIPTION
@mazameli I made a boo-boo. I was fixing links in the new Operations Guide breakout, and fixed some other things too - while referencing some new stuff in `0.33-docs`.
But how do I get this PR over to `release-0.33.x`, when the breakout was merged with `master`?