### PR TITLE
Fix BigQuery executing of parameterized queries

### DIFF
--- a/modules/drivers/bigquery/test/metabase/driver/bigquery_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery_test.clj
@@ -227,3 +227,15 @@
   (qp/query->native
     (data/mbql-query venues
       {:aggregation [[:avg $category_id]], :breakout [$price], :order-by [[:asc [:aggregation 0]]]})))
+
+;; Do we properly unprepare, and can we execute, queries that still have parameters for one reason or another? (EE #277)
+(datasets/expect-with-driver :bigquery
+  [["Red Medicine"]]
+  (qp.test/rows
+    (qp/process-query
+      {:database (data/id)
+       :type     :native
+       :native   {:query  (str "SELECT `test_data.venues`.`name` AS `name` "
+                               "FROM `test_data.venues` "
+                               "WHERE `test_data.venues`.`name` = ?")
+                  :params ["Red Medicine"]}})))

--- a/project.clj
+++ b/project.clj
@@ -99,7 +99,7 @@
                  com.sun.jmx/jmxri]]
    [medley "1.2.0"]                                                   ; lightweight lib of useful functions
    [metabase/connection-pool "1.0.2"]                                 ; simple wrapper around C3P0. JDBC connection pools
-   [metabase/mbql "1.3.4"]                                            ; MBQL language schema & util fns
+   [metabase/mbql "1.3.5"]                                            ; MBQL language schema & util fns
    [metabase/throttle "1.0.2"]                                        ; Tools for throttling access to API endpoints and other code pathways
    [javax.xml.bind/jaxb-api "2.4.0-b180830.0359"]                     ; add the `javax.xml.bind` classes which we're still using but were removed in Java 11
    [net.sf.cssbox/cssbox "4.12" :exclusions [org.slf4j/slf4j-api]]    ; HTML / CSS rendering
@@ -152,7 +152,7 @@
   :profiles
   {:dev
    {:source-paths ["dev/src" "local/src"]
-    
+
     :dependencies
     [[clj-http-fake "1.0.3" :exclusions [slingshot]]                  ; Library to mock clj-http responses
      [expectations "2.1.10"]                                          ; unit tests

--- a/src/metabase/driver/sql/util/unprepare.clj
+++ b/src/metabase/driver/sql/util/unprepare.clj
@@ -63,15 +63,14 @@
   :hierarchy #'driver/hierarchy)
 
 (defmethod unprepare :sql [driver [sql & args]]
-  (loop [sql sql, [arg & more-args, :as args] args]
-    (if-not (seq args)
-      sql
-      ;; Only match single question marks; do not match ones like `??` which JDBC converts to `?` to use as Postgres
-      ;; JSON operators amongst other things.
-      ;;
-      ;; TODO - this is not smart enough to handle question marks in non argument contexts, for example if someone
-      ;; were to have a question mark inside an identifier such as a table name. I think we'd have to parse the SQL in
-      ;; order to handle those situations.
-      (recur
-       (str/replace-first sql #"(?<!\?)\?(?!\?)" (unprepare-value driver arg))
-       more-args))))
+  (reduce
+   (fn [sql arg]
+     ;; Only match single question marks; do not match ones like `??` which JDBC converts to `?` to use as Postgres
+     ;; JSON operators amongst other things.
+     ;;
+     ;; TODO - this is not smart enough to handle question marks in non argument contexts, for example if someone
+     ;; were to have a question mark inside an identifier such as a table name. I think we'd have to parse the SQL in
+     ;; order to handle those situations.
+     (str/replace-first sql #"(?<!\?)\?(?!\?)" (unprepare-value driver arg)))
+   sql
+   args))


### PR DESCRIPTION
Backported from EE. Not sure this fix affects anything in CE since the bug in EE only affected row-level permissions.

Bonus:

*  BigQuery tests can now be ran in REPL without having to change `DRIVERS` env var to include `bigquery`