### PR TITLE
Fixes the error while sorting group by results

### DIFF
--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -1009,7 +1009,7 @@
   [_ {limit :limit} updated-query]
   (if-not limit
     (-> updated-query
-      (assoc-in [:query :limitSpec :type]  :default))
+        (assoc-in [:query :limitSpec :type]  :default))
     (-> updated-query
         (assoc-in [:query :limitSpec :type]  :default)
         (assoc-in [:query :limitSpec :limit] limit))))

--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -84,7 +84,8 @@
     :distinct___count
 
     (= ag-type :aggregation-options)
-    (recur (second ag))
+    (let [[_ wrapped-ag options] ag]
+      (or (:name options) (recur wrapped-ag)))
 
     ag-type
     ag-type
@@ -1007,7 +1008,8 @@
 (defmethod handle-limit ::groupBy
   [_ {limit :limit} updated-query]
   (if-not limit
-    updated-query
+    (-> updated-query
+      (assoc-in [:query :limitSpec :type]  :default))
     (-> updated-query
         (assoc-in [:query :limitSpec :type]  :default)
         (assoc-in [:query :limitSpec :limit] limit))))

--- a/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
@@ -49,50 +49,46 @@
 
 (datasets/expect-with-driver :druid
   {:projections [:venue_category_name :user_name :__count_0]
-    :query       {:queryType        :groupBy
-                  :granularity      :all
-                  :dataSource       "checkins"
-                  :dimensions       ["venue_category_name", "user_name"]
-                  :context          {:timeout 60000, :queryId "<Query ID>"}
-                  :intervals        ["1900-01-01/2100-01-01"]
-                  :aggregations
-                  [{:type       :cardinality
-                    :name       "__count_0"
-                    :fieldNames ["venue_name"]}]
-                  :limitSpec    {:type    :default
-                                  :columns [
-                                            {:dimension "__count_0", :direction :descending} 
-                                            {:dimension "venue_category_name", :direction :ascending} 
-                                            {:dimension "user_name", :direction :ascending}]}}
+   :query       {:queryType        :groupBy
+                 :granularity      :all
+                 :dataSource       "checkins"
+                 :dimensions       ["venue_category_name", "user_name"]
+                 :context          {:timeout 60000, :queryId "<Query ID>"}
+                 :intervals        ["1900-01-01/2100-01-01"]
+                 :aggregations     [{:type       :cardinality
+                                     :name       "__count_0"
+                                     :fieldNames ["venue_name"]}]
+                 :limitSpec        {:type    :default
+                                    :columns [{:dimension "__count_0", :direction :descending}
+                                              {:dimension "venue_category_name", :direction :ascending}
+                                              {:dimension "user_name", :direction :ascending}]}}
     :query-type  ::druid.qp/groupBy
     :mbql?       true}
   (query->native
     {:aggregation [[:aggregation-options [:distinct [:field-id (data/id :checkins :venue_name)]] {:name "__count_0"}]]
-    :breakout    [$venue_category_name $user_name]
-    :order-by    [[:desc [:aggregation 0]] [:asc [:field-id (data/id :checkins :venue_category_name)]]]}))
+     :breakout    [$venue_category_name $user_name]
+     :order-by    [[:desc [:aggregation 0]] [:asc [:field-id (data/id :checkins :venue_category_name)]]]}))
 
 (datasets/expect-with-driver :druid
   {:projections [:venue_category_name :user_name :__count_0]
-    :query       {:queryType        :groupBy
-                  :granularity      :all
-                  :dataSource       "checkins"
-                  :dimensions       ["venue_category_name", "user_name"]
-                  :context          {:timeout 60000, :queryId "<Query ID>"}
-                  :intervals        ["1900-01-01/2100-01-01"]
-                  :aggregations
-                  [{:type       :cardinality
-                    :name       "__count_0"
-                    :fieldNames ["venue_name"]}]
-                  :limitSpec    {:type    :default
-                                  :columns [
-                                            {:dimension "__count_0", :direction :descending} 
-                                            {:dimension "venue_category_name", :direction :ascending} 
-                                            {:dimension "user_name", :direction :ascending}]
-                                  :limit   5}}
-    :query-type  ::druid.qp/groupBy
-    :mbql?       true}
+   :query       {:queryType        :groupBy
+                 :granularity      :all
+                 :dataSource       "checkins"
+                 :dimensions       ["venue_category_name", "user_name"]
+                 :context          {:timeout 60000, :queryId "<Query ID>"}
+                 :intervals        ["1900-01-01/2100-01-01"]
+                 :aggregations     [{:type       :cardinality
+                                     :name       "__count_0"
+                                     :fieldNames ["venue_name"]}]
+                 :limitSpec        {:type    :default
+                                    :columns [{:dimension "__count_0", :direction :descending}
+                                              {:dimension "venue_category_name", :direction :ascending}
+                                              {:dimension "user_name", :direction :ascending}]
+                                    :limit   5}}
+   :query-type  ::druid.qp/groupBy
+   :mbql?       true}
   (query->native
     {:aggregation [[:aggregation-options [:distinct [:field-id (data/id :checkins :venue_name)]] {:name "__count_0"}]]
-    :breakout    [$venue_category_name $user_name]
-    :order-by    [[:desc [:aggregation 0]] [:asc [:field-id (data/id :checkins :venue_category_name)]]]
-    :limit       5}))
+     :breakout    [$venue_category_name $user_name]
+     :order-by    [[:desc [:aggregation 0]] [:asc [:field-id (data/id :checkins :venue_category_name)]]]
+     :limit       5}))

--- a/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
@@ -46,3 +46,53 @@
   (query->native
    {:aggregation [[:* [:count $id] 10]]
     :breakout    [$venue_price]}))
+
+(datasets/expect-with-driver :druid
+  {:projections [:venue_category_name :user_name :__count_0]
+    :query       {:queryType        :groupBy
+                  :granularity      :all
+                  :dataSource       "checkins"
+                  :dimensions       ["venue_category_name", "user_name"]
+                  :context          {:timeout 60000, :queryId "<Query ID>"}
+                  :intervals        ["1900-01-01/2100-01-01"]
+                  :aggregations
+                  [{:type       :cardinality
+                    :name       "__count_0"
+                    :fieldNames ["venue_name"]}]
+                  :limitSpec    {:type    :default
+                                  :columns [
+                                            {:dimension "__count_0", :direction :descending} 
+                                            {:dimension "venue_category_name", :direction :ascending} 
+                                            {:dimension "user_name", :direction :ascending}]}}
+    :query-type  ::druid.qp/groupBy
+    :mbql?       true}
+  (query->native
+    {:aggregation [[:aggregation-options [:distinct [:field-id (data/id :checkins :venue_name)]] {:name "__count_0"}]]
+    :breakout    [$venue_category_name $user_name]
+    :order-by    [[:desc [:aggregation 0]] [:asc [:field-id (data/id :checkins :venue_category_name)]]]}))
+
+(datasets/expect-with-driver :druid
+  {:projections [:venue_category_name :user_name :__count_0]
+    :query       {:queryType        :groupBy
+                  :granularity      :all
+                  :dataSource       "checkins"
+                  :dimensions       ["venue_category_name", "user_name"]
+                  :context          {:timeout 60000, :queryId "<Query ID>"}
+                  :intervals        ["1900-01-01/2100-01-01"]
+                  :aggregations
+                  [{:type       :cardinality
+                    :name       "__count_0"
+                    :fieldNames ["venue_name"]}]
+                  :limitSpec    {:type    :default
+                                  :columns [
+                                            {:dimension "__count_0", :direction :descending} 
+                                            {:dimension "venue_category_name", :direction :ascending} 
+                                            {:dimension "user_name", :direction :ascending}]
+                                  :limit   5}}
+    :query-type  ::druid.qp/groupBy
+    :mbql?       true}
+  (query->native
+    {:aggregation [[:aggregation-options [:distinct [:field-id (data/id :checkins :venue_name)]] {:name "__count_0"}]]
+    :breakout    [$venue_category_name $user_name]
+    :order-by    [[:desc [:aggregation 0]] [:asc [:field-id (data/id :checkins :venue_category_name)]]]
+    :limit       5}))

--- a/modules/drivers/druid/test/metabase/driver/druid_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid_test.clj
@@ -439,3 +439,27 @@
         (u/pprint-to-str 'red results))
       {:cols (->> results :data :cols (map :name))
        :rows (-> results :data :rows)})))
+
+(datasets/expect-with-driver :druid
+  [["Bar" "Felipinho Asklepios" 8.015665809687173]
+    ["Bar" "Spiros Teofil" 8.015665809687173]
+    ["Japanese" "Felipinho Asklepios" 7.011990219885757]
+    ["Japanese" "Frans Hevel" 7.011990219885757]
+    ["Mexican" "Shad Ferdynand" 7.011990219885757]]
+  (druid-query-returning-rows
+    {:aggregation [[:aggregation-options [:distinct [:field-id (data/id :checkins :venue_name)]] {:name "__count_0"}]]
+      :breakout    [$venue_category_name $user_name]
+      :order-by    [[:desc [:aggregation 0]] [:asc [:field-id (data/id :checkins :venue_category_name)]]]
+      :limit       5}))
+
+(datasets/expect-with-driver :druid
+  [["American" "Rüstem Hebel" 1.0002442201269182]
+  ["Artisan" "Broen Olujimi" 1.0002442201269182]
+  ["Artisan" "Conchúr Tihomir" 1.0002442201269182]
+  ["Artisan" "Dwight Gresham" 1.0002442201269182]
+  ["Artisan" "Plato Yeshua" 1.0002442201269182]]
+  (druid-query-returning-rows
+    {:aggregation [[:aggregation-options [:distinct [:field-id (data/id :checkins :venue_name)]] {:name "__count_0"}]]
+      :breakout    [$venue_category_name $user_name]
+      :order-by    [[:asc [:aggregation 0]] [:asc [:field-id (data/id :checkins :venue_category_name)]]]
+      :limit       5}))


### PR DESCRIPTION
This PR fixes issues with group by native query generated by druid driver,
1. Wrong native query generated by the driver when the results are sorted by the aggregated metric (like distinct count). The driver did not handle named aggregated metric. The error is seen only when a limit is applied to result.
1. Second, if no limit is applied, the native query generated will return a result but it does not sort the results. This is also an issue with the generated native query. It is fixed by adding `:type :default` to limit spec.