### PR TITLE
Assume dates from MongoDB are in UTC [WIP]

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -635,7 +635,7 @@
      (for [[k v] row]
        [k (if (and (map? v)
                    (contains? v :___date))
-            (du/->Timestamp (:___date v) (TimeZone/getDefault))
+            (du/->Timestamp (:___date v) (TimeZone/getTimeZone "UTC"))
             v)]))))
 
 


### PR DESCRIPTION
_**Not ready for review**, as I'm still testing the impact of aggregation between the reporting time-zone and MongoDB's UTC dates..._

According to the docs:

> MongoDB stores times in UTC by default...

-- https://docs.mongodb.com/manual/tutorial/model-time-data/

Despite the language implying that the time-zone can be changed, it
appears that it cannot:

> MongoDB will always store time in UTC. MongoDB has no internal
> knowledge of timezones.

-- https://stackoverflow.com/a/14601327

So until we find a reason to think that MongoDB dates are not stored in
UTC, let's treat them as if they are.