### PR TITLE
fix null key in tooltips

### DIFF
--- a/frontend/src/metabase/visualizations/lib/RowRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/RowRenderer.js
@@ -6,10 +6,14 @@ import dc from "dc";
 
 import { formatValue } from "metabase/lib/formatting";
 
-import { initChart, forceSortedGroup, makeIndexMap } from "./renderer_utils";
+import {
+  initChart,
+  forceSortedGroup,
+  makeIndexMap,
+  formatNull,
+} from "./renderer_utils";
 import { getFriendlyName } from "./utils";
 import { checkXAxisLabelOverlap } from "./LineAreaBarPostRender";
-import { NULL_DISPLAY_VALUE } from "./constants";
 
 export default function rowRenderer(
   element,
@@ -29,7 +33,7 @@ export default function rowRenderer(
   // dc.js doesn't give us a way to format the row labels from unformatted data, so we have to
   // do it here then construct a mapping to get the original dimension for tooltipsd/clicks
   const rowsWithFormattedNull = series[0].data.rows.map(([first, ...rest]) => [
-    first === null ? NULL_DISPLAY_VALUE : first,
+    formatNull(first),
     ...rest,
   ]);
   const rows = rowsWithFormattedNull.map(([a, b]) => [

--- a/frontend/src/metabase/visualizations/lib/apply_tooltips.js
+++ b/frontend/src/metabase/visualizations/lib/apply_tooltips.js
@@ -5,7 +5,7 @@ import moment from "moment";
 
 import { formatValue } from "metabase/lib/formatting";
 
-import { isNormalized, isStacked } from "./renderer_utils";
+import { isNormalized, isStacked, formatNull } from "./renderer_utils";
 import { determineSeriesIndexFromElement } from "./tooltip";
 import { getFriendlyName } from "./utils";
 
@@ -83,8 +83,9 @@ export function getClickHoverObject(
           // this catches values like years that don't parse correctly above
           formatValue(key, { column: rawCols[0] }) === String(x)
         : // otherwise, we just check if the string value matches
+          // we also format null so it matches a key displayed as "(empty)"
           // e.g. String("123") === String(123)
-          String(x) === String(key),
+          String(formatNull(x)) === String(key),
     );
 
     // try to get row from _origin but fall back to the row we already have
@@ -106,7 +107,7 @@ export function getClickHoverObject(
         }
         return {
           key: getColumnDisplayName(col),
-          value: rawRow[i],
+          value: formatNull(rawRow[i]),
           col: col,
         };
       });

--- a/frontend/src/metabase/visualizations/lib/constants.js
+++ b/frontend/src/metabase/visualizations/lib/constants.js
@@ -1,3 +1,0 @@
-import { t } from "ttag";
-
-export const NULL_DISPLAY_VALUE = t`(empty)`;

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -2,6 +2,7 @@
 
 import _ from "underscore";
 import { getIn } from "icepick";
+import { t } from "ttag";
 
 import { datasetContainsNoResults } from "metabase/lib/dataset";
 import { parseTimestamp } from "metabase/lib/time";
@@ -10,7 +11,6 @@ import { dimensionIsNumeric } from "./numeric";
 import { dimensionIsTimeseries } from "./timeseries";
 import { getAvailableCanvasWidth, getAvailableCanvasHeight } from "./utils";
 import { invalidDateWarning, nullDimensionWarning } from "./warnings";
-import { NULL_DISPLAY_VALUE } from "./constants";
 
 export function initChart(chart, element) {
   // set the bounds
@@ -110,11 +110,7 @@ const memoizedParseXValue = _.memoize(
     if (isTimeseries && !isQuantitative) {
       return parseTimestampAndWarn(xValue, unit);
     }
-    const parsedValue = isNumeric
-      ? xValue
-      : xValue === null
-      ? NULL_DISPLAY_VALUE
-      : String(xValue);
+    const parsedValue = isNumeric ? xValue : String(formatNull(xValue));
     return { parsedValue };
   },
   // create cache key from args
@@ -243,3 +239,8 @@ export const isRemappedToString = series =>
 export const isMultiCardSeries = series =>
   series.length > 1 &&
   getIn(series, [0, "card", "id"]) !== getIn(series, [1, "card", "id"]);
+
+const NULL_DISPLAY_VALUE = t`(empty)`;
+export function formatNull(value) {
+  return value === null ? NULL_DISPLAY_VALUE : value;
+}


### PR DESCRIPTION
#10609 updated how we display nulls and added a test.
#10555 updated how tooltips are generated, but didn't account for nulls.

When they were merged yesterday, the test from #10609 broke. This PR fixes how tooltips handle nulls. 
