### PR TITLE
update timeouts for ELB

### DIFF
--- a/bin/aws-eb-docker/.ebextensions/metabase_config/metabase-setup.sh
+++ b/bin/aws-eb-docker/.ebextensions/metabase_config/metabase-setup.sh
@@ -82,6 +82,11 @@ server {
         proxy_set_header    Host                $host;
         proxy_set_header    X-Real-IP            $remote_addr;
         proxy_set_header    X-Forwarded-For        $proxy_add_x_forwarded_for;
+        proxy_connect_timeout 600;
+        proxy_send_timeout 600;
+        proxy_read_timeout 600;
+        send_timeout 600;
+
     }
 
 
@@ -98,6 +103,10 @@ server {
         proxy_set_header    Host                $host;
         proxy_set_header    X-Real-IP            $remote_addr;
         proxy_set_header    X-Forwarded-For        $proxy_add_x_forwarded_for;
+        proxy_connect_timeout 600;
+        proxy_send_timeout 600;
+        proxy_read_timeout 600;
+        send_timeout 600;
     }
 }
 EOF


### PR DESCRIPTION
https://github.com/metabase/metabase/pull/4217 did not work for me but this did

updates timeouts when using ELB for queries to 10 minutes.

Also updates health check timeouts because health checks would bring metabase offline when under load.

cc @omnibs