### PR TITLE
Log database connection error before humanizing it

### DIFF
--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -31,6 +31,7 @@
       ;; actually if we are going to `throw-exceptions` we'll rethrow the original but attempt to humanize the message
       ;; first
       (catch Throwable e
+        (log/info (trs "Database connection error: {0}" (.getMessage e)))
         (throw (Exception. (str (driver/humanize-connection-error-message driver (.getMessage e))) e))))
     (try
       (can-connect-with-details? driver details-map :throw-exceptions)

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -31,7 +31,7 @@
       ;; actually if we are going to `throw-exceptions` we'll rethrow the original but attempt to humanize the message
       ;; first
       (catch Throwable e
-        (log/info (trs "Database connection error: {0}" (.getMessage e)))
+        (log/error e (trs "Database connection error"))
         (throw (Exception. (str (driver/humanize-connection-error-message driver (.getMessage e))) e))))
     (try
       (can-connect-with-details? driver details-map :throw-exceptions)


### PR DESCRIPTION
The original, non-humanized error message may contain clues regarding the error state, that might get lost in the humanization process.
