### PR TITLE
MySQL additions to troubleshooting guide

### DIFF
--- a/docs/administration-guide/01-managing-databases.md
+++ b/docs/administration-guide/01-managing-databases.md
@@ -14,7 +14,7 @@ Now you’ll see a list of your databases. To connect another database to Metaba
 - [Google BigQuery](databases/bigquery.md)
 - H2
 - [MongoDB (version 3.4 or higher)](databases/mongodb.md)
-- MySQL (version 4.1 or higher, as well as MariaDB)
+- [MySQL (version 4.1 or higher, as well as MariaDB)](databases/mysql.md)
 - Postgres
 - SQLite
 - SQL Server

--- a/docs/administration-guide/databases/mysql.md
+++ b/docs/administration-guide/databases/mysql.md
@@ -1,0 +1,7 @@
+## Working with MySQL in Metabase
+
+### Connecting to MySQL 8+ servers
+
+Metabase uses the MariaDB connector to connect to MariaDB and MySQL servers. Because of this you may experience authentication issues when connecting to MySQL 8+ servers with its updated default authentication plugin.
+
+Please refer to the [troubleshooting guide](../troubleshooting-guide/datawarehouse.md#mysql-unable-to-log-in-to-mysql-8-with-correct-credentials) for more information on how to connect to MySQL 8+ instances.

--- a/docs/administration-guide/databases/mysql.md
+++ b/docs/administration-guide/databases/mysql.md
@@ -2,6 +2,6 @@
 
 ### Connecting to MySQL 8+ servers
 
-Metabase uses the MariaDB connector to connect to MariaDB and MySQL servers. Because of this you may experience authentication issues when connecting to MySQL 8+ servers with its updated default authentication plugin.
+Metabase uses the MariaDB connector to connect to MariaDB and MySQL servers. The MariaDB connector does not currently support MySQL 8's default authentication plugin, so in order to connect, you'll need to change the plugin used by the Metabase user to `mysql_native_password`: `ALTER USER 'metabase'@'%' IDENTIFIED WITH mysql_native_password BY 'thepassword';`
 
-Please refer to the [troubleshooting guide](../../troubleshooting-guide/datawarehouse.md#mysql-unable-to-log-in-to-mysql-8-with-correct-credentials) for more information on how to connect to MySQL 8+ instances.
+If you're still experiencing problems connecting, please refer to the [troubleshooting guide](../../troubleshooting-guide/datawarehouse.md#mysql-unable-to-log-in-to-mysql-8-with-correct-credentials).

--- a/docs/administration-guide/databases/mysql.md
+++ b/docs/administration-guide/databases/mysql.md
@@ -4,4 +4,4 @@
 
 Metabase uses the MariaDB connector to connect to MariaDB and MySQL servers. The MariaDB connector does not currently support MySQL 8's default authentication plugin, so in order to connect, you'll need to change the plugin used by the Metabase user to `mysql_native_password`: `ALTER USER 'metabase'@'%' IDENTIFIED WITH mysql_native_password BY 'thepassword';`
 
-If you're still experiencing problems connecting, please refer to the [troubleshooting guide](../../troubleshooting-guide/datawarehouse.md#mysql-unable-to-log-in-to-mysql-8-with-correct-credentials).
+If you're still experiencing problems connecting, please refer to the [troubleshooting guide](../../troubleshooting-guide/datawarehouse.html#mysql-unable-to-log-in-to-mysql-8-with-correct-credentials).

--- a/docs/administration-guide/databases/mysql.md
+++ b/docs/administration-guide/databases/mysql.md
@@ -4,4 +4,4 @@
 
 Metabase uses the MariaDB connector to connect to MariaDB and MySQL servers. Because of this you may experience authentication issues when connecting to MySQL 8+ servers with its updated default authentication plugin.
 
-Please refer to the [troubleshooting guide](../troubleshooting-guide/datawarehouse.md#mysql-unable-to-log-in-to-mysql-8-with-correct-credentials) for more information on how to connect to MySQL 8+ instances.
+Please refer to the [troubleshooting guide](../../troubleshooting-guide/datawarehouse.md#mysql-unable-to-log-in-to-mysql-8-with-correct-credentials) for more information on how to connect to MySQL 8+ instances.

--- a/docs/troubleshooting-guide/datawarehouse.md
+++ b/docs/troubleshooting-guide/datawarehouse.md
@@ -48,7 +48,7 @@ If your credentials are incorrect, you should see an error message letting you k
 If the database name or the user/password combination are incorrect, ask the person running your data warehouse for correct credentials.
 
 
-### Connection time out ("Your question took too long")
+### Connection time out: "Your question took too long"
 
 #### How to detect this
 If you see the error message, "Your question took too long," something in your setup timed out. Depending on the specifics of your deployment, this could be a timeout in:

--- a/docs/troubleshooting-guide/datawarehouse.md
+++ b/docs/troubleshooting-guide/datawarehouse.md
@@ -103,7 +103,7 @@ Metabase fails to connect to your MySQL 8 server with the error message "Looks l
 You may still be able to successfully connect to the server using another MySQL client, such as the command-line client: `mysql -h 127.0.0.1 -u metabase -p`
 
 #### How to fix this
-Change the authentication plugin used by the Metabase user's to `mysql_native_password`: `ALTER USER 'metabase'@'%' IDENTIFIED WITH mysql_native_password BY 'thepassword';`
+Change the authentication plugin used by the Metabase user to `mysql_native_password`: `ALTER USER 'metabase'@'%' IDENTIFIED WITH mysql_native_password BY 'thepassword';`
 
 This is necessary because the MariaDB connector, used by Metabase to connect to MySQL servers, unfortunately does not support MySQL 8's default authentication plugin. From [StackOverflow](https://stackoverflow.com/a/54190598):
 

--- a/docs/troubleshooting-guide/datawarehouse.md
+++ b/docs/troubleshooting-guide/datawarehouse.md
@@ -70,3 +70,49 @@ Fixing this depends on your specific setup. Here are some potentially helpful re
 - [Elastic Load Balancing Connection Timeout Management](https://aws.amazon.com/blogs/aws/elb-idle-timeout-control/)
 - [Heroku timeouts](https://devcenter.heroku.com/articles/request-timeout)
 - [App Engine: Dealing with DeadlineExceededErrors](https://cloud.google.com/appengine/articles/deadlineexceedederrors)
+
+
+### MySQL: Unable to log in with correct credentials
+#### How to detect this
+Metabase fails to connect to your MySQL server with the error message "Looks like the username or password is incorrect", but you are sure that the username and password is correct. You may have created the MySQL user with an allowed host other than that which you are connecting from.
+
+For example, if the MySQL server is running in a Docker container, and your `metabase` user was created with `CREATE USER 'metabase'@'localhost' IDENTIFIED BY 'thepassword';`, the `localhost` will be resolved to the Docker container, and not the host machine, causing access to be denied.
+
+You can identify this issue, by looking in the Metabase server logs for the error message `Access denied for user 'metabase'@'172.17.0.1' (using password: YES)`. Note the host name `172.17.0.1` (in this case a Docker network IP address), and `using password: YES` at the end.
+
+You will see the same error message when attempting to connect to the MySQL server with the command-line client: `mysql -h 127.0.0.1 -u metabase -p`
+
+#### How to fix this
+Recreate the MySQL user with the correct host name: `CREATE USER 'metabase'@'172.17.0.1' IDENTIFIED BY 'thepassword';`. Otherwise, if necessary, a wildcard may be used for the host name: `CREATE USER 'metabase'@'%' IDENTIFIED BY 'thepassword';`
+
+That user's permissions will need to be set:
+
+```sql
+GRANT SELECT ON targetdb.* TO 'metabase'@'172.17.0.1';
+FLUSH PRIVILEGES;
+```
+
+Remember to `DROP USER 'metabase'@'localhost';` the old user.
+
+
+### MySQL: Unable to log in to MySQL 8 with correct credentials
+
+#### How to detect this
+Metabase fails to connect to your MySQL 8 server with the error message "Looks like the username or password is incorrect", and the Metabase server logs include the error message `Access denied for user 'metabase'@'172.17.0.1' (using password: NO)`. Note the `using password: NO` at the end.
+
+You may still be able to successfully connect to the server using another MySQL client, such as the command-line client: `mysql -h 127.0.0.1 -u metabase -p`
+
+#### How to fix this
+Change the authentication plugin used by the Metabase user's to `mysql_native_password`: `ALTER USER 'metabase'@'%' IDENTIFIED WITH mysql_native_password BY 'thepassword';`
+
+This is necessary because the MariaDB connector, used by Metabase to connect to MySQL servers, unfortunately does not support MySQL 8's default authentication plugin. From [StackOverflow](https://stackoverflow.com/a/54190598):
+
+> MySQL 8 uses caching_sha2_password rather than mysql_native_password as of MySQL 5.7 (and MariaDB).
+>
+> "caching_sha2_password, it is as of MySQL 8.0 the preferred authentication plugin, and is also the default authentication plugin rather than mysql_native_password. This change affects both the server and the libmysqlclient client library:"
+>
+> https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password
+>
+> MariaDB's Java Connector does not yet implement this, but has a task assigned:
+>
+> https://jira.mariadb.org/browse/CONJ-663

--- a/docs/troubleshooting-guide/datawarehouse.md
+++ b/docs/troubleshooting-guide/datawarehouse.md
@@ -7,21 +7,21 @@
 6. Run a native "SELECT 1" query to verify the connection to the data warehouse
 7. If the sync process has completed, attempt to do a "Raw data" query to verify that you are able to use the database
 
-## Specific Problems:
+## Specific Problems
 
 ### The Data Warehouse Server is not running
-#### How to detect this:
+#### How to detect this
 As silly as this sounds, occasionally database servers go down.
 
 If you are using a hosted database service, go to its console and verify that its status is Green. If you have direct access to a command line interface, log in and make sure that it is up and running and accepting queries.
 
-#### How to fix this:
+#### How to fix this
 It's out of the scope of this troubleshooting guide to get your data warehouse server back up. Check with whomever set it up for you!
 
 
 ### The Data Warehouse Server is not accepting connections from your IP
 
-#### How to detect this:
+#### How to detect this
 
 If you are able to access the server from a bastion host, or another machine, use `nc` on Linux (or your operating system's equivalent) to verify that you can connect to the host on a given port.
 
@@ -29,13 +29,13 @@ The port a data warehouse's server software is attached to varies, but an exampl
 
 `nc -v your-db-host 5432`
 
-#### How to fix this:
+#### How to fix this
 It's out of the scope of this troubleshooting guide to change your network configuration. Talk to whomever is responsible for the network your data warehouse is running on.
 
 
 ### Incorrect credentials
 
-#### How to detect this:
+#### How to detect this
 If you've verified that you can connect to the host and port on the data warehouse, the next step is to check your credentials.
 
 Again, connecting to a data warehouse depends on your database server software, but for PostgreSQL, the below uses a command line interface (`psql`) to connect to your data warehouse.
@@ -44,13 +44,13 @@ Again, connecting to a data warehouse depends on your database server software, 
 
 If your credentials are incorrect, you should see an error message letting you know if the database name or the user/password are incorrect.
 
-#### How to fix this:
+#### How to fix this
 If the database name or the user/password combination are incorrect, ask the person running your data warehouse for correct credentials.
 
 
 ### Connection time out ("Your question took too long")
 
-#### How to detect this:
+#### How to detect this
 If you see the error message, "Your question took too long," something in your setup timed out. Depending on the specifics of your deployment, this could be a timeout in:
 
 - Your load balancer
@@ -61,7 +61,7 @@ If you see the error message, "Your question took too long," something in your s
 - Heroku
 - App Engine
 
-#### How to fix this:
+#### How to fix this
 Fixing this depends on your specific setup. Here are some potentially helpful resources:
 
 - [How to Fix 504 Gateway Timeout using Nginx](https://www.scalescale.com/tips/nginx/504-gateway-time-out-using-nginx/)

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -31,6 +31,7 @@
       ;; actually if we are going to `throw-exceptions` we'll rethrow the original but attempt to humanize the message
       ;; first
       (catch Throwable e
+        (log/info (trs "Database connection error: {0}" (.getMessage e)))
         (throw (Exception. (str (driver/humanize-connection-error-message driver (.getMessage e))) e))))
     (try
       (can-connect-with-details? driver details-map :throw-exceptions)

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -31,7 +31,7 @@
       ;; actually if we are going to `throw-exceptions` we'll rethrow the original but attempt to humanize the message
       ;; first
       (catch Throwable e
-        (log/info (trs "Database connection error: {0}" (.getMessage e)))
+        (log/error e (trs "Database connection error"))
         (throw (Exception. (str (driver/humanize-connection-error-message driver (.getMessage e))) e))))
     (try
       (can-connect-with-details? driver details-map :throw-exceptions)


### PR DESCRIPTION
I see that there are database specific pages under `administration-guide/databases`. Perhaps the MySQL details should be moved there, and linked to from the troubleshooting guide.

What do you think, @mazameli?