### PR TITLE
more REPL ergonomics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ target/checksum.txt
 /resources/frontend_client/app/locales
 *.iml
 .idea/
+/local/src

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -9,7 +9,7 @@
              [util :as u]]
             [metabase.api.common :as api-common]
             [metabase.models.interface :as mi]
-            [toucan.db :as db]))
+            [toucan.db :as tdb]))
 
 
 (defn init!
@@ -47,9 +47,3 @@
   [permissions & body]
   `(binding [api-common/*current-user-permissions-set* (delay ~permissions)]
      ~@body))
-
-;; The linter will punch you in the face if you require a namespace without using anything from it, so here we pull a
-;; fast one on it. We want to require the namespaces so that they're within easy reach during REPL dev, without having
-;; to specify beforehand what exactly we want to use.
-(def appease-the-linter
-  [u/get-id mi/can-read?])

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -7,8 +7,10 @@
              [plugins :as pluguns]
              [server :as server]
              [util :as u]]
+            [metabase.api.common :as api-common]
             [metabase.models.interface :as mi]
-            [metabase.api.common :as api-common]))
+            [toucan.db :as db]))
+
 
 (defn init!
   []

--- a/project.clj
+++ b/project.clj
@@ -249,7 +249,7 @@
      [[jonase/eastwood "0.3.1" :exclusions [org.clojure/clojure]]]
 
      :eastwood
-     {:exclude-namespaces [:test-paths]
+     {:exclude-namespaces [:test-paths dev]
       :config-files       ["./test_resources/eastwood-config.clj"]
       :add-linters        [:unused-private-vars
                            :unused-namespaces
@@ -285,7 +285,7 @@
    :check-namespace-decls
    [:include-all-drivers
     {:plugins               [[lein-check-namespace-decls "1.0.2"]]
-     :source-paths          ["test"]
+     :source-paths          ^:replace ["src" "test"]
      :check-namespace-decls {:prefix-rewriting true}}]
 
    ;; build the uberjar with `lein uberjar`

--- a/project.clj
+++ b/project.clj
@@ -151,7 +151,7 @@
 
   :profiles
   {:dev
-   {:source-paths ["dev/src"]
+   {:source-paths ["dev/src" "local/src"]
     
     :dependencies
     [[clj-http-fake "1.0.3" :exclusions [slingshot]]                  ; Library to mock clj-http responses


### PR DESCRIPTION
Added a couple more tools to the `dev` namespace for REPL happiness.

I also added `local/src` as a source path that's gitignore'd so that one can keep handy snippets on the local filesystem and easily load them into the `dev` ns, which for me is like the REPL home base