### PR TITLE
bandaid to resolve #10651, avoid migration crashes.

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -211,10 +211,9 @@
     (if (has-unrun-migrations? liquibase)
       (do
         (log/info (trs "Migration lock is cleared. Running migrations..."))
-        (let [^Contexts contexts nil]
-          (.update liquibase contexts)))
+        (u/auto-retry 3 (let [^Contexts contexts nil] (.update liquibase contexts))))
       (log/info
-       (trs "Migration lock cleared, but nothing to do here! Migrations were finished by another instance.")))))
+        (trs "Migration lock cleared, but nothing to do here! Migrations were finished by another instance.")))))
 
 (defn- force-migrate-up-if-needed!
   "Force migrating up. This does two things differently from `migrate-up-if-needed!`:


### PR DESCRIPTION
When multiple instances run migrations race conditions are encountered that result in exceptions getting thrown. We try to mitigate this using auto-retry. The code in this PR is one more instance where a race condition can cause an exception, and it gets mitigated with an auto-retry.

@camsaul I think there are a couple ways we could do this better:

* Use [diehard](https://github.com/sunng87/diehard), a more featureful and robust library for dealing with these kinds of concurrency issues
* Update `setup-db!` such that it considers _any_ exception thrown to be a signal that there's a concurrency issue, and to handle those exceptions at a higher level rather than many layers deep in individual function calls. I'm not sure exactly what this would look like, but it might be something like:

```clojure
(with-multiple-instances
  :verify-db-connection    (verify-db-connection db-details)
  :schema-migrations       (run-schema-migrations! auto-migrate db-details)
  :create-connection-pool! (create-connection-pool! (jdbc-details db-details))
  :run-data-migrations!    (run-data-migrations!))
```

`with-multiple-instances` would be a macro that wraps each step of the db setup process in a die-hard call that catches an exception, logs that the exceptions, and waits n seconds before retrying.

It could log something like `"Exception while attempting `:verify-db-connection`: blah blah blah. This often happens when multiple instances are setting up the metabase database. Retrying in n seconds."`

The keywords for each step aren't really necessary but I added them here to hopefully clarify my idea.