### PR TITLE
xrays: add table name to title for fields from joined tables

### DIFF
--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -319,7 +319,9 @@
   [_ {:keys [display_name full-name link table_id]}]
   (cond
     full-name full-name
-    link      (format "%s → %s" (->reference :string (Table table_id)) display_name)
+    link      (format "%s → %s"
+                      (-> link Field :display_name (str/replace #"(?i)\sid$" ""))
+                      display_name)
     :else     display_name))
 
 (defmethod ->reference [:string (type Table)]

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -316,8 +316,11 @@
       reference)))
 
 (defmethod ->reference [:string (type Field)]
-  [_ {:keys [display_name full-name]}]
-  (or full-name display_name))
+  [_ {:keys [display_name full-name link table_id]}]
+  (cond
+    full-name full-name
+    link      (format "%s → %s" (->reference :string (Table table_id)) display_name)
+    :else     display_name))
 
 (defmethod ->reference [:string (type Table)]
   [_ {:keys [display_name full-name]}]


### PR DESCRIPTION
Adds table name to fields we pull from other tables.

Before:
<img width="1040" alt="Screenshot 2019-08-27 16 53 53" src="https://user-images.githubusercontent.com/178038/63788224-fcc33780-c8ec-11e9-9c91-2db4da998229.png">
After:
<img width="1059" alt="Screenshot 2019-08-27 16 53 44" src="https://user-images.githubusercontent.com/178038/63788234-0187eb80-c8ed-11e9-924b-afc9f225a5bb.png">

I'm not sure why the frontend changes the axis name to singular.  This should probably be unified before we ship it. cc @mazameli 

Implements #9696