### PR TITLE
Don't overwrite column unit before getting column settings

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
@@ -77,13 +77,18 @@ const TooltipRow = ({ name, value, column, settings }) => (
     <td className="text-bold text-left">
       {React.isValidElement(value)
         ? value
-        : formatValue(value, {
-            ...(settings && settings.column && column
-              ? settings.column(column)
-              : { column }),
-            type: "tooltip",
-            majorWidth: 0,
-          })}
+        : formatValueForTooltip({ value, column, settings })}
     </td>
   </tr>
 );
+
+// only exported for testing, so leaving this here rather than a formatting file
+export function formatValueForTooltip({ value, column, settings }) {
+  return formatValue(value, {
+    ...(settings && settings.column && column
+      ? settings.column(column)
+      : { column }),
+    type: "tooltip",
+    majorWidth: 0,
+  });
+}

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -122,6 +122,7 @@ export function applyChartTimeseriesXAxis(
 
     // special handling for weeks
     // TODO: are there any other cases where we should do this?
+    let tickFormatUnit = dimensionColumn.unit;
     if (dataInterval.interval === "week") {
       // if tick interval is compressed then show months instead of weeks because they're nicer formatted
       const newTickInterval = computeTimeseriesTicksInterval(
@@ -133,8 +134,8 @@ export function applyChartTimeseriesXAxis(
         newTickInterval.interval !== tickInterval.interval ||
         newTickInterval.count !== tickInterval.count
       ) {
-        (dimensionColumn = { ...dimensionColumn, unit: "month" }),
-          (tickInterval = { interval: "month", count: 1 });
+        tickFormatUnit = "month";
+        tickInterval = { interval: "month", count: 1 };
       }
     }
 
@@ -144,8 +145,10 @@ export function applyChartTimeseriesXAxis(
       const timestampFixed = moment(timestamp)
         .utcOffset(dataOffset)
         .format();
+      const { column, columnSettings } = chart.settings.column(dimensionColumn);
       return formatValue(timestampFixed, {
-        ...chart.settings.column(dimensionColumn),
+        ...columnSettings,
+        column: { ...column, unit: tickFormatUnit },
         type: "axis",
         compact: chart.settings["graph.x_axis.axis_enabled"] === "compact",
       });

--- a/frontend/test/metabase/visualizations/__support__/visualizations.js
+++ b/frontend/test/metabase/visualizations/__support__/visualizations.js
@@ -2,6 +2,7 @@ import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settin
 import lineAreaBarRenderer from "metabase/visualizations/lib/LineAreaBarRenderer";
 
 import { formatValue } from "metabase/lib/formatting";
+import { formatValueForTooltip } from "metabase/visualizations/components/ChartTooltip";
 
 export function makeCard(card) {
   return {
@@ -185,7 +186,7 @@ export function renderLineAreaBar(...args) {
 }
 
 // mirrors logic in ChartTooltip
-export function getFormattedTooltips(hover) {
+export function getFormattedTooltips(hover, settings) {
   let data;
   if (hover.data) {
     data = hover.data;
@@ -200,7 +201,9 @@ export function getFormattedTooltips(hover) {
       data.push({ value: hover.value, col: hover.column });
     }
   }
-  return data.map(d => formatValue(d.value, { column: d.col }));
+  return data.map(({ value, col: column }) =>
+    formatValueForTooltip({ value, column, settings }),
+  );
 }
 
 export function createFixture() {

--- a/frontend/test/metabase/visualizations/__support__/visualizations.js
+++ b/frontend/test/metabase/visualizations/__support__/visualizations.js
@@ -1,7 +1,6 @@
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
 import lineAreaBarRenderer from "metabase/visualizations/lib/LineAreaBarRenderer";
 
-import { formatValue } from "metabase/lib/formatting";
 import { formatValueForTooltip } from "metabase/visualizations/components/ChartTooltip";
 
 export function makeCard(card) {


### PR DESCRIPTION
Resolves #10841 

# The Issue

When grouping by week, we want to show months for the ticks but week ranges in the tooltip. We were showing months in both.

## Before

<img width="1260" src="https://user-images.githubusercontent.com/691495/64725988-b1d82100-d4a3-11e9-9159-68d73da9ef66.png">

## After

<img width="1260" src="https://user-images.githubusercontent.com/691495/64726002-b8ff2f00-d4a3-11e9-9584-4e045eca4273.png">

# The Bug

`settings.column` caches its result. We had a special case in `apply_axis` where we overwrote the column's unit from 'week' to 'month' _before_ calling `settings.column`. That affected the column's formatting beyond just the axes because of the caching.

# The Fix

Overwrite the unit in result of `settings.column` rather than in the column we pass to it. That keeps the caching in place, but localizes the special case to just axes.

# Tests

To test this I extended the `getFormattedTooltips` test helper to accept settings. It then uses the formatting logic from `ChartTooltip`.

