### PR TITLE
Don't lookup field ID for template tags, without a query

### DIFF
--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -63,7 +63,7 @@ export const getParametersBySlug = (
 /** Returns the field ID that this parameter target points to, or null if it's not a dimension target. */
 export function getParameterTargetFieldId(
   target: ?ParameterTarget,
-  datasetQuery: DatasetQuery,
+  datasetQuery: ?DatasetQuery,
 ): ?FieldId {
   if (target && target[0] === "dimension") {
     const dimension = target[1];

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -67,12 +67,8 @@ export function getParameterTargetFieldId(
 ): ?FieldId {
   if (target && target[0] === "dimension") {
     const dimension = target[1];
-    if (
-      Array.isArray(dimension) &&
-      dimension[0] === "template-tag" &&
-      !!datasetQuery
-    ) {
-      if (datasetQuery.type === "native") {
+    if (Array.isArray(dimension) && dimension[0] === "template-tag") {
+      if (datasetQuery && datasetQuery.type === "native") {
         const templateTag =
           datasetQuery.native["template-tags"][String(dimension[1])];
         if (templateTag && templateTag.type === "dimension") {

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -70,7 +70,7 @@ export function getParameterTargetFieldId(
     if (
       Array.isArray(dimension) &&
       dimension[0] === "template-tag" &&
-      datasetQuery !== undefined
+      !!datasetQuery
     ) {
       if (datasetQuery.type === "native") {
         const templateTag =

--- a/frontend/src/metabase/meta/Parameter.js
+++ b/frontend/src/metabase/meta/Parameter.js
@@ -67,7 +67,11 @@ export function getParameterTargetFieldId(
 ): ?FieldId {
   if (target && target[0] === "dimension") {
     const dimension = target[1];
-    if (Array.isArray(dimension) && dimension[0] === "template-tag") {
+    if (
+      Array.isArray(dimension) &&
+      dimension[0] === "template-tag" &&
+      datasetQuery !== undefined
+    ) {
       if (datasetQuery.type === "native") {
         const templateTag =
           datasetQuery.native["template-tags"][String(dimension[1])];


### PR DESCRIPTION
Based on snarfed/metabase@846f884

I isolated the mentioned patch to the only code path that requires that `datasetQuery` has a value.

@tlrobinson Does this look OK to you? I'm still figuring out what this actually does :mag: 