### PR TITLE
use the dimension column for getXValues and getParseOptions

### DIFF
--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -119,11 +119,12 @@ const memoizedParseXValue = _.memoize(
 );
 
 function getParseOptions({ settings, data }) {
+  const columnIndex = getColumnIndex({ settings, data });
   return {
-    isNumeric: dimensionIsNumeric(data),
-    isTimeseries: dimensionIsTimeseries(data),
+    isNumeric: dimensionIsNumeric(data, columnIndex),
+    isTimeseries: dimensionIsTimeseries(data, columnIndex),
     isQuantitative: isQuantitative(settings),
-    unit: data.cols[0].unit,
+    unit: data.cols[columnIndex].unit,
   };
 }
 
@@ -140,17 +141,21 @@ export function getDatas({ settings, series }, warn) {
 }
 
 export function getXValues({ settings, series }) {
-  // if _.raw isn't set then we already have the raw series
+  // if _raw isn't set then we already have the raw series
   const { _raw: rawSeries = series } = series;
   const warn = () => {}; // no op since warning in handled by getDatas
   const uniqueValues = new Set();
   let isAscending = true;
   let isDescending = true;
   for (const { data } of rawSeries) {
+    // In the raw series, the dimension isn't necessarily in the first element
+    // of each row. This finds the correct column index.
+    const columnIndex = getColumnIndex({ settings, data });
+
     const parseOptions = getParseOptions({ settings, data });
     let lastValue;
-    for (const [x] of data.rows) {
-      const value = parseXValue(x, parseOptions, warn);
+    for (const row of data.rows) {
+      const value = parseXValue(row[columnIndex], parseOptions, warn);
       if (lastValue !== undefined) {
         isAscending = isAscending && lastValue <= value;
         isDescending = isDescending && value <= lastValue;
@@ -169,6 +174,12 @@ export function getXValues({ settings, series }) {
     xValues = _.sortBy(xValues, x => x);
   }
   return xValues;
+}
+
+function getColumnIndex({ settings, data: { cols } }) {
+  const [dim] = settings["graph.dimensions"] || [];
+  const i = cols.findIndex(c => c.name === dim);
+  return i === -1 ? 0 : i;
 }
 
 // Crossfilter calls toString on each moment object, which calls format(), which is very slow.

--- a/frontend/test/metabase/visualizations/lib/renderer_utils.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/renderer_utils.unit.spec.js
@@ -64,12 +64,48 @@ describe("getXValues", () => {
   it("should use raw row ordering rather than broken out series", () => {
     const series = [
       // these are broken out series. the ordering here is ignored
-      { data: { rows: [["bar"]], cols: [{}] } },
-      { data: { rows: [["foo"]], cols: [{}] } },
+      { data: { rows: [["a"], ["b"]], cols: [{}] } },
+      { data: { rows: [["c"], ["d"]], cols: [{}] } },
     ];
-    series._raw = [{ data: { rows: [["foo"], ["bar"]], cols: [{}] } }];
+    series._raw = [
+      { data: { rows: [["d"], ["c"], ["b"], ["a"]], cols: [{}] } },
+    ];
     const settings = {};
-    expect(getXValues({ settings, series })).toEqual(["foo", "bar"]);
+    expect(getXValues({ settings, series })).toEqual(["d", "c", "b", "a"]);
+  });
+  it("should use the correct column as the dimension for raw series", () => {
+    const series = [
+      {
+        data: {
+          rows: [["second", "first"]],
+          cols: [{ name: "second" }, { name: "first" }],
+        },
+      },
+    ];
+    series._raw = [
+      {
+        data: {
+          rows: [["first", "second"]],
+          cols: [{ name: "first" }, { name: "second" }],
+        },
+      },
+    ];
+    const settings = { "graph.dimensions": ["second"] };
+    expect(getXValues({ settings, series })).toEqual(["second"]);
+  });
+  it("should use the correct column as the dimension for parsing options", () => {
+    const series = [
+      {
+        data: {
+          rows: [["foo", "2019-09-01T00:00:00Z"]],
+          cols: [{ name: "other" }, { name: "date" }],
+        },
+      },
+    ];
+    series._raw = series;
+    const settings = { "graph.dimensions": ["date"] };
+    const [xVal] = getXValues({ settings, series });
+    expect(moment.isMoment(xVal)).toBe(true);
   });
   it("should sort values according to parsed value", () => {
     expect(


### PR DESCRIPTION
I merged #10827 into master accidentally. That's fine, but we also need these changes on `release-0.33.x`.