### PR TITLE
Druid: type numerical fields in checkins

### DIFF
--- a/modules/drivers/druid/test/metabase/test/data/druid.clj
+++ b/modules/drivers/druid/test/metabase/test/data/druid.clj
@@ -73,10 +73,13 @@
                                                                                    "user_name"
                                                                                    "user_password"
                                                                                    "venue_category_name"
-                                                                                   "venue_latitude"
-                                                                                   "venue_longitude"
+                                                                                   {:name "venue_latitude"
+                                                                                    :type "double"}
+                                                                                   {:name "venue_longitude"
+                                                                                    :type "double"}
                                                                                    "venue_name"
-                                                                                   "venue_price"]}}}
+                                                                                   {:name "venue_price"
+                                                                                    :type "float"}]}}}
                        :metricsSpec     [{:type :count
                                           :name :count}]
                        :granularitySpec {:type               :uniform


### PR DESCRIPTION
This makes `price`, and `longitude` and `latitude` numbers via Druid [https://druid.apache.org/docs/latest/ingestion/ingestion-spec.html#dimension-schema](DataSchema). With everything being a string we aren't testing some of the sync and fingerprinting features.