### PR TITLE
Allow up to maxMetric and maxDimensions while getting defaults

### DIFF
--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -279,12 +279,6 @@ export function getDefaultDimensionsAndMetrics(
   );
   if (
     dimensionNotMetricColumns.length <= maxDimensions &&
-    metricColumns.length === 1
-  ) {
-    dimensions = dimensionNotMetricColumns;
-    metrics = metricColumns;
-  } else if (
-    dimensionNotMetricColumns.length === 1 &&
     metricColumns.length <= maxMetrics
   ) {
     dimensions = dimensionNotMetricColumns;

--- a/frontend/test/metabase/visualizations/lib/utils.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/utils.unit.spec.js
@@ -302,5 +302,41 @@ describe("metabase/visualization/lib/utils", () => {
         ]),
       ).toEqual({ dimensions: ["date", "category"], metrics: ["count"] });
     });
+    it("should pick two metrics and two dimensions", () => {
+      expect(
+        getDefaultDimensionsAndMetrics([
+          {
+            data: {
+              rows: [[0, 0, 0, 0]],
+              cols: [
+                {
+                  name: "count",
+                  base_type: "type/Number",
+                  source: "aggregation",
+                },
+                {
+                  name: "sum",
+                  base_type: "type/Number",
+                  source: "aggregation",
+                },
+                {
+                  name: "date",
+                  base_type: "type/DateTime",
+                  source: "breakout",
+                },
+                {
+                  name: "category",
+                  base_type: "type/Text",
+                  source: "breakout",
+                },
+              ],
+            },
+          },
+        ]),
+      ).toEqual({
+        dimensions: ["date", "category"],
+        metrics: ["count", "sum"],
+      });
+    });
   });
 });


### PR DESCRIPTION
Resolves #10840 (probably)

The bug prevented us from picking default dimensions and metrics if there were two of each:

![image](https://user-images.githubusercontent.com/691495/64644409-9ce68980-d3e0-11e9-8db9-9dd5cf3782a3.png)

The fix loosened a constraint where we'd only have defaults if there was exactly one metric or one dimension column. @tlrobinson, this code looks new as of 0.33.0. Is there a reason I'm missing to keep it more constrained? 