### PR TITLE
Fix links that use anchors by changing .md to .html [ci skip]

### DIFF
--- a/docs/administration-guide/databases/oracle.md
+++ b/docs/administration-guide/databases/oracle.md
@@ -10,8 +10,7 @@ Head to this page, accept the license agreement, and download `ojdbc8.jar`:
 
 ![Oracle JDBC Download](../images/oracle_jdbc_download.png)
 
-Before downloading this JAR you may need to sign up for a free account with Oracle. We have had success with the latest version at the time of this writing, 19.3 (even with older Oracle 12c databases), but any version *should* work. 
-
+Before downloading this JAR you may need to sign up for a free account with Oracle. We have had success with the latest version at the time of this writing, 19.3 (even with older Oracle 12c databases), but any version _should_ work.
 
 ### Adding the Oracle JDBC Driver JAR to the Metabase Plugins Directory
 
@@ -43,4 +42,4 @@ Finally, you can choose a custom plugins directory if the default doesn't suit y
 
 #### When running from Docker
 
-The process for adding plugins when running via Docker is similar, but you'll need to mount the `plugins` directory. Refer to instructions [here](../../operations-guide/running-metabase-on-docker.md#adding-external-dependencies-or-plugins) for more details.
+The process for adding plugins when running via Docker is similar, but you'll need to mount the `plugins` directory. Refer to instructions [here](../../operations-guide/running-metabase-on-docker.html#adding-external-dependencies-or-plugins) for more details.

--- a/docs/administration-guide/databases/vertica.md
+++ b/docs/administration-guide/databases/vertica.md
@@ -44,4 +44,4 @@ If you are running the Docker image or you want to use another directory for plu
 
 #### When running from Docker
 
-The process for adding plugins when running via Docker is similar, but you'll need to mount the `plugins` directory. Refer to instructions [here](../../operations-guide/running-metabase-on-docker.md#adding-external-dependencies-or-plugins) for more details.
+The process for adding plugins when running via Docker is similar, but you'll need to mount the `plugins` directory. Refer to instructions [here](../../operations-guide/running-metabase-on-docker.html#adding-external-dependencies-or-plugins) for more details.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,22 +8,22 @@ If you are running the MacOS application on your laptop, you can click on the He
 
 If you are using a browser to access Metabase, then someone downloaded our software and installed it on a server. We at Metabase don't host your instance. We write software that someone at your company decided to run. You should ask whomever it was that set up your company's Metabase for help resetting your password.
 
-
 ## Metabase on macOS
 
 ### How should I use the macOS application?
 
 Our macOS application is best thought of as Metabase in single-player mode. It's meant to be a way to quickly try Metabase out and see if it's something you'd want to use across your team. It's also useful for use on your own.
 
-When you need to share dashboards or pulses with others, we *strongly* recommend you run our server application.
-
+When you need to share dashboards or pulses with others, we _strongly_ recommend you run our server application.
 
 ## Asking questions and running queries
 
 ### Can I use SQL with Metabase?
+
 [Yes](users-guide/writing-sql.md).
 
 ### Do I need to know SQL to use Metabase?
+
 [No](users-guide/04-asking-questions.md)
 
 ### Does Metabase support SQL Joins?
@@ -53,35 +53,40 @@ To manually fix field or table names if they still look wrong, you can go to the
 ## Dashboards
 
 ### Can I add headings, free text, section dividers, or images to my dashboards?
-Yes, by using [text cards](users-guide/07-dashboards.md#adding-headings-or-descriptions-with-text-cards).
+
+Yes, by using [text cards](users-guide/07-dashboards.html#adding-headings-or-descriptions-with-text-cards).
 
 ### Why do my cards fade out when I use dashboard filters?
-When one or more dashboard filters are active, any card on that dashboard that isn't connected to *every currently active filter* will fade out a bit to clarify that they are not being affected by all active filters. We understand this behavior is contentious, so we're [actively discussing it on GitHub](https://github.com/metabase/metabase/issues/4220).
+
+When one or more dashboard filters are active, any card on that dashboard that isn't connected to _every currently active filter_ will fade out a bit to clarify that they are not being affected by all active filters. We understand this behavior is contentious, so we're [actively discussing it on GitHub](https://github.com/metabase/metabase/issues/4220).
 
 ### Can I set permissions to choose which users can view which dashboards?
-Not directly. But if a user does not have permission to view *any* of the cards that a dashboard includes, she won't see that dashboard listed in the Dashboards section, and won't be allowed to see that dashboard if given a direct link to it. Additionally, we're currently actively considering placing dashboards inside collections, which would allow administrators to use collection permissions to restrict user group access to dashboards the same way they currently can to restrict access to saved questions.
+
+Not directly. But if a user does not have permission to view _any_ of the cards that a dashboard includes, she won't see that dashboard listed in the Dashboards section, and won't be allowed to see that dashboard if given a direct link to it. Additionally, we're currently actively considering placing dashboards inside collections, which would allow administrators to use collection permissions to restrict user group access to dashboards the same way they currently can to restrict access to saved questions.
 
 ### Why can't I make my dashboard cards smaller?
-Metabase has minimum size limits for dashboard cards to ensure that numbers and charts on dashboards are legible. You might be asking this question because you're trying to fit a lot of things in a dashboard, and another way we're exploring to solve *that* problem is by making it easier to put more than one series or metric in the same question, which would reduce the number of cards required to be on a dashboard in the first place.
+
+Metabase has minimum size limits for dashboard cards to ensure that numbers and charts on dashboards are legible. You might be asking this question because you're trying to fit a lot of things in a dashboard, and another way we're exploring to solve _that_ problem is by making it easier to put more than one series or metric in the same question, which would reduce the number of cards required to be on a dashboard in the first place.
 
 ### When I make a number card on a dashboard small, the number changes. Why?
-In an effort to make sure that dashboards are legible, Metabase changes the way charts and numbers in cards look at different sizes. When a number card is small, Metabase abbreviates numbers like 42,177 to 42k, for example.
 
+In an effort to make sure that dashboards are legible, Metabase changes the way charts and numbers in cards look at different sizes. When a number card is small, Metabase abbreviates numbers like 42,177 to 42k, for example.
 
 ## Pulses and Metabot
 
 ### Why do my charts look different when I put them in a Pulse?
+
 Metabase automatically changes the visualization type of saved questions you put in Pulses so that they fit better in emails and Slack. Here is [an inventory of how charts get changed](https://github.com/metabase/metabase/issues/5493#issuecomment-318198816), and here is [the logic for how this works](https://github.com/metabase/metabase/blob/8f1a287496899250d89a20ec57ac8477cd20bce5/src/metabase/pulse/render.clj#L385-L397).
 
 We understand this behavior isn't expected, and are currently exploring ways to handle this better.
 
 ### Can I set more specific or granular schedules for Pulses?
+
 Not yet, but [we'd love your help](https://github.com/metabase/metabase/issues/3846#issuecomment-318516189) working on implementing designs for this feature.
 
 ### Can I send Pulses to private Slack channels, or to multiple channels?
+
 No, this is currently [a limitation with the way we're required to implement our Slack integration](https://github.com/metabase/metabase/issues/2694).
-
-
 
 ## Databases
 
@@ -89,16 +94,16 @@ No, this is currently [a limitation with the way we're required to implement our
 
 Metabase currently supports:
 
-* Amazon Redshift
-* BigQuery
-* Druid
-* H2
-* MongoDB (version 3.4 or higher)
-* MySQL (and MariaDB)
-* PostgreSQL
-* Presto
-* SQL Server
-* SQLite
+- Amazon Redshift
+- BigQuery
+- Druid
+- H2
+- MongoDB (version 3.4 or higher)
+- MySQL (and MariaDB)
+- PostgreSQL
+- Presto
+- SQL Server
+- SQLite
 
 ### Can Metabase support database X?
 
@@ -117,8 +122,6 @@ We do not currently offer a way to connect to other third-party APIs or services
 ### Can I upload data to Metabase?
 
 Not exactly. Metabase provides access to data you have in an existing database you control. We currently do not add or modify the information in your database. You should ask whomever controls the database you are accessing how to upload the data you're interested in accessing.
-
-
 
 ## Support and troubleshooting
 
@@ -139,5 +142,6 @@ We are experimenting with offering paid support to a limited number of companies
 ### Can I embed charts or dashboards in another application?
 
 Yes, Metabase offers two solutions for sharing charts and dashboards:
+
 - [Public links](administration-guide/12-public-links.md) let you share or embed charts with simplicity.
 - A powerful [application embedding](administration-guide/13-embedding.md) let you to embed and customize charts in your own web applications.

--- a/docs/operations-guide/upgrading-metabase.md
+++ b/docs/operations-guide/upgrading-metabase.md
@@ -6,8 +6,8 @@ How you upgrade Metabase depends on how you are running it. See below for inform
 
 ### Specific Platforms
 
-
 #### Docker Image
+
 If you are running Metabase via docker, then you simply need to kill the Docker process and start a new container with the latest Metabase image. On startup, Metabase will perform any upgrade tasks it needs to perform, and once it's finished you'll be running the new version.
 
 To pull the latest Metabase:
@@ -15,16 +15,19 @@ To pull the latest Metabase:
     $ docker pull metabase/metabase:latest
 
 #### Jar file
+
 If you are running the JVM Jar file directly, then you simply kill the process, replace the .jar file with the newer version and restart the server. On startup, Metabase will perform any upgrade tasks it needs to perform, and once it's finished you'll be running the new version.
 
-
 #### macOS Application
+
 If you are using the Metabase macOS app, you will be notified when there is a new version available. You will see a dialog displaying the changes in the latest version and prompting you to upgrade.
 
 ![Autoupdate Confirmation Dialog](images/AutoupdateScreenshot.png)
 
-#### [Upgrading AWS Elastic Beanstalk deployments](running-metabase-on-elastic-beanstalk.md#deploying-new-versions-of-metabase)
+#### [Upgrading AWS Elastic Beanstalk deployments](running-metabase-on-elastic-beanstalk.html#deploying-new-versions-of-metabase)
+
 Step-by-step instructions on how to upgrade Metabase running on Elastic Beanstalk using RDS.
 
-#### [Upgrading Heroku deployments](running-metabase-on-heroku.md#deploying-new-versions-of-metabase)
+#### [Upgrading Heroku deployments](running-metabase-on-heroku.html#deploying-new-versions-of-metabase)
+
 Step-by-step instructions on how to upgrade Metabase running on Heroku.

--- a/docs/troubleshooting-guide/docker.md
+++ b/docs/troubleshooting-guide/docker.md
@@ -1,16 +1,15 @@
-
 While Docker simplifies a lot of aspects of running Metabase, there are a number of potential pitfalls to keep in mind.
 
 If you are having issues with Metabase under Docker, we recommend going through the troubleshooting process below. Then look below for details about the specific issue you've found.
 
 ## Troubleshooting Process
+
 1. Check that the container is running
 2. Check that the server is running inside the container
 3. Check whether Metabase is using the correct application database
 4. Check that you can connect to the Docker host on the Metabase port
 5. Check that you can connect to the container from the Docker host
 6. Check that you can connect to the server from within the container
-
 
 ## Specific Problems
 
@@ -27,9 +26,10 @@ Look at that container's logs with:
 
 `Docker logs CONTAINER_ID`
 
-
 ### Metabase Container is running but the Server is not
+
 #### How to detect this:
+
 Run `docker ps` to make sure the container is running
 
 The server should be logging to the Docker container logs. Check this by running:
@@ -37,22 +37,26 @@ The server should be logging to the Docker container logs. Check this by running
 `docker logs CONTAINER_NAME`
 
 You should see a line like this at the beginning:
+
 ```
 05-10 18:11:32 INFO metabase.util :: Loading Metabase...
 ```
 
 and eventually:
+
 ```
 05-10 18:12:30 INFO metabase.core :: Metabase Initialization COMPLETE
 ```
 
 If you see the below lines:
+
 ```
 05-15 19:07:11 INFO metabase.core :: Metabase Shutting Down ...
 05-15 19:07:11 INFO metabase.core :: Metabase Shutdown COMPLETE
 ```
 
 #### How to fix this:
+
 Check this for errors about connecting to the application database.
 Watch the logs to see if Metabase is still being started:
 
@@ -64,9 +68,10 @@ If the container is being killed before it finished starting it could be a healt
 
 If the container is not being killed from the outside, and is failing to start anyway, this problem is probably not specific to Docker. If you are using a Metabase-supplied image, you should [open a GitHub issue](https://github.com/metabase/metabase/issues/new/choose).
 
-
 ### Not connecting to a remote application database
+
 #### How to detect this:
+
 If this is a new Metabase instance, then the database you specified via the environment variables will be empty. If this is an existing Metabase instance with incorrect environment parameters, the server will create a new H2 embedded database to use for application data and you’ll see lines similar to these:
 
 ```
@@ -77,17 +82,20 @@ If this is a new Metabase instance, then the database you specified via the envi
 ```
 
 #### How to fix this:
+
 Double check you are passing environments to Docker in the correct way.
 You can list the environment variables for a container with this command:
 
 `docker inspect some-postgres -f '{% raw %}{{ .Config.Env }}{% endraw %}'`
 
-
 ### The Metabase server isn’t able to connect to a MySQL or PostgreSQL database
+
 #### How to detect this:
+
 The logs for the Docker container return an error message after the “Verifying Database Connection” line.
 
 #### How to fix this:
+
 Try to connect with `mysql` or `psql` commands with the connection string parameters you are passing in [via the environment variables](../operations-guide/configuring-application-database.md).
 
 If you can’t connect to the database, the problem is due to either the credentials or connectivity. Verify that the credentials are correct. If you are able to log in with those credentials from another machine then try to make the same connection from the host running the Docker container.
@@ -109,30 +117,34 @@ This will make it clear if this is a network or authentication problem.
 ### The Metabase application database is not being persisted
 
 #### How to detect this:
+
 This occurs if you get the Setup screen every time you start the application. The most common root cause is not giving the Docker container a persistent filesystem mount to put the application database in.
 
 #### How to fix this:
-Make sure you are giving the container a [persistent volume](../operations-guide/running-metabase-on-docker.md#mounting-a-mapped-file-storage-volume)
+
+Make sure you are giving the container a [persistent volume](../operations-guide/running-metabase-on-docker.html#mounting-a-mapped-file-storage-volume)
 
 ### The internal port isn’t being remapped correctly
 
 #### How to detect this:
+
 Run `docker ps` and look at the port mapping
 Run `curl http://localhost:port-number-here/api/health`. This should return a response with a JSON response like:
+
 ```
 {"status":"ok"}
 ```
 
 #### How to fix this:
-Make sure to include a `-p 3000:3000` or similar remapping in the `docker run` command you execute to start the Metabase container image.
 
+Make sure to include a `-p 3000:3000` or similar remapping in the `docker run` command you execute to start the Metabase container image.
 
 ## Helpful tidbits
 
 ### How to get to the shell in the Metabase container
 
-`docker  exec -ti CONTAINER_NAME bash`
+`docker exec -ti CONTAINER_NAME bash`
 
 ### How to get the logs for the Metabase container
 
-`docker  logs -f CONTAINER_NAME`
+`docker logs -f CONTAINER_NAME`


### PR DESCRIPTION
Links with anchor tags weren't getting properly switched over to `.html` from `.md` in our build process, so this PR changes any links like `…/page.md#anchor-link` to `…/page.html#anchor-link`

There are also a bunch of whitespace changes in this PR because of Prettier.