### PR TITLE
Mark vis warnings as translatable

### DIFF
--- a/frontend/src/metabase/visualizations/lib/warnings.js
+++ b/frontend/src/metabase/visualizations/lib/warnings.js
@@ -6,7 +6,7 @@ export const NULL_DIMENSION_WARNING = "NULL_DIMENSION_WARNING";
 export function nullDimensionWarning() {
   return {
     key: NULL_DIMENSION_WARNING,
-    text: "Data includes missing dimension values.",
+    text: t`Data includes missing dimension values.`,
   };
 }
 
@@ -14,7 +14,7 @@ export const INVALID_DATE_WARNING = "INVALID_DATE_WARNING";
 export function invalidDateWarning(value) {
   return {
     key: INVALID_DATE_WARNING,
-    text: `We encountered an invalid date: "${value}"`,
+    text: t`We encountered an invalid date: "${value}"`,
   };
 }
 


### PR DESCRIPTION
Tiny change to mark all vis warnings as translatable.

I don't have to regenerate `metabase.pot" as part of this PR, right? We do that later?