### PR TITLE
fix i18n files; Update toucan

### DIFF
--- a/locales/fr.po
+++ b/locales/fr.po
@@ -13038,8 +13038,7 @@ msgstr "Incapable de mettre à jour le champ binné: la requête manque de méta
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
-msgstr "Dans l'incapacité de mttre à jour le champ binné: métadonnées correspondantes non trouvées pour le champ \"{0}\"\n"
-""
+msgstr "Dans l'incapacité de mttre à jour le champ binné: métadonnées correspondantes non trouvées pour le champ \"{0}\""
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Using query processor cache backend: {0}"
@@ -13149,7 +13148,7 @@ msgstr "Echec à la planification des tâches pour la base de données {0}"
 msgid "All elements must be distinct."
 msgstr "Tous les éléments doivent être distincts."
 
-#: 
+#:
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Choisissez les colonnes concernées"
@@ -13191,4 +13190,3 @@ msgstr "Erreur lors de la détermination des colonnes attendues pour la requête
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Exception non gérée, aurait du être prise en charge par le middleware `catch-exceptions`."
-

--- a/locales/it.po
+++ b/locales/it.po
@@ -13075,8 +13075,7 @@ msgstr "Caricamento database di esempio..."
 
 #: src/metabase/sample_data.clj
 msgid "Failed to load sample dataset"
-msgstr "Caricamento del database di esempio fallito\n"
-""
+msgstr "Caricamento del database di esempio fallito"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Found new tables:"
@@ -13112,10 +13111,9 @@ msgstr ""
 
 #: src/metabase/util/schema.clj
 msgid "All elements must be distinct."
-msgstr "All elements must be distinct.\n"
-""
+msgstr "All elements must be distinct."
 
-#: 
+#:
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Scegli le colonne che desideri includere"
@@ -13157,4 +13155,3 @@ msgstr ""
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr ""
-

--- a/locales/nl.po
+++ b/locales/nl.po
@@ -75,8 +75,7 @@ msgid "Metabase can scan the values present in each\n"
 "field in this database to enable checkbox filters in dashboards and questions. This\n"
 "can be a somewhat resource-intensive process, particularly if you have a very large\n"
 "database."
-msgstr "Metabase kan de waardes van elk veld in deze database scannen om de checkbox filters in dashboards en vragen weer te geven. Dit is een resource-intensief proces, voornamelijk indien je een grote database hebt.\n"
-""
+msgstr "Metabase kan de waardes van elk veld in deze database scannen om de checkbox filters in dashboards en vragen weer te geven. Dit is een resource-intensief proces, voornamelijk indien je een grote database hebt."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
@@ -8783,8 +8782,7 @@ msgstr "JVM timezone is {0} and detected database timezone is {1}."
 
 #: src/metabase/util/date.clj
 msgid "Configure a report timezone to ensure proper date and time conversions."
-msgstr "Configure a report timezone to ensure proper date and time conversions.\n"
-""
+msgstr "Configure a report timezone to ensure proper date and time conversions."
 
 #: src/metabase/util/embed.clj
 msgid "Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints."
@@ -11309,8 +11307,7 @@ msgstr "Database {0} bestaat niet"
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Database is not present in the Query Processor Store."
-msgstr "\n"
-"Error: Database is not present in the Query Processor Store."
+msgstr "Error: Database is not present in the Query Processor Store."
 
 #: src/metabase/util/embed.clj
 msgid "Invalid embedding-secret-key! Secret key must be a hexadecimal-encoded 256-bit key (i.e., a 64-character string)."
@@ -11737,8 +11734,7 @@ msgstr "Plug-ins laden in {0} ..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using Clojure base loader as shared context classloader: {0}"
-msgstr "\n"
-"Using Clojure base loader as shared context classloader: {0}"
+msgstr "Using Clojure base loader as shared context classloader: {0}"
 
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to shared classloader {0}..."
@@ -12787,8 +12783,7 @@ msgstr "Kon driver {0} niet vinden."
 
 #: src/metabase/driver.clj
 msgid "Abstract drivers cannot derive from concrete parent drivers."
-msgstr "\n"
-"Abstract drivers cannot derive from concrete parent drivers."
+msgstr "Abstract drivers cannot derive from concrete parent drivers."
 
 #: src/metabase/driver/mysql.clj
 msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
@@ -12898,8 +12893,7 @@ msgstr "Cannot resolve :field-literal inside :fk-> unless inside join with expli
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot find Table ID for {0}"
-msgstr "\n"
-"Cannot find Table ID for {0}"
+msgstr "Cannot find Table ID for {0}"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found."
@@ -13040,8 +13034,7 @@ msgstr "Unable to resolve driver for query: Database {0} does not exist."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
-msgstr "\n"
-"Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr "Cannot use :fields :all in join against source query unless it has :source-metadata."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
@@ -13119,7 +13112,7 @@ msgstr "Kan taken voor database {0} niet plannen"
 msgid "All elements must be distinct."
 msgstr "Alle elementen moeten uniek zijn."
 
-#: 
+#:
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Kies de kolommen die je mee wilt nemen"
@@ -13161,4 +13154,3 @@ msgstr "Fout bij het bepalen van verwachte kolommen voor query"
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Onbehandelde exceptie, `catch-exceptions` middleware werd verwacht om dit af te handelen."
-

--- a/locales/pl.po
+++ b/locales/pl.po
@@ -11837,8 +11837,7 @@ msgstr "Wtyczka \"{0}\" zależy od wtyczki \"{1}\""
 
 #: src/metabase/plugins/dependencies.clj
 msgid "{0} dependency {1} satisfied? {2}"
-msgstr "{0} zależności {1} zadowolony? {2}\n"
-""
+msgstr "{0} zależności {1} zadowolony? {2}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugins with unsatisfied deps: {0}"
@@ -12885,8 +12884,7 @@ msgstr "Błąd podczas niszczenia puli wątków dla bazy danych."
 
 #: src/metabase/models/humanization.clj
 msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
-msgstr "Aktualizowanie nazwy wyświetlanej dla {0} ''{1}'': ''{2}'' -> ''{3}''\n"
-""
+msgstr "Aktualizowanie nazwy wyświetlanej dla {0} ''{1}'': ''{2}'' -> ''{3}''"
 
 #: src/metabase/models/humanization.clj
 msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
@@ -13183,7 +13181,7 @@ msgstr "Nie udało się zaplanować zadań dla bazy danych {0}"
 msgid "All elements must be distinct."
 msgstr "Wszystkie elementy muszą być unikalne."
 
-#: 
+#:
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Wybierz kolumny, które chcesz uwzględnić"
@@ -13225,4 +13223,3 @@ msgstr "Błąd podczas określania oczekiwanych kolumn dla zapytania"
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Nieobsługiwany wyjątek, oczekiwane oprogramowanie pośredniczące `catch-exceptions`  do obsługi."
-

--- a/project.clj
+++ b/project.clj
@@ -122,7 +122,7 @@
    [org.eclipse.jetty/jetty-server "9.4.15.v20190215"]                ; We require JDK 8 which allows us to run Jetty 9.4, ring-jetty-adapter runs on 1.7 which forces an older version
    [ring/ring-json "0.4.0"]                                           ; Ring middleware for reading/writing JSON automatically
    [stencil "0.5.0"]                                                  ; Mustache templates for Clojure
-   [toucan "1.13.0" :exclusions [org.clojure/java.jdbc honeysql]]     ; Model layer, hydration, and DB utilities
+   [toucan "1.14.0" :exclusions [org.clojure/java.jdbc honeysql]]     ; Model layer, hydration, and DB utilities
    [weavejester/dependency "0.2.1"]]                                  ; Dependency graphs and topological sorting
 
   :main ^:skip-aot metabase.core


### PR DESCRIPTION
*  Fix errors in i18n files where translation had newline but original string did not
*  Update Toucan to [version 1.14.0](https://github.com/metabase/toucan/releases/tag/1.14.0), which fixes annoyances with reloading model namespaces in REPL and `lein ring server`-based development