### PR TITLE
Speed up getAllFeaturesPoints by swapping concat for push

### DIFF
--- a/frontend/src/metabase/visualizations/lib/mapping.js
+++ b/frontend/src/metabase/visualizations/lib/mapping.js
@@ -57,16 +57,16 @@ export function computeLargestGap(items, valueAccessor = d => d) {
 }
 
 export function getAllFeaturesPoints(features) {
-  let points = [];
+  const points = [];
   for (const feature of features) {
     if (feature.geometry.type === "Polygon") {
       for (const coordinates of feature.geometry.coordinates) {
-        points = points.concat(coordinates);
+        points.push(...coordinates);
       }
     } else if (feature.geometry.type === "MultiPolygon") {
       for (const coordinatesList of feature.geometry.coordinates) {
         for (const coordinates of coordinatesList) {
-          points = points.concat(coordinates);
+          points.push(...coordinates);
         }
       }
     } else {


### PR DESCRIPTION
Resolves #10483

On my computer `getAllFeaturesPoints` took 30-40 seconds with `concat`. With `push` it takes ~10ms. Avoiding allocations makes a big difference!