### PR TITLE
Fix issues with object detail FK queries

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -1081,6 +1081,7 @@ export const loadObjectDetailFKReferences = createThunkAction(
   LOAD_OBJECT_DETAIL_FK_REFERENCES,
   () => {
     return async (dispatch, getState) => {
+      dispatch.action(CLEAR_OBJECT_DETAIL_FK_REFERENCES);
       // TODO Atte Keinänen 6/1/17: Should use `queryResults` instead
       const {
         qb: { card },
@@ -1141,10 +1142,23 @@ export const loadObjectDetailFKReferences = createThunkAction(
         fkReferences[fk.origin.id] = info;
       }
 
+      // It's possible that while we were running those queries, the object
+      // detail id changed. If so, these fk reference are stale and we shouldn't
+      // put them in state.
+      const updatedQueryResult = getFirstQueryResult(getState());
+      if (
+        getObjectDetailIdValue(queryResult.data) !==
+        getObjectDetailIdValue(updatedQueryResult.data)
+      ) {
+        return null;
+      }
       return fkReferences;
     };
   },
 );
+
+export const CLEAR_OBJECT_DETAIL_FK_REFERENCES =
+  "metabase/qb/CLEAR_OBJECT_DETAIL_FK_REFERENCES";
 
 // DEPRECATED: use metabase/entities/questions
 export const ARCHIVE_QUESTION = "metabase/qb/ARCHIVE_QUESTION";

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -22,6 +22,7 @@ import {
   QUERY_COMPLETED,
   QUERY_ERRORED,
   LOAD_OBJECT_DETAIL_FK_REFERENCES,
+  CLEAR_OBJECT_DETAIL_FK_REFERENCES,
   SET_CURRENT_STATE,
   CREATE_PUBLIC_LINK,
   DELETE_PUBLIC_LINK,
@@ -257,6 +258,7 @@ export const tableForeignKeyReferences = handleActions(
     [LOAD_OBJECT_DETAIL_FK_REFERENCES]: {
       next: (state, { payload }) => payload,
     },
+    [CLEAR_OBJECT_DETAIL_FK_REFERENCES]: () => null,
   },
   null,
 );

--- a/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
@@ -97,7 +97,9 @@ export class ObjectDetail extends Component {
 
   componentDidMount() {
     // load up FK references
-    this.props.loadObjectDetailFKReferences();
+    if (this.props.tableForeignKeys) {
+      this.props.loadObjectDetailFKReferences();
+    }
     window.addEventListener("keydown", this.onKeyDown, true);
   }
 
@@ -106,8 +108,10 @@ export class ObjectDetail extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    // if the card has changed then reload fk references
-    if (this.props.data != nextProps.data) {
+    // if the card has changed or table metadat laoded then reload fk references
+    const tableFKsJustLoaded =
+      nextProps.tableForeignKeys && !this.props.tableForeignKeys;
+    if (this.props.data != nextProps.data || tableFKsJustLoaded) {
       this.props.loadObjectDetailFKReferences();
     }
   }

--- a/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
@@ -108,7 +108,7 @@ export class ObjectDetail extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    // if the card has changed or table metadat laoded then reload fk references
+    // if the card changed or table metadata loaded then reload fk references
     const tableFKsJustLoaded =
       nextProps.tableForeignKeys && !this.props.tableForeignKeys;
     if (this.props.data != nextProps.data || tableFKsJustLoaded) {


### PR DESCRIPTION
Resolves #6830 

There were three small related issues:

1. The FK count data never loads.
This issue was caused by a race between loading table metadata and calling `loadObjectDetailFKReferences`. We can't query the FK references until the table metadata has loaded.
2. If you quickly advance from one object to the next the old FK references API calls are still in flight and overwrite the current counts when they return. 
Here, I added a check that the object id hasn't changed. If it has, we throw out the result.
3. When you advance to the prev/next object, you still see the old FK counts until new data loads.
To fix this I added `CLEAR_OBJECT_DETAIL_FK_REFERENCES`. Calling `loadObjectDetailFKReferences` first clears out the old data, which will display spinners until the new data loads.

It didn't seem practical to test this since the initial bug relies on a race condition. Any ideas one a good way to add some coverage?