### PR TITLE
Run apt-get update before apt-get install gettext

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,6 +211,9 @@ jobs:
       - attach-workspace
       - restore-fe-deps-cache
       - run:
+          name: Update apt
+          command: sudo apt-get update
+      - run:
           name: Install gettext
           command: sudo apt-get install gettext
       - run:


### PR DESCRIPTION
Hopefully fixes intermittent CI failures e.x. https://circleci.com/gh/metabase/metabase/152932