### PR TITLE
Make x-ray size adapt to DB query speed

### DIFF
--- a/src/metabase/api/automagic_dashboards.clj
+++ b/src/metabase/api/automagic_dashboards.clj
@@ -28,7 +28,7 @@
             [schema.core :as s]))
 
 (def ^:private Show
-  (su/with-api-error-message (s/maybe (s/enum "all"))
+  (su/with-api-error-message (s/maybe (s/enum "all" "summary"))
     (deferred-tru "invalid show value")))
 
 (def ^:private Prefix

--- a/src/metabase/automagic_dashboards/adaptive_dashboard_size.clj
+++ b/src/metabase/automagic_dashboards/adaptive_dashboard_size.clj
@@ -1,0 +1,40 @@
+(ns metabase.automagic-dashboards.adaptive-dashboard-size
+  (:require [bigml.histogram.core :as hist]
+            [clojure.core.memoize :as memo]
+            [metabase.models
+             [database :refer [Database]]
+             [query-execution :refer [QueryExecution]]]
+            [metabase.public-settings :as public-settings]
+            [metabase.sync.analyze.fingerprint.fingerprinters :refer [histogram]]
+            [redux.core :as redux]
+            [toucan.db :as db]))
+
+(def ^:private ^Long long-running-90th-percentile-threshold
+  "If 10% of queries take longer than this to run, consider the DB to be slow. Unit is ms."
+  5000)
+
+(def ^:private ^Long max-cards 15)
+(def ^:private ^Long max-cards-if-no-summary 3)
+
+(def ^:private ^{:arglists '([db-id])} running-time-90th-percentile
+  (memo/ttl #(transduce identity
+                        (redux/post-complete
+                         histogram
+                         (fn [h]
+                           ((hist/percentiles h 0.9) 0.9)))
+                        (db/select-field :running_time QueryExecution :database_id %))
+            :ttl/threshold (* (public-settings/query-caching-max-ttl) 1000)))
+
+(defn- slow-db?
+  [db-id]
+  (> (running-time-90th-percentile db-id) long-running-90th-percentile-threshold))
+
+(defn max-cards-for-dashboard
+  [{{:keys [database]} :root groups :groups}]
+  (let [summary (if (some (partial contains? groups) ["Summary" "Overview"])
+                  :summary
+                  max-cards-if-no-summary)]
+    (cond
+      (-> database Database :auto_run_queries false?) summary
+      (slow-db? database)                             summary
+      :else                                           max-cards)))

--- a/src/metabase/automagic_dashboards/adaptive_dashboard_size.clj
+++ b/src/metabase/automagic_dashboards/adaptive_dashboard_size.clj
@@ -31,6 +31,8 @@
   (some-> db-id running-time-90th-percentile (> long-running-90th-percentile-threshold)))
 
 (defn max-cards-for-dashboard
+  "What is the maximum number of cards to to show for the given dashboard? Returns either a number,
+   or `:summary` (show just the summary section of an x-ray)."
   [{{:keys [database]} :root groups :groups}]
   (let [summary (if (some (partial contains? groups) ["Summary" "Overview"])
                   :summary

--- a/src/metabase/automagic_dashboards/adaptive_dashboard_size.clj
+++ b/src/metabase/automagic_dashboards/adaptive_dashboard_size.clj
@@ -4,7 +4,6 @@
             [metabase.models
              [database :refer [Database]]
              [query-execution :refer [QueryExecution]]]
-            [metabase.public-settings :as public-settings]
             [metabase.sync.analyze.fingerprint.fingerprinters :refer [histogram]]
             [redux.core :as redux]
             [toucan.db :as db]))
@@ -13,7 +12,7 @@
   "If 10% of queries take longer than this to run, consider the DB to be slow. Unit is ms."
   5000)
 
-(def running-time-cache-ttl (* 60 60 24 7 1000)) ; 1 week
+(def ^:private ^Long running-time-cache-ttl (* 60 60 24 7 1000)) ; 1 week in ms
 
 (def ^:private ^Long max-cards 15)
 (def ^:private ^Long max-cards-if-no-summary 3)

--- a/src/metabase/automagic_dashboards/populate.clj
+++ b/src/metabase/automagic_dashboards/populate.clj
@@ -246,7 +246,6 @@
    (consider a group of 4 cards which starts as 7/9; in that case only 2 cards
    from the group will be picked)."
   [max-cards cards]
-  (println max-cards)
   (->> (cond->> (sort-by :score > cards)
          (= max-cards :all)     identity
          (= max-cards :summary) (filter (comp #{"Summary" "Overview"} :group))

--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -172,7 +172,7 @@
    (redux/fuse {:earliest earliest
                 :latest   latest})))
 
-(defn- histogram
+(defn histogram
   "Transducer that summarizes numerical data with a histogram."
   ([] (hist/create))
   ([^Histogram histogram] histogram)

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -182,19 +182,24 @@
            (filter :card)
            count))))
 
+;; Do nothing -- size below cutoff
 (expect
   13
   (resulting-number-of-cards "table/%s" [(data/id :checkins)]))
 
+;; Limit results
 (expect
   1
   (with-redefs [adaptive-size/max-cards 1]
     (resulting-number-of-cards "table/%s" [(data/id :checkins)])))
 
+;; show=all overwrides
 (expect
   13
-  (resulting-number-of-cards "table/%s?show=all" [(data/id :checkins)]))
+  (with-redefs [adaptive-size/max-cards 1]
+    (resulting-number-of-cards "table/%s?show=all" [(data/id :checkins)])))
 
+;; Explicitly just show a summary
 (expect
   4
   (resulting-number-of-cards "table/%s?show=summary" [(data/id :checkins)]))

--- a/test/metabase/automagic_dashboards/adaptive_dashboard_size_test.clj
+++ b/test/metabase/automagic_dashboards/adaptive_dashboard_size_test.clj
@@ -1,0 +1,32 @@
+(ns metabase.automagic-dashboards.adaptive-dashboard-size
+  (:require [expectations :refer :all]
+            [metabase.automagic-dashboards.adaptive-dashboard-size :as adaptive-size]
+            [metabase.models.database :refer [Database]]
+            [metabase.test.data :as data]
+            [toucan.db :as db]))
+
+(def ^:private dummy-dashboard
+  (delay {:root   {:database (data/id)}
+          :groups {"Summary" {:title "Summary"}}}))
+
+(expect
+  #'adaptive-size/max-cards
+  (adaptive-size/max-cards-for-dashboard @dummy-dashboard))
+
+(expect
+  :summary
+  (with-redefs [adaptive-size/long-running-90th-percentile-threshold 0]
+    (adaptive-size/max-cards-for-dashboard @dummy-dashboard)))
+
+(expect
+  #'adaptive-size/max-cards-if-no-summary
+  (with-redefs [adaptive-size/long-running-90th-percentile-threshold 0]
+    (adaptive-size/max-cards-for-dashboard (dissoc @dummy-dashboard :groups))))
+
+(expect
+  :summary
+  (do
+    (db/update! Database (data/id) {:auto_run_queries false})
+    (let [result (adaptive-size/max-cards-for-dashboard @dummy-dashboard)]
+      (db/update! Database (data/id) {:auto_run_queries false})
+      result)))

--- a/test/metabase/automagic_dashboards/adaptive_dashboard_size_test.clj
+++ b/test/metabase/automagic_dashboards/adaptive_dashboard_size_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.automagic-dashboards.adaptive-dashboard-size
+(ns metabase.automagic-dashboards.adaptive-dashboard-size-test
   (:require [expectations :refer :all]
             [metabase.automagic-dashboards.adaptive-dashboard-size :as adaptive-size]
             [metabase.models.database :refer [Database]]
@@ -28,5 +28,5 @@
   (do
     (db/update! Database (data/id) {:auto_run_queries false})
     (let [result (adaptive-size/max-cards-for-dashboard @dummy-dashboard)]
-      (db/update! Database (data/id) {:auto_run_queries false})
+      (db/update! Database (data/id) {:auto_run_queries true})
       result)))


### PR DESCRIPTION
This makes x-rays (somewhat) respect DB performance. If either `auto_run_queries` is disabled, or we are consistently seeing slow running queries (thershold set at >5s for the 90th percentile), show only either the "summary" section of an x-ray (these tend do be just a few cards and highly aggregated), or the first 3 cards if the x-ray does not have a "summary" section.