### PR TITLE
use compact formatting for long choropleth legends

### DIFF
--- a/frontend/test/metabase/visualizations/components/ChoroplethMap.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/ChoroplethMap.unit.spec.js
@@ -1,0 +1,35 @@
+import { getLegendTitles } from "metabase/visualizations/components/ChoroplethMap";
+
+describe("getLegendTitles", () => {
+  it("should not format short values compactly", () => {
+    const groups = [[1.12, 1.12, 1.25], [1.32, 1.48], [9, 12, 13]];
+    const columnSettings = {
+      column: { base_type: "type/Float" },
+      number_style: "currency",
+      currency: "USD",
+      currency_style: "symbol",
+    };
+
+    const titles = getLegendTitles(groups, columnSettings);
+
+    expect(titles).toEqual(["$1.12 - $1.25", "$1.32 - $1.48", "$9.00 +"]);
+  });
+
+  it("should format long values compactly", () => {
+    const groups = [
+      [1000.12, 1100.12, 1200.25],
+      [2000.32, 2200, 2500.48],
+      [11000, 12000, 13000],
+    ];
+    const columnSettings = {
+      column: { base_type: "type/Float" },
+      number_style: "currency",
+      currency: "USD",
+      currency_style: "symbol",
+    };
+
+    const titles = getLegendTitles(groups, columnSettings);
+
+    expect(titles).toEqual(["$1.0k - $1.2k", "$2.0k - $2.5k", "$11.0k +"]);
+  });
+});


### PR DESCRIPTION
Resolves #6766

Before
![image](https://user-images.githubusercontent.com/691495/63393719-6b9f0e80-c38a-11e9-935d-5014611dbc20.png)

After
![image](https://user-images.githubusercontent.com/691495/63393701-4ad6b900-c38a-11e9-859e-5d1d306b6d5e.png)

With this PR we switch to compact formatting if the average formatted length is over five characters. Why five? It was pretty arbitrary. I wouldn't be opposed to increasing it.

I also included the suggested fix of "collapsing" zero width ranges. For example "10k - 10k" would be "10k". With this and compact formatting there's some risk of narrow ranges appearing to be a single value. If "10k - 10k" was based on `10012, 10054, 10060`, it might be somewhat misleading to just show "10k".