### PR TITLE
fix safari bug in chart settings

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -236,38 +236,36 @@ class ChartSettings extends Component {
             {widgetList}
           </div>
         ) : (
-          <div className="full-height relative">
-            <div className="Grid spread">
-              <div className="Grid-cell Cell--1of3 scroll-y scroll-show border-right py4">
-                {widgetList}
-              </div>
-              <div className="Grid-cell flex flex-column pt2">
-                <div className="mx4 flex flex-column">
-                  <Warnings
-                    className="mx2 align-self-end text-gold"
-                    warnings={this.state.warnings}
-                    size={20}
-                  />
-                </div>
-                <div className="mx4 flex-full relative">
-                  <Visualization
-                    className="spread"
-                    rawSeries={rawSeries}
-                    showTitle
-                    isEditing
-                    isDashboard
-                    isSettings
-                    showWarnings
-                    onUpdateVisualizationSettings={this.handleChangeSettings}
-                    onUpdateWarnings={warnings => this.setState({ warnings })}
-                  />
-                </div>
-                <ChartSettingsFooter
-                  onDone={this.handleDone}
-                  onCancel={this.handleCancel}
-                  onReset={onReset}
+          <div className="Grid">
+            <div className="Grid-cell Cell--1of3 scroll-y scroll-show border-right py4">
+              {widgetList}
+            </div>
+            <div className="Grid-cell flex flex-column pt2">
+              <div className="mx4 flex flex-column">
+                <Warnings
+                  className="mx2 align-self-end text-gold"
+                  warnings={this.state.warnings}
+                  size={20}
                 />
               </div>
+              <div className="mx4 flex-full relative">
+                <Visualization
+                  className="spread"
+                  rawSeries={rawSeries}
+                  showTitle
+                  isEditing
+                  isDashboard
+                  isSettings
+                  showWarnings
+                  onUpdateVisualizationSettings={this.handleChangeSettings}
+                  onUpdateWarnings={warnings => this.setState({ warnings })}
+                />
+              </div>
+              <ChartSettingsFooter
+                onDone={this.handleDone}
+                onCancel={this.handleCancel}
+                onReset={onReset}
+              />
             </div>
           </div>
         )}


### PR DESCRIPTION
Resolves #10677 

Safari didn't like the new css from notebook mode. I fixed it my removing a (hopefully unnecessary) wrapper div. @tlrobinson was the original change related to all the mobile stuff you were doing? Here's the change I made:

## Before
```jsx
<div className="full-height relative">
  <div className="Grid spread">
    {/* content */}
  </div>
</div>
```

## After
```jsx
<div className="Grid">
  {/* content */}
</div>
```

The `full-height` and `relative` classes are pretty descriptive. The `spread` class turns on absolute positioning and sets top/left/right/bottom to zero.

## What's the issue with Safari?

I _think_ [this](https://bugs.webkit.org/show_bug.cgi?id=137730) might be the issue. They claim it was fixed a while ago but the example still fails for me in Safari 12. That said, the flex properties in that don't quite map onto what I'm seeing.

## Some pictures

### Broken
![image](https://user-images.githubusercontent.com/691495/63540985-2f36f400-c4eb-11e9-8476-e0eac57986eb.png)

### Not broken
![image](https://user-images.githubusercontent.com/691495/63540880-fb5bce80-c4ea-11e9-8e62-92b7fb93e9b6.png)
