### PR TITLE
Fix table selection for single db with multiple schemas

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -136,8 +136,6 @@ export const TableTriggerContent = ({ selectedTable }) =>
 @connect(
   state => ({ metadata: getMetadata(state) }),
   { fetchTableMetadata },
-  undefined,
-  { withRef: true },
 )
 export default class DataSelector extends Component {
   constructor(props) {

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -136,6 +136,8 @@ export const TableTriggerContent = ({ selectedTable }) =>
 @connect(
   state => ({ metadata: getMetadata(state) }),
   { fetchTableMetadata },
+  undefined,
+  { withRef: true },
 )
 export default class DataSelector extends Component {
   constructor(props) {
@@ -250,7 +252,7 @@ export default class DataSelector extends Component {
       this.props.databases.length === 1 &&
       !this.props.segments;
     if (useOnlyAvailableDatabase) {
-      setTimeout(() => this.onChangeDatabase(0));
+      setTimeout(() => this.onChangeDatabase(0, true));
     }
 
     this.hydrateActiveStep();

--- a/frontend/test/metabase/query_builder/components/DataSelector.integ.spec.js
+++ b/frontend/test/metabase/query_builder/components/DataSelector.integ.spec.js
@@ -1,0 +1,46 @@
+import React from "react";
+import { mount } from "enzyme";
+import { getStore } from "metabase/store";
+import normalReducers from "metabase/reducers-main";
+
+import DataSelector, {
+  TableTriggerContent,
+} from "metabase/query_builder/components/DataSelector.jsx";
+
+describe("DatabaseSchemaAndTableDataSelector",  () => {
+  it("should render", async () => {
+    const store = getStore(normalReducers);
+    const dataSelector = mount(
+      <DataSelector
+				store={store}
+        steps={["DATABASE_SCHEMA", "TABLE"]}
+        getTriggerElementContent={TableTriggerContent}
+        databases={[
+          {
+            id: 1,
+            name: "db-1",
+            tables: [
+              { name:"table-1",display_name: "table-1", schema: "schema-1" },
+              { name:"table-2",display_name: "table-2", schema: "schema-2" },
+            ],
+          },
+        ]}
+        isInitiallyOpen={true}
+      />,
+    );
+
+		// this await is because onChangeDatabase get scheduled for the next tick
+		await new Promise(r => setTimeout(r))
+
+    const dataSelectorInstance = dataSelector.instance().getWrappedInstance();
+    let popoverContent = mount(dataSelectorInstance.renderActiveStep());
+    const schemaNames = popoverContent.find("h4").map(e => e.text());
+    expect(schemaNames).toEqual(["Schema-1", "Schema-2"]);
+    popoverContent
+      .find("a")
+      .first()
+      .simulate("click");
+    popoverContent = mount(dataSelectorInstance.renderActiveStep());
+    expect(popoverContent.find("h4").text()).toBe("table-1");
+  });
+});

--- a/frontend/test/metabase/query_builder/components/DataSelector.integ.spec.js
+++ b/frontend/test/metabase/query_builder/components/DataSelector.integ.spec.js
@@ -7,12 +7,12 @@ import DataSelector, {
   TableTriggerContent,
 } from "metabase/query_builder/components/DataSelector.jsx";
 
-describe("DatabaseSchemaAndTableDataSelector",  () => {
+describe("DatabaseSchemaAndTableDataSelector", () => {
   it("should render", async () => {
     const store = getStore(normalReducers);
     const dataSelector = mount(
       <DataSelector
-				store={store}
+        store={store}
         steps={["DATABASE_SCHEMA", "TABLE"]}
         getTriggerElementContent={TableTriggerContent}
         databases={[
@@ -20,8 +20,8 @@ describe("DatabaseSchemaAndTableDataSelector",  () => {
             id: 1,
             name: "db-1",
             tables: [
-              { name:"table-1",display_name: "table-1", schema: "schema-1" },
-              { name:"table-2",display_name: "table-2", schema: "schema-2" },
+              { name: "table-1", display_name: "table-1", schema: "schema-1" },
+              { name: "table-2", display_name: "table-2", schema: "schema-2" },
             ],
           },
         ]}
@@ -29,8 +29,8 @@ describe("DatabaseSchemaAndTableDataSelector",  () => {
       />,
     );
 
-		// this await is because onChangeDatabase get scheduled for the next tick
-		await new Promise(r => setTimeout(r))
+    // this await is because onChangeDatabase get scheduled for the next tick
+    await new Promise(r => setTimeout(r));
 
     const dataSelectorInstance = dataSelector.instance().getWrappedInstance();
     let popoverContent = mount(dataSelectorInstance.renderActiveStep());

--- a/frontend/test/metabase/query_builder/components/DataSelector.integ.spec.js
+++ b/frontend/test/metabase/query_builder/components/DataSelector.integ.spec.js
@@ -1,46 +1,42 @@
 import React from "react";
-import { mount } from "enzyme";
-import { getStore } from "metabase/store";
-import normalReducers from "metabase/reducers-main";
+import { delay } from "metabase/lib/promise";
 
-import DataSelector, {
-  TableTriggerContent,
-} from "metabase/query_builder/components/DataSelector.jsx";
+import { mountWithStore } from "__support__/integration_tests";
+
+import { DatabaseSchemaAndTableDataSelector } from "metabase/query_builder/components/DataSelector.jsx";
+
+jest.mock("metabase/components/Popover.jsx");
 
 describe("DatabaseSchemaAndTableDataSelector", () => {
-  it("should render", async () => {
-    const store = getStore(normalReducers);
-    const dataSelector = mount(
-      <DataSelector
-        store={store}
-        steps={["DATABASE_SCHEMA", "TABLE"]}
-        getTriggerElementContent={TableTriggerContent}
+  it("should render with one db that has multiple schemas", async () => {
+    const { wrapper } = mountWithStore(
+      <DatabaseSchemaAndTableDataSelector
         databases={[
           {
             id: 1,
             name: "db-1",
             tables: [
-              { name: "table-1", display_name: "table-1", schema: "schema-1" },
-              { name: "table-2", display_name: "table-2", schema: "schema-2" },
+              { display_name: "table-1", schema: "schema-1" },
+              { display_name: "table-2", schema: "schema-2" },
             ],
           },
         ]}
-        isInitiallyOpen={true}
+        isOpen={true}
       />,
     );
 
     // this await is because onChangeDatabase get scheduled for the next tick
-    await new Promise(r => setTimeout(r));
+    await delay(0);
 
-    const dataSelectorInstance = dataSelector.instance().getWrappedInstance();
-    let popoverContent = mount(dataSelectorInstance.renderActiveStep());
-    const schemaNames = popoverContent.find("h4").map(e => e.text());
+    const schemaNames = wrapper.find("h4").map(e => e.text());
     expect(schemaNames).toEqual(["Schema-1", "Schema-2"]);
-    popoverContent
+
+    wrapper
+      .find("TestPopover")
       .find("a")
       .first()
       .simulate("click");
-    popoverContent = mount(dataSelectorInstance.renderActiveStep());
-    expect(popoverContent.find("h4").text()).toBe("table-1");
+
+    expect(wrapper.find("h4").text()).toBe("table-1");
   });
 });


### PR DESCRIPTION
Resolves #8532

# The Fix

To fix the bug, I set `schemaInSameStep` to `true` in the relevant call to `onChangeDatabase`. This seems safe, but I don't really understand when we want `schemaInSameStep` to be false.

# The Test

The test ...works. 

But, it's way too verbose and fragile. The main issue I had was accessing the popover content. Rather than grabbing the raw DOM node from document.body, I reached through the connected component and called the component method to render the popover content directly.

In its current state, I think I'd rather omit this test. Is there anyway to improve it? Do we test popover content in integration tests elsewhere?
