### PR TITLE
Save immediately when moving a question

### DIFF
--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -136,7 +136,11 @@ export default class QueryModals extends React.Component {
           initialCollectionId={question.collectionId()}
           onClose={onCloseModal}
           onMove={collection => {
-            question.setCollectionId(collection && collection.id).update();
+            const card = question
+              .setCollectionId(collection && collection.id)
+              .card();
+
+            this.props.onSave(card);
             onCloseModal();
           }}
         />


### PR DESCRIPTION
Resolves #10763

This fixes the bug, but it also changes behavior. Currently when you move a question, it enters the "dirty" state and you still need to explicitly save (well, that's broken). With this change a question would immediately move when you click "Move" in the modal.

@mazameli @kdoh thoughts?