### PR TITLE
add param_fields and param_values to Dashboard API response

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -193,7 +193,7 @@
   [id]
   (-> (Dashboard id)
       api/check-404
-      (hydrate [:ordered_cards :card :series] :can_write)
+      (hydrate [:ordered_cards :card :series] :can_write :param_fields :param_values)
       api/read-check
       api/check-not-archived
       hide-unreadable-cards

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -249,8 +249,8 @@
                                                              :result_metadata        nil})
                              :series                 []}]})
     ;; fetch a dashboard WITH a dashboard card on it
-    (tt/with-temp* [Table         [{table-id :id} {:id table-id}]
-                    Field         [{field-id :id} {:table_id table-id :id field-id :display_name display-name}]
+    (tt/with-temp* [Table         [_ {:id table-id}]
+                    Field         [_ {:table_id table-id :id field-id :display_name display-name}]
 
                     Dashboard     [{dashboard-id :id} {:name "Test Dashboard"}]
                     Card          [{card-id :id}      {:name "Dashboard Test Card"}]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -180,6 +180,8 @@
           :creator_id    (user->id :rasta)
           :collection_id true
           :can_write     false
+          :param_values  nil
+          :param_fields  nil
           :ordered_cards [{:sizeX                  2
                            :sizeY                  2
                            :col                    0

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -210,58 +210,54 @@
         (dashboard-response ((user->client :rasta) :get 200 (format "dashboard/%d" dashboard-id)))))))
 
 ;; As above, but with a param
-(let [field-id     100
-      table-id     100
-      display-name "bloop"]
-  (expect
-    (merge dashboard-defaults
-           {:name          "Test Dashboard"
-            :creator_id    (user->id :rasta)
-            :collection_id true
-            :can_write     false
-            :param_values  {}
-            :param_fields  {(keyword (str field-id)) {:id               field-id
-                                                      :table_id         table-id
-                                                      :display_name     display-name
-                                                      :base_type        "type/Text"
-                                                      :special_type     nil
-                                                      :has_field_values "search" :name_field nil
-                                                      :dimensions       ()}}
-            :ordered_cards [{:sizeX                  2
-                             :sizeY                  2
-                             :col                    0
-                             :row                    0
-                             :updated_at             true
-                             :created_at             true
-                             :parameter_mappings     [{:card_id      1
-                                                       :parameter_id "foo"
-                                                       :target       ["dimension" ["field-id" field-id]]}]
-                             :visualization_settings {}
-                             :card                   (merge card-api-test/card-defaults
-                                                            {:name                   "Dashboard Test Card"
-                                                             :creator_id             (user->id :rasta)
-                                                             :collection_id          true
-                                                             :display                "table"
-                                                             :query_type             nil
-                                                             :dataset_query          {}
-                                                             :read_permissions       nil
-                                                             :visualization_settings {}
-                                                             :result_metadata        nil})
-                             :series                 []}]})
-    ;; fetch a dashboard WITH a dashboard card on it
-    (tt/with-temp* [Table         [_ {:id table-id}]
-                    Field         [_ {:table_id table-id :id field-id :display_name display-name}]
+(tt/expect-with-temp [Table         [{table-id :id} {}]
+                      Field         [{field-id :id display-name :display_name} {:table_id table-id}]
 
-                    Dashboard     [{dashboard-id :id} {:name "Test Dashboard"}]
-                    Card          [{card-id :id}      {:name "Dashboard Test Card"}]
-                    DashboardCard [{dc-id :id}        {:dashboard_id       dashboard-id
-                                                       :card_id            card-id
-                                                       :parameter_mappings [{:card_id      1
-                                                                             :parameter_id "foo"
-                                                                             :target       [:dimension [:field_id field-id]]}]}]]
-      (with-dashboards-in-readable-collection [dashboard-id]
-        (card-api-test/with-cards-in-readable-collection [card-id]
-          (dashboard-response ((user->client :rasta) :get 200 (format "dashboard/%d" dashboard-id))))))))
+                      Dashboard     [{dashboard-id :id} {:name "Test Dashboard"}]
+                      Card          [{card-id :id}      {:name "Dashboard Test Card"}]
+                      DashboardCard [{dc-id :id}        {:dashboard_id       dashboard-id
+                                                         :card_id            card-id
+                                                         :parameter_mappings [{:card_id      1
+                                                                               :parameter_id "foo"
+                                                                               :target       [:dimension [:field_id field-id]]}]}]]
+  (merge dashboard-defaults
+         {:name          "Test Dashboard"
+          :creator_id    (user->id :rasta)
+          :collection_id true
+          :can_write     false
+          :param_values  {}
+          :param_fields  {(keyword (str field-id)) {:id               field-id
+                                                    :table_id         table-id
+                                                    :display_name     display-name
+                                                    :base_type        "type/Text"
+                                                    :special_type     nil
+                                                    :has_field_values "search" :name_field nil
+                                                    :dimensions       ()}}
+          :ordered_cards [{:sizeX                  2
+                           :sizeY                  2
+                           :col                    0
+                           :row                    0
+                           :updated_at             true
+                           :created_at             true
+                           :parameter_mappings     [{:card_id      1
+                                                     :parameter_id "foo"
+                                                     :target       ["dimension" ["field-id" field-id]]}]
+                           :visualization_settings {}
+                           :card                   (merge card-api-test/card-defaults
+                                                          {:name                   "Dashboard Test Card"
+                                                           :creator_id             (user->id :rasta)
+                                                           :collection_id          true
+                                                           :display                "table"
+                                                           :query_type             nil
+                                                           :dataset_query          {}
+                                                           :read_permissions       nil
+                                                           :visualization_settings {}
+                                                           :result_metadata        nil})
+                           :series                 []}]})
+  ;; fetch a dashboard WITH a dashboard card on it
+  (with-dashboards-in-readable-collection [dashboard-id]
+    (card-api-test/with-cards-in-readable-collection [card-id]
+      (dashboard-response ((user->client :rasta) :get 200 (format "dashboard/%d" dashboard-id))))))
 
 ;; ## GET /api/dashboard/:id with a series, should fail if the user doesn't have access to the collection
 (expect

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -17,10 +17,12 @@
              [dashboard-card :refer [DashboardCard retrieve-dashboard-card]]
              [dashboard-card-series :refer [DashboardCardSeries]]
              [dashboard-test :as dashboard-test]
+             [field :refer [Field]]
              [permissions :as perms]
              [permissions-group :as group]
              [pulse :refer [Pulse]]
-             [revision :refer [Revision]]]
+             [revision :refer [Revision]]
+             [table :refer [Table]]]
             [metabase.test.data.users :refer :all]
             [metabase.test.util :as tu]
             [toucan.db :as db]
@@ -204,6 +206,60 @@
     (with-dashboards-in-readable-collection [dashboard-id]
       (card-api-test/with-cards-in-readable-collection [card-id]
         (dashboard-response ((user->client :rasta) :get 200 (format "dashboard/%d" dashboard-id)))))))
+
+;; As above, but with a param
+(let [field-id     100
+      table-id     100
+      display-name "bloop"]
+  (expect
+    (merge dashboard-defaults
+           {:name          "Test Dashboard"
+            :creator_id    (user->id :rasta)
+            :collection_id true
+            :can_write     false
+            :param_values  {}
+            :param_fields  {(keyword (str field-id)) {:id               field-id
+                                                      :table_id         table-id
+                                                      :display_name     display-name
+                                                      :base_type        "type/Text"
+                                                      :special_type     nil
+                                                      :has_field_values "search" :name_field nil
+                                                      :dimensions       ()}}
+            :ordered_cards [{:sizeX                  2
+                             :sizeY                  2
+                             :col                    0
+                             :row                    0
+                             :updated_at             true
+                             :created_at             true
+                             :parameter_mappings     [{:card_id      1
+                                                       :parameter_id "foo"
+                                                       :target       ["dimension" ["field-id" field-id]]}]
+                             :visualization_settings {}
+                             :card                   (merge card-api-test/card-defaults
+                                                            {:name                   "Dashboard Test Card"
+                                                             :creator_id             (user->id :rasta)
+                                                             :collection_id          true
+                                                             :display                "table"
+                                                             :query_type             nil
+                                                             :dataset_query          {}
+                                                             :read_permissions       nil
+                                                             :visualization_settings {}
+                                                             :result_metadata        nil})
+                             :series                 []}]})
+    ;; fetch a dashboard WITH a dashboard card on it
+    (tt/with-temp* [Table         [{table-id :id} {:id table-id}]
+                    Field         [{field-id :id} {:table_id table-id :id field-id :display_name display-name}]
+
+                    Dashboard     [{dashboard-id :id} {:name "Test Dashboard"}]
+                    Card          [{card-id :id}      {:name "Dashboard Test Card"}]
+                    DashboardCard [{dc-id :id}        {:dashboard_id       dashboard-id
+                                                       :card_id            card-id
+                                                       :parameter_mappings [{:card_id      1
+                                                                             :parameter_id "foo"
+                                                                             :target       [:dimension [:field_id field-id]]}]}]]
+      (with-dashboards-in-readable-collection [dashboard-id]
+        (card-api-test/with-cards-in-readable-collection [card-id]
+          (dashboard-response ((user->client :rasta) :get 200 (format "dashboard/%d" dashboard-id))))))))
 
 ;; ## GET /api/dashboard/:id with a series, should fail if the user doesn't have access to the collection
 (expect


### PR DESCRIPTION
@camsaul would love some help on getting the tests right here: the expected value references some values that don't exist until they're generated by `with-temp*`. What's the best way to make sure those values line up? I'm using a `let` binding here but that's not working, the db is complaining about `Unique index or primary key violation: "PRIMARY KEY ON PUBLIC.METABASE_TABLE(ID)"`, at least locally, which makes sense to me.