### PR TITLE
Fix existing column settings for native/nested queries

### DIFF
--- a/frontend/src/metabase/lib/dataset.js
+++ b/frontend/src/metabase/lib/dataset.js
@@ -131,7 +131,11 @@ function fieldRefForColumn_LEGACY(
 
 export const keyForColumn = (column: Column): string => {
   const ref = fieldRefForColumn(column);
-  return JSON.stringify(ref ? ["ref", ref] : ["name", column.name]);
+  // match legacy behavior which didn't have "field-literal" or "aggregation" field refs
+  if (ref && ref[0] !== "field-literal" && ref[0] !== "aggregation") {
+    return JSON.stringify(["ref", ref]);
+  }
+  return JSON.stringify(["name", column.name]);
 };
 
 /**

--- a/frontend/src/metabase/lib/dataset.js
+++ b/frontend/src/metabase/lib/dataset.js
@@ -132,7 +132,11 @@ function fieldRefForColumn_LEGACY(
 export const keyForColumn = (column: Column): string => {
   const ref = fieldRefForColumn(column);
   // match legacy behavior which didn't have "field-literal" or "aggregation" field refs
-  if (ref && ref[0] !== "field-literal" && ref[0] !== "aggregation") {
+  if (
+    Array.isArray(ref) &&
+    ref[0] !== "field-literal" &&
+    ref[0] !== "aggregation"
+  ) {
     return JSON.stringify(["ref", ref]);
   }
   return JSON.stringify(["name", column.name]);

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -58,7 +58,7 @@ type ColumnSettingDef = SettingDef & {
 export function columnSettings({
   getColumns = DEFAULT_GET_COLUMNS,
   ...def
-}: ColumnSettingDef) {
+}: ColumnSettingDef = {}) {
   return nestedSettings("column_settings", {
     section: t`Formatting`,
     objectName: "column",

--- a/frontend/test/metabase/visualizations/lib/settings/column.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/settings/column.unit.spec.js
@@ -1,0 +1,98 @@
+import { columnSettings } from "metabase/visualizations/lib/settings/column";
+
+import { getComputedSettings } from "metabase/visualizations/lib/settings";
+
+function seriesWithColumn(col) {
+  return [
+    {
+      card: {},
+      data: {
+        cols: [
+          {
+            name: "foo",
+            base_type: "type/Float",
+            special_type: "type/Currency",
+            ...col,
+          },
+        ],
+      },
+    },
+  ];
+}
+
+describe("column settings", () => {
+  it("should find by column name", () => {
+    const series = seriesWithColumn({});
+    const defs = { ...columnSettings() };
+    const stored = {
+      column_settings: {
+        '["name","foo"]': {
+          currency: "BTC",
+        },
+      },
+    };
+    const computed = getComputedSettings(defs, series, stored);
+    expect(computed.column(series[0].data.cols[0]).currency).toEqual("BTC");
+  });
+  it("should find by column 'field-id' ref", () => {
+    const series = seriesWithColumn({
+      id: 42,
+      field_ref: ["field-id", 42],
+    });
+    const defs = { ...columnSettings() };
+    const stored = {
+      column_settings: {
+        '["ref",["field-id",42]]': {
+          currency: "BTC",
+        },
+      },
+    };
+    const computed = getComputedSettings(defs, series, stored);
+    expect(computed.column(series[0].data.cols[0]).currency).toEqual("BTC");
+  });
+  it("should find by column 'field-literal' ref", () => {
+    const series = seriesWithColumn({
+      field_ref: ["field-literal", "foo", "type/Float"],
+    });
+    const defs = { ...columnSettings() };
+    const stored = {
+      column_settings: {
+        '["ref",["field-literal","foo","type/Float"]]': {
+          currency: "BTC",
+        },
+      },
+    };
+    const computed = getComputedSettings(defs, series, stored);
+    expect(computed.column(series[0].data.cols[0]).currency).toEqual("BTC");
+  });
+  it("should find by column name if it also has a 'field-literal' ref", () => {
+    const series = seriesWithColumn({
+      field_ref: ["field-literal", "foo", "type/Float"],
+    });
+    const defs = { ...columnSettings() };
+    const stored = {
+      column_settings: {
+        '["name","foo"]': {
+          currency: "BTC",
+        },
+      },
+    };
+    const computed = getComputedSettings(defs, series, stored);
+    expect(computed.column(series[0].data.cols[0]).currency).toEqual("BTC");
+  });
+  it("should find by column name if it also has a 'aggregation' ref", () => {
+    const series = seriesWithColumn({
+      field_ref: ["aggregation", 0],
+    });
+    const defs = { ...columnSettings() };
+    const stored = {
+      column_settings: {
+        '["name","foo"]': {
+          currency: "BTC",
+        },
+      },
+    };
+    const computed = getComputedSettings(defs, series, stored);
+    expect(computed.column(series[0].data.cols[0]).currency).toEqual("BTC");
+  });
+});

--- a/frontend/test/metabase/visualizations/lib/settings/column.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/settings/column.unit.spec.js
@@ -50,7 +50,8 @@ describe("column settings", () => {
     const computed = getComputedSettings(defs, series, stored);
     expect(computed.column(series[0].data.cols[0]).currency).toEqual("BTC");
   });
-  it("should find by column 'field-literal' ref", () => {
+  // DISABLED to match legacy behavior until we determine the best way to reference columns
+  xit("should find by column 'field-literal' ref", () => {
     const series = seriesWithColumn({
       field_ref: ["field-literal", "foo", "type/Float"],
     });


### PR DESCRIPTION
I'm not sure how to best fix this yet, so I put a special case in `keyForColumn` to not return `ref` type keys for `field-literal` and `aggregation`.

It could also be fixed fixed in the nested settings code, since that assumes a single key per object but we need to check two different keys (e.x. `["name", "foo"]` and `["ref",["field-literal","foo","type/Text"]]`.

We should verify `field_ref` is indeed the best way to stably reference columns. See my comments in #10703 

Resolves #10703