### PR TITLE
Data Reference: Only show queryable tables when there are multiple schemas

### DIFF
--- a/frontend/src/metabase/reference/databases/TableList.jsx
+++ b/frontend/src/metabase/reference/databases/TableList.jsx
@@ -73,6 +73,7 @@ export const separateTablesBySchema = (
         ? 0
         : -1,
     )
+    .filter(isQueryable)
     .map((table, index, sortedTables) => {
       if (!table || !table.id || !table.name) {
         return;

--- a/frontend/test/metabase/reference/databases/TableList.unit.spec.js
+++ b/frontend/test/metabase/reference/databases/TableList.unit.spec.js
@@ -1,0 +1,8 @@
+import { separateTablesBySchema } from "metabase/reference/databases/TableList";
+
+describe("separateTablesBySchema", () => {
+  it("should filter out hidden tables", () => {
+    const tables = { 1: {}, 2: { visibility_type: "hidden" } };
+    expect(separateTablesBySchema(tables).length).toBe(1);
+  });
+});


### PR DESCRIPTION
Same as #6093 but with a test.

Ideally I would have just added the test to the external PR. Is there a way to check if metabase maintainers were granted permissions to do so without cloning the fork? 