### PR TITLE
"Open in scratch" button

### DIFF
--- a/frontend/src/metabase/components/TextEditor.jsx
+++ b/frontend/src/metabase/components/TextEditor.jsx
@@ -19,11 +19,13 @@ export default class TextEditor extends Component {
     value: PropTypes.string,
     defaultValue: PropTypes.string,
     onChange: PropTypes.func,
+    maxHeight: PropTypes.number,
   };
 
   static defaultProps = {
     mode: "ace/mode/plain_text",
     theme: null,
+    maxHeight: Infinity,
   };
 
   componentWillReceiveProps(nextProps) {
@@ -62,7 +64,10 @@ export default class TextEditor extends Component {
     const doc = this._editor.getSession().getDocument();
     const element = ReactDOM.findDOMNode(this);
     element.style.height =
-      2 * SCROLL_MARGIN + LINE_HEIGHT * doc.getLength() + "px";
+      Math.min(
+        this.props.maxHeight,
+        2 * SCROLL_MARGIN + LINE_HEIGHT * doc.getLength(),
+      ) + "px";
     this._editor.resize();
   }
 

--- a/frontend/src/metabase/internal/components/ComponentsApp.jsx
+++ b/frontend/src/metabase/internal/components/ComponentsApp.jsx
@@ -6,10 +6,7 @@ import { Link, Route } from "react-router";
 import { slugify } from "metabase/lib/formatting";
 import cx from "classnames";
 
-// $FlowFixMe: react-virtualized ignored
-import reactElementToJSXString from "react-element-to-jsx-string";
-import prettier from "prettier/standalone";
-import prettierParserBabylon from "prettier/parser-babylon";
+import { sourceToScratchUrl, reactToSource } from "../lib/scratch";
 
 import COMPONENTS from "../lib/components-webpack";
 
@@ -146,20 +143,8 @@ class SourcePane extends React.Component {
   render() {
     const { element } = this.props;
     const { isOpen } = this.state;
-    let source = reactElementToJSXString(element, {
-      showFunctions: true,
-      showDefaultProps: false,
-    });
-    try {
-      source = prettier.format(source, {
-        parser: "babel",
-        plugins: [prettierParserBabylon],
-      });
-    } catch (e) {
-      console.log(e);
-    }
-
-    const scratchUrl = "/_internal/scratch#" + btoa(source);
+    const source = reactToSource(element);
+    const scratchUrl = sourceToScratchUrl(source);
     return (
       <div
         className={cx("relative", {

--- a/frontend/src/metabase/internal/components/QuestionApp.jsx
+++ b/frontend/src/metabase/internal/components/QuestionApp.jsx
@@ -3,12 +3,19 @@
 import React from "react";
 import { Route } from "react-router";
 
+import _ from "underscore";
+
+import Link from "metabase/components/Link";
+import Icon from "metabase/components/Icon";
+
 import QuestionAndResultLoader from "metabase/containers/QuestionAndResultLoader";
 import Visualization from "metabase/visualizations/components/Visualization";
+import { reactToScratchUrl } from "../lib/scratch";
 
 type Props = {
   location: {
     hash: ?string,
+    query: { [key: string]: string },
   },
   params: {
     questionId?: string,
@@ -30,16 +37,40 @@ export default class QuestionApp extends React.Component {
         </div>
       );
     }
+    console.log("location.hash", location.hash);
     return (
       <QuestionAndResultLoader
         questionHash={location.hash}
         questionId={params.questionId ? parseInt(params.questionId) : null}
       >
-        {({ rawSeries }) =>
-          rawSeries && (
-            <Visualization className="flex-full" rawSeries={rawSeries} />
-          )
-        }
+        {({ rawSeries }) => {
+          if (rawSeries) {
+            const scratchUrl = reactToScratchUrl(
+              <Visualization
+                rawSeries={rawSeries.map(({ card, data }) => ({
+                  card: _.pick(card, "display", "visualization_settings"),
+                  data: _.pick(data, "cols", "rows", "insights"),
+                }))}
+                className="spread"
+              />,
+            );
+            if (location.query.scratch) {
+              window.location = scratchUrl;
+            }
+            return (
+              <div className="flex-full relative">
+                <Visualization className="spread" rawSeries={rawSeries} />
+                <Link className="absolute top right" to={scratchUrl}>
+                  <Icon
+                    name="pencil"
+                    className="m2 text-brand-hover cursor-pointer"
+                  />
+                </Link>
+              </div>
+            );
+          }
+          return null;
+        }}
       </QuestionAndResultLoader>
     );
   }

--- a/frontend/src/metabase/internal/components/ScratchApp.jsx
+++ b/frontend/src/metabase/internal/components/ScratchApp.jsx
@@ -12,13 +12,15 @@ const BABEL_CONFIG = {
 import AceEditor from "metabase/components/TextEditor";
 
 import context from "../lib/scratch-context";
+import { sourceToScratchUrl } from "../lib/scratch";
+import { b64_to_utf8 } from "metabase/lib/card";
 
 export default class ScratchApp extends React.Component {
   constructor(props) {
     super(props);
     const hash = window.location.hash.replace(/^#/, "");
     this.state = {
-      code: hash ? atob(hash) : `<Button>Hello World</Button>`,
+      code: hash ? b64_to_utf8(hash) : `<Button>Hello World</Button>`,
       error: null,
       centered: true,
     };
@@ -26,7 +28,7 @@ export default class ScratchApp extends React.Component {
 
   handleChange = code => {
     this.setState({ code });
-    history.replaceState({}, null, "/_internal/scratch#" + btoa(code));
+    history.replaceState({}, null, sourceToScratchUrl(code));
   };
 
   async _update() {
@@ -101,6 +103,7 @@ export default class ScratchApp extends React.Component {
           }}
           value={this.state.code}
           onChange={this.handleChange}
+          maxHeight={window.innerHeight / 3}
         />
         <div className="absolute bottom right flex align-center p1">
           <span className="mr1">Centered:</span>

--- a/frontend/src/metabase/internal/lib/scratch.js
+++ b/frontend/src/metabase/internal/lib/scratch.js
@@ -1,0 +1,29 @@
+// $FlowFixMe: react-virtualized ignored
+import reactElementToJSXString from "react-element-to-jsx-string";
+import prettier from "prettier/standalone";
+import prettierParserBabylon from "prettier/parser-babylon";
+import { utf8_to_b64 } from "metabase/lib/card";
+
+export function reactToSource(element) {
+  let source = reactElementToJSXString(element, {
+    showFunctions: true,
+    showDefaultProps: false,
+  });
+  try {
+    source = prettier.format(source, {
+      parser: "babel",
+      plugins: [prettierParserBabylon],
+    });
+  } catch (e) {
+    console.log(e);
+  }
+  return source;
+}
+
+export function reactToScratchUrl(element) {
+  return sourceToScratchUrl(reactToSource(element));
+}
+
+export function sourceToScratchUrl(source) {
+  return "/_internal/scratch#" + utf8_to_b64(source);
+}

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -7,6 +7,7 @@ import { Flex } from "grid-styled";
 import { color, darken } from "metabase/lib/colors";
 
 import Icon from "metabase/components/Icon";
+import Link from "metabase/components/Link";
 
 import ButtonBar from "metabase/components/ButtonBar";
 
@@ -171,6 +172,25 @@ const ViewFooter = ({
               className="mx1 hide sm-show"
               card={question.card()}
             />
+          ),
+          // eslint-disable-next-line no-undef
+          process.env.NODE_ENV !== "production" && (
+            <Link
+              to={
+                "/_internal" +
+                window.location.pathname +
+                "?scratch=true" +
+                window.location.hash
+              }
+            >
+              <Icon
+                name="beaker"
+                size={16}
+                className="mx1 cursor-pointer text-brand-hover"
+                style={{ opacity: 0.5 }}
+                tooltip="Open in scratchpad"
+              />
+            </Link>
           ),
         ]}
       />


### PR DESCRIPTION
Easily lets you open a visualization in "scratch" for playing with or linking in GitHub issues.

Maybe a bad idea to have an actual button in the QB (it's not there in production builds). Alternatively could have a command you run in the JS console.

Don't try with large datasets...

![Screen Recording 2019-09-17 at 10 34 48 AM 2019-09-17 10_40_10](https://user-images.githubusercontent.com/18193/65065613-9a7fb480-d937-11e9-93e7-abd5472039a7.gif)
