### PR TITLE
Refresh database list after re-adding sample dataset

### DIFF
--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -140,7 +140,7 @@ export const addSampleDataset = createThunkAction(
     return async function(dispatch, getState) {
       try {
         const sampleDataset = await MetabaseApi.db_add_sample_dataset();
-        dispatch(Databases.actions.fetchList(null, { reload: true }));
+        dispatch(Databases.actions.fetchList(undefined, { reload: true }));
         MetabaseAnalytics.trackEvent("Databases", "Add Sample Data");
         return sampleDataset;
       } catch (error) {

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -140,6 +140,7 @@ export const addSampleDataset = createThunkAction(
     return async function(dispatch, getState) {
       try {
         const sampleDataset = await MetabaseApi.db_add_sample_dataset();
+        dispatch(Databases.actions.fetchList(null, { reload: true }));
         MetabaseAnalytics.trackEvent("Databases", "Add Sample Data");
         return sampleDataset;
       } catch (error) {


### PR DESCRIPTION
Resolves #3746

Adding the sample dataset isn't part of the entities system. Even after the API call succeeds the list wasn't being updated. I added an additional call to refresh the databases list. 

My first instinct was to pull this into the Database entity. That was going to be a bunch of code that is specific just to re-adding the sample dataset. I figured this API is lightweight and this flow happens infrequently. Whenever we're moving the rest of this admin code to use entities, it will make sense to consolidate.