### PR TITLE
Clarify microcopy for Do Not Include column metadata setting

### DIFF
--- a/frontend/src/metabase/lib/core.js
+++ b/frontend/src/metabase/lib/core.js
@@ -266,12 +266,12 @@ export const field_visibility_types = [
   },
   {
     id: "details-only",
-    name: t`Only in Detail Views`,
+    name: t`Only in detail views`,
     description: t`This field will only be displayed when viewing the details of a single record. Use this for information that's lengthy or that isn't useful in a table or chart.`,
   },
   {
     id: "sensitive",
-    name: t`Do Not Include`,
-    description: t`Metabase will never retrieve this field. Use this for sensitive or irrelevant information.`,
+    name: t`Do not include`,
+    description: t`This field won't be visible or selectable in questions created with the GUI interfaces. It will still be accessible in SQL/native queries.`,
   },
 ];

--- a/frontend/test/metabase/admin/datamodel/FieldApp.e2e.spec.js
+++ b/frontend/test/metabase/admin/datamodel/FieldApp.e2e.spec.js
@@ -150,7 +150,7 @@ describe("FieldApp", () => {
       const { fieldApp } = await initFieldApp({ fieldId: CREATED_AT_ID });
 
       const picker = fieldApp.find(FieldVisibilityPicker);
-      expect(picker.text()).toMatch(/Only in Detail Views/);
+      expect(picker.text()).toMatch(/Only in detail views/);
     });
 
     afterAll(async () => {

--- a/frontend/test/metabase/admin/datamodel/datamodel.e2e.spec.js
+++ b/frontend/test/metabase/admin/datamodel/datamodel.e2e.spec.js
@@ -75,7 +75,7 @@ describe("admin/datamodel", () => {
         .find(ColumnarSelector)
         .find(".ColumnarSelector-row")
         .at(1);
-      expect(onlyInDetailViewsRow.text()).toMatch(/Only in Detail Views/);
+      expect(onlyInDetailViewsRow.text()).toMatch(/Only in detail views/);
       click(onlyInDetailViewsRow);
       await store.waitForActions([Fields.actions.update]);
 
@@ -86,7 +86,7 @@ describe("admin/datamodel", () => {
         .find(ColumnarSelector)
         .find(".ColumnarSelector-row")
         .at(2);
-      expect(doNotIncludeRow.text()).toMatch(/Do Not Include/);
+      expect(doNotIncludeRow.text()).toMatch(/Do not include/);
       click(doNotIncludeRow);
 
       await store.waitForActions([Fields.actions.update]);


### PR DESCRIPTION
This addresses part of https://github.com/metabase/metabase/issues/6338 — the Do Not Include setting for columns. It doesn't address the Hidden setting for tables (which maybe we should remove entirely since data access perms are a thing).

This changes the microcopy to clarify that applying this setting to a column only affects GUI queries; not SQL ones.