### PR TITLE
More clarity around password reset

### DIFF
--- a/docs/administration-guide/04-managing-users.md
+++ b/docs/administration-guide/04-managing-users.md
@@ -24,7 +24,9 @@ To reactivate a deactivated user, click on the Deactivated tab at the top of the
 You can edit a user’s name and email address by clicking the three dots icon and choosing **Edit Details**. Note: be careful when changing a user’s email address, because *this will change the address they’ll use to log in to Metabase*.
 
 ### Resetting a user’s password
-A user can always reset their password using the forgot password link on the login screen, but if you want to do this for them, just click the three dots icon and choose Reset Password. If you haven’t configured your email settings yet, you’ll be given a temporary password that you’ll have to share with that user. Otherwise, they’ll receive a password reset email.
+If you've already [configured your email settings](02-setting-up-email.md), a user can reset their password using the forgot password link on the login screen. If you have not yet configured your email settings, they will see a message telling them to ask an admin to reset their password for them. 
+
+To reset a password for a user, just click the three dots icon and choose Reset Password. If you haven’t [configured your email settings](02-setting-up-email.md) yet, you’ll be given a temporary password that you’ll have to share with that user. Otherwise, they’ll receive a password reset email.
 
 ### Changing a user’s role
 Right now, the only special role a user can have is Admin. The only difference is that Admins can access the Admin Panel and make changes there, and can set [permissions on collections](06-collections.md).

--- a/docs/faq/start.md
+++ b/docs/faq/start.md
@@ -21,6 +21,7 @@ Here is a list of some frequently asked questions about Metabase.
 
 ## Using Metabase
 
+* [How do I reset my password?](using-metabase/how-do-i-reset-my-password.md)
 * [How do I ask questions about my data?](using-metabase/how-do-i-ask-questions.md)
 * [I'm not getting the email notifications I expect to!](using-metabase/i-am-not-getting-email-notifications.md)
 * [How do I answer questions about data that lives in multiple databases?](using-metabase/how-do-i-answer-questions-when-data-is-in-multiple-databases.md)

--- a/docs/faq/using-metabase/how-do-i-reset-my-password.md
+++ b/docs/faq/using-metabase/how-do-i-reset-my-password.md
@@ -1,0 +1,3 @@
+# How do I reset my password?
+
+If you're having trouble logging in due to a forgotten password, click the `I seem to have forgotten my password` button in the lower right of the log-in screen. If your Metabase administrator has already [configured your email settings](02-setting-up-email.md), you will be able to generate a Reset Password email. If email has not been configured, you will need to contact them to perform a password reset.

--- a/docs/troubleshooting-guide/loggingin.md
+++ b/docs/troubleshooting-guide/loggingin.md
@@ -19,7 +19,7 @@ Remove the old token from the Google Auth SSO tab in the Admin Panel and create 
 
 ### Forgotten Password
 
-If you're having trouble logging in due to a forgotten password, click the `I seem to have forgotten my password` button in the lower right of the log-in screen. If your Metabase administrator has already [configured your email settings](02-setting-up-email.md), you will be able to generate a Reset Password email. If email has not been configured, you will need to contact them to perform a password reset.
+[This FAQ](../faq/how-do-i-reset-my-password.md) will tell you what to do in the event of a forgotten password.
 
 
 

--- a/docs/troubleshooting-guide/loggingin.md
+++ b/docs/troubleshooting-guide/loggingin.md
@@ -17,6 +17,10 @@ Also open up your server logs, and see if there are any errors related to authen
 #### How to fix this:
 Remove the old token from the Google Auth SSO tab in the Admin Panel and create a new one. If the root cause was an invalid auth token, this should fix the problem.
 
+### Forgotten Password
+
+If you're having trouble logging in due to a forgotten password, click the `I seem to have forgotten my password` button in the lower right of the log-in screen. If your Metabase administrator has already [configured your email settings](02-setting-up-email.md), you will be able to generate a Reset Password email. If email has not been configured, you will need to contact them to perform a password reset.
+
 
 
 ## Helpful tidbits


### PR DESCRIPTION
"Forgot" is the most common search term in Discourse, figured I'd make the docs a little more clear.