### PR TITLE
QB3 permissions fixes

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/StructuredQuery.js
@@ -107,15 +107,21 @@ export default class StructuredQuery extends AtomicQuery {
    * @returns true if this query is in a state where it can be run.
    */
   canRun() {
-    // TODO: do we need other logic here or do we now ensure queries are always valid?
-    return !!this.table();
+    return !!(this.sourceTableId() || this.sourceQuery());
+  }
+
+  /**
+   * @returns true if we have metadata for the root source table loaded
+   */
+  hasMetadata() {
+    return this.metadata() && !!this.rootTable();
   }
 
   /**
    * @returns true if this query is in a state where it can be edited. Must have database and table set, and metadata for the table loaded.
    */
   isEditable(): boolean {
-    return !!this.tableMetadata();
+    return this.hasMetadata();
   }
 
   /* AtomicQuery superclass methods */
@@ -208,17 +214,16 @@ export default class StructuredQuery extends AtomicQuery {
   }
 
   /**
-   * @returns a new query with the provided Table set.
+   * @returns the table ID, if a table is selected.
    */
-  setTable(table: Table): StructuredQuery {
-    return this.setTableId(table.id);
+  sourceTableId(): ?TableId {
+    return this.query()["source-table"];
   }
-
   /**
    * @returns a new query with the provided Table ID set.
    */
-  setTableId(tableId: TableId): StructuredQuery {
-    if (tableId !== this.tableId()) {
+  setSourceTableId(tableId: TableId): StructuredQuery {
+    if (tableId !== this.sourceTableId()) {
       return new StructuredQuery(
         this._originalQuestion,
         chain(this.datasetQuery())
@@ -232,10 +237,22 @@ export default class StructuredQuery extends AtomicQuery {
   }
 
   /**
-   * @returns the table ID, if a table is selected.
+   * @deprecated: use sourceTableId
    */
   tableId(): ?TableId {
-    return this.query()["source-table"];
+    return this.sourceTableId();
+  }
+  /**
+   * @deprecated: use setSourceTableId
+   */
+  setTableId(tableId: TableId): StructuredQuery {
+    return this.setSourceTableId(tableId);
+  }
+  /**
+   * @deprecated: use setSourceTableId
+   */
+  setTable(table: Table): StructuredQuery {
+    return this.setSourceTableId(table.id);
   }
 
   /**
@@ -296,7 +313,7 @@ export default class StructuredQuery extends AtomicQuery {
       augmentDatabase({ tables: [table] });
       return table;
     } else {
-      return this.metadata().table(this.tableId());
+      return this.metadata().table(this.sourceTableId());
     }
   }
 
@@ -318,7 +335,7 @@ export default class StructuredQuery extends AtomicQuery {
    * Removes invalid clauses from the query (and source-query, recursively)
    */
   clean() {
-    if (!this.metadata()) {
+    if (!this.hasMetadata()) {
       console.warn("Warning: can't clean query without metadata!");
       return this;
     }
@@ -1381,9 +1398,8 @@ export default class StructuredQuery extends AtomicQuery {
 
   /**
    * returns the original Table object at the beginning of the nested queries
-   * NOTE: this is inconsistent with sourceQuery() returning the `source-query`. Should we swap `table()` and `sourceTable()`?
    */
-  sourceTable(): Table {
+  rootTable(): Table {
     return this.rootQuery().table();
   }
 
@@ -1415,15 +1431,17 @@ export default class StructuredQuery extends AtomicQuery {
     const tableIds = new Set();
 
     // source-table, if set
-    const tableId = this.tableId();
+    const tableId = this.sourceTableId();
     if (tableId) {
       tableIds.add(tableId);
       // implicit joins via foreign keys
       if (includeFKs) {
         const table = this.table();
-        for (const field of table.fields) {
-          if (field.target && field.target.table_id) {
-            tableIds.add(field.target.table_id);
+        if (table) {
+          for (const field of table.fields) {
+            if (field.target && field.target.table_id) {
+              tableIds.add(field.target.table_id);
+            }
           }
         }
       }

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -534,11 +534,11 @@ export const loadMetadataForCard = createThunkAction(
       const query = new Question(getMetadata(getState()), card).query();
       if (query instanceof StructuredQuery) {
         try {
-          const sourceTable = query.sourceTable();
-          if (sourceTable) {
+          const rootTable = query.rootTable();
+          if (rootTable) {
             await Promise.all([
-              dispatch(Tables.actions.fetchTableMetadata(sourceTable)),
-              dispatch(Tables.actions.fetchForeignKeys(sourceTable)),
+              dispatch(Tables.actions.fetchTableMetadata(rootTable)),
+              dispatch(Tables.actions.fetchForeignKeys(rootTable)),
             ]);
           }
           await Promise.all(
@@ -761,22 +761,26 @@ export const updateQuestion = (
       dispatch(setIsShowingTemplateTagsEditor(false));
     }
 
-    if (
-      !_.isEqual(
-        oldQuestion.query().dependentTableIds(),
-        newQuestion.query().dependentTableIds(),
-      )
-    ) {
-      await dispatch(loadMetadataForCard(newQuestion.card()));
-    }
+    try {
+      if (
+        !_.isEqual(
+          oldQuestion.query().dependentTableIds(),
+          newQuestion.query().dependentTableIds(),
+        )
+      ) {
+        await dispatch(loadMetadataForCard(newQuestion.card()));
+      }
 
-    // setDefaultQuery requires metadata be loaded, need getQuestion to use new metadata
-    const question = getQuestion(getState());
-    const questionWithDefaultQuery = question.setDefaultQuery();
-    if (!questionWithDefaultQuery.isEqual(question)) {
-      await dispatch.action(UPDATE_QUESTION, {
-        card: questionWithDefaultQuery.setDefaultDisplay().card(),
-      });
+      // setDefaultQuery requires metadata be loaded, need getQuestion to use new metadata
+      const question = getQuestion(getState());
+      const questionWithDefaultQuery = question.setDefaultQuery();
+      if (!questionWithDefaultQuery.isEqual(question)) {
+        await dispatch.action(UPDATE_QUESTION, {
+          card: questionWithDefaultQuery.setDefaultDisplay().card(),
+        });
+      }
+    } catch (e) {
+      // this will fail if user doesn't have data permissions but thats ok
     }
 
     // run updated query

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -8,6 +8,7 @@ import { NotebookCell, NotebookCellItem } from "../NotebookCell";
 import { getDatabasesList } from "metabase/query_builder/selectors";
 
 function DataStep({ color, query, databases, updateQuery }) {
+  const table = query.table();
   return (
     <NotebookCell color={color}>
       <DatabaseSchemaAndTableDataSelector
@@ -28,12 +29,12 @@ function DataStep({ color, query, databases, updateQuery }) {
             </NotebookCellItem>
           ) : (
             <NotebookCellItem color={color} icon="table2">
-              {query.table().displayName()}
+              {table && table.displayName()}
             </NotebookCellItem>
           )
         }
       />
-      {query.table() && query.isRaw() && (
+      {table && query.isRaw() && (
         <DataFieldsPicker
           className="ml-auto mb1 text-bold"
           query={query}

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -8,15 +8,26 @@ import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
 
 import cx from "classnames";
 
-const QuestionDataSource = ({
-  question,
-  query = question.query(),
-  subHead,
-  noLink,
-  ...props
-}) => {
+const QuestionDataSource = ({ question, subHead, noLink, ...props }) => {
+  const parts = getDataSourceParts({ question, subHead, noLink });
+  return subHead ? (
+    <SubHeadBreadcrumbs parts={parts} {...props} />
+  ) : (
+    <HeadBreadcrumbs parts={parts} {...props} />
+  );
+};
+
+QuestionDataSource.shouldRender = ({ question }) =>
+  getDataSourceParts({ question }).length > 0;
+
+function getDataSourceParts({ question, noLink, subHead }) {
+  if (!question) {
+    return [];
+  }
+
   const parts = [];
 
+  let query = question.query();
   if (query instanceof StructuredQuery) {
     query = query.rootQuery();
   }
@@ -67,12 +78,8 @@ const QuestionDataSource = ({
     });
   }
 
-  return subHead ? (
-    <SubHeadBreadcrumbs parts={parts} {...props} />
-  ) : (
-    <HeadBreadcrumbs parts={parts} {...props} />
-  );
-};
+  return parts.filter(({ name, icon }) => name || icon);
+}
 
 export default QuestionDataSource;
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx
@@ -5,38 +5,43 @@ import EntityMenu from "metabase/components/EntityMenu";
 
 import cx from "classnames";
 
-const QuestionEntityMenu = ({ className, onOpenModal }) => (
-  <EntityMenu
-    triggerIcon="pencil"
-    className={cx("text-light", className)}
-    items={[
-      {
-        icon: "edit_document",
-        title: t`Edit this question`,
-        action: () => onOpenModal("edit"),
-      },
-      {
-        icon: "history",
-        title: t`View revision history`,
-        action: () => onOpenModal("history"),
-      },
-      {
-        icon: "add_to_dash",
-        title: t`Add to dashboard`,
-        action: () => onOpenModal("add-to-dashboard"),
-      },
-      {
-        icon: "move",
-        title: t`Move`,
-        action: () => onOpenModal("move"),
-      },
-      {
-        icon: "archive",
-        title: `Archive`,
-        action: () => onOpenModal("archive"),
-      },
-    ]}
-  />
-);
-
-export default QuestionEntityMenu;
+export default function QuestionEntityMenu({
+  className,
+  question,
+  onOpenModal,
+}) {
+  const canWrite = question && question.canWrite();
+  return (
+    <EntityMenu
+      triggerIcon="pencil"
+      className={cx("text-light", className)}
+      items={[
+        canWrite && {
+          icon: "edit_document",
+          title: t`Edit this question`,
+          action: () => onOpenModal("edit"),
+        },
+        {
+          icon: "history",
+          title: t`View revision history`,
+          action: () => onOpenModal("history"),
+        },
+        {
+          icon: "add_to_dash",
+          title: t`Add to dashboard`,
+          action: () => onOpenModal("add-to-dashboard"),
+        },
+        canWrite && {
+          icon: "move",
+          title: t`Move`,
+          action: () => onOpenModal("move"),
+        },
+        canWrite && {
+          icon: "archive",
+          title: `Archive`,
+          action: () => onOpenModal("archive"),
+        },
+      ]}
+    />
+  );
+}

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx
@@ -98,11 +98,12 @@ export function QuestionFilterWidget({
 QuestionFilters.shouldRender = ({ question, queryBuilderMode }) =>
   queryBuilderMode === "view" &&
   question.isStructured() &&
+  question.query().isEditable() &&
   question.query().topLevelFilters().length > 0 &&
   !question.isObjectDetail();
 
 QuestionFilterWidget.shouldRender = ({ question, queryBuilderMode }) =>
   queryBuilderMode === "view" &&
   question.isStructured() &&
-  question.query().table() &&
+  question.query().isEditable() &&
   !question.isObjectDetail();

--- a/frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import { t } from "ttag";
+import cx from "classnames";
+
+import Tooltip from "metabase/components/Tooltip";
+import Button from "metabase/components/Button";
+
+export default function QuestionNotebookButton({
+  className,
+  question,
+  isShowingNotebook,
+  setQueryBuilderMode,
+  ...props,
+}) {
+  return QuestionNotebookButton.shouldRender({ question }) ? (
+    <Tooltip tooltip={isShowingNotebook ? t`Hide editor` : t`Show editor`}>
+      <Button
+        borderless={!isShowingNotebook}
+        primary={isShowingNotebook}
+        medium
+        className={cx(className, {
+          "text-brand-hover": !isShowingNotebook,
+        })}
+        icon="notebook"
+        onClick={() =>
+          setQueryBuilderMode(isShowingNotebook ? "view" : "notebook")
+        }
+        {...props}
+      />
+    </Tooltip>
+  ) : null;
+}
+
+QuestionNotebookButton.shouldRender = ({ question }) =>
+  question.isStructured() && question.query().isEditable();

--- a/frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionNotebookButton.jsx
@@ -11,7 +11,7 @@ export default function QuestionNotebookButton({
   question,
   isShowingNotebook,
   setQueryBuilderMode,
-  ...props,
+  ...props
 }) {
   return QuestionNotebookButton.shouldRender({ question }) ? (
     <Tooltip tooltip={isShowingNotebook ? t`Hide editor` : t`Show editor`}>

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -113,7 +113,12 @@ export default class View extends React.Component {
     const isStructured = query instanceof StructuredQuery;
     const isNative = query instanceof NativeQuery;
 
-    if (isStructured && queryBuilderMode === "view" && !query.table()) {
+    const isNewQuestion =
+      query instanceof StructuredQuery &&
+      !query.sourceTableId() &&
+      !query.sourceQuery();
+
+    if (isNewQuestion && queryBuilderMode === "view") {
       return (
         <div className={fitClassNames}>
           <div className="p4 mx2">
@@ -168,8 +173,6 @@ export default class View extends React.Component {
           onClose={() => this.props.toggleDataReference()}
         />
       ) : null;
-
-    const isNewQuestion = query instanceof StructuredQuery && !query.table();
 
     const isSidebarOpen = leftSideBar || rightSideBar;
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -5,10 +5,8 @@ import { Box } from "grid-styled";
 
 import Icon from "metabase/components/Icon";
 import Link from "metabase/components/Link";
-import Button from "metabase/components/Button";
 import ButtonBar from "metabase/components/ButtonBar";
 import CollectionBadge from "metabase/questions/components/CollectionBadge";
-import Tooltip from "metabase/components/Tooltip.jsx";
 
 import ViewSection, { ViewHeading, ViewSubHeading } from "./ViewSection";
 
@@ -17,6 +15,7 @@ import QuestionDescription from "./QuestionDescription";
 import QuestionEntityMenu from "./QuestionEntityMenu";
 import QuestionLineage from "./QuestionLineage";
 import QuestionPreviewToggle from "./QuestionPreviewToggle";
+import QuestionNotebookButton from "./QuestionNotebookButton";
 
 import QuestionFilters, { QuestionFilterWidget } from "./QuestionFilters";
 import { QuestionSummarizeWidget } from "./QuestionSummaries";
@@ -126,9 +125,17 @@ export class ViewTitleHeader extends React.Component {
                 collectionId={question.collectionId()}
               />
 
-              <span className="mb1 mx2 text-light text-smaller">•</span>
+              {QuestionDataSource.shouldRender({ question }) && (
+                <span className="mb1 mx2 text-light text-smaller">•</span>
+              )}
 
-              <QuestionDataSource className="mb1" question={question} subHead />
+              {QuestionDataSource.shouldRender({ question }) && (
+                <QuestionDataSource
+                  className="mb1"
+                  question={question}
+                  subHead
+                />
+              )}
 
               {QuestionFilters.shouldRender(this.props) && (
                 <QuestionFilters
@@ -217,24 +224,14 @@ export class ViewTitleHeader extends React.Component {
               onCloseSummary={onCloseSummary}
             />
           )}
-          {question.isStructured() && (
-            <Tooltip
-              tooltip={isShowingNotebook ? t`Hide editor` : t`Show editor`}
-            >
-              <Button
-                borderless={!isShowingNotebook}
-                primary={isShowingNotebook}
-                medium
-                className={cx("hide sm-show", {
-                  "text-brand-hover": !isShowingNotebook,
-                })}
-                icon="notebook"
-                ml={2}
-                onClick={() =>
-                  setQueryBuilderMode(isShowingNotebook ? "view" : "notebook")
-                }
-              />
-            </Tooltip>
+          {QuestionNotebookButton.shouldRender({ question }) && (
+            <QuestionNotebookButton
+              className="hide sm-show"
+              ml={2}
+              question={question}
+              isShowingNotebook={isShowingNotebook}
+              setQueryBuilderMode={setQueryBuilderMode}
+            />
           )}
           {NativeQueryButton.shouldRender(this.props) && (
             <Box


### PR DESCRIPTION
For when the user doesn't have data permissions, this PR:

* [x] fixes crashes when loading (Resolves #10402)
* [x] hides filters button  
* [x] hides notebook button
* [x] cleans up collection/data source subheader

Also does a bit of cleanup of `StructuredQuery` etc