### PR TITLE
Fix trend widget for years

### DIFF
--- a/src/metabase/sync/analyze/fingerprint/insights.clj
+++ b/src/metabase/sync/analyze/fingerprint/insights.clj
@@ -205,16 +205,6 @@
                    :best-fit       best-fit
                    :col            (:name number-col)})))))))
 
-(defn- datetime-truncated-to-year?
-  "This is hackish as hell, but we change datetimes with year granularity to strings upstream and
-   this is the only way to recover the information they were once datetimes."
-  [{:keys [base_type unit fingerprint] :as field}]
-  (and (= base_type :type/Text)
-       (contains? field :unit)
-       (nil? unit)
-       (or (nil? (:type fingerprint))
-           (-> fingerprint :type :type/DateTime))))
-
 (defn insights
   "Based on the shape of returned data construct a transducer to statistically analyize data."
   [cols]
@@ -224,7 +214,6 @@
                           (group-by (fn [{:keys [base_type special_type unit] :as field}]
                                       (cond
                                         (#{:type/FK :type/PK} special_type)          :others
-                                        (datetime-truncated-to-year? field)          :datetimes
                                         (= unit :year)                               :datetimes
                                         (metabase.util.date/date-extract-units unit) :numbers
                                         (field/unix-timestamp? field)                :datetimes

--- a/src/metabase/sync/analyze/fingerprint/insights.clj
+++ b/src/metabase/sync/analyze/fingerprint/insights.clj
@@ -225,6 +225,7 @@
                                       (cond
                                         (#{:type/FK :type/PK} special_type)          :others
                                         (datetime-truncated-to-year? field)          :datetimes
+                                        (= unit :year)                               :datetimes
                                         (metabase.util.date/date-extract-units unit) :numbers
                                         (field/unix-timestamp? field)                :datetimes
                                         (isa? base_type :type/Number)                :numbers

--- a/test/metabase/sync/analyze/fingerprint/insights_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/insights_test.clj
@@ -35,12 +35,10 @@
       :last-value))
 
 (expect
-  false
-  (nil? (transduce identity
-    (insights
-      [{:base_type :type/DateTime :unit :year} {:base_type :type/Integer}])
-    [["2014" 100]
-     ["2015" 200]])))
+  (transduce identity
+             (insights [{:base_type :type/DateTime :unit :year}
+                        {:base_type :type/Integer}])
+             [["2014" 100] ["2015" 200]]))
 
 (defn- inst->day
   [inst]

--- a/test/metabase/sync/analyze/fingerprint/insights_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/insights_test.clj
@@ -34,6 +34,13 @@
       first
       :last-value))
 
+(expect
+  false
+  (nil? (transduce identity
+    (insights
+      [{:base_type :type/DateTime :unit :year} {:base_type :type/Integer}])
+    [["2014" 100]
+     ["2015" 200]])))
 
 (defn- inst->day
   [inst]

--- a/test/metabase/sync/analyze/fingerprint/insights_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/insights_test.clj
@@ -38,7 +38,8 @@
   (transduce identity
              (insights [{:base_type :type/DateTime :unit :year}
                         {:base_type :type/Integer}])
-             [["2014" 100] ["2015" 200]]))
+             [["2014-01-01T00:00:00Z" 100]
+              ["2015-01-01T00:00:00Z" 200]]))
 
 (defn- inst->day
   [inst]


### PR DESCRIPTION
Resolves #10699

@sbelak It looks like there was already some code in there to catch dates truncated to years. However, it seems that something changed? Now they do come through as `:type/DateTime` and `unit` is set correctly. Does this look like the right fix to you?