### PR TITLE
Add back in fa.po and zh.po

### DIFF
--- a/locales/de.po
+++ b/locales/de.po
@@ -47,7 +47,7 @@ msgstr "Speichern"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:122
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
-msgstr "Damit Metabase etwas seiner Magie entfalten kann, muss deine Datenbank untersucht werden. Alsdann werden wir sie periodisch prüfen, um die Metadaten aktuell zu halten. Du kannst den Zeitpunkt dieses Scans unten festlegen."
+msgstr "Damit Metabase etwas seiner Magie entfalten kann, muss deine Datenbank untersucht werden. Als dann werden wir sie periodisch prüfen, um die Metadaten aktuell zu halten. Du kannst den Zeitpunkt dieses Scans unten festlegen."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:127
 msgid "Database syncing"
@@ -12850,11 +12850,11 @@ msgstr ""
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, canceling query"
-msgstr ""
+msgstr "Client-Verbindung geschlossen. Breche die Abfrage ab."
 
 #: src/metabase/integrations/ldap.clj
 msgid "{0} is not a valid DN."
-msgstr ""
+msgstr "{0} ist keine gültige DN."
 
 #: src/metabase/middleware/log.clj
 msgid "Error logging API request"
@@ -12896,7 +12896,7 @@ msgstr ""
 
 #: src/metabase/plugins/files.clj
 msgid "Failed to copy file"
-msgstr ""
+msgstr "Fehler beim Kopieren der Datei."
 
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"

--- a/locales/fa.po
+++ b/locales/fa.po
@@ -272,9 +272,7 @@ msgstr "بررسی انجام نگرفت"
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
-msgstr "اسکن شروع شد\n"
-"\n"
-""
+msgstr "اسکن شروع شد"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
@@ -9530,13 +9528,11 @@ msgstr "HH:MM"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:240
 msgid "HH:MM:SS"
-msgstr "HH:MM:SS\n"
-""
+msgstr "HH:MM:SS"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:243
 msgid "HH:MM:SS.MS"
-msgstr "HH:MM:SS.MS\n"
-""
+msgstr "HH:MM:SS.MS"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:254
 msgid "Time style"
@@ -9809,8 +9805,7 @@ msgstr "فقط یک بخش Google Analytics به طور همزمان مجاز ا
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "MONGO AGGREGATION PIPELINE:"
-msgstr "MONGO AGGREGATION PIPELINE:\n"
-""
+msgstr ":خط لوله مونگو"
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "Error: mismatched columns in results! Expected: {0} Got: {1}"
@@ -10184,8 +10179,7 @@ msgstr "رویدادها در هر ساعت از روز"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Singleton]]"
-msgstr "[[Singleton]]\n"
-""
+msgstr "[[Singleton]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
@@ -10686,8 +10680,7 @@ msgstr "10 کشور برتر با فروش"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Timestamp]]"
-msgstr "[[Timestamp]]\n"
-""
+msgstr "[[Timestamp]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Where these transactions happened"
@@ -11353,8 +11346,7 @@ msgstr "کلاس"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:32
 msgid "Triggers"
-msgstr "ماشه ها\n"
-""
+msgstr "ماشه ها"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:48
 msgid "View triggers"
@@ -11722,8 +11714,7 @@ msgstr "بانک اطلاعاتی نمی توانند در دایرکتوری م
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory."
-msgstr "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory.\n"
-""
+msgstr "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory."
 
 #: src/metabase/plugins.clj
 msgid "Failied to initialize plugin {0}"
@@ -12033,8 +12024,7 @@ msgstr "[[CreateTimestamp]] تا چهارم سال"
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
-msgstr "نحوه مقایسه انها در سراسر مکان یا نحوه مقایه انها بر اساس موقعیت مکانی\n"
-""
+msgstr "نحوه مقایسه انها در سراسر مکان یا نحوه مقایه انها بر اساس موقعیت مکانی"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Here's a closer look at your [[this]] by products"
@@ -12207,8 +12197,7 @@ msgstr "{0} به اتمام رسید به {1}"
 
 #: src/metabase/api/metric.clj
 msgid "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id."
-msgstr "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id.\n"
-""
+msgstr "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id."
 
 #: src/metabase/api/segment.clj
 msgid "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id."
@@ -12544,8 +12533,7 @@ msgstr "تجمیع"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
 msgid "Breakout"
-msgstr "Breakout\n"
-""
+msgstr "برک آوت"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
 msgid "Pick the metric you want to see"
@@ -12696,8 +12684,7 @@ msgstr "این معمولاً خیلی سریع است اما به نظر می �
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
 msgid "Combo"
-msgstr "Combo\n"
-""
+msgstr "ترکیب"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
@@ -12709,7 +12696,7 @@ msgstr "روند"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:129
 msgid "Boolean"
-msgstr "Boolean"
+msgstr "بول"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
 msgid "Unknown Segment"
@@ -12927,37 +12914,36 @@ msgstr "ستون {0} پیش بینی شده است ، اما ردیف اول ا�
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "No expression named {0} found. Found: {1}"
-msgstr "هیچ عبارتی به نام {0} یافت نشد. یافت شده: {1}"
+msgstr "{هیچ عبارتی به نام {0} یافت نشد. یافت شده: {1"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Distinct values of {0}"
-msgstr "مقادیر مشخص {0}"
+msgstr "{مقادیر مشخص {0"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Average of {0}"
-msgstr "میانگین {0}"
+msgstr "{میانگین {0"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0}"
-msgstr "جمع {0}"
+msgstr "{جمع {0"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "SD of {0}"
-msgstr "SD of {0}"
+msgstr "{0} انحراف استاندارد از"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Min of {0}"
-msgstr "Min of {0}\n"
-""
+msgstr "{0} حداقل از"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Max of {0}"
-msgstr "Max of {0}"
+msgstr "{0} حداکثر از"
 
 #. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0} matching condition"
-msgstr "مجموع شرط تطبیق {0}"
+msgstr "{مجموع شرط تطبیق {0"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Share of rows matching condition"
@@ -12977,7 +12963,7 @@ msgstr "به طور غیر منتظره پاسخ 'nil' پردازنده Query ر
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Got InterruptedException. Canceling query."
-msgstr "InterpreException در حال لغو پرس و جو"
+msgstr "InterruptedException در حال لغو پرس و جو"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
@@ -12989,11 +12975,11 @@ msgstr "زمان پرس و جو بعد از %s پایان یافت"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Creating new query thread pool for Database {0}"
-msgstr "ایجاد استخر جدید برای جستجوی موضوعات برای پایگاه داده {0}"
+msgstr "{ایجاد استخر جدید برای جستجوی موضوعات برای پایگاه داده {0"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Destroying query thread pool for Database {0}"
-msgstr "از بین بردن استخر موضوع جستجو برای بانک اطلاعات {0}"
+msgstr "{از بین بردن استخر موضوع جستجو برای بانک اطلاعات {0"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Request canceled, canceling pending query"
@@ -13005,7 +12991,7 @@ msgstr "می توانید زمینه binned را به روز نکنید: پرس 
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
-msgstr "زمینه بنه به روزرسانی نمی شود: یافت نشد. منبع داده منطبق با فیلد '' {0}''"
+msgstr “''{زمینه بنه به روزرسانی نمی شود: یافت نشد. منبع داده منطبق با فیلد ''{0”
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Using query processor cache backend: {0}"
@@ -13041,11 +13027,11 @@ msgstr "استفاده از فیلدها امکان پذیر نیست: زمین�
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
-msgstr "بد: بند پیوستن به فیلد: پیوستن به نام مستعار '' {0} '' وجود ندارد. یافت شده: {1}"
+msgstr "{بد: بند پیوستن به فیلد: پیوستن به نام مستعار ''{0}'' وجود ندارد. یافت شده: {1"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
-msgstr "نامعتبر: جدول مبدأ '' {0} '' ': اکنون باید به شناسه جدول حل شود."
+msgstr "نامعتبر: جدول مبدأ ''{0}'' ': اکنون باید به شناسه جدول حل شود."
 
 #: src/metabase/query_processor/store.clj
 msgid "Cannot store Tables or Fields before Database is stored."
@@ -13065,11 +13051,11 @@ msgstr "واگذاری زمینه {0} انجام نشد: فیلد وجود ند�
 
 #: src/metabase/routes/index.clj
 msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
-msgstr "الگوی '' {0} '' بارگیری نشد. یادتان هست که جبهه Metabase را بسازید؟"
+msgstr "الگوی ''{0}'' بارگیری نشد. یادتان هست که جبهه Metabase را بسازید؟"
 
 #: src/metabase/sample_data.clj
 msgid "Sample dataset DB file ''{0}'' cannot be found."
-msgstr "نمونه پرونده داده {DB '' {0'' یافت نشد."
+msgstr "نمونه پرونده داده DB ''{0}'' یافت نشد."
 
 #: src/metabase/sample_data.clj
 msgid "Loading sample dataset..."
@@ -13081,19 +13067,19 @@ msgstr "بارگیری مجموعه داده نمونه انجام نشد"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Found new tables:"
-msgstr "جداول جدید یافت:"
+msgstr ":جداول جدید یافت"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Marking tables as inactive:"
-msgstr "علامت گذاری جداول به عنوان غیرفعال:"
+msgstr ":علامت گذاری جداول به عنوان غیرفعال"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Updating description for tables:"
-msgstr "به روزرسانی توضیحات برای جداول:"
+msgstr ":به روزرسانی توضیحات برای جداول"
 
 #: src/metabase/task.clj
 msgid "Rescheduling job {0}"
-msgstr "تنظیم مجدد کار {0}"
+msgstr "{تنظیم مجدد کار {0"
 
 #: src/metabase/task.clj
 msgid "Error rescheduling job"
@@ -13101,11 +13087,11 @@ msgstr "خطا در تنظیم مجدد کار"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Starting Pulse Execution: {0}"
-msgstr "شروع اجرای پالس: {0}"
+msgstr "{شروع اجرای پالس: {0"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Finished Pulse Execution: {0}"
-msgstr "اجرای پالس به پایان رسید: {0}"
+msgstr "{اجرای پالس به پایان رسید: {0"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to schedule tasks for Database {0}"
@@ -13113,9 +13099,9 @@ msgstr "برنامه ریزی وظایف برای بانک اطلاعات {0} ا
 
 #: src/metabase/util/schema.clj
 msgid "All elements must be distinct."
-msgstr "همه عناصر باید مشخص باشند."
+msgstr ".همه عناصر باید مشخص باشند"
 
-#: 
+#:
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "ستون هایی را که می خواهید گنجانید انتخاب کنید"
@@ -13134,13 +13120,13 @@ msgstr "نمی دانید چگونه شناسه {0} ، انتظار می رود 
 
 #: src/metabase/integrations/common.clj
 msgid "Error adding User {0} to Group {1}"
-msgstr "خطا در افزودن کاربر {0} به گروه {1}"
+msgstr "{خطا در افزودن کاربر {0} به گروه {1"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr "تغییر استراتژی انسان سازی جدول و زمینه از '' {0} ''به ''{1}''"
+msgstr "''{تغییر استراتژی انسان سازی جدول و زمینه از ''{0}'' به ''{1"
 
 #: src/metabase/query_processor.clj
 msgid "Infinite loop detected: recursively preprocessed query {0} times."
@@ -13157,4 +13143,3 @@ msgstr "خطا در تعیین ستون های مورد انتظار برای پ
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "استثناء نامحدود ، انتظار می رود واسطه میانجی \"گرفتن استثناء\" برای رسیدگی به آن."
-

--- a/locales/fa.po
+++ b/locales/fa.po
@@ -5,29 +5,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 "Project-Id-Version: Metabase\n"
-"Language: ja\n"
+"Language: fa\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:24
 msgid "Your database has been added!"
-msgstr "データベースが追加されました！"
+msgstr "پایگاه داده‌ی شما اضافه شده است!"
 
-#. explorationsはどう訳すべきか？
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:28
+#, fuzzy
 msgid "We took a look at your data, and we have some automated explorations that we can show you!"
-msgstr "あなたのデータに基づく自動探索結果を提示することができます！"
+msgstr "با نگاهی اجمالی به داده های شما، ما یکسری پویش اتوماتیک داریم که می توانیم به شما نشان دهیم!"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:35
+#, fuzzy
 msgid "I'm good thanks"
-msgstr "結構です"
+msgstr "من خوبم ممنون"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:42
+#, fuzzy
 msgid "Explore this data"
-msgstr "このデータを詳しく見る"
+msgstr "این داده ها را کاوش کن"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:42
+#, fuzzy
 msgid "Select a database type"
-msgstr "データベースタイプを選択する"
+msgstr "یک نوع پایگاه داده را انتخاب کن"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
@@ -43,60 +46,67 @@ msgstr "データベースタイプを選択する"
 #: frontend/src/metabase/reference/components/EditHeader.jsx:69
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:180
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:164
+#, fuzzy
 msgid "Save"
-msgstr "保存"
+msgstr "ذخیره کردن"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:122
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
-msgstr "効果的に使用するため、Metabaseはデータベースをスキャンします。また、メタデータを最新に保つために定期的に再スキャンします。以下から再スキャンの頻度を設定することができます。"
+msgstr "برای ادامه کار، متابیس نیاز دارد پایگاه داده شما را اسکن کند.\n"
+"همچنان برای آپدیت ماندن متابیس این کار به صورت دوره ای و اتوماتیک نیز انجام میشود، شما میتوانید زمان بازه ها را تنظیم کنید."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:127
+#, fuzzy
 msgid "Database syncing"
-msgstr "データベース同期中"
+msgstr "همگام سازی پایگاه داده"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:128
 msgid "This is a lightweight process that checks for\n"
 "updates to this database’s schema. In most cases, you should be fine leaving this\n"
 "set to sync hourly."
-msgstr "データベーススキーマの更新チェックは軽量なプロセスです。ほとんどの場合、1時間ごとの同期で問題ありません。"
+msgstr "این یک فرایند سبک برای برسی بروز بودن شمای پایگاه داده هست. در بیشتر موارد، بهتر است برای همگام سازی ساعتی صبر نمایید."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
+#, fuzzy
 msgid "Scan"
-msgstr "スキャン"
+msgstr "بررسی"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:152
+#, fuzzy
 msgid "Scanning for Filter Values"
-msgstr "フィルター値をスキャン中"
+msgstr "جستجو برای مقادیر فیلتر"
 
-#. リソース負荷の高い、という意味だとは思いますが、リソース集約的という表現は一般的な表現でしょうか？私は聞いたことがなかったもので。
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:153
 msgid "Metabase can scan the values present in each\n"
 "field in this database to enable checkbox filters in dashboards and questions. This\n"
 "can be a somewhat resource-intensive process, particularly if you have a very large\n"
 "database."
-msgstr "Metabaseは、このデータベースの各フィールドの値をスキャンして、ダッシュボードや質問のチェックボックスフィルターを有効にすることができます。 データベースが非常に大きい場合は、ややリソースに負荷がかかる処理となります。"
+msgstr "متابیس می‌تواند تمامی مقادیر حاضر در هر فید این دیتابیس را اسکن کند تا فیلترهای جعبه چک را در داشبوردها و سؤالات فعّال کند. این می‌تواند تاحدّی یک پردازش با مصرف زیاد از منابع باشد، به‌خصوص اگر شما یک دیتابیس خیلی بزرگ دارید."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
+#, fuzzy
 msgid "When should Metabase automatically scan and cache field values?"
-msgstr "フィールド値のスキャンとキャッシュをいつ行いますか？"
+msgstr "چه زمانی باید متابیس به صورت اتوماتیک مقادیر فیلدها را برسی و در حافظه نگه دارد؟"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
-msgstr "スケジュール通り定期的に行う"
+msgstr "به طور معمول، روی یک زمانبندی"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
-msgstr "新しいフィルターウィジェットを追加したときのみ行う"
+msgstr "تنها وقتی که یک ویجت فیلتر افزوده شود"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
-msgstr "ユーザーがダッシュボードまたは質問に新しいフィルターを追加すると、Metabaseはそのフィルターにマップされたフィールドをスキャンし、選択可能な値一覧を表示します"
+msgstr "هنگامی که یک کاربر یک فیلتر جدید را به یک داشبورد یا سوال SQL اضافه می کند، Metabase خواهد شد\n"
+"اسکن فیلد (ها) به آن فیلتر برای نمایش لیستی از مقادیر انتخاب شده."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
+#, fuzzy
 msgid "Never, I'll do this manually if I need to"
-msgstr "自動的に行わず、必要な時に手動設定する"
+msgstr "هرگز، اگر لازم داشته باشم به صورت دستی انجام خواهم داد"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
@@ -104,39 +114,42 @@ msgstr "自動的に行わず、必要な時に手動設定する"
 #: frontend/src/metabase/components/ActionButton.jsx:52
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
+#, fuzzy
 msgid "Saving..."
-msgstr "保存中..."
+msgstr "درحال ذخیره‌سازی..."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
+#, fuzzy
 msgid "Server error encountered"
-msgstr "サーバーエラーが発生しました"
+msgstr "با مشکلی در سمت سرور مواجه شدیم"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
+#, fuzzy
 msgid "Delete this database?"
-msgstr "データベースを削除しますか？"
+msgstr "آیا این پایگاه داده حذف شود؟"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
-msgstr "保存された全ての質問、メトリクスおよびセグメントは、このデータベースが削除されると同時に削除されます。"
+msgstr "تمام سوالات ذخیره شده، معیارها و بخش هایی که بر اساس این پایگاه داده تکیه می کنند، از بین می روند."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
-msgstr "この操作はやり直しできません。"
+msgstr "این قابل بازگشت نیست."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
-msgstr "間違いなければ入力してください。"
+msgstr "اگر اطمینان دارید، لطفا بنویسید"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
-msgstr "削除"
+msgstr "حذف کردن"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
-msgstr "このテキストボックスに:"
+msgstr "داخل این کادر:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
@@ -173,14 +186,14 @@ msgstr "このテキストボックスに:"
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
-msgstr "キャンセル"
+msgstr "لغو"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
-msgstr "削除"
+msgstr "حذف"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
@@ -192,20 +205,20 @@ msgstr "削除"
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
-msgstr "データベース"
+msgstr "پایگاه داده"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
-msgstr "データベースを追加"
+msgstr "اضافه کردن پایگاه داده"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
-msgstr "接続"
+msgstr "ارتباط"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:61
 msgid "Scheduling"
-msgstr "スケジューリング"
+msgstr "برنامه ریزی کردن"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
@@ -216,17 +229,17 @@ msgstr "スケジューリング"
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
-msgstr "変更を保存"
+msgstr "ذخیره کردن تغییرات"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
-msgstr "アクション"
+msgstr "اقدام"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
-msgstr "今すぐデータベーススキーマと同期する"
+msgstr "در حال همگام سازی شمای دیتابیس"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
@@ -235,49 +248,51 @@ msgstr "今すぐデータベーススキーマと同期する"
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
-msgstr "開始しています..."
+msgstr "در حال شروع..."
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
-msgstr "同期に失敗しました"
+msgstr "موفق به همگام سازی نشد"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
-msgstr "同期を開始しました！"
+msgstr "همگام سازی شروع شد!"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
-msgstr "今すぐフィールド値を再スキャンする"
+msgstr "در حال بررسی مجدد مقادیر فیلد"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
-msgstr "スキャンのスタートに失敗しました"
+msgstr "بررسی انجام نگرفت"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
-msgstr "スキャンを開始しました！"
+msgstr "اسکن شروع شد\n"
+"\n"
+""
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
-msgstr "危険ゾーン"
+msgstr "منطقه خطر"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
-msgstr "保存されたフィールド値を破棄する"
+msgstr "نادیده گرفتن مقادیر فیلد ذخیره شده"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
-msgstr "このデータベースを削除する"
+msgstr "این پایگاه داده را حذف کنید"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
-msgstr "データベースを追加"
+msgstr "اضافه کردن پایگاه داده"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
@@ -293,35 +308,35 @@ msgstr "データベースを追加"
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
-msgstr "名前"
+msgstr "نام"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
-msgstr "エンジン"
+msgstr "موتور"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
-msgstr "削除中..."
+msgstr "درحال حذف کردن"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
-msgstr "読込中..."
+msgstr "در حال بارگذاری"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
-msgstr "サンプルデータセットを復元"
+msgstr "مجموعه داده نمونه را بازگردانید"
 
 #: frontend/src/metabase/admin/databases/database.js:175
 msgid "Couldn't connect to the database. Please check the connection details."
-msgstr "データベースに接続できません。接続設定を確認してください。"
+msgstr "نمیتوانم به پایگاه داده وصل شوم لطفا جزئیات اتصال را بررسی کنید."
 
 #: frontend/src/metabase/admin/databases/database.js:383
 msgid "Successfully created!"
-msgstr "作成されました！"
+msgstr "با موفقیت ایجاد شد!"
 
 #: frontend/src/metabase/admin/databases/database.js:393
 msgid "Successfully saved!"
-msgstr "保存されました！"
+msgstr "با موفقیت ذخیره شد!"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:281
@@ -329,62 +344,63 @@ msgstr "保存されました！"
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
-msgstr "編集"
+msgstr "ویرایش"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:59
 msgid "Revision History"
-msgstr "履歴"
+msgstr "تاریخچه نسخه گذاری"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
-msgstr "{0}を放棄しますか？"
+msgstr "بازنشستگی این {0}؟"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
-msgstr "保存されている{0}に依存する質問やその他情報は保持されますが、{1}はクエリビルダーから選択できなくなります。"
+msgstr "سوالات ذخیره شده و موارد دیگر که به این {0} بستگی دارد، به کار ادامه خواهد داد، اما این {1} دیگر از سازنده پرس و جو انتخاب نخواهد شد."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
-msgstr "{0}を放棄して問題なければ、放棄する理由を簡単に説明してください。:"
+msgstr "اگر مطمئن هستید که می خواهید این {0} بازنشسته شود، لطفا یک توضیح سریع از اینکه چرا بازنشسته می شوید، بنویسید:"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
-msgstr "{0}を使用して作成をした場合、アクティビティフィードと、あなたのチームに送信されるメールに表示されます。"
+msgstr "این در خوراک فعالیت و در یک ایمیل نشان داده خواهد شد که به هر کسی که در تیم شما ارسال می شود، چیزی را که از این {0} استفاده می کند، ارسال می کند."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
-msgstr "放棄する"
+msgstr "بازنشستگی"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
-msgstr "放棄中..."
+msgstr "بازنشستگی ..."
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
-msgstr "失敗"
+msgstr "ناموفق"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
-msgstr "成功"
+msgstr "موفقیت"
 
 #: frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx:91
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:110
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
+#, fuzzy
 msgid "Preview"
-msgstr "プレビュー"
+msgstr "پیش نمایش"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
-msgstr "列説明はまだありません"
+msgstr "هیچ توصیف ستونی هنوز وجود ندارد"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
-msgstr "フィールドの可視性を選択する"
+msgstr "انتخاب قابلیت مشاهده یک فیلد"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
-msgstr "特別タイプなし"
+msgstr "نوع خاصی یافت نشد"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:148
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
@@ -392,15 +408,15 @@ msgstr "特別タイプなし"
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
-msgstr "その他"
+msgstr "سایر"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
-msgstr "特別タイプを選択する"
+msgstr "یک نوع خاص را انتخاب کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
-msgstr "ターゲットを選択する"
+msgstr "یک هدف را انتخاب کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
@@ -409,93 +425,93 @@ msgstr "ターゲットを選択する"
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
-msgstr "列"
+msgstr "ستون‌ها"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
-msgstr "列"
+msgstr "ستون"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
-msgstr "可視性"
+msgstr "رؤیت"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
 msgid "Type"
-msgstr "タイプ"
+msgstr "نوع"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
-msgstr "現在のデータベース:"
+msgstr "پایگاه داده فعلی:"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
-msgstr "元のスキーマを表示する"
+msgstr "نمایش طرح اولیه"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
-msgstr "データタイプ"
+msgstr "نوع داده"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
-msgstr "付加情報"
+msgstr "اطلاعات اضافی"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
-msgstr "スキーマを見つける"
+msgstr "یک طرح را پیدا کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
-msgstr[0] "{0} スキーマ"
+msgstr[0] "{0} طرح"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
-msgstr "なぜ非表示にしますか？"
+msgstr "چرا پنهان شدی؟"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
-msgstr "テクニカルデータ"
+msgstr "داده های فنی"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
-msgstr "無関係/不正データ"
+msgstr "بی ربط / Cruft"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
 msgid "Queryable"
-msgstr "利用可能"
+msgstr "قابل پرس و جو"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
-msgstr "非表示"
+msgstr "پنهان"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
-msgstr "テーブルの説明はまだありません"
+msgstr "هیچ توضیحی در جدول وجود ندارد"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:124
 msgid "Metadata Strength"
-msgstr "メタデータ強度"
+msgstr "قدرت متادیتا"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
-msgstr[0] "{0} 件の利用可能なテーブル"
+msgstr[0] "{0} جدول پرس و جو"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
-msgstr[0] "{0} 非表示のテーブル"
+msgstr[0] "{0} جدول پنهان"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
-msgstr "テーブルを探す"
+msgstr "یک جدول را پیدا کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
-msgstr "スキーマ"
+msgstr "طرح ها"
 
 #: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
@@ -507,21 +523,21 @@ msgstr "スキーマ"
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
-msgstr "メトリクス"
+msgstr "متریک‌ها"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
-msgstr "メトリクスを追加する"
+msgstr "یک سنجش اضافه کن"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
-msgstr "定義"
+msgstr "تعریف"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
-msgstr "クエリビルダーの表示ドロップダウンにメトリクスを作成し追加する"
+msgstr "ایجاد متریک برای اضافه کردن آنها به نمایش کشویی در سازنده پرس و جو"
 
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
 #: frontend/src/metabase/home/containers/SearchApp.jsx:73
@@ -531,293 +547,294 @@ msgstr "クエリビルダーの表示ドロップダウンにメトリクスを
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
-msgstr "セグメント"
+msgstr "بخش ها"
 
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
-msgstr "セグメントを追加する"
+msgstr "یک بخش اضافه کن"
 
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
-msgstr "クエリビルダーのフィルタードロップダウンにセグメントを作成し追加する"
+msgstr "ایجاد بخش ها برای افزودن آنها به فیلتر کشویی در کوری ساز"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "created"
-msgstr "作成済み"
+msgstr "ایجاد شده"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
 msgid "reverted to a previous version"
-msgstr "以前のバージョンに戻す"
+msgstr "به نسخه قبلی برگشت"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
 msgid "edited the title"
-msgstr "タイトルを編集する"
+msgstr "ویرایش عنوان"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
 msgid "edited the description"
-msgstr "説明を編集する"
+msgstr "ویرایش توضیحات"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "edited the "
-msgstr "␣を編集する"
+msgstr "ویرایش ␣"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
 msgid "made some changes"
-msgstr "変更されました"
+msgstr "ایجاد بعضی تغییرات"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
 #: frontend/src/metabase/home/components/Activity.jsx:82
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
-msgstr "あなた"
+msgstr "شما"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
-msgstr "データモデル"
+msgstr "مدل داده"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
-msgstr "履歴"
+msgstr "تاریخچه␣"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
-msgstr "履歴"
+msgstr "تاریخچه نسخه گذاری برای"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
-msgstr "{0} - フィールド設定"
+msgstr "{0} - تنظیمات فیلد"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
-msgstr "Metabase上でフィールドが表示される箇所"
+msgstr "کجا این فیلد در سراسر Metabase ظاهر می شود"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
-msgstr "このフィールドでフィルター設定しています"
+msgstr "فیلتر کردن این فیلد"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
-msgstr "このフィールドでフィルター設定がされている場合、他ユーザーがフィルター設定したい値をどのように入力すればよいですか？"
+msgstr "هنگامی که این فیلد در یک فیلتر استفاده می شود، چه افرادی باید برای وارد کردن مقدار مورد نظر برای فیلتر کردن، چه استفاده کنند؟"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
-msgstr "このフィールドには説明がまだありません"
+msgstr "هنوز برای این قیلد توضیحی نوشته نشده است"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
-msgstr "元の値"
+msgstr "مقدار اصلی"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
 msgid "Mapped value"
-msgstr "マップされた値"
+msgstr "مقدار Map شده"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
-msgstr "値を入力する"
+msgstr "مقدار را وارد کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
 msgid "Use original value"
-msgstr "元の値を使う"
+msgstr "از مقدار اصلی استفاده کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use foreign key"
-msgstr "外部キーを使う"
+msgstr "از کلید خارجی استفاده کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Custom mapping"
-msgstr "カスタムマッピング"
+msgstr "Map سفارشی"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
 msgid "Unrecognized mapping type"
-msgstr "マッピングタイプを識別できません"
+msgstr "نوع Map غیر قابل تشخیص"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
-msgstr "現在のフィールドは外部キーではないか、FKターゲットテーブルのメタデータがありません"
+msgstr "فیلد جاری دارای کلید خارجی نیست یا متا دیتای جدولی که هدف کلید خارجی است وجود ندارد"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
-msgstr "選択されたフィールドは外部キーではありません"
+msgstr "فیلد انتخابی کلید خارجی نیست"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
-msgstr "値を表示する"
+msgstr "نمایش مقادیر"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
-msgstr "データベースから元の値を表示するか、このフィールドに関連する情報またはカスタム情報を表示するかを選択します。"
+msgstr "انتخاب کنید که ارزش اصلی را از پایگاه داده نشان می دهد یا این اطلاعات را نمایش داده یا مرتبط کنید."
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
-msgstr "フィールドを選択"
+msgstr "یک فیلد را انخاب کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
-msgstr "表示に使用する列を選択してください。"
+msgstr "لطفا یک ستون را برای نمایش انتخاب کنید."
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:771
 msgid "Tip:"
-msgstr "ヒント:"
+msgstr "نکته:"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
-msgstr "再マッピングの選択と内容が合うようにフィールド名を更新すると良いでしょう。"
+msgstr "شما ممکن است بخواهید نام فیلد را به روز کنید تا مطمئن شوید که هنوز بر اساس گزینه های بازخوانی شما منطقی است."
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
-msgstr "フィールド値をキャッシュする"
+msgstr "مقادیر فیلد ذخیره شده"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
-msgstr "Metabaseは、ダッシュボードまたは質問のチェックボックスを有効化するため、このフィールドの値をスキャンします"
+msgstr "Metabase می تواند مقادیر این فیلد را فعال کند تا فیلترهای جعبه چک را در داشبورد و سوالات فعال کند."
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:14
 msgid "Re-scan this field"
-msgstr "このフィールドを再スキャンする"
+msgstr "دوباره این زمینه را اسکن کنید"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
-msgstr "キャッシュしたフィールド値を削除する"
+msgstr "نادیده گرفتن مقادیر فیلد ذخیره شده"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
-msgstr "値の削除に失敗しました"
+msgstr "نادیده گرفتن مقادیر ناموفق بود"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard triggered!"
-msgstr "削除されました！"
+msgstr "تغییرات را نادیده بگیر!"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
-msgstr "テーブルを選択し、スキーマを見てメタデータを追加・編集する"
+msgstr "جدولی را برای مشاهد شما و یا ویرایش متادیتا انتخاب نمایید."
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
 #: frontend/src/metabase/entities/collections.js:97
+#, fuzzy
 msgid "Name is required"
-msgstr "名前が必要です"
+msgstr "نام مورد نیاز است"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
-msgstr "説明が必要です"
+msgstr "توضیح مورد نیاز است"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
-msgstr "履歴メッセージが必要です"
+msgstr "پیام بازبینی مورد نیاز است"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
-msgstr "アグリゲーションが必要です"
+msgstr "یکپارچه‌سازی لازم است"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
-msgstr "メトリクスを編集する"
+msgstr "متریک خود را ویرایش کنید"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
-msgstr "メトリクスを作成する"
+msgstr "متریک خود را ایجاد کنید"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
-msgstr "メトリクスを変更し注釈を加える"
+msgstr "تغییر در متریک خود را انجام دهید و یک یادداشت توضیحی را ترک کنید."
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
-msgstr "保存されたメトリクスを使用して、このテーブルに名前付きメトリクスオプションを追加することができます。 保存されたメトリクスには、集約タイプ、集約フィールド、およびオプションで追加するフィルターが含まれます。 たとえば、これを使用してOrdersテーブルの「平均価格」の公式な計算方法を作成することができます。"
+msgstr "شما می توانید معیارهای ذخیره شده را برای افزودن یک گزینه متریک نام به این جدول ایجاد کنید. معیارهای ذخیره شده شامل نوع تجمع، فیلد جمع شده و به صورت اختیاری هر فیلتر اضافه می شود. به عنوان مثال، شما ممکن است از این برای ایجاد چیزی شبیه روش رسمی محاسبه \"میانگین قیمت\" برای جدول سفارشات استفاده کنید."
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
-msgstr "結果: "
+msgstr "نتیجه:"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
-msgstr "メトリクスに名前を付ける"
+msgstr "نام متریک خود را"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
-msgstr "他ユーザーのためにメトリクスに名前を付ける"
+msgstr "نام متریک خود را برای کمک به دیگران پیدا کنید."
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
-msgstr "簡単な説明"
+msgstr "چیزی توصیفی اما نه خیلی طولانی"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
-msgstr "メトリクスを説明する"
+msgstr "متریک خود را شرح دهید"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
-msgstr "他ユーザーのためにメトリクスに説明を加える"
+msgstr "توضیحات متریک خود را برای کمک به دیگران درک کنید."
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
-msgstr "メトリクスのルールについてより詳細な情報をこちらに記入してください"
+msgstr "این مکان بسیار خوبی است که درمورد قوانین متریک کمتر آشکارتر باشد"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
-msgstr "変更理由"
+msgstr "دلیل تغییرات"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
-msgstr "変更箇所と変更理由を記入する"
+msgstr "یک یادداشت را برای توضیح آنچه که تغییراتی ایجاد کرده اید و چرا آنها مورد نیاز بود را ترک کنید."
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
-msgstr "他ユーザーにも変更理由がわかるよう、このメトリクスの履歴に表示されます"
+msgstr "این در تاریخ تجدید نظر برای این متریک نشان داده خواهد شد تا به همه کمک کند که به یاد داشته باشید که چرا همه چیز تغییر کرده است"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
-msgstr "最低1つのフィルターが必要です"
+msgstr "حداقل یک فیلتر مورد نیاز است"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
-msgstr "セグメントを編集する"
+msgstr "بخش شما را ویرایش کنید"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
-msgstr "セグメントを作成する"
+msgstr "ایجاد بخش شما"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
-msgstr "セグメントを変更し注釈を加える"
+msgstr "تغییرات را در بخش خود انجام دهید و یک یادداشت توضیحی را ترک کنید."
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
-msgstr "{0}テーブルの新しいセグメントを作成するためのフィルターを選択し追加する"
+msgstr "برای ایجاد بخش جدید خود برای جدول {0} را انتخاب کنید و فیلترها را اضافه کنید"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
-msgstr "セグメントに名前を付ける"
+msgstr "بخش خود را بنویسید"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
-msgstr "他ユーザーのためにセグメントを名前を付ける"
+msgstr "بخش خود را به نام برای کمک به دیگران پیدا کنید."
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
-msgstr "セグメントを説明する"
+msgstr "بخش خود را توصیف کنید"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
 msgid "Give your segment a description to help others understand what it's about."
-msgstr "他ユーザーのためにセグメントに説明を加える"
+msgstr "شرح خود را به بخش خود بدهید تا دیگران را در درک آنچه در مورد آن هستید کمک کنید."
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
-msgstr "セグメントのルールについてより詳細な情報をこちらに記入してください"
+msgstr "این مکان خوبی است که در مورد قوانین جزئی کمتر آشکار باشد"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
-msgstr "他ユーザーにも変更理由がわかるよう、このセグメントの履歴に表示されます"
+msgstr "این در تاریخ تجدید نظر برای این بخش نشان داده خواهد شد تا به همه کمک کند که به یاد داشته باشید که چرا همه چیز تغییر کرده است"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
@@ -827,38 +844,38 @@ msgstr "他ユーザーにも変更理由がわかるよう、このセグメン
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
-msgstr "設定"
+msgstr "تنضیمات"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
-msgstr "Metabaseは、ダッシュボードまたは質問のチェックボックスを有効化するため、このテーブルの値をスキャンします"
+msgstr "Metabase می تواند مقادیر در این جدول را اسکن کند تا فیلترهای جعبه چک را در داشبورد و سوالات فعال کند."
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
-msgstr "このテーブルを再スキャンする"
+msgstr "دوباره این جدول را اسکن کنید"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
-msgstr "追加"
+msgstr "اضافه کردن"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:103
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:67
 msgid "Not a valid formatted email address"
-msgstr "有効なメールアドレスではありません"
+msgstr "یک آدرس ایمیل فرمت معتبر نیست"
 
 #: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:100
 msgid "First name"
-msgstr "名"
+msgstr "نام"
 
 #: frontend/src/metabase/entities/users.js:42
 #: frontend/src/metabase/setup/components/UserStep.jsx:203
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:117
 msgid "Last name"
-msgstr "姓"
+msgstr "نام خانوادگی"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:77
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:161
@@ -867,34 +884,36 @@ msgstr "姓"
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
-msgstr "メールアドレス"
+msgstr "آدرس ایمیل"
 
 #: frontend/src/metabase/admin/people/components/EditUserForm.jsx:202
 msgid "Permission Groups"
-msgstr "権限グループ"
+msgstr "گروه های مجوز"
 
 #: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
 msgid "Make this user an admin"
-msgstr "このユーザーを管理者にする"
+msgstr "این کاربر را admin کنید"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
-msgstr "全てのユーザーは{0}グループに属しており、そのグループから削除することはできません。 このグループの権限を設定することで、新しいMetabaseユーザーの閲覧可能範囲を確認することができます。"
+msgstr "تمام کاربران متعلق به گروه {0} هستند و نمی توانند از آن حذف شوند. تنظیم مجوز برای این گروه راهی عالی برای\n"
+"مطمئن شوید که می دانید چه کاربران جدید Metabase قادر خواهند بود ببینند."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
-msgstr "これは、メンバーがMetabaseインスタンス内の全データを参照できるだけでなく、権限の変更などを含む管理者パネルの設定ができる特別なグループです。このグループにメンバーを追加する場合は、十分にご注意ください。"
+msgstr "این یک گروه خاص است که اعضا میتوانند همه چیز را در نمونه متاباز ببینند و چه کسی میتواند به آن دسترسی پیدا کند و تغییر دهد\n"
+"تنظیمات در پنل مدیریت، از جمله تغییر مجوز! بنابراین، افراد را به این گروه اضافه کنید."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
-msgstr "Metabaseからロックアウトされないため、このグループには最低1ユーザーの登録が必要です"
+msgstr "برای اینکه اطمینان حاصل کنید که از Metabase قفل نشده اید، همیشه باید حداقل یک کاربر در این گروه باشد."
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
-msgstr "メンバー"
+msgstr "اعضا"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
@@ -903,66 +922,66 @@ msgstr "メンバー"
 #: frontend/src/metabase/lib/core.js:55
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
-msgstr "メール"
+msgstr "ایمیل"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
-msgstr "グループもそのメンバーもどちらも大事です。"
+msgstr "گروه فقط به عنوان اعضای آن است."
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
 #: frontend/src/metabase/admin/routes.jsx:48
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:49
 msgid "Admin"
-msgstr "管理者"
+msgstr "مدیر/ مدیر سیستم"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
-msgstr "そして"
+msgstr "و"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:19
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:31
 msgid "{0} other group"
 msgid_plural "{0} other groups"
-msgstr[0] "{0} 他グループ"
+msgstr[0] "{0} گروه دیگر"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:37
 msgid "Default"
-msgstr "デフォルト"
+msgstr "پیش‌فرض"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:39
 msgid "Something like \"Marketing\""
-msgstr "「マーケティング」等"
+msgstr "چیزی شبیه \"بازاریابی\""
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:58
 msgid "Remove this group?"
-msgstr "このグループを削除しますか？"
+msgstr "این گروه حذف شود؟"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:60
 msgid "Are you sure? All members of this group will lose any permissions settings they have based on this group.\n"
 "This can't be undone."
-msgstr "本気ですか？ このグループのすべてのメンバーは、このグループに基づいて設定されている権限設定を失います。\n"
-"これは元に戻せません。"
+msgstr "شما مطمئن هستید؟ همه اعضای این گروه هر تنظیمات مجوزی که براساس این گروه قرار دارند را از دست خواهند داد.\n"
+"این نمیتواند لغو شود"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
-msgstr "はい"
+msgstr "بله"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
-msgstr "いいえ"
+msgstr "خیر"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:92
 msgid "Edit Name"
-msgstr "名前を編集する"
+msgstr "ویرایش نام"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:95
 msgid "Remove Group"
-msgstr "グループを削除する"
+msgstr "حذف گروه"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:46
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:138
@@ -977,11 +996,11 @@ msgstr "グループを削除する"
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
-msgstr "完了"
+msgstr "انجام شد"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Group name"
-msgstr "グループ名"
+msgstr "نام گروه"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
@@ -989,382 +1008,384 @@ msgstr "グループ名"
 #: frontend/src/metabase/admin/routes.jsx:88
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
-msgstr "グループ"
+msgstr "گروه‌ها"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:364
 msgid "Create a group"
-msgstr "グループを作成する"
+msgstr "یک گروه بساز/ ساختن گروه"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:370
 msgid "You can use groups to control your users' access to your data. Put users in groups and then go to the Permissions section to control each group's access. The Administrators and All Users groups are special default groups that can't be removed."
-msgstr "グループを使用して、ユーザーのデータへのアクセスを管理することができます。 ユーザーをグループに入れた後、権限のセクションに移動して各グループのアクセスを管理してください。 管理者グループとAll Users グループは、削除できない特殊なデフォルトグループです。"
+msgstr "شما می توانید از گروه ها برای کنترل دسترسی کاربران به اطلاعات خود استفاده کنید. کاربران را در گروه قرار دهید و سپس به قسمت مجوز دسترسی داشته باشید تا هر گروه را کنترل کنید. مدیران و گروه های همه کاربران گروه های پیش فرض خاصی هستند که قابل حذف نیستند."
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:79
 msgid "Edit Details"
-msgstr "詳細を編集する"
+msgstr "ویرایش جزئیات"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:85
 msgid "Re-send Invite"
-msgstr "招待を再送する"
+msgstr "ارسال مجدد دعوت"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:90
 msgid "Reset Password"
-msgstr "パスワードをリセットする"
+msgstr "بازیابی گذرواژه"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:40
 msgid "Deactivate"
-msgstr "無効化"
+msgstr "غیرفعال"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
 #: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
-msgstr "ユーザー"
+msgstr "مردم"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:192
 msgid "Who do you want to add?"
-msgstr "誰を追加したいですか？"
+msgstr "چه کسی را میخواهید اضافه کید؟"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:207
 msgid "Edit {0}'s details"
-msgstr "{0}の詳細を編集する"
+msgstr "ویرایش {0} جزئیات"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:40
 msgid "{0} has been added"
-msgstr "{0}が追加されました"
+msgstr "{0} اضافه شد"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:224
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:262
 msgid "Add another person"
-msgstr "他のユーザーを追加する"
+msgstr "یک نفر دیگر را اضافه کنید"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:231
 msgid "We couldn’t send them an email invitation,\n"
 "so make sure to tell them to log in using {0}\n"
 "and this password we’ve generated for them:"
-msgstr "招待メールを送信できませんでした。{0}とこのパスワードを利用してログインいただくようご指示ください。:"
+msgstr "ما نمی توانیم آنها را دعوت نامه ای بفرستیم\n"
+"بنابراین اطمینان حاصل کنید که آنها را وارد کنید با استفاده از {0}\n"
+"و این رمز عبور که برای آنها ایجاد کردیم:"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:73
 msgid "If you want to be able to send email invites, just go to the {0} page."
-msgstr "招待メールを送信したい場合は、{0}ページへお進みください"
+msgstr "اگر می خواهید دعوت نامه های ایمیل را ارسال کنید، فقط به صفحه {0} بروید."
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:55
 msgid "We’ve sent an invite to {0} with instructions to set their password."
-msgstr "パスワード設定方法を記載した招待メールを{0}へ送信しました"
+msgstr "ما دعوت نامه ای برای {0} با دستورالعمل هایی برای تنظیم رمز عبور خود فرستاده ایم."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:283
 msgid "We've re-sent {0}'s invite"
-msgstr "招待メールを{0}に再送しました"
+msgstr "دعوت {0} را دوباره فرستادیم"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
 msgid "Okay"
-msgstr "確認しました"
+msgstr "باشه"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:289
 msgid "Any previous email invites they have will no longer work."
-msgstr "これより前に送信された招待メールは無効です"
+msgstr "هر گونه دعوتنامه ایمیل قبلی آنها دیگر کار نخواهد کرد."
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:31
 msgid "Deactivate {0}?"
-msgstr "{0}を無効化しますか？"
+msgstr "غیر فعال کردن {0}"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:34
 msgid "{0} won't be able to log in anymore."
-msgstr "{0}はログインすることができません"
+msgstr "{0} دیگر قادر به ورود به سیستم نخواهد بود."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:320
 msgid "Reactivate {0}'s account?"
-msgstr "{0}のアカウントを再有効化しますか？"
+msgstr "مجدد {0} حساب کاربری را فعال کنید؟"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:58
 msgid "Reactivate"
-msgstr "再有効化する"
+msgstr "فعالسازی مجدد"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:51
 msgid "They'll be able to log in again, and they'll be placed back into the groups they were in before their account was deactivated."
-msgstr "ログインが可能になり、無効化される前のグループに戻りました。"
+msgstr "آنها دوباره قادر به ورود به سیستم خواهند بود و قبل از اینکه حساب کاربری آنها غیرفعال شود، آنها را به گروههایی که در آن قرار داشتند، قرار می دهند."
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:51
 msgid "Reset {0}'s password?"
-msgstr "{0}のパスワードをリセットしますか？"
+msgstr "رمز عبور {0} را دوباره تنظیم کنید؟"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
-msgstr "リセットする"
+msgstr "بارگذازی مجدد"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
-msgstr "よろしいですか？"
+msgstr "آیا مطمئنید که می خواهید این کار را انجام دهید؟"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:41
 msgid "{0}'s password has been reset"
-msgstr "{0}のパスワードがリセットされました"
+msgstr "{0} رمز عبور تنظیم مجدد شده است"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:45
 msgid "Here’s a temporary password they can use to log in and then change their password."
-msgstr "この仮パスワードでログインし、パスワードを変更してください"
+msgstr "در اینجا یک گذرواژه موقت است که می تواند برای ورود به سیستم و سپس رمز عبور خود را تغییر دهد."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:388
 msgid "We've sent them an email with instructions for creating a new password."
-msgstr "新しいパスワードの作成方法を記載したメールを送信しました"
+msgstr "ما آنها را یک ایمیل با دستورالعمل برای ایجاد یک رمز عبور جدید فرستاده ایم."
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
-msgstr "有効化する"
+msgstr "فعال"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
-msgstr "無効化した"
+msgstr "غیرفعالسازی"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
-msgstr "追加する"
+msgstr "کسی را اضافه کنید"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
-msgstr "最終ログイン"
+msgstr "آخرین ورود"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
-msgstr "Googleを利用して登録する"
+msgstr "ثبت نام شده به وسیله گوگل"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
-msgstr "LDAP経由で登録されました"
+msgstr "ثبت نام شده به وسیله LDAP"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
-msgstr "このアカウントを再有効化する"
+msgstr "این اکانت را مجددا فعال کنید"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
-msgstr "しない"
+msgstr "هرگز"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
-msgstr[0] "{0}テーブル"
+msgstr[0] "{0} جدول"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
-msgstr "␣は␣になります"
+msgstr " خواهد بود"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
-msgstr "にアクセスを付与する"
+msgstr "دسترسی داده به"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
-msgstr "␣と␣"
+msgstr "-و-"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
-msgstr "拒否されたアクセス"
+msgstr "عدم دسترسی به / امکان سترسی به .... وجود ندارد"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
-msgstr "␣はこれ以降␣できません"
+msgstr " دیگر قادر نخواهد بود"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
-msgstr "␣は␣できます"
+msgstr " حالا قادر خواهد بود"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
-msgstr "のネイティブクエリ"
+msgstr " نمایش داده بومی برای"
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
 #: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
-msgstr "権限"
+msgstr "دسترسی ها"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:32
 msgid "Save permissions?"
-msgstr "権限を保存しますか？"
+msgstr "دسترسی ها ذخیره شوند ؟"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:38
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:161
 msgid "Save Changes"
-msgstr "変更を保存する"
+msgstr "تغییرات ذخیره شود"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:44
 msgid "Discard changes?"
-msgstr "変更を破棄する"
+msgstr "دور انداختن تغییرات؟ "
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:46
 msgid "No changes to permissions will be made."
-msgstr "権限は変更されません"
+msgstr "هیچ تغییری در مجوز انجام نخواهد شد."
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:65
 msgid "You've made changes to permissions."
-msgstr "権限が変更されました"
+msgstr "شما مجوزها را تغییر داده اید."
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
-msgstr "このコレクションの権限"
+msgstr "مجوزهای این مجموعه"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
-msgstr "保存されていない変更があります"
+msgstr "شما تغییرات ذخیره نشده دارید"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
-msgstr "変更を破棄してこのページから離れますか？"
+msgstr "آیا می خواهید این صفحه را ترک کنید و تغییرات خود را رد کنید؟"
 
 #: frontend/src/metabase/admin/permissions/permissions.js:126
 msgid "Sorry, an error occurred."
-msgstr "申し訳ありません、エラーが発生しました"
+msgstr "متاسفم، خطایی رخ داده است."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:65
 msgid "Administrators always have the highest level of access to everything in Metabase."
-msgstr "管理者にはMetabaseの全データへのアクセス権限があります"
+msgstr "مدیران همیشه دارای بالاترین سطح دسترسی به همه چیز در Metabase هستند."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:67
 msgid "Every Metabase user belongs to the All Users group. If you want to limit or restrict a group's access to something, make sure the All Users group has an equal or lower level of access."
-msgstr "全てのMetabaseユーザーは、All Users グループに属します。 グループへのアクセスを制限またはブロックする場合は、All Users グループのアクセスレベルが同等かそれ以下であることをご確認ください。"
+msgstr "هر کاربر Metabase متعلق به گروه همه کاربران است. اگر میخواهید دسترسی گروهی به چیزی محدود یا محدود شود، مطمئن شوید که تمام کاربران گروه دارای دسترسی برابر یا کمتر هستند."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:69
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
-msgstr "MetaBotはMetabaseのSlackボットです。 ここにアクセスできるものを選択できます。"
+msgstr "MetaBot ربات Slack Metabase است. شما می توانید آنچه را که به آن دسترسی داشته اید را انتخاب کنید."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
-msgstr "\"{0}\"グループは、このグループとは異なる{1}セットにアクセスする可能性があります。その場合、{0}グループには{2}への追加アクセス権が与えられます。"
+msgstr "گروه \"{0}\" ممکن است به یک مجموعه متفاوت از {1} از این گروه دسترسی داشته باشد، که ممکن است این گروه دسترسی اضافی به برخی {2} را داشته باشد."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
-msgstr "\"{0}\"グループのアクセスレベルはこれより高くなり、この設定が上書きされます。 \"{1}\"グループのこのアイテムへのアクセスをブロックまたは取り消す必要があります。"
+msgstr "گروه \"{0}\" سطح دسترسی بیشتری نسبت به این دارد که این تنظیم را برطرف می کند. شما باید \"{1}\" دسترسی گروه به این مورد را محدود یا لغو کنید."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
-msgstr "制限する"
+msgstr "محدودیت"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
-msgstr "取り消す"
+msgstr "لغو"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
-msgstr "{0}の方がより広いアクセス権限を持っていますが、アクセスを"
+msgstr "حتی اگر {0} دسترسی بیشتری داشته باشد"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
-msgstr "アクセスを制限する"
+msgstr "محدودیت دسترسی"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
-msgstr "アクセスを取り消す"
+msgstr "لغو دسترسی"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
-msgstr "このデータベースへのアクセスを制限しますか？"
+msgstr "تغییر دسترسی به این پایگاه داده به محدود؟"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
-msgstr "変更する"
+msgstr "تغییر"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
-msgstr "ロークエリの作成を許可しますか？"
+msgstr "اجازه نوشتن پرس و جو خام را بدهید؟"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
-msgstr "これにより、このデータベースのこのグループのデータアクセスも無制限に変更されます。"
+msgstr "این امر همچنین دسترسی داده های این گروه را به Unrestricted برای این پایگاه داده تغییر خواهد داد."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
-msgstr "許可する"
+msgstr "مجاز"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
-msgstr "すべてのテーブルへのアクセスを取り消しますか？"
+msgstr "دسترسی به تمام جداول را لغو کنید؟"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
-msgstr "このグループのデータベースのロークエリへのアクセスも取り消されます。"
+msgstr "این همچنین دسترسی این گروه به درخواستهای خام برای این پایگاه داده را لغو خواهد کرد."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
-msgstr "無制限のアクセスを許可する"
+msgstr "دسترسی غیر محدود"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
-msgstr "無制限のアクセス"
+msgstr "دسترسی نامحدود"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
-msgstr "制限されたアクセス"
+msgstr "دسترسی محدود"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
-msgstr "アクセスがありません"
+msgstr "دسترسی ندارید"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
-msgstr "ロークエリを書く"
+msgstr "نامه های خام را بنویسید"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
-msgstr "ロークエリを書くことができる"
+msgstr "می توانید پرس و جوهای خام را بنویسید"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
-msgstr "コレクションを公開する"
+msgstr "مجموعه گردنبند"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
-msgstr "コレクションを見る"
+msgstr "مشاهده مجموعه"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:430
 #: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
-msgstr "データアクセス"
+msgstr "دسترسی به داده ها"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:495
 #: frontend/src/metabase/admin/permissions/selectors.js:652
 #: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
-msgstr "テーブルを見る"
+msgstr "مشاهده جداول"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
-msgstr "SQLクエリ"
+msgstr "SQL Queries"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
-msgstr "スキーマを見る"
+msgstr "نمایش طرح ها"
 
 #: frontend/src/metabase/admin/routes.jsx:59
 #: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
-msgstr "データモデル"
+msgstr "مدل داده"
 
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:11
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:118
 msgid "Sign in with Google"
-msgstr "Googleを利用してサインインする"
+msgstr "با Google وارد شوید"
 
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
-msgstr "Metabaseアカウント保有者に、Metabaseユーザーネームとパスワード以外に、登録されたメールアドレスと一致するGoogleアカウントでログインすることを許可する"
+msgstr "به کاربران امکان می دهد با حساب های Metabase موجود برای ورود به حساب Google که با آدرس ایمیل خود علاوه بر نام کاربری و رمز عبور متاباز خود نیز منطبق باشد."
 
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
-msgstr "設定"
+msgstr "پیکربندی"
 
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
@@ -1374,142 +1395,142 @@ msgstr "LDAP"
 
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
-msgstr "LDAPディレクトリ内のユーザーに対し、LDAP資格情報によるMetabaseへのログインを許可し、LDAPグループをMetabaseグループに自動的にマッピングできるようにする。"
+msgstr "اجازه می دهد تا کاربران در دایرکتوری LDAP خود را به Metabase با اعتبار LDAP خود وارد شوند، و اجازه می دهد تا نقشه های خودکار LDAP را به گروه های Metabase بطور خودکار."
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
 #: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
-msgstr "有効なメールアドレスではありません"
+msgstr "این یک آدرس ایمیل معتبر نیست"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:21
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:73
 msgid "That's not a valid integer"
-msgstr "有効な整数ではありません"
+msgstr "این یک عدد صحیح معتبر نیست"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:161
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:223
 msgid "Changes saved!"
-msgstr "変更が保存されました！"
+msgstr "تغییرات ذخیره شد!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:157
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:132
 msgid "Looks like we ran into some problems"
-msgstr "問題が発生したようです"
+msgstr "به نظر می رسد ما به برخی از مشکلات رسیدگی کردیم"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:12
 msgid "Send test email"
-msgstr "テストメールを送信する"
+msgstr "ارسال ایمیل آزمایشی"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:13
 msgid "Sending..."
-msgstr "送信中..."
+msgstr "درحال ارسال..."
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:14
 msgid "Sent!"
-msgstr "送信しました！"
+msgstr "ارسال شد!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:82
 msgid "Clear"
-msgstr "クリア"
+msgstr "پاک کردن"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
-msgstr "認証"
+msgstr "احراز هویت"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:18
 msgid "Server Settings"
-msgstr "サーバー設定"
+msgstr "تنضیمات سرور"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:29
 msgid "User Schema"
-msgstr "ユーザースキーマ"
+msgstr "طرحواره کاربر"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:33
 msgid "Attributes"
-msgstr "属性"
+msgstr "خصوصیات"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:42
 msgid "Group Schema"
-msgstr "グループスキーマ"
+msgstr "طرح طرح گروه"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetting.jsx:28
 msgid "Using "
-msgstr "を利用して"
+msgstr "درحال استفاده"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:105
 msgid "Getting set up"
-msgstr "開始する"
+msgstr "راه اندازی"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:106
 msgid "A few things you can do to get the most out of Metabase."
-msgstr "Metabaseを有効活用するためにできること"
+msgstr "چند چیز که می توانید انجام دهید برای به دست آوردن بیشتر از Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:115
 msgid "Recommended next step"
-msgstr "おすすめの次のステップ"
+msgstr "گام بعدی توصیه شده است"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:114
 msgid "Google Sign-In"
-msgstr "Googleサインイン"
+msgstr "ورود با گوگل"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:123
 msgid "To allow users to sign in with Google you'll need to give Metabase a Google Developers console application client ID. It only takes a few steps and instructions on how to create a key can be found {0}"
-msgstr "ユーザーがGoogleでログインできるようにするには、MetabaseにGoogle DevelopersコンソールアプリケーションクライアントIDを指定する必要があります。 キーの作成方法の確認は非常に簡単です。{0}"
+msgstr "برای اجازه دادن به کاربران برای ورود به سیستم با Google شما نیاز به Metabase را برای شناسه مشتری برنامه کنسول Google Developers فراهم کنید. تنها چند مرحله دارد و دستورالعمل هایی درباره نحوه ایجاد یک کلید می توان یافت {0}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:137
 msgid "Your Google client ID"
-msgstr "GoogleクライアントID"
+msgstr "نشانه کاربری شما در گوگل"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:142
 msgid "Allow users to sign up on their own if their Google account email address is from:"
-msgstr "Googleアカウントのメールアドレスが以下のものである場合、ユーザーが自分でサインアップできるようにする:"
+msgstr "اجازه دهید کاربران خود را ثبت نام کنند اگر آدرس ایمیل حساب Google خود از آن است:"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
 msgid "Answers sent right to your Slack #channels"
-msgstr "Slackに回答が送信されました"
+msgstr "پاسخ های ارسال شده به اسلک #channels شما درست است"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
 msgid "Create a Slack Bot User for MetaBot"
-msgstr "MetaBotのSlack Botユーザーを作成する"
+msgstr "برای استفاده از MetaBot یک کاربر Slack Bot ایجاد کنید"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
-msgstr "名前を付けて{0}をクリックします。 ボットAPIトークンをコピーし、下のフィールドに貼り付けます。 完了したら、Slackで \"metabase_files\"チャンネルを作成します。 これはMetabaseでグラフをアップロードするために必要な作業です。"
+msgstr "هنگامی که شما آنجا هستید، نام آن را بنویسید و {0} را کلیک کنید. سپس Token Bot API را به فیلد زیر کپی و جایگذاری کنید. پس از اتمام کار، کانال \"metabase_files\" را در Slack ایجاد کنید. Metabase برای بارگذاری نمودارها نیاز دارد."
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
-msgstr "お使いのMetabase {0}は最新です"
+msgstr "شما Metabase {0} را اجرا می کنید که آخرین و بزرگترین است!"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
-msgstr "Metabase {0}が利用可能です。現在{1}を利用中です。"
+msgstr "Metabase {0} در دسترس است شما در حال اجرا {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
-msgstr "アップデートする"
+msgstr "به روز رسانی"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
-msgstr "変更箇所:"
+msgstr "تغییر چه چیزی است:"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:131
 msgid "Add a map"
-msgstr "マップを追加する"
+msgstr "یک نقشه اضافه کنید"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
 #: frontend/src/metabase/lib/core.js:105
 msgid "URL"
-msgstr "URL"
+msgstr "نشانی اینترنتی"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
-msgstr "カスタムマップを削除する"
+msgstr "حذف نقشه سفارشی"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
@@ -1518,7 +1539,7 @@ msgstr "カスタムマップを削除する"
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
-msgstr "削除する"
+msgstr "پاک کردن"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
@@ -1526,578 +1547,581 @@ msgstr "削除する"
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
-msgstr "選択..."
+msgstr "اتخاب..."
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
-msgstr "サンプル値:"
+msgstr "متغیر نمونه"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
-msgstr "新しいマップを追加する"
+msgstr "یک نقشه‌ی جدید وارد کنید"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
-msgstr "マップを編集する"
+msgstr "ویرایش نقشه"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
-msgstr "このマップを何と呼びますか？"
+msgstr "چه چیزی می خواهید این نقشه را فرا بگیرید؟"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
-msgstr "例: イギリス、ブラジル、火星"
+msgstr "به عنوان مثال، بریتانیا، برزیل، مریخ"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
-msgstr "使用したいGeoJSONファイルのURL"
+msgstr "URL برای فایل GeoJSON که می خواهید استفاده کنید"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
-msgstr "例: https://my-mb-server.com/maps/my-map.json"
+msgstr "مانند https://my-mb-server.com/maps/my-map.json"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
-msgstr "更新"
+msgstr "تازه کردن"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
-msgstr "読み込み"
+msgstr "بارگذاری"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
-msgstr "地域の識別子を指定するプロパティはどれですか？"
+msgstr "کدام ویژگی شناسه منطقه را مشخص می کند؟"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
-msgstr "地域の表示名を指定するプロパティはどれですか？"
+msgstr "کدام ویژگی نام نمایشی منطقه را مشخص می کند؟"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
-msgstr "GeoJSONファイルを読み込み、プレビューを表示する"
+msgstr "بارگذاری یک فایل GeoJSON برای دیدن یک پیش نمایش"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
-msgstr "マップを保存する"
+msgstr "ذخیره نقشه"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
-msgstr "マップを追加する"
+msgstr "اضافه کردن نقشه"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:7
 msgid "Using embedding"
-msgstr "埋め込みを利用中"
+msgstr "با استفاده از تعبیه"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:9
 msgid "By enabling embedding you're agreeing to the embedding license located at"
-msgstr "埋め込みを有効にすると、␣にある埋め込みライセンスに同意します。"
+msgstr "با فعال کردن تعبیه، شما موافقت میکنید که مجوز تعبیه در آن قرار دارد"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
-msgstr "Metabaseから独自のアプリケーションにチャートやダッシュボードを埋め込む場合、Metabaseのロゴと「Powered by Metabase」が埋め込みの中でも表示させている限り、そのアプリケーションはMetabaseの残りの部分をカバーするAffero General Public Licenseには拘束されません。ただし、この機能を有効にした場合に同意したことになる実際のライセンスですから、上記リンク先のライセンステキストを必ずお読みください。"
+msgstr "در زبان انگليسي ساده، هنگامي كه نمودارها يا داشبوردهاي خود را از Metabase در برنامه خود قرار ميدهيد، اين نرم افزار تحت مجوز Public Affero General كه بقيه متاباز را پوشش ميدهد، در صورتي كه آرم Metabase را حفظ كرده و «Powered by Metabase» را مشاهده كنيد در آن جاسازی ها. با این حال، باید متن مجوزی که در بالا به آن اشاره شد را بخوانید زیرا این مجوز واقعی است که با فعال کردن این ویژگی موافقت می کنید."
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
-msgstr "有効化する"
+msgstr "فعال کردن"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:24
 msgid "Premium embedding enabled"
-msgstr "プレミアム埋め込みが有効化された"
+msgstr "تعبیه حق بیمه فعال است"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:26
 msgid "Enter the token you bought from the Metabase Store"
-msgstr "Metabase Storeから購入したトークンを入力する"
+msgstr "رمزتان را که از Metabase Store خریداری کرده اید وارد کنید"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:53
 msgid "Premium embedding lets you disable \"Powered by Metabase\" on your embedded dashboards and questions."
-msgstr "プレミアム埋め込みを利用すると、埋め込みされたダッシュボードや質問の「Powered by Metabase」という表示を無効化することができます"
+msgstr "تعبیه حق بیمه به شما اجازه می دهد تا \"Powered by Metabase\" را در داشبورد و سوالات جاسازی شده خود غیر فعال کنید."
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:60
 msgid "Buy a token"
-msgstr "トークンを購入する"
+msgstr "خرید یک علامت"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:63
 msgid "Enter a token"
-msgstr "トークンを入力する"
+msgstr "یک نشانه وارد کنید"
 
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
-msgstr "マッピングを編集する"
+msgstr "ویرایش نقشه ها"
 
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
-msgstr "グループマッピング"
+msgstr "نقشه های گروه"
 
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
-msgstr "マッピングを作成する"
+msgstr "ایجاد یک نقشه برداری"
 
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
-msgstr "マッピングをすると、ディレクトリサーバーから提供される利用者情報に基づいて、グループからユーザーを自動的に追加または削除することができます。管理者グループへのメンバーシップはマッピングを介して付与できますが、フェイルセーフ対策として自動的に削除されることはありません。"
+msgstr "نقشه ها اجازه می دهد Metabase به طور خودکار کاربران را از گروه ها بر اساس اطلاعات عضویت ارائه شده توسط گروه ها حذف و حذف کند\n"
+"سرور دایرکتوری عضویت در گروه مدیریت می تواند از طریق نمایش داده شود، اما به صورت خودکار به عنوان یک حذف نمی شود\n"
+"اندازه گیری بی وقفه"
 
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
-msgstr "識別名"
+msgstr "نام متمایز"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:92
 msgid "Public Link"
-msgstr "公開リンク"
+msgstr "لینک عمومی"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:93
 msgid "Revoke Link"
-msgstr "リンクを取り消す"
+msgstr "لینک لغو"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
-msgstr "このリンクを無効化しますか？"
+msgstr "این لینک را غیرفعال کنید؟"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
-msgstr "作動ならびに復元はできません。ただし新しいリンクを作成することができます。"
+msgstr "آنها دیگر کار نخواهند کرد و نمی توانند بازسازی شوند، اما شما می توانید لینک های جدید ایجاد کنید."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
-msgstr "ダッシュボード一覧を公開する"
+msgstr "فهرست داشبورد عمومی"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
-msgstr "公開されたダッシュボードがまだありません"
+msgstr "هیچ داشبورد به صورت عمومی به اشتراک گذاشته نشده است."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
-msgstr "カード一覧を公開する"
+msgstr "لیست کارت های عمومی"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
-msgstr "公開された質問はまだありません。"
+msgstr "هنوز هیچ سؤالی به صورت عمومی منتشر نشده است."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
-msgstr "埋め込みダッシュボード一覧"
+msgstr "فهرست داشبورد جاسازی شده"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
-msgstr "埋め込みされたダッシュボードはまだありません"
+msgstr "هیچ داشبورد هنوز تعبیه نشده است."
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
-msgstr "埋め込みカード一覧"
+msgstr "فهرست کارت های جاسازی شده"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
-msgstr "埋め込みされた質問はまだありません"
+msgstr "هیچ سؤالی هنوز تعبیه نشده است."
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:35
 msgid "Regenerate embedding key?"
-msgstr "埋め込みキーを再生成しますか？"
+msgstr "کلید تعبیه را بازسازی کنید؟"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:36
 msgid "This will cause existing embeds to stop working until they are updated with the new key."
-msgstr "すでに埋め込んでいる質問は、新しいキーで更新されない限り使用できなくなります"
+msgstr "این باعث می شود که جاسازی های موجود کار را متوقف کنند تا زمانی که با کلید جدید به روز شوند."
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:39
 msgid "Regenerate key"
-msgstr "キーを再発行する"
+msgstr "تولید مجدد کلید"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:47
 msgid "Generate Key"
-msgstr "キーを発行する"
+msgstr "تولید کلید"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
 #: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
-msgstr "有効"
+msgstr "فعالسازی"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
 #: frontend/src/metabase/admin/settings/selectors.js:82
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
-msgstr "無効"
+msgstr "غیرفعال سازی"
 
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
-msgstr "不明な設定{0}"
+msgstr "تنظیم ناشناخته {0}"
 
 #: frontend/src/metabase/admin/settings/selectors.js:23
 msgid "Setup"
-msgstr "設定"
+msgstr "برپایی"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
-msgstr "一般"
+msgstr "عمومی"
 
 #: frontend/src/metabase/admin/settings/selectors.js:33
 msgid "Site Name"
-msgstr "サイト名"
+msgstr "نام پایگاه"
 
 #: frontend/src/metabase/admin/settings/selectors.js:38
 msgid "Site URL"
-msgstr "サイトのURL"
+msgstr "لینک پایگاه"
 
 #: frontend/src/metabase/admin/settings/selectors.js:43
 msgid "Email Address for Help Requests"
-msgstr "ヘルプリクエストのメールアドレス"
+msgstr "آدرس ایمیل برای درخواست کمک"
 
 #: frontend/src/metabase/admin/settings/selectors.js:48
 msgid "Report Timezone"
-msgstr "タイムゾーン"
+msgstr "گزارش منطقه زمانی"
 
 #: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Database Default"
-msgstr "データベースのデフォルト"
+msgstr "پایگاه داده پیش فرض"
 
 #: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Select a timezone"
-msgstr "タイムゾーンを選択する"
+msgstr "یک منطقه زمانی انتخاب کنید"
 
 #: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
-msgstr "すべてのデータベースがタイムゾーンをサポートしているわけではありません。この場合、この設定は有効になりません。"
+msgstr "همه پایگاه های داده از زمان زنجیره پشتیبانی نمی کنند، و در این صورت این تنظیم تاثیری نخواهد داشت."
 
 #: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
-msgstr "言語"
+msgstr "زبان"
 
 #: frontend/src/metabase/admin/settings/selectors.js:65
 msgid "Select a language"
-msgstr "言語を選択する"
+msgstr "یک زبان انتخاب کنید"
 
 #: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
-msgstr "匿名のトラッキング"
+msgstr "پیگیری ناشناس"
 
 #: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
-msgstr "わかりやすいテーブル名とフィールド名"
+msgstr "جدول دوستانه و نام های میدان"
 
 #: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
-msgstr "アンダースコアとダッシュをスペースに置き換える"
+msgstr "فقط با استفاده از فضاهای زیر حروف و خطوط را جایگزین کنید"
 
 #: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
-msgstr "ネストしたクエリを有効化する"
+msgstr "مسدود سازی پرس و جوها را فعال کنید"
 
 #: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
-msgstr "アップデート"
+msgstr "به روز رسانی"
 
 #: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
-msgstr "アップデートを確認する"
+msgstr "بررسی برای به روز رسانی"
 
 #: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
-msgstr "SMTPホスト"
+msgstr "میزبان SMTP"
 
 #: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
-msgstr "SMTPポート"
+msgstr "پورت SMTP"
 
 #: frontend/src/metabase/admin/settings/selectors.js:127
 #: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
-msgstr "無効なポート番号です"
+msgstr "این یک شماره پورت معتبر نیست"
 
 #: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
-msgstr "SMTPセキュリティ"
+msgstr "SMTP امنیت"
 
 #: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
-msgstr "SMTPユーザーネーム"
+msgstr "نام کاربری SMTP"
 
 #: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
-msgstr "SMTPパスワード"
+msgstr "رمز عبور SMTP"
 
 #: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
-msgstr "送信元アドレス"
+msgstr "از آدرس"
 
 #: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
-msgstr "Slack APIトークン"
+msgstr "Slack API Token"
 
 #: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
-msgstr "Slackから受け取ったトークンを入力する"
+msgstr "رمزتان را که از Slack دریافت کرده اید وارد کنید"
 
 #: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
-msgstr "シングルサインオン(SSO)"
+msgstr "تنها ورودی"
 
 #: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
-msgstr "LDAP認証"
+msgstr "تأیید هویت LDAP"
 
 #: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
-msgstr "LDAPホスト"
+msgstr "میزبان LDAP"
 
 #: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
-msgstr "LDAPポート"
+msgstr "پورت LDAP"
 
 #: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
-msgstr "LDAPセキュリティ"
+msgstr "امنیت LDAP"
 
 #: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
-msgstr "ユーザーネームまたはDN"
+msgstr "نام کاربری یا DN"
 
 #: frontend/src/metabase/admin/settings/selectors.js:244
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:191
 #: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
-msgstr "パスワード"
+msgstr "کلمه عبور"
 
 #: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "User search base"
-msgstr "ユーザー検索ベース"
+msgstr "پایگاه جستجوی کاربر"
 
 #: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
-msgstr "ユーザーフィルター"
+msgstr "فیلتر کاربر"
 
 #: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
-msgstr "かっこを確認する"
+msgstr "پرانتزهای خود را بررسی کنید"
 
 #: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
-msgstr "メール属性"
+msgstr "ویژگی ایمیل"
 
 #: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
-msgstr "名の属性"
+msgstr "نام شناسه اول"
 
 #: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
-msgstr "姓の属性"
+msgstr "مولفه‌ی نام خانوادگی"
 
 #: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
-msgstr "グループメンバーを同期する"
+msgstr "همگام سازی اعضای گروه"
 
 #: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
-msgstr "グループ検索ベース"
+msgstr "پایگاه جستجوی گروهی"
 
 #: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
-msgstr "マップ"
+msgstr "نقشه"
 
 #: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
-msgstr "マップタイルサーバーのURL"
+msgstr "URL کاشی نقشه کاشی"
 
 #: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
-msgstr "Metabaseはデフォルト設定でOpenStreetMapsを使用します"
+msgstr "Metabase از طریق OpenStreetMaps به طور پیش فرض استفاده می کند."
 
 #: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
-msgstr "カスタムマップ"
+msgstr "نقشه های سفارشی"
 
 #: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
-msgstr "独自のGeoJSONファイルを追加して、異なるリージョンマップのビジュアライゼーションを可能にする"
+msgstr "فایل های GeoJSON خودتان را برای افزودن تصویر های مختلف نقشه های منطقه اضافه کنید"
 
 #: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
-msgstr "公開"
+msgstr "اشتراک عمومی"
 
 #: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
-msgstr "公開を有効化する"
+msgstr "اشتراکگذاری عمومی را فعال کنید"
 
 #: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
-msgstr "公開されたダッシュボード"
+msgstr "داشبورد به اشتراک گذاشته شده"
 
 #: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
-msgstr "公開された質問"
+msgstr "سوالات مشترک"
 
 #: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
-msgstr "他アプリケーションに埋め込む"
+msgstr "تعبیه در برنامه های دیگر"
 
 #: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
-msgstr "他アプリケーションへのMetabaseの埋め込みを有効化する"
+msgstr "Enable Embedage Metabase در برنامه های دیگر"
 
 #: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
-msgstr "秘密キーを埋め込む"
+msgstr "بستن کلید مخفی"
 
 #: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
-msgstr "埋め込みダッシュボード"
+msgstr "داشبورد جاسازی شده"
 
 #: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
-msgstr "埋め込み質問"
+msgstr "سوالات جاسازی شده"
 
 #: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
-msgstr "キャッシュ"
+msgstr "ذخیره سازی"
 
 #: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
-msgstr "キャッシュを有効化する"
+msgstr "فعال کردن ذخیره سازی"
 
 #: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
-msgstr "最低クエリ期間"
+msgstr "حداقل مدت زمان پرس و جو"
 
 #: frontend/src/metabase/admin/settings/selectors.js:424
 msgid "Cache Time-To-Live (TTL) multiplier"
-msgstr "キャッシュTTL乗数"
+msgstr "زمان کشیدن به زمان (TTL) ضرب"
 
 #: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
-msgstr "最大キャッシュエントリーサイズ"
+msgstr "حداکثر اندازه ورودی کش"
 
 #: frontend/src/metabase/alert/alert.js:60
 msgid "Your alert is all set up."
-msgstr "アラートが設定されました"
+msgstr "هشدار شما تنظیم شده است."
 
 #: frontend/src/metabase/alert/alert.js:101
 msgid "Your alert was updated."
-msgstr "アラートがアップデートされました"
+msgstr "هشدار شما به روز شد"
 
 #: frontend/src/metabase/alert/alert.js:149
 msgid "The alert was successfully deleted."
-msgstr "アラートが削除されました"
+msgstr "هشدار با موفقیت حذف شد"
 
 #: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
-msgstr "有効なメールアドレスを入力してください"
+msgstr "لطفا یک آدرس ایمیل فرمت شده معتبر وارد کنید"
 
 #: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
-msgstr "パスワードが一致しません"
+msgstr "رمزهای ورود مطابقت ندارند"
 
 #: frontend/src/metabase/auth/components/BackToLogin.jsx:6
 msgid "Back to login"
-msgstr "ログイン画面に戻る"
+msgstr "به صفحه ورود بازگردید"
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:15
 msgid "No Metabase account exists for this Google account."
-msgstr "このGoogleアカウントを利用したMetabaseアカウントは存在しません"
+msgstr "هیچ حساب Metabase برای این حساب Google وجود ندارد."
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:17
 msgid "You'll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Googleを利用してログインするには、管理者からMetabaseアカウントを作成してもらう必要があります"
+msgstr "قبل از اینکه بتوانید از Google برای ورود به سیستم، یک حساب کاربری Metabase ایجاد کنید، به یک مدیر نیاز خواهید داشت."
 
 #: frontend/src/metabase/auth/components/SSOLoginButton.jsx:18
 msgid "Sign in with {0}"
-msgstr "{0}を利用してサインインする"
+msgstr "با {0} وارد شوید"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:56
 msgid "Please contact an administrator to have them reset your password"
-msgstr "パスワードをリセットするには管理者へお問い合わせください"
+msgstr "لطفا با یک سرپرست تماس بگیرید تا رمز عبور خود را بازنشانی کنید"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:69
 msgid "Forgot password"
-msgstr "パスワードをお忘れの場合"
+msgstr "فراموشی پسورد / پسورد خود را فراموش کرده اید؟"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:84
 msgid "The email you use for your Metabase account"
-msgstr "Metabaseアカウントのメールアドレス"
+msgstr "ایمیل شما برای حساب Metabase شما استفاده می شود"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:99
 msgid "Send password reset email"
-msgstr "パスワードリセットのメールを送信する"
+msgstr "ارسال ایمیل بازیابی پسورد"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:110
 msgid "Check your email for instructions on how to reset your password."
-msgstr "パスワードのリセット方法についてはメールをご確認ください"
+msgstr "برای دریافت دستورالعمل در مورد چگونگی بازنشانی گذرواژه خود، ایمیل خود را بررسی کنید."
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
-msgstr "Metabaseにサインインする"
+msgstr "به Metabase وارد شوید"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
-msgstr "または"
+msgstr "یا"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
-msgstr "ユーザーネームまたはメールアドレス"
+msgstr "نام کاربری یا آدرس ایمیل"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
-msgstr "サインイン"
+msgstr "ورود"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
-msgstr "パスワードを忘れてしまいました"
+msgstr "به نظر می رسد رمز عبور من را فراموش کرده ام"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
-msgstr "パスワードリセットのメールをリクエストする"
+msgstr "درخواست یک ایمیل"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
-msgstr "このリンクは有効期限切れです"
+msgstr "اوه، این یک لینک منقضی شده است"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
-msgstr "セキュリティの理由により、パスワードリセットのリンクは一定期間を過ぎると無効となります。パスワードリセットが必要な場合は、{0}ができます"
+msgstr "به دلایل امنیتی، لینک های بازنشانی رمز عبور بعد از چند لحظه منقضی می شوند. اگر هنوز هم نیاز دارید\n"
+"برای بازنشانی گذرواژه خود، میتوانید {0} را انتخاب کنید."
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
-msgstr "新しいパスワード"
+msgstr "رمز عبور جدید"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
-msgstr "データを安全に保つため、パスワードは{0}"
+msgstr "برای حفظ اطلاعات خود، گذرواژه {0}"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
-msgstr "新しいパスワードを作成する"
+msgstr "پسورد جدید بسازید"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
-msgstr "設定方法に従いセキュリティ度の高いパスワードを設定してください"
+msgstr "مطمئن شوید که ایمن مانند دستورالعمل بالا است"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
-msgstr "新しいパスワードの確認"
+msgstr "تایید پسورد جدید"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
-msgstr "上記で入力したパスワードと同じものを入力してください"
+msgstr "اطمینان حاصل کنید که آن را با آنکه وارد کردید مطابقت دهید"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
-msgstr "パスワードがリセットされました"
+msgstr "گذرواژه شما تنظیم مجدد شده است"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
-msgstr "新しいパスワードでサインインする"
+msgstr "با گذرواژه جدید خود وارد شوید"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
-msgstr "保存が失敗しました"
+msgstr "ذخیره سازی ناموفق"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
@@ -2105,19 +2129,19 @@ msgstr "保存が失敗しました"
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
-msgstr "保存されました"
+msgstr "ذخیره شد"
 
 #: frontend/src/metabase/components/Alert.jsx:12
 msgid "Ok"
-msgstr "確認しました"
+msgstr "خوب"
 
 #: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
-msgstr "このコレクションをアーカイブしますか？"
+msgstr "این مجموعه را بایگانی کنید؟"
 
 #: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
-msgstr "このコレクション内のダッシュボード、コレクション、パルスもアーカイブされます"
+msgstr "داشبورد، مجموعه ها و پالس ها در این مجموعه نیز بایگانی خواهند شد."
 
 #: frontend/src/metabase/components/ArchiveModal.jsx:38
 #: frontend/src/metabase/components/CollectionLanding.jsx:620
@@ -2129,150 +2153,150 @@ msgstr "このコレクション内のダッシュボード、コレクション
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
-msgstr "アーカイブ"
+msgstr "آرشیو"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:63
 msgid "This {0} has been archived"
-msgstr "この{0}はアーカイブされました"
+msgstr "این {0} بایگانی شده است"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
-msgstr "アーカイブを見る"
+msgstr "آرشیو را ببینید"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
-msgstr "この{0}のアーカイブを取り消す"
+msgstr "این را {0} بایگانی کنید"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:39
 #: frontend/src/metabase/components/BrowseApp.jsx:102
 #: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
-msgstr "データ"
+msgstr "اطلاعات ما"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
-msgstr "このテーブルを自動探査(X-ray)する"
+msgstr "اشعه ایکس این جدول"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
-msgstr "このテーブルについて詳細を見る"
+msgstr "درباره این جدول اطلاعاتی کسب کنید"
 
 #: frontend/src/metabase/components/Button.info.js:11
 #: frontend/src/metabase/components/Button.info.js:12
 #: frontend/src/metabase/components/Button.info.js:13
 msgid "Clickity click"
-msgstr "カチカチ"
+msgstr "Clickity کلیک کنید"
 
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:9
 msgid "Saved!"
-msgstr "保存されました！"
+msgstr "ذخیره شد!"
 
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:10
 msgid "Saving failed."
-msgstr "保存が失敗しました"
+msgstr "ذخیره سازی ناموفق بود."
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
-msgstr "日"
+msgstr "ی‌ش"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
-msgstr "月"
+msgstr "دش"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
-msgstr "火"
+msgstr "س‌ش"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
-msgstr "水"
+msgstr "چ‌ش"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
-msgstr "木"
+msgstr "پ‌ش"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
-msgstr "金"
+msgstr "جم"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
-msgstr "土"
+msgstr "شن"
 
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:41
 msgid "Your admin's email address"
-msgstr "管理者のメールアドレス"
+msgstr "آدرس ایمیل مدیر سیستم شما"
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:37
 msgid "To send {0}, you'll need to set up {1} integration."
-msgstr "{0}を送信するには、{1}インテグレーションを設定する必要があります"
+msgstr "برای ارسال {0}، باید {1} یکپارچگی را تنظیم کنید."
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:38
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:41
 msgid " or "
-msgstr "␣または␣"
+msgstr "یا"
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:40
 msgid "To send {0}, an admin needs to set up {1} integration."
-msgstr "{0}を送信するには、管理者が{1}インテグレーションを設定する必要があります "
+msgstr "برای ارسال {0}، یک مدیر باید {1} یکپارچه سازی را راه اندازی کند."
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:15
 msgid "This collection is empty, like a blank canvas"
-msgstr "このコレクションは空です"
+msgstr "این مجموعه خالی است مانند بوم خالی"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:16
 msgid "You can use collections to organize and group dashboards, questions and pulses for your team or yourself"
-msgstr "コレクションを使用して、ダッシュボード、質問とパルスを整理してグループ化することができます。"
+msgstr "شما می توانید از مجموعه ها برای سازماندهی و دسته بندی داشبورد ها، سوالات و پالس ها برای تیم یا خودتان استفاده کنید"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:28
 msgid "Create another collection"
-msgstr "他のコレクションを作成する"
+msgstr "یک مجموعه دیگر ایجاد کنید"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:68
 msgid "Dashboards let you collect and share data in one place."
-msgstr "ダッシュボードを利用することで、データを一箇所に集約し共有することができます"
+msgstr "داشبورد به شما اجازه می دهد اطلاعات را در یک مکان جمع آوری و به اشتراک بگذارید."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:77
 msgid "Pulses let you send out the latest data to your team on a schedule via email or slack."
-msgstr "パルスを利用することで、メールやSlackを通じて定期的にチームメンバーへ最新情報を送ることができます"
+msgstr "پالس ها به شما اجازه می دهد تا آخرین اطلاعات را به تیم خود ارسال کنید."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:86
 msgid "Questions are a saved look at your data."
-msgstr "データのクエリは質問として保存されました"
+msgstr "سوالات نگاه ذخیره شده به اطلاعات شما هستند."
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
-msgstr "固定"
+msgstr "پین"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
-msgstr "ドラッグしてトップに固定してください"
+msgstr "چیزی را در اینجا بکشید تا آن را به بالا ببرید"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:740
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
-msgstr "コレクション"
+msgstr "مجموعه‌ها"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:431
 #: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
-msgstr "固定を外すにはドラッグしてください"
+msgstr "برای un-pin به اینجا بکشید"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
-msgstr[0] "{0}アイテムが選択されました"
+msgstr[0] "{0} مورد انتخاب شده است"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
-msgstr "{0}アイテムを移動しますか？"
+msgstr "{0} موارد را انتقال دهید؟"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
-msgstr "{0}を移動しますか？"
+msgstr "حرکت \"{0}\"؟"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
@@ -2280,81 +2304,84 @@ msgstr "{0}を移動しますか？"
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
-msgstr "移動する"
+msgstr "انتقال"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
-msgstr "このコレクションを編集する"
+msgstr "این مجموعه را ویرایش کنید"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
-msgstr "このコレクションをアーカイブする"
+msgstr "بایگانی این مجموعه"
 
 #: frontend/src/metabase/components/CollectionList.jsx:67
 #: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
-msgstr "個人のコレクション"
+msgstr "مجموعه شخصی من"
 
 #: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
-msgstr "新しいコレクション"
+msgstr "مجموعه جدید"
 
 #: frontend/src/metabase/components/CopyButton.jsx:35
 msgid "Copied!"
-msgstr "コピーされました"
+msgstr "کپی شده!"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
-msgstr "データベース接続にSSHトンネルを利用する"
+msgstr "برای اتصال به پایگاه داده از یک تونل SSH استفاده کنید"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
-msgstr "一部のデータベースインストールは、SSHホストを介して接続することによってのみアクセスできます。VPNが利用できない場合、このオプションを使用することでセキュリティーレベルを高めることができます。この機能を有効にすると直接接続するよりも動作が遅くなりことがあります。"
+msgstr "برخی از تاسیسات پایگاه داده تنها با اتصال از طریق یک میزبان باسانی SSH می توانند دسترسی پیدا کنند.\n"
+"این گزینه همچنین یک لایه اضافی امنیتی را هنگامی که یک VPN در دسترس نیست فراهم می کند.\n"
+"فعال کردن این معمولا کمتر از یک اتصال مستقیم است."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
-msgstr "データベースが大きいため、Metabaseの同期とスキャンのタイミングを選択します"
+msgstr "این یک پایگاه داده بزرگ است، بنابراین اجازه دهید زمانی که Metabase همگام سازی و اسکن کند، انتخاب کنم"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
-msgstr "Metabaseはフィールド値に対し1時間毎のクイックスキャンと毎日のフルスキャンを行うようデフォルトで設定されています。データベースが大きい場合、この設定をオンにし、いつどのようにフィールド値のスキャンをするか確認することをお勧めします。"
+msgstr "به طور پیش فرض، Metabase یک همگام سازی ساعته سبک و یک روزه اسکن شدید از مقادیر فیلد را می دهد.\n"
+"اگر شما یک پایگاه داده بزرگ دارید، توصیه می کنیم این را به کار ببندید و بررسی کنید که چه زمانی و چه مقدار ارزش فیلد اتفاق می افتد."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
-msgstr "クライアントIDとクライアントシークレットを作成するには{0}してください"
+msgstr "{0} برای ایجاد شناسه مشتری و مشتری راز برای پروژه شما."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
-msgstr "こちらをクリックしてください"
+msgstr "اینجا کلیک کنید"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
-msgstr "アプリケーションタイプは「その他」を選択してください。名前は自由に付けられます。"
+msgstr "به عنوان نوع برنامه، \"دیگر\" را انتخاب کنید. نام هر آنچه را که دوست دارید."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
-msgstr "認証コードを取得するため{0}"
+msgstr "{0} برای دریافت کد Auth"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
-msgstr "Googleドライブ権限で"
+msgstr "با مجوزهای Google Drive"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
-msgstr "このデータでMetabaseを利用するには、Google Developers ConsoleのAPIアクセスを有効化する必要があります"
+msgstr "برای استفاده از Metabase با این داده ها باید دسترسی API را در کنسول Google Developers ها فعال کنید."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
-msgstr "有効化していない場合は、Consoleで{0}してください"
+msgstr "{0} برای رفتن به کنسول اگر قبلا چنین کاری نکرده اید."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
-msgstr "どのようにこのデータベースを参照しますか？"
+msgstr "چگونه می خواهید به این پایگاه داده مراجعه کنید؟"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
@@ -2364,148 +2391,148 @@ msgstr "どのようにこのデータベースを参照しますか？"
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
-msgstr "次へ"
+msgstr "بعدی"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
-msgstr "この{0}を削除する"
+msgstr "حذف این {0}"
 
 #: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
-msgstr "このアイテムを固定する"
+msgstr "این مورد را پین کنید"
 
 #: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
-msgstr "このアイテムを移動する"
+msgstr "این گزینه را انتقال بدین"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
-msgstr "この質問を編集する"
+msgstr "این سوال را ویرایش کنید"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:26
 #: frontend/src/metabase/components/EntityMenu.info.js:47
 #: frontend/src/metabase/components/EntityMenu.info.js:82
 #: frontend/src/metabase/components/EntityMenu.info.js:99
 msgid "Action type"
-msgstr "アクションタイプ"
+msgstr "نوع اقدام"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
-msgstr "履歴を見る"
+msgstr "مشاهده تاریخچه ویرایش"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 msgid "Move action"
-msgstr "アクションを移動する"
+msgstr "حرکت عمل"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:33
 #: frontend/src/metabase/components/EntityMenu.info.js:89
 msgid "Archive action"
-msgstr "アクションをアーカイブする"
+msgstr "اقدام بایگانی"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
-msgstr "ダッシュボードに追加する"
+msgstr "اضافه کردن به داشبورد"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:49
 #: frontend/src/metabase/components/EntityMenu.info.js:101
 msgid "Download results"
-msgstr "結果をダウンロードする"
+msgstr "نتایج را دانلود کنید"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:51
 #: frontend/src/metabase/components/EntityMenu.info.js:103
 #: frontend/src/metabase/public/components/widgets/EmbedWidget.jsx:52
 msgid "Sharing and embedding"
-msgstr "共有と埋め込み"
+msgstr "به اشتراک گذاری و تعبیه"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:53
 #: frontend/src/metabase/components/EntityMenu.info.js:105
 msgid "Another action type"
-msgstr "他のアクションタイプ"
+msgstr "نوع دیگری از عمل"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:65
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
 msgid "Get alerts about this"
-msgstr "これに関するアラートを受け取る"
+msgstr "دریافت هشدار در مورد این"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
-msgstr "SQLを見る"
+msgstr "مشاهده SQL"
 
 #: frontend/src/metabase/components/EntitySegments.jsx:18
 msgid "Segments for this"
-msgstr "このセグメント"
+msgstr "بخش برای این"
 
 #: frontend/src/metabase/components/ErrorDetails.jsx:20
 msgid "Show error details"
-msgstr "エラー詳細を表示する"
+msgstr "نمایش جزئیات خطا"
 
 #: frontend/src/metabase/components/ErrorDetails.jsx:26
 msgid "Here's the full error message"
-msgstr "エラーメッセージ全文です"
+msgstr "اینجا پیام خطای کامل است"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:19
 msgid "Hi, Metabot here."
-msgstr "やあ、MetaBotです。"
+msgstr "سلام متابوت اینجاست"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
-msgstr "スキーマに基づく"
+msgstr "بر اساس طرح"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
-msgstr "見てみる"
+msgstr "یک نگاه به تو"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
-msgstr "一覧を検索する"
+msgstr "جستجو در لیست"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
-msgstr "{0}で検索する"
+msgstr "جستجو توسط {0}"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
-msgstr "␣またはIDを入力する"
+msgstr " یا یک شناسه وارد کنید"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
-msgstr "IDを入力する"
+msgstr "یک شناسه وارد کنید"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
-msgstr "番号を入力する"
+msgstr "شماره را وارد کنید"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
-msgstr "テキストを入力する"
+msgstr "بعضی از متن ها را وارد کنید"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
-msgstr "一致する{0}が見つかりませんでした"
+msgstr "هیچ تطابق {0} یافت نشد"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
-msgstr "フィルターに全てのオプションを含めてしまうと、効果的な結果が得られない場合があります"
+msgstr "از جمله هر گزینه ای در فیلتر شما احتمالا زیاد کار نمی کند ..."
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:24
 msgid "Something's gone wrong"
-msgstr "問題が発生しました"
+msgstr "چیزی اشتباه رفته است"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:25
 msgid "We've run into an error. You can try refreshing the page, or just go back."
-msgstr "エラーが発生しました。このページを更新するか、前のページにお戻りください"
+msgstr "ما به خطا رسیده ایم شما می توانید صفحه را تمیز کنید یا فقط به عقب برگردید."
 
 #: frontend/src/metabase/components/Header.jsx:97
 #: frontend/src/metabase/components/HeaderBar.jsx:45
@@ -2518,329 +2545,329 @@ msgstr "エラーが発生しました。このページを更新するか、前
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
-msgstr "まだ説明がありません"
+msgstr "هنوز توضیحی ندارید"
 
 #: frontend/src/metabase/components/Header.jsx:112
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
-msgstr "新しい{0}"
+msgstr "جدید {0}"
 
 #: frontend/src/metabase/components/Header.jsx:123
 msgid "Asked by {0}"
-msgstr "{0}により質問された"
+msgstr "درخواست شده توسط {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
-msgstr "本日は、"
+msgstr "امروز"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
-msgstr "昨日は、"
+msgstr "دیروز"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
-msgstr "最初の履歴"
+msgstr "تجدید نظر اول"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
-msgstr "以前の履歴と{0}に戻しました"
+msgstr "بازگشت به یک نسخه پیشین و {0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
-msgstr "履歴"
+msgstr "تاریخچه ویرایشهای"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
-msgstr "いつ"
+msgstr "چه زمیانی"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
-msgstr "誰が"
+msgstr "چه کسی"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
-msgstr "何を"
+msgstr "چه چیز"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
-msgstr "元に戻す"
+msgstr "بازگرداندن"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
-msgstr "元に戻しています..."
+msgstr "بازگرداندن ..."
 
 #: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
-msgstr "元に戻すことができませんでした"
+msgstr "بازگرداندن ناموفق بود"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
-msgstr "元に戻しました"
+msgstr "بازگشت"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:13
 msgid "Everything"
-msgstr "全て"
+msgstr "هر چیز"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
 msgid "Dashboards"
-msgstr "ダッシュボード"
+msgstr "داشبورد"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
 msgid "Questions"
-msgstr "質問"
+msgstr "سوال"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
 #: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
-msgstr "パルス"
+msgstr "پالس ها"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
 #: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
-msgstr "戻る"
+msgstr "بازگشت"
 
 #: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
-msgstr "探す..."
+msgstr "یافتن..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 msgid "An error occured"
-msgstr "エラーが発生しました"
+msgstr "خطایی رخ داده"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:35
 msgid "Loading..."
-msgstr "読込中..."
+msgstr "درحال بارگذاری....."
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:71
 msgid "Metabase Newsletter"
-msgstr "Metabaseニュースレター"
+msgstr "خبرنامه Metabase"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:81
 msgid "Get infrequent emails about new releases and feature updates."
-msgstr "新しいリリースやアップデートに関するメールの回数を減らす"
+msgstr "دریافت ایمیل های نادر در مورد نسخه های جدید و به روز رسانی ویژگی ها."
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:99
 msgid "Subscribe"
-msgstr "購読する"
+msgstr "اشتراک در"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:106
 msgid "You're subscribed. Thanks for using Metabase!"
-msgstr "購読の登録がされました。Metabaseをご利用いただきありがとうございます！"
+msgstr "شما مشترک هستید با تشکر برای استفاده از Metabase!"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:44
 msgid "We're a little lost..."
-msgstr "エラーが発生しました..."
+msgstr "ما کمی گم شده ..."
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:27
 msgid "Temporary Password"
-msgstr "仮パスワード"
+msgstr "گذرواژه موقت"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:411
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
-msgstr "非表示にする"
+msgstr "پنهان"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:412
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
-msgstr "表示する"
+msgstr "نمایش دادن"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:17
 msgid "Saved! Add this to a dashboard?"
-msgstr "保存しました！ダッシュボードに追加しますか？"
+msgstr "ذخیره! این را به داشبورد اضافه کنید؟"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:25
 msgid "Yes please!"
-msgstr "お願いします！"
+msgstr "بله لطفا!"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:29
 msgid "Not now"
-msgstr "今はしない"
+msgstr "اکنون نه"
 
 #: frontend/src/metabase/components/SaveStatus.jsx:53
 msgid "Error:"
-msgstr "エラー:"
+msgstr "خطا:"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:23
 msgid "Sunday"
-msgstr "日曜日"
+msgstr "یکشنبه"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:24
 msgid "Monday"
-msgstr "月曜日"
+msgstr "دوشنبه"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:25
 msgid "Tuesday"
-msgstr "火曜日"
+msgstr "سه شنبه"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:26
 msgid "Wednesday"
-msgstr "水曜日"
+msgstr "چهارشنبه"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:27
 msgid "Thursday"
-msgstr "木曜日"
+msgstr "پنج شنبه"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:28
 msgid "Friday"
-msgstr "金曜日"
+msgstr "جمعه"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:29
 msgid "Saturday"
-msgstr "土曜日"
+msgstr "شنبه"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:33
 msgid "First"
-msgstr "最初"
+msgstr "اولین"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:34
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
 msgid "Last"
-msgstr "最後"
+msgstr "دومین"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:35
 msgid "15th (Midpoint)"
-msgstr "15日（中日）"
+msgstr "15th (Midpoint)"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:125
 msgid "Calendar Day"
-msgstr "カレンダー日"
+msgstr "روز تقویم"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
-msgstr "Metabaseのタイムゾーン"
+msgstr "منطقه زمانی Metabase شما"
 
 #: frontend/src/metabase/components/SearchHeader.jsx:21
 msgid "Filter this list..."
-msgstr "この一覧にフィルターをかける..."
+msgstr "این لیست را فیلتر کنید ..."
 
 #: frontend/src/metabase/components/Select.info.js:8
 msgid "Blue"
-msgstr "青"
+msgstr "آبی"
 
 #: frontend/src/metabase/components/Select.info.js:9
 msgid "Green"
-msgstr "緑"
+msgstr "سبز"
 
 #: frontend/src/metabase/components/Select.info.js:10
 msgid "Red"
-msgstr "赤"
+msgstr "قرمز"
 
 #: frontend/src/metabase/components/Select.info.js:11
 msgid "Yellow"
-msgstr "黄"
+msgstr "زرد"
 
 #: frontend/src/metabase/components/Select.info.js:14
 msgid "A component used to make a selection"
-msgstr "選択に使用された要素"
+msgstr "جزء مورد استفاده برای انتخاب"
 
 #: frontend/src/metabase/components/Select.info.js:20
 #: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
-msgstr "選択されました"
+msgstr "انتخاب کنید"
 
 #: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
-msgstr "選択するものがありません"
+msgstr "هیچ چیز برای انتخاب"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:54
 msgid "Sorry, you don’t have permission to see that."
-msgstr "申し訳ありません、閲覧権限がありません"
+msgstr "با عرض پوزش، شما مجاز به دیدن آن نیستید"
 
 #: frontend/src/metabase/components/form/FormMessage.jsx:5
 msgid "Unknown error encountered"
-msgstr "不明エラーが発生しました"
+msgstr "خطای ناشناخته رخ داده است"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
 #: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
-msgstr "作成する"
+msgstr "بسازید"
 
 #: frontend/src/metabase/containers/DashboardForm.jsx:9
 msgid "Create dashboard"
-msgstr "ダッシュボードを作成する"
+msgstr "ایجاد داشبورد"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
-msgstr "テーブル"
+msgstr "جدول"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
 msgid "Database"
-msgstr "ダッシュボード"
+msgstr "پایگاه داده"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:49
 msgid "Creator"
-msgstr "作成者"
+msgstr "ایجاد کننده"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
-msgstr "結果が見つかりませんでした"
+msgstr "نتیجه ای پیدا نشد"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
-msgstr "お探しのデータを見つけるためフィルターの調整をお試しください"
+msgstr "سعی کنید فیلتر خود را برای پیدا کردن آنچه که دنبال می کنید، تنظیم کنید."
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
-msgstr "で見る"
+msgstr "مشاهده توسط"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:495
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
-msgstr "の"
+msgstr "از"
 
 #: frontend/src/metabase/containers/Overworld.jsx:75
 msgid "Don't tell anyone, but you're my favorite."
-msgstr "皆には内緒ですが、あなたは私のお気に入りです"
+msgstr "به کسی نگویید، اما شما مورد علاقه من است."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:85
 msgid "Once you connect your own data, I can show you some automatic explorations called x-rays. Here are some examples with sample data."
-msgstr "データを接続すると、X線と呼ばれる自動探査を表示できます。サンプルデータの例をいくつか表示します。"
+msgstr "هنگامی که دادههای خود را به هم وصل میکنید، میتوانم به شما برخی از کاوشهای خودکار را به نام اشعه ایکس نشان دهم. در اینجا چند نمونه با داده های نمونه است."
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
 #: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
-msgstr "ここから開始する"
+msgstr "از اینجا شروع کنید"
 
 #: frontend/src/metabase/containers/Overworld.jsx:296
 #: frontend/src/metabase/entities/collections.js:150
 #: src/metabase/models/collection.clj
 msgid "Our analytics"
-msgstr "分析"
+msgstr "تجزیه و تحلیل ما"
 
 #: frontend/src/metabase/containers/Overworld.jsx:203
 msgid "Browse all items"
-msgstr "全データをブラウズする"
+msgstr "همه موارد را مرور کنید"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
-msgstr "上書きしますか？新しいデータとして保存しますか？"
+msgstr "جایگزین یا ذخیره شده به عنوان جدید؟"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
-msgstr "元の質問”{0}”を上書きする"
+msgstr "سوال اصلی را تغییر دهید، \"{0}\""
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
-msgstr "新しい質問として保存する"
+msgstr "به عنوان سوال جدید ذخیره کنید"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
-msgstr "まずは、質問を保存してください"
+msgstr "اول، سوال خود را ذخیره کنید"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
-msgstr "質問を保存する"
+msgstr "صرفه جویی در سوال"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
-msgstr "カードの名前は？"
+msgstr "نام کارت شما چیست؟"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
@@ -2856,453 +2883,453 @@ msgstr "カードの名前は？"
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
-msgstr "説明"
+msgstr "توضیحات"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
 #: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
-msgstr "任意ですが、入力しておくととても便利です"
+msgstr "این اختیاری است اما اوه، خیلی مفید است"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
-msgstr "これはどのコレクションに保存しますか？"
+msgstr "کدام مجموعه باید این باشد؟"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:34
 msgid "modified"
-msgstr "修正された"
+msgstr "اصلاح شده"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:34
 msgid "item"
-msgstr "アイテム"
+msgstr "آیتم"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
-msgstr "やり直す"
+msgstr "لغو"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "Applying Question"
-msgstr "質問を適用中"
+msgstr "درخواست سوال"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:274
 msgid "That question isn't compatible"
-msgstr "この質問は互換性がありません"
+msgstr "این سوال سازگار نیست"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:310
 msgid "Search for a question"
-msgstr "質問を検索する"
+msgstr "جستجو برای یک سوال"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:339
 msgid "We're not sure if this question is compatible"
-msgstr "この質問の互換性が不明です"
+msgstr "ما مطمئن نیستیم که آیا این سوال سازگار است"
 
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:43
 msgid "Archive Dashboard"
-msgstr "ダッシュボードをアーカイブする"
+msgstr "داشبورد بایگانی"
 
 #: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
-msgstr "各シリーズを必ず選択してください。選択しない場合、このカードでフィルターは機能しません。"
+msgstr "اطمینان حاصل کنید که انتخاب برای هر سری، یا فیلتر بر روی این کارت کار نخواهد کرد."
 
 #: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
-msgstr "このダッシュボードは空です"
+msgstr "این داشبورد خالی است."
 
 #: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
-msgstr "質問を追加して使い易くしましょう！"
+msgstr "یک سوال برای شروع مفید بودن اضافه کنید"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:38
 msgid "Daytime mode"
-msgstr "昼モード"
+msgstr "حالت روزانه"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:38
 msgid "Nighttime mode"
-msgstr "夜モード"
+msgstr "حالت شبانه"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:56
 msgid "Exit fullscreen"
-msgstr "フルスクリーンを解除する"
+msgstr "خروج از تمام صفحه"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:56
 msgid "Enter fullscreen"
-msgstr "フルスクリーン"
+msgstr "ورود به حالت تمام صفحه"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
-msgstr "保存中..."
+msgstr "درحال ذخیره‌ سازی"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
-msgstr "質問を追加する"
+msgstr "سوالی اضافه کنید"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
-msgstr "このダッシュボードに質問を追加する"
+msgstr "یک سوال به این داشبورد اضافه کنید"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
-msgstr "フィルターを追加する"
+msgstr "یک فیلتر اضافه کنید"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
-msgstr "パラメーター"
+msgstr "مولفه های"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
-msgstr "テキストボックスを追加する"
+msgstr "یک جعبه متن را اضافه کنید"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
-msgstr "ダッシュボードを移動する"
+msgstr "حرکت داشبورد"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
-msgstr "ダッシュボードを編集する"
+msgstr "ویرایش داشبورد"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
-msgstr "ダッシュボードのレイアウトを編集する"
+msgstr "ویرایش طرح بندی داشبورد"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
-msgstr "ダッシュボード編集中"
+msgstr "شما در حال ویرایش داشبورد هستید"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
-msgstr "各カードにフィルタリングするフィールドを選択する"
+msgstr "فیلد را انتخاب کنید که باید برای هر کارت فیلتر شود"
 
 #: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
-msgstr "ダッシュボードを移動する..."
+msgstr "حرکت داشبورد به ..."
 
 #: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
-msgstr "{0}にダッシュボードを移動しました"
+msgstr "داشبورد به {0} منتقل شد"
 
 #: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
 msgid "What do you want to filter?"
-msgstr "何をフィルターしますか？"
+msgstr "چه میخواهید فیلتر کنید؟"
 
 #: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
 msgid "What kind of filter?"
-msgstr "どのようなフィルター？"
+msgstr "چه نوع فیلتر؟"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
-msgstr "オフ"
+msgstr "خاموش"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:14
 msgid "1 minute"
-msgstr "1分"
+msgstr "۱ دقیقه"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:15
 msgid "5 minutes"
-msgstr "5分"
+msgstr "۵ دقیقه"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:16
 msgid "10 minutes"
-msgstr "10分"
+msgstr "۱۰ دقیقه"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:17
 msgid "15 minutes"
-msgstr "15分"
+msgstr "۱۵ دقیقه"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:18
 msgid "30 minutes"
-msgstr "30分"
+msgstr "۳۰ دقیقه"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:19
 msgid "60 minutes"
-msgstr "60分"
+msgstr "۶۰ دقیقه"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:31
 msgid "Auto-refresh"
-msgstr "自動更新"
+msgstr "خودکار تازه کردن"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:37
 msgid "Refreshing in"
-msgstr "更新間隔"
+msgstr "بازخوانی در"
 
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:36
 msgid "Remove this question?"
-msgstr "この質問を削除しますか？"
+msgstr "این سوال پاک شود؟"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
-msgstr "ダッシュボードが保存されました"
+msgstr "پایگاه داده شما ذخیره شده است"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:744
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
-msgstr "見る"
+msgstr "آن را ببینید"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
-msgstr "保存する"
+msgstr "ذخیرش کن"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
-msgstr "詳細を表示する"
+msgstr "نمایش بیشتر در مورد این"
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
-msgstr "このパラメータータイプにマップできるフィールドやパラメーターがこのカードにはありません。"
+msgstr "این کارت هیچ فیلدی یا پارامتری ندارد که بتواند به این نوع پارامتر نقشه بگذارد."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
-msgstr "このフィールドの値は、選択した他のフィールドの値と重複しません。"
+msgstr "مقادیر این فیلد با مقادیر هر فیلد دیگری که انتخاب کرده اید همپوشانی ندارد."
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
-msgstr "有効なフィールドがありません"
+msgstr "هیچ فیلد معتبر وجود ندارد"
 
 #: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
-msgstr "名前は100文字以下で入力してください"
+msgstr "نام باید 100 عدد یا کمتر باشد"
 
 #: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
-msgstr "色が必要です"
+msgstr "رنگ مورد نیاز است"
 
 #: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
-msgstr "このダッシュボードの名前は？"
+msgstr "نام داشبورد شما چیست؟"
 
 #: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
-msgstr "表現できないぐらい最高なことをやろう"
+msgstr "برخی چیزهای فوق العاده بسیار عالی که برای توصیف سخت است انجام داد"
 
 #: frontend/src/metabase/home/components/Activity.jsx:103
 #: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
-msgstr "␣に関するアラートを作成しました"
+msgstr "هشدار در مورد ایجاد کرد"
 
 #: frontend/src/metabase/home/components/Activity.jsx:128
 #: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
-msgstr "␣に関するアラートを削除しました"
+msgstr "هشدار در مورد حذف شد"
 
 #: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
-msgstr "␣に関する質問を保存しました"
+msgstr "یک سوال در مورد ذخیره کرد"
 
 #: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
-msgstr "質問を保存しました"
+msgstr "یک سوال را ذخیره کردید"
 
 #: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
-msgstr "質問を削除しました"
+msgstr "یک سوال را حذف کرد"
 
 #: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
-msgstr "ダッシュボードを作成しました"
+msgstr "یک داشبورد ایجاد کرد"
 
 #: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
-msgstr "ダッシュボードを削除しました"
+msgstr "داشبورد حذف شد"
 
 #: frontend/src/metabase/home/components/Activity.jsx:183
 #: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
-msgstr "ダッシュボードに質問を追加しました"
+msgstr "یک سوال به داشبورد اضافه کرد -"
 
 #: frontend/src/metabase/home/components/Activity.jsx:208
 #: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
-msgstr "ダッシュボードから質問を削除しました"
+msgstr "یک سوال از داشبورد حذف شد -"
 
 #: frontend/src/metabase/home/components/Activity.jsx:233
 #: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
-msgstr "から最新のデータを受信しました"
+msgstr "آخرین اطلاعات دریافت شده از"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:814
 #: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
-msgstr "不明"
+msgstr "ناشناخته"
 
 #: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
-msgstr "こんにちは世界！"
+msgstr "سلام دنیا!"
 
 #: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
-msgstr "Metabaseを起動しています。"
+msgstr "Metabase در حال اجرا است."
 
 #: frontend/src/metabase/home/components/Activity.jsx:260
 #: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
-msgstr "メトリクスを追加しました"
+msgstr "متریک اضافه شده است"
 
 #: frontend/src/metabase/home/components/Activity.jsx:274
 #: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
-msgstr "に"
+msgstr " به"
 
 #: frontend/src/metabase/home/components/Activity.jsx:284
 #: frontend/src/metabase/home/components/Activity.jsx:324
 #: frontend/src/metabase/home/components/Activity.jsx:374
 #: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
-msgstr "␣テーブル"
+msgstr " جدول"
 
 #: frontend/src/metabase/home/components/Activity.jsx:300
 #: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
-msgstr "メトリクスが変更されました"
+msgstr "تغییرات را به متریک انجام داد"
 
 #: frontend/src/metabase/home/components/Activity.jsx:314
 #: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
-msgstr "の中"
+msgstr " در"
 
 #: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
-msgstr "メトリクスを削除しました"
+msgstr "متریک را حذف کرد"
 
 #: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
-msgstr "パルスを作成しました"
+msgstr "پالس ایجاد کرد"
 
 #: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
-msgstr "パルスを削除しました"
+msgstr "پالس را حذف کردید"
 
 #: frontend/src/metabase/home/components/Activity.jsx:349
 #: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
-msgstr "フィルターを追加しました"
+msgstr "فیلتر اضافه شد"
 
 #: frontend/src/metabase/home/components/Activity.jsx:390
 #: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
-msgstr "フィルターが変更されました"
+msgstr "ساخته شده تغییرات در فیلتر"
 
 #: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
-msgstr "フィルター{0}を削除しました"
+msgstr "فیلتر {0} را حذف کرد"
 
 #: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
-msgstr "参加しました！"
+msgstr "پیوست"
 
 #: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
-msgstr "何も起こりませんでした"
+msgstr "هوم، به نظر می رسد هیچ چیز هنوز اتفاق افتاده است."
 
 #: frontend/src/metabase/home/components/Activity.jsx:534
 msgid "Save a question and get this baby going!"
-msgstr "質問を保存して次に進みましょう！"
+msgstr "یک سوال را ذخیره کنید و این نوزاد را در حال رفتن!"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:19
 msgid "Ask questions and explore"
-msgstr "質問して調査する"
+msgstr "از سوالات بپرس و اکتشاف کنید"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:20
 msgid "Click on charts or tables to explore, or ask a new question using the easy interface or the powerful SQL editor."
-msgstr "チャートまたはテーブルをクリックして探索したり、簡単なインターフェースやSQLエディターを使用して新たに質問する"
+msgstr "با کلیک بر روی نمودار یا جداول برای کشف، و یا از یک سوال جدید با استفاده از رابط آسان و یا ویرایشگر قدرتمند SQL بپرسید."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:30
 msgid "Make your own charts"
-msgstr "自分でチャートを作成する"
+msgstr "نمودارهای خود را ایجاد کنید"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:31
 msgid "Create line charts, scatter plots, maps, and more."
-msgstr "棒グラフ、散布図、マップ等を作成する"
+msgstr "ایجاد نمودار خطوط، قطعه پراکنده، نقشه ها و موارد دیگر."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:41
 msgid "Share what you find"
-msgstr "結果を共有する"
+msgstr "به اشتراک گذاشتن آنچه شما پیدا کنید"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:42
 msgid "Create powerful and flexible dashboards, and send regular updates via email or Slack."
-msgstr "強力かつ柔軟なダッシュボードを作って、更新情報をメールもしくはSlackで受け取りましょう"
+msgstr "داشبورد قدرتمند و قابل انعطاف را ایجاد کنید و به روز رسانی به طور منظم از طریق ایمیل یا اسلک ارسال کنید."
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
 msgid "Let's go"
-msgstr "始めましょう"
+msgstr "بزن بریم"
 
 #: frontend/src/metabase/home/components/NextStep.jsx:34
 msgid "Setup Tip"
-msgstr "設定のヒント"
+msgstr "نکته راه اندازی"
 
 #: frontend/src/metabase/home/components/NextStep.jsx:40
 msgid "View all"
-msgstr "全て見る"
+msgstr "نمایش همه"
 
 #: frontend/src/metabase/home/components/RecentViews.jsx:40
 msgid "Recently Viewed"
-msgstr "最近見たデータ"
+msgstr "به تازگی بازدید شده"
 
 #: frontend/src/metabase/home/components/RecentViews.jsx:75
 msgid "You haven't looked at any dashboards or questions recently"
-msgstr "最近ダッシュボードや質問を見ていないようです"
+msgstr "شما اخیرا به هیچ داشبورد یا سوالی نگاه نکردید"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
-msgstr "{0}アイテムが選択されました"
+msgstr "{0} مورد انتخاب شده است"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
-msgstr "アーカイブを取り消す"
+msgstr "بازخوانی"
 
 #: frontend/src/metabase/home/containers/HomepageApp.jsx:77
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
-msgstr "アクティビティ"
+msgstr "فعالیت"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
-msgstr "{0}の結果"
+msgstr "نتایج برای \"{0}\""
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:138
 msgid "Pulse"
-msgstr "パルス"
+msgstr "نبض"
 
 #: frontend/src/metabase/lib/core.js:7
 msgid "Entity Key"
-msgstr "エンティティキー"
+msgstr "کلید خصوصی"
 
 #: frontend/src/metabase/lib/core.js:8 frontend/src/metabase/lib/core.js:14
 #: frontend/src/metabase/lib/core.js:20
 msgid "Overall Row"
-msgstr "行全体"
+msgstr "ردیف کلی"
 
 #: frontend/src/metabase/lib/core.js:9
 msgid "The primary key for this table."
-msgstr "プライマリーキー"
+msgstr "کلید اولیه برای این جدول."
 
 #: frontend/src/metabase/lib/core.js:13
 msgid "Entity Name"
-msgstr "エンティティ名"
+msgstr "نام شخصیت"
 
 #: frontend/src/metabase/lib/core.js:15
 msgid "The \"name\" of each record. Usually a column called \"name\", \"title\", etc."
-msgstr "各レコードの名前、通常は「名前」「タイトル」等の列"
+msgstr "\"نام\" هر رکورد. معمولا یک ستون به نام \"نام\"، \"عنوان\" و غیره"
 
 #: frontend/src/metabase/lib/core.js:19
 msgid "Foreign Key"
-msgstr "外部キー"
+msgstr "کلید خارجی"
 
 #: frontend/src/metabase/lib/core.js:21
 msgid "Points to another table to make a connection."
-msgstr "接続する別のテーブルを提示する"
+msgstr "اشاره به جدول دیگری برای ایجاد ارتباط"
 
 #: frontend/src/metabase/lib/core.js:25
 msgid "Avatar Image URL"
-msgstr "アバターイメージURL"
+msgstr "URL تصویر آواتار"
 
 #: frontend/src/metabase/lib/core.js:26 frontend/src/metabase/lib/core.js:31
 #: frontend/src/metabase/lib/core.js:36 frontend/src/metabase/lib/core.js:41
@@ -3326,199 +3353,199 @@ msgstr "アバターイメージURL"
 #: frontend/src/metabase/lib/core.js:216 frontend/src/metabase/lib/core.js:221
 #: frontend/src/metabase/lib/core.js:226 frontend/src/metabase/lib/core.js:231
 msgid "Common"
-msgstr "一般"
+msgstr "مشترک"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
 msgid "Category"
-msgstr "カテゴリー"
+msgstr "دسته بندی"
 
 #: frontend/src/metabase/lib/core.js:35
 #: frontend/src/metabase/meta/Dashboard.js:61
 msgid "City"
-msgstr "都市"
+msgstr "شهر"
 
 #: frontend/src/metabase/lib/core.js:40
 #: frontend/src/metabase/meta/Dashboard.js:73
 msgid "Country"
-msgstr "国"
+msgstr "کشور"
 
 #: frontend/src/metabase/lib/core.js:60
 msgid "Enum"
-msgstr "列挙型"
+msgstr "انووم"
 
 #: frontend/src/metabase/lib/core.js:65
 msgid "Image URL"
-msgstr "イメージURL"
+msgstr "URL تصویر"
 
 #: frontend/src/metabase/lib/core.js:70
 msgid "Field containing JSON"
-msgstr "JSONを含むフィールド"
+msgstr "فیلد حاوی JSON"
 
 #: frontend/src/metabase/lib/core.js:75
 msgid "Latitude"
-msgstr "緯度"
+msgstr "عرض جغرافیایی"
 
 #: frontend/src/metabase/lib/core.js:80
 msgid "Longitude"
-msgstr "経度"
+msgstr "عرض جغرافیایی"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
-msgstr "数値"
+msgstr "شماره"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:19
 #: frontend/src/metabase/lib/core.js:90
 #: frontend/src/metabase/meta/Dashboard.js:65
 msgid "State"
-msgstr "州"
+msgstr "دولت"
 
 #: frontend/src/metabase/lib/core.js:95
 msgid "UNIX Timestamp (Seconds)"
-msgstr "UNIX時刻（秒）"
+msgstr "زمان بندی یونیکس (ثانیه)"
 
 #: frontend/src/metabase/lib/core.js:100
 msgid "UNIX Timestamp (Milliseconds)"
-msgstr "UNIX時刻（ミリ秒）"
+msgstr "زمان بندی یونیکس (میلی ثانیه)"
 
 #: frontend/src/metabase/lib/core.js:110
 msgid "Zip Code"
-msgstr "郵便番号"
+msgstr "کد پستی"
 
 #: frontend/src/metabase/lib/core.js:115
 msgid "Quantity"
-msgstr "量"
+msgstr "مقدار"
 
 #: frontend/src/metabase/lib/core.js:120
 msgid "Income"
-msgstr "収益"
+msgstr "درآمد"
 
 #: frontend/src/metabase/lib/core.js:125
 msgid "Discount"
-msgstr "割引"
+msgstr "تخفیف"
 
 #: frontend/src/metabase/lib/core.js:130
 msgid "Creation timestamp"
-msgstr "タイムスタンプ作成"
+msgstr "زمان رسم ایجاد"
 
 #: frontend/src/metabase/lib/core.js:135
 msgid "Creation time"
-msgstr "作成時間"
+msgstr "زمان ایجاد"
 
 #: frontend/src/metabase/lib/core.js:140
 msgid "Creation date"
-msgstr "作成日"
+msgstr "تاریخ ایجاد"
 
 #: frontend/src/metabase/lib/core.js:145
 msgid "Product"
-msgstr "商品"
+msgstr "تولید - محصول"
 
 #: frontend/src/metabase/lib/core.js:150
 msgid "User"
-msgstr "ユーザー"
+msgstr "کاربر"
 
 #: frontend/src/metabase/lib/core.js:155
 msgid "Source"
-msgstr "ソース"
+msgstr "منبع"
 
 #: frontend/src/metabase/lib/core.js:160
 msgid "Price"
-msgstr "料金"
+msgstr "قیمت"
 
 #: frontend/src/metabase/lib/core.js:165
 msgid "Join timestamp"
-msgstr "タイムスタンプ参加"
+msgstr "تاریخ تایمر"
 
 #: frontend/src/metabase/lib/core.js:170
 msgid "Join time"
-msgstr "参加時間"
+msgstr "زمان پیوستن"
 
 #: frontend/src/metabase/lib/core.js:175
 msgid "Join date"
-msgstr "登録日"
+msgstr "تاریخ عضویت"
 
 #: frontend/src/metabase/lib/core.js:180
 msgid "Share"
-msgstr "共有する"
+msgstr "اشتراک گذاری"
 
 #: frontend/src/metabase/lib/core.js:185
 msgid "Owner"
-msgstr "オーナー"
+msgstr "صاحب"
 
 #: frontend/src/metabase/lib/core.js:190
 msgid "Company"
-msgstr "会社"
+msgstr "شرکت"
 
 #: frontend/src/metabase/lib/core.js:195
 msgid "Subscription"
-msgstr "購読"
+msgstr "اشتراک، ابونمان"
 
 #: frontend/src/metabase/lib/core.js:200
 msgid "Score"
-msgstr "スコア"
+msgstr "امتیاز"
 
 #: frontend/src/metabase/lib/core.js:210
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
-msgstr "タイトル"
+msgstr "عنوان"
 
 #: frontend/src/metabase/lib/core.js:215
 msgid "Comment"
-msgstr "コメント"
+msgstr "اظهار نظر"
 
 #: frontend/src/metabase/lib/core.js:220
 msgid "Cost"
-msgstr "コスト"
+msgstr "هزینه"
 
 #: frontend/src/metabase/lib/core.js:225
 msgid "Gross margin"
-msgstr "売上総利益"
+msgstr "حاشیه ناخالص"
 
 #: frontend/src/metabase/lib/core.js:230
 msgid "Birthday"
-msgstr "生年月日"
+msgstr "تاریخ تولد"
 
 #: frontend/src/metabase/lib/core.js:241
 msgid "Search box"
-msgstr "検索ボックス"
+msgstr "کادر جستوجو"
 
 #: frontend/src/metabase/lib/core.js:242
 msgid "A list of all values"
-msgstr "全値の一覧"
+msgstr "لیستی از تمام ارزش ها"
 
 #: frontend/src/metabase/lib/core.js:243
 msgid "Plain input box"
-msgstr "入力ボックス"
+msgstr "جعبه ورودی ساده"
 
 #: frontend/src/metabase/lib/core.js:249
 msgid "Everywhere"
-msgstr "どこでも"
+msgstr "هر کجا"
 
 #: frontend/src/metabase/lib/core.js:250
 msgid "The default setting. This field will be displayed normally in tables and charts."
-msgstr "デフォルト設定。このフィールドは通常テーブルやチャートに表示されます。"
+msgstr "تنظیم پیش فرض این فیلد به طور معمول در جداول و نمودار نمایش داده خواهد شد."
 
 #: frontend/src/metabase/lib/core.js:254
 msgid "Only in Detail Views"
-msgstr "詳細表示のみ"
+msgstr "فقط در نمایش جزئیات"
 
 #: frontend/src/metabase/lib/core.js:255
 msgid "This field will only be displayed when viewing the details of a single record. Use this for information that's lengthy or that isn't useful in a table or chart."
-msgstr "このフィールドは、単一のレコードの詳細を閲覧する場合にのみ表示されます。 処理に時間のかかる情報や、テーブルやチャート内では利用できない情報に使用してください。"
+msgstr "این قسمت فقط در هنگام مشاهده جزئیات یک رکورد تنها نمایش داده می شود. برای اطلاعاتی که طولانی است یا در جدول یا نمودار سودمند نیست، از این استفاده کنید."
 
 #: frontend/src/metabase/lib/core.js:259
 msgid "Do Not Include"
-msgstr "含まない"
+msgstr "شامل نیست"
 
 #: frontend/src/metabase/lib/core.js:260
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
-msgstr "Metabaseはこのフィールドを取得しなくなります。取得するとセキュリティ上問題があったり、無関係なフィールドに使いましょう"
+msgstr "Metabase هرگز این فیلد را بازیابی نخواهد کرد. از این اطلاعات برای اطلاعات حساس یا بی اهمیت استفاده کنید."
 
 #: frontend/src/metabase/lib/expressions/config.js:7
 #: frontend/src/metabase/lib/query.js:300
@@ -3530,174 +3557,174 @@ msgstr "Metabaseはこのフィールドを取得しなくなります。取得�
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Count"
-msgstr "カウント"
+msgstr "شمردن"
 
 #: frontend/src/metabase/lib/expressions/config.js:8
 msgid "CumulativeCount"
-msgstr "累積カウント"
+msgstr "جمع انباشته"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
-msgstr "合計"
+msgstr "جمع"
 
 #: frontend/src/metabase/lib/expressions/config.js:10
 msgid "CumulativeSum"
-msgstr "累積和"
+msgstr "مجموع جمله"
 
 #: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
-msgstr "ディスティンクト"
+msgstr "متمایز"
 
 #: frontend/src/metabase/lib/expressions/config.js:12
 msgid "StandardDeviation"
-msgstr "標準偏差"
+msgstr "انحراف معیار"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
 #: frontend/src/metabase/visualizations/lib/utils.js:129
 msgid "Average"
-msgstr "平均"
+msgstr "میانگین"
 
 #: frontend/src/metabase/lib/expressions/config.js:14
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:25
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
-msgstr "最低"
+msgstr "کمترین"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
-msgstr "最高"
+msgstr "بیشترین"
 
 #: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
-msgstr "字句エラーが検出されました"
+msgstr "غم انگیز غم انگیز پاندا، اشتباهات لایسنس شناسایی شده است"
 
 #: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
 msgid_plural "{0} seconds"
-msgstr[0] "{0}秒"
+msgstr[0] "{0} ثانیه"
 
 #: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
-msgstr[0] "{0}分"
+msgstr[0] "{0} دقیقه"
 
 #: frontend/src/metabase/lib/greeting.js:4
 msgid "Hey there"
-msgstr "ようこそ！"
+msgstr "سلام اونجا"
 
 #: frontend/src/metabase/lib/greeting.js:5
 #: frontend/src/metabase/lib/greeting.js:29
 msgid "How's it going"
-msgstr "調子はどう？"
+msgstr "اوضاع چطوره"
 
 #: frontend/src/metabase/lib/greeting.js:6
 msgid "Howdy"
-msgstr "よお"
+msgstr "چطوری"
 
 #: frontend/src/metabase/lib/greeting.js:7
 msgid "Greetings"
-msgstr "こんにちは"
+msgstr "با درود"
 
 #: frontend/src/metabase/lib/greeting.js:8
 msgid "Good to see you"
-msgstr "ようこそ！"
+msgstr "از دیدنت خوشحالم"
 
 #: frontend/src/metabase/lib/greeting.js:12
 msgid "What do you want to know?"
-msgstr "何を知りたいですか？"
+msgstr "چه می خواهید بدانید؟"
 
 #: frontend/src/metabase/lib/greeting.js:13
 msgid "What's on your mind?"
-msgstr "何を知りたいですか？"
+msgstr "در ذهن شما چیست؟"
 
 #: frontend/src/metabase/lib/greeting.js:14
 msgid "What do you want to find out?"
-msgstr "何を調べますか？"
+msgstr "چه می خواهید بیرون بیایید؟"
 
 #: frontend/src/metabase/lib/query.js:298
 #: frontend/src/metabase/lib/schema_metadata.js:458
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
-msgstr "ローデータ"
+msgstr "داده های خام"
 
 #: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
-msgstr "累積カウント"
+msgstr "شمارش تجمعی"
 
 #: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
-msgstr "の平均"
+msgstr "میانگین از"
 
 #: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
-msgstr "␣の重複を除いた値"
+msgstr "مقادیر مشخصی از"
 
 #: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
-msgstr "の標準偏差"
+msgstr "انحراف استاندارد از"
 
 #: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
-msgstr "の合計"
+msgstr "مجموع از"
 
 #: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
-msgstr "の累積和"
+msgstr "جمع تجمعی"
 
 #: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
-msgstr "の最高"
+msgstr "حداکثر"
 
 #: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
-msgstr "の最低"
+msgstr "حداقل از"
 
 #: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
-msgstr "グループ化された"
+msgstr "گروه بندی شده توسط"
 
 #: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
-msgstr "フィルターされた"
+msgstr "فیلتر شده توسط"
 
 #: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
-msgstr "ソートされた"
+msgstr "مرتب شده بر اساس"
 
 #: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
-msgstr "正"
+msgstr "درست است"
 
 #: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
-msgstr "誤"
+msgstr "نادرست"
 
 #: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
-msgstr "経度フィールドを選択する"
+msgstr "فیلد طول جغرافیایی را انتخاب کنید"
 
 #: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
-msgstr "もっと上の緯度を入力する"
+msgstr "طول عرضی بالا را وارد کنید"
 
 #: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
-msgstr "もっと左の経度を入力する"
+msgstr "طول جغرافیایی را وارد کنید"
 
 #: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
-msgstr "もっと下の緯度を入力する"
+msgstr "عرض پایین را وارد کنید"
 
 #: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
-msgstr "もっと右の経度を入力する"
+msgstr "طول جغرافیایی را وارد کنید"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:505
 #: frontend/src/metabase-lib/lib/Dimension.js:507
@@ -3709,7 +3736,7 @@ msgstr "もっと右の経度を入力する"
 #: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
-msgstr "である"
+msgstr "است"
 
 #: frontend/src/metabase/lib/schema_metadata.js:352
 #: frontend/src/metabase/lib/schema_metadata.js:372
@@ -3717,7 +3744,7 @@ msgstr "である"
 #: frontend/src/metabase/lib/schema_metadata.js:396
 #: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
-msgstr "ではない"
+msgstr "نیست"
 
 #: frontend/src/metabase/lib/schema_metadata.js:353
 #: frontend/src/metabase/lib/schema_metadata.js:367
@@ -3727,7 +3754,7 @@ msgstr "ではない"
 #: frontend/src/metabase/lib/schema_metadata.js:397
 #: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
-msgstr "空"
+msgstr "خالی است"
 
 #: frontend/src/metabase/lib/schema_metadata.js:354
 #: frontend/src/metabase/lib/schema_metadata.js:368
@@ -3737,435 +3764,435 @@ msgstr "空"
 #: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
-msgstr "空ではない"
+msgstr "خالی نیست"
 
 #: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
-msgstr "同等"
+msgstr "مساوی با"
 
 #: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
-msgstr "同等ではない"
+msgstr "برابر نیست با"
 
 #: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
-msgstr "より大きい"
+msgstr "بزرگتر از"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
-msgstr "より小さい"
+msgstr "کمتر از"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:390
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
-msgstr "間"
+msgstr "بین"
 
 #: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
-msgstr "以上"
+msgstr "بزرگتر یا مساوی با"
 
 #: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
-msgstr "以下"
+msgstr "کمتر یا برابر است"
 
 #: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
-msgstr "含む"
+msgstr "شامل"
 
 #: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
-msgstr "含まない"
+msgstr "شامل نمی شود"
 
 #: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
-msgstr "で始まる"
+msgstr "شروع می شود با"
 
 #: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
-msgstr "で終わる"
+msgstr "به پایان می رسد با"
 
 #: frontend/src/metabase/lib/schema_metadata.js:388
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
-msgstr "前"
+msgstr "قبل از"
 
 #: frontend/src/metabase/lib/schema_metadata.js:389
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
-msgstr "後"
+msgstr "بعد از"
 
 #: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
-msgstr "中"
+msgstr "داخل"
 
 #: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
-msgstr "回答内の行を含むテーブルのみ、他操作なし"
+msgstr "فقط یک جدول با ردیف در پاسخ، هیچ عملیات اضافی."
 
 #: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
-msgstr "行のカウント"
+msgstr "تعداد ردیف ها"
 
 #: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
-msgstr "回答の全行数"
+msgstr "تعداد ردیف ها در پاسخ."
 
 #: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
-msgstr "の合計"
+msgstr "مجموع ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
-msgstr "列の全値の合計"
+msgstr "مجموع تمام مقادیر یک ستون."
 
 #: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
-msgstr "の平均"
+msgstr "میانگین ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
-msgstr "列の全値の平均"
+msgstr "میانگین تمام مقادیر یک ستون"
 
 #: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
-msgstr "...の異なる値の数"
+msgstr "تعداد مقادیر متمایز ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
-msgstr "回答の全行のうちユニーク値の列数"
+msgstr "تعداد مقادیر منحصر به فرد یک ستون در میان تمام ردیف در پاسخ."
 
 #: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
-msgstr "累積合計"
+msgstr "جمع تجمعی ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
-msgstr "列の全値の合計\\\\ne.x. 経年の全収入"
+msgstr "مجموع افزودنی تمام مقادیر یک ستون. \\\\ ne.x. درآمد کل در طول زمان."
 
 #: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
-msgstr "行の累積カウント"
+msgstr "تعداد تجمعی ردیف"
 
 #: frontend/src/metabase/lib/schema_metadata.js:501
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
-msgstr "行数の合計\\\\ne.x.経年の販売数合計"
+msgstr "تعداد افزودنی تعداد ردیفها. \\\\ ne.x. تعداد کل فروش در طول زمان."
 
 #: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
-msgstr "...の標準偏差"
+msgstr "انحراف استاندارد ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
-msgstr "回答の全行の間で列の値がどれくらい異なるかを表す数値"
+msgstr "شماره ای که بیان می کند مقدار مقادیر یک ستون در میان تمام ردیف ها در جواب متفاوت است."
 
 #: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
-msgstr "...の最低"
+msgstr "حداقل از ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
-msgstr "列の最低値"
+msgstr "حداقل مقدار یک ستون"
 
 #: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
-msgstr "...の最高"
+msgstr "حداکثر ..."
 
 #: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
-msgstr "列の最高値"
+msgstr "حداکثر مقدار یک ستون"
 
 #: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
-msgstr "ディメンション別に分割する"
+msgstr "شکستن بعد"
 
 #: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
-msgstr "小文字"
+msgstr "حروف کوچک"
 
 #: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
-msgstr "大文字"
+msgstr "نامه بزرگ"
 
 #: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
-msgstr "番号"
+msgstr "عدد"
 
 #: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
-msgstr "特殊文字"
+msgstr "شخصیت خاص"
 
 #: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
-msgstr "でなければならない"
+msgstr "باید باشد"
 
 #: frontend/src/metabase/lib/settings.js:120
 #: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
-msgstr "文字数"
+msgstr "شخصیت های طولانی"
 
 #: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
-msgstr "でなければならない"
+msgstr "باید باشد"
 
 #: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
-msgstr "含む"
+msgstr "و شامل"
 
 #: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
-msgstr "0"
+msgstr "صفر"
 
 #: frontend/src/metabase/lib/utils.js:86
 msgid "one"
-msgstr "1"
+msgstr "یکی"
 
 #: frontend/src/metabase/lib/utils.js:87
 msgid "two"
-msgstr "2"
+msgstr "دو"
 
 #: frontend/src/metabase/lib/utils.js:88
 msgid "three"
-msgstr "3"
+msgstr "سه"
 
 #: frontend/src/metabase/lib/utils.js:89
 msgid "four"
-msgstr "4"
+msgstr "چهار"
 
 #: frontend/src/metabase/lib/utils.js:90
 msgid "five"
-msgstr "5"
+msgstr "پنج"
 
 #: frontend/src/metabase/lib/utils.js:91
 msgid "six"
-msgstr "6"
+msgstr "شش"
 
 #: frontend/src/metabase/lib/utils.js:92
 msgid "seven"
-msgstr "7"
+msgstr "هفت"
 
 #: frontend/src/metabase/lib/utils.js:93
 msgid "eight"
-msgstr "8"
+msgstr "هشت"
 
 #: frontend/src/metabase/lib/utils.js:94
 msgid "nine"
-msgstr "9"
+msgstr "نه"
 
 #: frontend/src/metabase/meta/Dashboard.js:30
 msgid "Month and Year"
-msgstr "月年"
+msgstr "ماه و سال"
 
 #: frontend/src/metabase/meta/Dashboard.js:31
 msgid "Like January, 2016"
-msgstr "例: 2016年1月"
+msgstr "مانند ژانویه 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:35
 msgid "Quarter and Year"
-msgstr "四半期と年"
+msgstr "چهار سال و سال"
 
 #: frontend/src/metabase/meta/Dashboard.js:36
 msgid "Like Q1, 2016"
-msgstr "例: 2016年Q1"
+msgstr "مانند Q1، 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:40
 msgid "Single Date"
-msgstr "年月日"
+msgstr "تاریخ تک"
 
 #: frontend/src/metabase/meta/Dashboard.js:41
 msgid "Like January 31, 2016"
-msgstr "例: 2016年１月31日"
+msgstr "مانند 31 ژانویه 2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:45
 msgid "Date Range"
-msgstr "日付範囲"
+msgstr "محدوده زمانی"
 
 #: frontend/src/metabase/meta/Dashboard.js:46
 msgid "Like December 25, 2015 - February 14, 2016"
-msgstr "例: 2015年12月25日〜2016年2月14日"
+msgstr "مانند 2015 دسامبر 25 - 2015 فوریه 14"
 
 #: frontend/src/metabase/meta/Dashboard.js:50
 msgid "Relative Date"
-msgstr "相対日付"
+msgstr "تاریخ نسبی"
 
 #: frontend/src/metabase/meta/Dashboard.js:51
 msgid "Like \"the last 7 days\" or \"this month\""
-msgstr "例: 「過去7日間」「今月」等"
+msgstr "مانند \"7 روز گذشته\" یا \"این ماه\""
 
 #: frontend/src/metabase/meta/Dashboard.js:55
 msgid "Date Filter"
-msgstr "日付フィルター"
+msgstr "فیلتر تاریخ"
 
 #: frontend/src/metabase/meta/Dashboard.js:56
 msgid "All Options"
-msgstr "全オプション"
+msgstr "همه گزینه ها"
 
 #: frontend/src/metabase/meta/Dashboard.js:57
 msgid "Contains all of the above"
-msgstr "上記全てを含む"
+msgstr "شامل همه موارد فوق"
 
 #: frontend/src/metabase/meta/Dashboard.js:69
 msgid "ZIP or Postal Code"
-msgstr "郵便番号"
+msgstr "کد پستی"
 
 #: frontend/src/metabase/meta/Dashboard.js:77
 #: frontend/src/metabase/meta/Dashboard.js:107
 msgid "ID"
-msgstr "ID"
+msgstr "شناسه"
 
 #: frontend/src/metabase/meta/Dashboard.js:95
 #: frontend/src/metabase/modes/components/actions/PivotByTimeAction.jsx:8
 msgid "Time"
-msgstr "時間"
+msgstr "زمان"
 
 #: frontend/src/metabase/meta/Dashboard.js:96
 msgid "Date range, relative date, time of day, etc."
-msgstr "時間範囲、相対日付、時間等"
+msgstr "دامنه تاریخ، تاریخ نسبی، زمان روز و غیره"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
-msgstr "場所"
+msgstr "محل"
 
 #: frontend/src/metabase/meta/Dashboard.js:102
 msgid "City, State, Country, ZIP code."
-msgstr "都市、州、国、郵便番号"
+msgstr "شهر، ایالت، کشور، کد پستی."
 
 #: frontend/src/metabase/meta/Dashboard.js:108
 msgid "User ID, product ID, event ID, etc."
-msgstr "ユーザーID、商品ID、イベントID等"
+msgstr "شناسه کاربر، شناسه محصول، شناسه رویداد و غیره"
 
 #: frontend/src/metabase/meta/Dashboard.js:113
 msgid "Other Categories"
-msgstr "他カテゴリー"
+msgstr "سایر دسته بندی ها"
 
 #: frontend/src/metabase/meta/Dashboard.js:114
 msgid "Category, Type, Model, Rating, etc."
-msgstr "カテゴリー、タイプ、モデル、レーティング等"
+msgstr "رده، نوع، مدل، رتبه و غیره"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
 #: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
-msgstr "アカウント設定"
+msgstr "تنظیمات حساب"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:49
 msgid "Exit admin"
-msgstr "管理画面から離れる"
+msgstr "خروج از مدیر"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:34
 msgid "Logs"
-msgstr "ログ"
+msgstr "سیاههها"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:64
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
-msgstr "ヘルプ"
+msgstr "کمک"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
-msgstr "Metabaseについて"
+msgstr "درباره Metabase"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
-msgstr "サインアウト"
+msgstr "خروج"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
-msgstr "ご利用ありがとうございます"
+msgstr "با تشکر برای استفاده"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
-msgstr "ご利用中のバージョンは"
+msgstr "شما در نسخه هستید"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
-msgstr "ビルド年月日: "
+msgstr "ساخته شده بر پایه ی"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
-msgstr "は右記の会社が有する商標です"
+msgstr "علامت تجاری است"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
-msgstr "カリフォルニアのサンフランシスコで制作されています"
+msgstr "و با مراقبت در سان فرانسیسکو، کالیفرنیا ساخته شده است"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
-msgstr "Metabase管理者"
+msgstr "مدیر متاباکس"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
-msgstr "照会する"
+msgstr "یک سوال بپرس"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
-msgstr "新しいダッシュボード"
+msgstr "داشبورد جدید"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:361
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
-msgstr "新しいパルス"
+msgstr "پالس جدید"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:323
 msgid "Reference"
-msgstr "参照"
+msgstr "ارجاع"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
-msgstr "どのメトリクスですか？"
+msgstr "کدام متریک؟"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
-msgstr "チームの共通のメトリクスを定義することで、さらに簡単に質問することができます"
+msgstr "تعریف معیارهای رایج برای تیم شما باعث می شود که سؤالاتتان را حتی ساده تر کنید"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
-msgstr "メトリクスの作成方法"
+msgstr "چگونه برای ایجاد معیارهای"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:138
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
-msgstr "経時的なデータをマップとして表示したり、傾向や変化を理解するのに役立つようにピボットしたりできます。"
+msgstr "اطلاعات را در طول زمان مشاهده کنید، به عنوان یک نقشه، و یا چرخش برای کمک به شما در درک روند و یا تغییرات."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
 msgid "Custom"
-msgstr "カスタム"
+msgstr "سفارشی"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
-msgstr "新しい質問"
+msgstr "سوال جدید"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:152
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
-msgstr "トレンドやリストを表示したり、独自のメトリクスを作成するには、簡単な質問ビルダーを使用してください。"
+msgstr "از سازنده سؤال ساده برای دیدن روند، فهرستی از چیزها یا برای ایجاد معیارهای خود استفاده کنید."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
-msgstr "ネイティブクエリ"
+msgstr "پرس و جو بومی"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
-msgstr "複雑な質問については、独自のSQLまたはネイティブクエリを記述することができます。"
+msgstr "برای سوالات پیچیده تر، شما می توانید پرس و جو SQL خود و یا بومی خود را بنویسید."
 
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
-msgstr "デフォルト値を選択する"
+msgstr "یک مقدار پیش فرض را انتخاب کنید ..."
 
 #: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
 #: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
-msgstr "フィルターをアップデートする"
+msgstr "به روز رسانی فیلتر"
 
 #: frontend/src/metabase/lib/query_time.js:112
 #: frontend/src/metabase/lib/query_time.js:123
@@ -4173,22 +4200,22 @@ msgstr "フィルターをアップデートする"
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
 #: src/metabase/pulse/render/datetime.clj
 msgid "Today"
-msgstr "本日"
+msgstr "امروز"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
 #: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
-msgstr "昨日"
+msgstr "دیروز"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:18
 msgid "Past 7 days"
-msgstr "過去7日"
+msgstr "7 روز گذشته"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:19
 msgid "Past 30 days"
-msgstr "過去30日"
+msgstr "30 روز گذشته"
 
 #: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
@@ -4196,7 +4223,7 @@ msgstr "過去30日"
 #: src/metabase/api/table.clj
 msgid "Week"
 msgid_plural "Weeks"
-msgstr[0] "週"
+msgstr[0] "هفته ها"
 
 #: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
@@ -4204,7 +4231,7 @@ msgstr[0] "週"
 #: src/metabase/api/table.clj
 msgid "Month"
 msgid_plural "Months"
-msgstr[0] "月"
+msgstr[0] "ماه ها"
 
 #: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
@@ -4212,798 +4239,798 @@ msgstr[0] "月"
 #: src/metabase/api/table.clj
 msgid "Year"
 msgid_plural "Years"
-msgstr[0] "年"
+msgstr[0] "سال ها"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:152
 msgid "Past 7 Days"
-msgstr "過去7日"
+msgstr "7 روز گذشته"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:156
 msgid "Past 30 Days"
-msgstr "過去30日"
+msgstr "30 روز گذشته"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:160
 msgid "Last Week"
-msgstr "先週"
+msgstr "هفته گذشته"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:164
 msgid "Last Month"
-msgstr "先月"
+msgstr "ماه گذشته"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:168
 msgid "Last Year"
-msgstr "昨年"
+msgstr "سال گذشته"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:172
 msgid "This Week"
-msgstr "今週"
+msgstr "این هفته"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:176
 msgid "This Month"
-msgstr "今月"
+msgstr "این ماه"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:180
 msgid "This Year"
-msgstr "今年"
+msgstr "امسال"
 
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:89
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
-msgstr "値を入力する..."
+msgstr "یک مقدار را وارد کنید"
 
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:90
 msgid "Enter a default value..."
-msgstr "デフォルト値を入力する..."
+msgstr "مقدار پیش فرض را وارد کنید ..."
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
-msgstr "エラーが発生しました"
+msgstr "یک خطا رخ داده است"
 
 #: frontend/src/metabase/public/components/PublicNotFound.jsx:11
 msgid "Not found"
-msgstr "見つかりませんでした"
+msgstr "پیدا نشد"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:82
 msgid "You’ve made changes that need to be published before they will be reflected in your application embed."
-msgstr "アプリケーションの埋め込みに反映される前に、公開する必要がある変更を加えました。"
+msgstr "شما تغییراتی را ایجاد کرده اید که باید قبل از اینکه آنها را در جاسازی برنامه خود منعکس کنید منتشر شود."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:83
 msgid "You will need to publish this {0} before you can embed it in another application."
-msgstr "この{0}を公開してから別のアプリケーションに埋め込む必要があります。"
+msgstr "قبل از اینکه بتوانید آن را در برنامه دیگری وارد کنید باید این {0} را منتشر کنید."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:92
 msgid "Discard Changes"
-msgstr "変更を破棄する"
+msgstr "لغو تغییرات"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:99
 msgid "Updating..."
-msgstr "アップデート中..."
+msgstr "در حال بروز رسانی..."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:100
 msgid "Updated"
-msgstr "アップデートしました"
+msgstr "به روز شد"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:101
 msgid "Failed!"
-msgstr "失敗しました！"
+msgstr "ناموفق!"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:102
 msgid "Publish"
-msgstr "公開"
+msgstr "انتشار"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:111
 msgid "Code"
-msgstr "コード"
+msgstr "کد"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
-msgstr "スタイル"
+msgstr "سبک"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
-msgstr "この埋め込みのユーザーはどのパラメーターを使用できますか？"
+msgstr "کدام پارامترها می توانند از کاربران این جاسازی استفاده کنند؟"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
-msgstr "この{0}には設定するパラメーターがまだありません。"
+msgstr "این {0} هیچ پارامتری برای پیکربندی هنوز وجود ندارد."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
-msgstr "編集可能"
+msgstr "قابل ویرایش"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
-msgstr "ロックされた"
+msgstr "قفل شده"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:113
 msgid "Preview Locked Parameters"
-msgstr "ロックされたパラメーターをプレビューする"
+msgstr "پیش نمایش پارامترهای قفل شده"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
-msgstr "ロックされたパラメーターにいくつかの値を入力してみてください。 これを実際に使用する場合には、サーバーは署名トークンに実際の値を提供する必要があります。"
+msgstr "سعی کنید برخی از مقادیر را به پارامترهای قفل شده خود منتقل کنید. هنگام استفاده از این برای واقعی، سرور شما باید مقادیر واقعی را در امضای امضا ارائه دهد."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
-msgstr "危険ゾーン"
+msgstr "منطقه خطر"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
-msgstr "この{0}への埋め込みを無効化します"
+msgstr "این تعبیه را برای این {0} غیرفعال می کند."
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
-msgstr "非公開"
+msgstr "لغو انتشار"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:17
 msgid "Light"
-msgstr "明るい"
+msgstr "سبک"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:18
 msgid "Dark"
-msgstr "暗い"
+msgstr "تاریکی"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:37
 msgid "Border"
-msgstr "境界"
+msgstr "مرز"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:62
 msgid "To embed this {0} in your application:"
-msgstr "アプリケーションへ{0}を埋め込むには:"
+msgstr "برای جاسازی این {0} در برنامه خود:"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:64
 msgid "Insert this code snippet in your server code to generate the signed embedding URL "
-msgstr "このコードスニペットをサーバーコードに挿入して、署名付き埋め込みURLを生成する"
+msgstr "این کد کد را در کد سرور خود وارد کنید تا نشانی اینترنتی جاسازی شده امضا شود"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:87
 msgid "Then insert this code snippet in your HTML template or single page app."
-msgstr "次に、このコードスニペットをHTMLテンプレートまたは単一ページアプリに挿入する"
+msgstr "سپس این قطعه کد را در قالب HTML خود و یا صفحه یک صفحه وارد کنید."
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:94
 msgid "Embed code snippet for your HTML or Frontend Application"
-msgstr "HTMLまたはフロントエンドアプリケーションにコードスニペットを埋め込む"
+msgstr "کد نویسی کد را برای HTML یا ظاهر برنامه خود بسازید"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:101
 msgid "More {0}"
-msgstr "さらに{0}"
+msgstr "بیشتر {0}"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:103
 msgid "examples on GitHub"
-msgstr "GitHubの例"
+msgstr "نمونه در GitHub"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
-msgstr "共有を有効化する"
+msgstr "اشتراکگذاری را فعال کنید"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
-msgstr "公開リンクを無効化しますか？"
+msgstr "این پیوند عمومی را غیرفعال کنید؟"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
-msgstr "リンクが作動しなくなる可能性があります。再度有効化することはできますが、異なるリンクが作成されます"
+msgstr "این باعث می شود که لینک فعلی کار را متوقف کند. شما می توانید آن را مجددا فعال کنید، اما زمانی که شما آن را انجام خواهد شد یک لینک متفاوت است."
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
-msgstr "リンクを公開する"
+msgstr "لینک عمومی"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
-msgstr "Metabaseアカウントを保有していない方に下記URLを利用して{0}を共有する:"
+msgstr "به اشتراک گذاشتن این {0} با افرادی که حساب متاباید با استفاده از URL زیر ندارند:"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
-msgstr "公開埋め込み"
+msgstr "جاسازی عمومی"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
-msgstr "このスニペットをコピーして貼り付けることで、ブログ投稿やウェブページにこの{0}を埋め込むことができます:"
+msgstr "قراردادن این {0} در پستهای وبلاگ یا صفحات وب با کپی کردن و چسباندن این قطعه:"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
-msgstr "アプリケーションへ{0}を埋め込む"
+msgstr "قراردادن این {0} در یک برنامه"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
-msgstr "アプリケーションサーバーコードと統合することで、特定のユーザー、顧客、組織などに限定された安全な統計情報{0}を提供することができます。"
+msgstr "با ادغام با کد سرور برنامه شما می توانید آمار امن {0} را به یک کاربر خاص، مشتری، سازمان و غیره ارائه دهید."
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
-msgstr "添付を削除する"
+msgstr "پیوست را حذف کنید"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
-msgstr "結果を添付する"
+msgstr "ضمیمه فایل با نتایج"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
-msgstr "この質問は添付ファイルとして追加されます"
+msgstr "این سوال به عنوان پیوست فایل اضافه می شود"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
-msgstr "この質問はパルスには含まれません"
+msgstr "این سوال در Pulse شما موجود نیست"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
-msgstr "このクエスチョンは{0} {1}にメールされません"
+msgstr "این پالس دیگر به {0} {1} ایمیل نخواهد شد"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
-msgstr[0] "{0}アドレス"
+msgstr[0] "{0} آدرس"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:102
 msgid "Slack channel {0} will no longer get this pulse {1}"
-msgstr "Slackチャンネル{0}からは、このパルス{1}を取得できません"
+msgstr "کانال Slack {0} دیگر این پالس را دریافت نخواهد کرد {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
-msgstr "チャンネル{0}からは、このパルス{1}を受信できません"
+msgstr "کانال {0} دیگر این پالس را دریافت نخواهد کرد {1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
-msgstr "パルスを編集する"
+msgstr "ویرایش پالس"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
-msgstr "パルスとは？"
+msgstr "پالس چیست؟"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
-msgstr "了解しました"
+msgstr "فهمیدم"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
-msgstr "このデータはどちらに保存しますか？"
+msgstr "این داده ها کجا باید برود؟"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
-msgstr "アーカイブ取消中..."
+msgstr "نوشتن ..."
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
-msgstr "アーカイブ取消が失敗しました"
+msgstr "بازخوانی نشد"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
-msgstr "アーカイブが取り消されました"
+msgstr "بازاریابی نشده"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
-msgstr "パルスを作成する"
+msgstr "ایجاد پالس"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:90
 msgid "Attachment"
-msgstr "添付"
+msgstr "ضمیمه"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
-msgstr "警告"
+msgstr "سر به بالا"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:105
 msgid "We'll show the first 10 columns and 20 rows of this table in your Pulse. If you email this, we'll add a file attachment with all columns and up to 2,000 rows."
-msgstr "パルス内のテーブルの最初の10列、20行を表示します。これをメールで送信する場合、全列、最大2,000行を添付ファイルとして送信します"
+msgstr "ما 10 ستون اول و 20 ردیف از این جدول را در Pulse خود نشان می دهیم. اگر این ایمیل را ارسال کنید، پیوست فایل را با تمام ستون ها و تا 2000 ردیف اضافه می کنیم."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:112
 msgid "Raw data questions can only be included as email attachments"
-msgstr "ローデータ質問はメール添付としてのみ含まれます"
+msgstr "سوالات داده های خام فقط می توانند به عنوان پیوست های ایمیل درج شوند"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:119
 msgid "Looks like this pulse is getting big"
-msgstr "パルスが大きくなっているようです"
+msgstr "به نظر می رسد این پالس بزرگ شده است"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:120
 msgid "We recommend keeping pulses small and focused to help keep them digestible and useful to the whole team."
-msgstr "パルスを小さく保ち、チーム全体にとって使いやすく処理することをお勧めします。"
+msgstr "ما توصیه می کنیم پالس ها را کوچک نگه داریم و متمرکز شویم تا بتوانیم آنها را هضم کنیم و برای کل تیم مفید باشیم."
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
 #: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
-msgstr "データを選ぶ"
+msgstr "اطلاعات خود را انتخاب کنید"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:162
 msgid "Choose questions you'd like to send in this pulse"
-msgstr "このパルス内で送信したい質問を選択する"
+msgstr "سؤالاتی را که میخواهید در این پالس ارسال کنید را انتخاب کنید"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
 msgid "Emails"
-msgstr "メール"
+msgstr "ایمیل ها"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
 msgid "Slack messages"
-msgstr "Slackメッセージ"
+msgstr "پیام های خالی"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
-msgstr "送信しました"
+msgstr "ارسال شد"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
-msgstr "{0}が送信されます"
+msgstr "{0} فرستاده خواهد شد"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
-msgstr "メッセージ"
+msgstr "پیام ها"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
-msgstr "今すぐメールを送信する"
+msgstr "اکنون ایمیل بفرست"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
-msgstr "今すぐ{0}に送信する"
+msgstr "ارسال به {0} در حال حاضر"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
-msgstr "送信中..."
+msgstr "در حال ارسال…"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
-msgstr "送信に失敗しました"
+msgstr "ارسال نشد"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
-msgstr "パルスの結果が存在しないため送信できませんでした"
+msgstr "فرستاده نشد زیرا پالس هیچ نتیجه ای ندارد"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
-msgstr "パルスが送信されました"
+msgstr "پالس ارسال شد"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
-msgstr "{0}は管理者が設定する必要があります"
+msgstr "{0} باید توسط یک مدیر تنظیم شود."
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
-msgstr "Slack"
+msgstr "لاغر"
 
 #: frontend/src/metabase/pulse/components/PulseEditCollection.jsx:12
 msgid "Which collection should this pulse live in?"
-msgstr "このパルスはどのコレクションに保存しますか？"
+msgstr "کدام مجموعه این نبض زندگی می کند؟"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:35
 msgid "Name your pulse"
-msgstr "パルスに名前を付けましょう"
+msgstr "نام پالس خود را"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:37
 msgid "Give your pulse a name to help others understand what it's about"
-msgstr "他ユーザーのためにパルスに名前を付けましょう"
+msgstr "نام پالس خود را برای کمک به دیگران درک کنید"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:49
 msgid "Important metrics"
-msgstr "重要なメトリクス"
+msgstr "معیارهای مهم"
 
 #: frontend/src/metabase/pulse/components/PulseEditSkip.jsx:22
 msgid "Skip if no results"
-msgstr "結果が存在しない場合スキップする"
+msgstr "جست و خیز اگر نتایجی نداشته باشد"
 
 #: frontend/src/metabase/pulse/components/PulseEditSkip.jsx:24
 msgid "Skip a scheduled Pulse if none of its questions have any results"
-msgstr "質問の結果が存在しない場合は予定されたパルスをスキップする"
+msgstr "پالس برنامه ریزی شده را رها کنید اگر هیچ یک از سوالات آن هیچ نتیجه ای نداشته باشد"
 
 #: frontend/src/metabase/pulse/components/RecipientPicker.jsx:65
 msgid "Enter email addresses you'd like this data to go to"
-msgstr "このデータを送りたいメールアドレスを入力する"
+msgstr "آدرس های ایمیل شما را که می خواهید این داده ها را وارد کنید را وارد کنید"
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:16
 msgid "Help everyone on your team stay in sync with your data."
-msgstr "チームが常にあなたのデータと同期されるよう心がけましょう"
+msgstr "هر کس در تیم خود کمک کند با داده های خود همگام باشد."
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:30
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
-msgstr "Metabaseのデータをご自身で設定した予定通りにメールまたはSlackで送信することができます"
+msgstr "پالس ها به شما اجازه می دهند اطلاعات را از Metabase به ایمیل یا Slack در برنامه انتخابی خود ارسال کنید."
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "After {0}"
-msgstr "{0}後"
+msgstr "پس از {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 msgid "Before {0}"
-msgstr "{0}前"
+msgstr "قبل از {0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
-msgstr "空"
+msgstr "خالی است"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
-msgstr "空ではない"
+msgstr "خالی نیست"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
-msgstr "全期間"
+msgstr "همیشه"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
-msgstr "適用する"
+msgstr "درخواست دادن"
 
 #: frontend/src/metabase/modes/components/actions/CommonMetricsAction.jsx:21
 msgid "View {0}"
-msgstr "{0}を見る"
+msgstr "نمایش {0}"
 
 #: frontend/src/metabase/modes/components/actions/CompareWithTable.jsx:29
 msgid "Compare this with all rows in the table"
-msgstr "テーブル内の全行と比較する"
+msgstr "این را با تمام سطرهای جدول مقایسه کنید"
 
 #: frontend/src/metabase/modes/components/actions/CompoundQueryAction.jsx:14
 msgid "Analyze the results of this Query"
-msgstr "このクエリの結果を分析する"
+msgstr "نتایج این درخواست را تجزیه و تحلیل کنید"
 
 #: frontend/src/metabase/modes/components/actions/CountByTimeAction.jsx:29
 msgid "Count of rows by time"
-msgstr "時間ごとの行数"
+msgstr "شمار ردیف ها بر اساس زمان"
 
 #: frontend/src/metabase/modes/components/actions/PivotByAction.jsx:52
 msgid "Break out by {0}"
-msgstr "{0}ごとに分割する"
+msgstr "شکستن توسط {0}"
 
 #: frontend/src/metabase/modes/components/actions/SummarizeBySegmentMetricAction.jsx:31
 msgid "Summarize this segment"
-msgstr "このセグメントを要約する"
+msgstr "خلاصه این بخش"
 
 #: frontend/src/metabase/modes/components/actions/UnderlyingDataAction.jsx:14
 msgid "View this as a table"
-msgstr "テーブルとして見る"
+msgstr "این را به عنوان یک جدول مشاهده کنید"
 
 #: frontend/src/metabase/modes/components/actions/UnderlyingRecordsAction.jsx:22
 msgid "View the underlying {0} records"
-msgstr "{0}の基本的なレコードを見る"
+msgstr "اسناد زیر {0} را مشاهده کنید"
 
 #: frontend/src/metabase/modes/components/actions/XRayCard.jsx:20
 msgid "X-Ray this question"
-msgstr "この質問を自動探査(X-ray)する"
+msgstr "X-Ray این سوال"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 msgid "X-ray {0} {1}"
-msgstr "{0} {1}を自動探査(X-ray)する"
+msgstr "اشعه ایکس {0} {1}"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "these"
-msgstr "これら"
+msgstr "اینها"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "this"
-msgstr "これ"
+msgstr "این"
 
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "Compare {0} {1} to the rest"
-msgstr "{0} {1}を結果と比較する"
+msgstr "{0} {1} را به بقیه مقایسه کنید"
 
 #: frontend/src/metabase/modes/components/drill/DistributionDrill.jsx:35
 msgid "Distribution"
-msgstr "分布"
+msgstr "توزیع"
 
 #: frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx:38
 msgid "View details"
-msgstr "詳細を見る"
+msgstr "دیدن جزئیات"
 
 #: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
-msgstr "{0}の{1}を見る"
+msgstr "مشاهده این {0} {1}"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:42
 msgid "Ascending"
-msgstr "昇順"
+msgstr "صعودی"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:50
 msgid "Descending"
-msgstr "降順"
+msgstr "نزولی"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js:47
 msgid "over time"
-msgstr "時間とともに"
+msgstr "اضافه کاری"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:21
 msgid "Avg"
-msgstr "平均"
+msgstr "میانگین"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:33
 msgid "Distincts"
-msgstr "Distinct"
+msgstr "تمایز"
 
 #: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
-msgstr[0] "この{0}を見る"
+msgstr[0] "مشاهده این {0}"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
-msgstr "拡大する"
+msgstr "بزرگنمایی"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
-msgstr "カスタムエクスプレッション"
+msgstr "عبارتی سفارشی"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
-msgstr "共通のメトリクス"
+msgstr "معیارهای معمول"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:209
 msgid "Metabasics"
-msgstr "Metabasics"
+msgstr "متابازیک"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
-msgstr "名前（任意）"
+msgstr "نام (اختیاری)"
 
 #: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:156
 msgid "Choose an aggregation"
-msgstr "集約を選択する"
+msgstr "یک تجمع را انتخاب کنید"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:100
 msgid "Set up your own alert"
-msgstr "アラートを設定する"
+msgstr "هشدار خود را تنظیم کنید"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
-msgstr "購読解除中..."
+msgstr "لغو اشتراک ..."
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
-msgstr "購読解除に失敗しました"
+msgstr "لغو عضویت لغو نشد"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
-msgstr "購読解除する"
+msgstr "لغو اشتراک"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
-msgstr "チャンネルがありません"
+msgstr "هیچ کانال"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
-msgstr "購読解除しました"
+msgstr "خوب، شما لغو اشتراک هستید"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
-msgstr "{0}のアラートを受け取る設定になっています"
+msgstr "شما هشدار {0} دریافت می کنید"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
-msgstr "{0}アラートを設定しました。"
+msgstr "{0} هشدار را تنظیم کنید"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:160
 msgid "alerts"
-msgstr "アラート"
+msgstr "هشدار"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:183
 msgid "Let's set up your alert"
-msgstr "アラートを設定しましょう"
+msgstr "بیایید هشدارمان را تنظیم کنیم"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:214
 msgid "The wide world of alerts"
-msgstr "アラートの広い世界"
+msgstr "دنیای گسترده ای از هشدارها"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:215
 msgid "There are a few different kinds of alerts you can get"
-msgstr "様々な種類のアラートがあります"
+msgstr "چند نوع هشدار وجود دارد که می توانید دریافت کنید"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:229
 msgid "When a raw data question {0}"
-msgstr "ローデータ質問が{0}のとき"
+msgstr "هنگامی که یک داده خام سوال {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:230
 msgid "returns any results"
-msgstr "どんな結果も返す"
+msgstr "هر نتیجه ای را برمی گرداند"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:241
 msgid "When a line or bar {0}"
-msgstr "折れ線グラフまたは棒グラフが{0}のとき"
+msgstr "وقتی یک خط یا نوار {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:242
 msgid "crosses a goal line"
-msgstr "目標値を超える"
+msgstr "عبور از یک خط دروازه"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:253
 msgid "When a progress bar {0}"
-msgstr "プログレスバーが{0}のとき"
+msgstr "هنگامی که یک نوار پیشرفت {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:254
 msgid "reaches its goal"
-msgstr "目標に到達する"
+msgstr "به هدف خود می رسد"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:262
 msgid "Set up an alert"
-msgstr "アラートを設定する"
+msgstr "هشدار را تنظیم کنید"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:331
 msgid "Edit your alert"
-msgstr "アラートを編有する"
+msgstr "هشدار خود را ویرایش کنید"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:331
 msgid "Edit alert"
-msgstr "アラートを編集する"
+msgstr "هشدار را ویرایش کنید"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
-msgstr "このアラートは{0}にメール送信されません"
+msgstr "این هشدار دیگر به {0} ایمیل نخواهد شد."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
-msgstr "Slackチャンネル{0}では、このアラートを取得できません"
+msgstr "کانال Slack {0} دیگر این هشدار را دریافت نخواهد کرد."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
-msgstr "チャンネル{0}では、このアラートを受信できません"
+msgstr "کانال {0} دیگر این هشدار را دریافت نخواهد کرد."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
-msgstr "このアラートを削除する"
+msgstr "این هشدار را حذف کنید"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
-msgstr "このアラートを削除する。この操作はやり直しできませんので、ご注意ください"
+msgstr "تحویل را متوقف کنید و این هشدار را حذف کنید. هیچ واکنشی وجود ندارد، پس مراقب باشید."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
-msgstr "このアラートを削除しますか？"
+msgstr "این هشدار را حذف کنید؟"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
-msgstr "線が...のときアラートする"
+msgstr "خط خطی من ..."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
-msgstr "プログレスバーが表示されたら..."
+msgstr "وقتی نوار پیشرفت من را آزار ..."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
-msgstr "目標値を超える"
+msgstr "می رود بالاتر از خط دروازه"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
-msgstr "目標に到達する"
+msgstr "رسیدن به هدف"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
-msgstr "目標値を下回る"
+msgstr "می رود زیر خط دروازه"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
-msgstr "目標を下回る"
+msgstr "می رود زیر هدف"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
-msgstr "最初に超えたときのみ、または超えたときは毎回"
+msgstr "اولین بار از آن عبور می کند یا هر بار؟"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
-msgstr "最初に目標に到達したときのみ、または目標に到達したときは毎回"
+msgstr "اولین بار به هدف یا هر زمان برمیگردد؟"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
-msgstr "最初のみ"
+msgstr "اولین بار"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
-msgstr "毎回"
+msgstr "هر زمان"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
-msgstr "アラートをどこに送信しますか？"
+msgstr "کجا می خواهید این هشدارها را ارسال کنید؟"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
-msgstr "アラートをメール送信する:"
+msgstr "هشدار ایمیل به:"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
-msgstr "{0} 2行以上のチャートでは目標ベースのアラートがサポートされていないため、チャートに{1}があるたびにアラートが送信されます。"
+msgstr "{0} هشدارهای مبتنی بر هدف برای نمودارها با بیش از یک خط هنوز پشتیبانی نمی شوند بنابراین این هشدار هر بار که {1} نمودار ارسال می شود ارسال می شود."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
-msgstr "結果"
+msgstr "نتایج"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
-msgstr "{0}このタイプのアラートは、保存された質問が{1}結果を返さない場合でも、いつ実行したかを知りたいときに最も便利です。"
+msgstr "{0} این نوع هشدار بیشتر مفید است وقتی که پرسش ذخیره شده شما {1} هر نتیجه را بر نمی گرداند، اما شما می خواهید بدانید که چه زمانی انجام می شود."
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
-msgstr "ヒント"
+msgstr "نکته"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
-msgstr "通常"
+msgstr "معمولا"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
-msgstr "セグメントまたはテーブルを選ぶ"
+msgstr "یک بخش یا جدول را انتخاب کنید"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
-msgstr "データベースを選択する"
+msgstr "یک پایگاه داده را انتخاب کنید"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
-msgstr "選択する..."
+msgstr "انتخاب کنید..."
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
-msgstr "テーブルを選択する"
+msgstr "یک جدول را انتخاب کنید"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
-msgstr "このデータベースにはテーブルが見つかりませんでした"
+msgstr "هیچ جداول موجود در این پایگاه داده یافت نشد."
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
-msgstr "質問がありませんか？"
+msgstr "یک سوال گم شده است؟"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
-msgstr "ネストしたクエリについてもっと調べる"
+msgstr "درباره پرس و جوهای توزیع شده بیشتر بدانید"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
-msgstr "フィールド"
+msgstr "زمینه های"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
-msgstr "セグメントが見つかりませんでした"
+msgstr "هیچ بخش یافت نشد"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
-msgstr "セグメントを探す"
+msgstr "یک قطعه را پیدا کنید"
 
 #: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
-msgstr "少く表示"
+msgstr "نمایش کمتر"
 
 #: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
-msgstr "さらに表示"
+msgstr "بیشتر ببینید"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:112
 msgid "Pick a field to sort by"
-msgstr "ソートするフィールドを選ぶ"
+msgstr "فیلد مرتب سازی را انتخاب کنید"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
-msgstr "ソート"
+msgstr "مرتب سازی"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
-msgstr "行数制限"
+msgstr "محدودیت ردیف"
 
 #: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
-msgstr "不明なフィールド"
+msgstr "میدان ناشناخته"
 
 #: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
-msgstr "フィールド"
+msgstr "رشته"
 
 #: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
-msgstr "一致"
+msgstr "مسابقات"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
-msgstr "回答を絞るためにフィルターを追加する"
+msgstr "فیلتر را اضافه کنید تا پاسخ شما محدود شود"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
-msgstr "グルーピングを追加する"
+msgstr "یک گروه را اضافه کنید"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
@@ -5021,107 +5048,107 @@ msgstr "グルーピングを追加する"
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
-msgstr "データ"
+msgstr "داده ها"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
-msgstr "フィルターされた"
+msgstr "فیلتر شده توسط"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
-msgstr "閲覧"
+msgstr "چشم انداز"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
-msgstr "グループ化された"
+msgstr "گروه بندی شده توسط"
 
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
-msgstr "なし"
+msgstr "هیچ یک"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
-msgstr "この質問は{0}で書かれました"
+msgstr "این سوال در {0} نوشته شده است."
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
-msgstr "エディターを非表示にする"
+msgstr "مخفی کردن ویرایشگر"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
-msgstr "クエリを非表示にする"
+msgstr "پنهان کردن پرس و جو"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
-msgstr "エディターを表示する"
+msgstr "بازکردن ویرایشگر"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
-msgstr "クエリを表示する"
+msgstr "نمایش پرس و جو"
 
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "This metric has been retired.  It's no longer available for use."
-msgstr "このメトリクスは放棄されており、使用することができません"
+msgstr "این متریک بازنشسته شده است. این دیگر برای استفاده در دسترس نیست"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:34
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:46
 msgid "Download full results"
-msgstr "全結果をダウンロードする"
+msgstr "نتایج کامل را دانلود کنید"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:35
 msgid "Download this data"
-msgstr "このデータをダウンロードする"
+msgstr "این داده ها را دانلود کنید"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:46
 msgid "Warning"
-msgstr "警告"
+msgstr "هشدار"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
-msgstr "行数が多いため、ダウンロードに時間がかかる場合があります"
+msgstr "پاسخ شما دارای تعداد زیادی ردیف است، بنابراین ممکن است چندین بار برای بارگیری استفاده شود."
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
-msgstr "最大ダウンロードサイズは100万行です"
+msgstr "حداکثر اندازه دانلود 1 میلیون ردیف است."
 
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
-msgstr "質問を編集する"
+msgstr "ویرایش سوال"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:249
 msgid "SAVE CHANGES"
-msgstr "変更を保存する"
+msgstr "ذخیره تغییرات"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:263
 msgid "CANCEL"
-msgstr "キャンセル"
+msgstr "لغو"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:276
 msgid "Move question"
-msgstr "質問を移動する"
+msgstr "انتقال سوال"
 
 #: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
-msgstr "これはどのコレクションに保存しますか？"
+msgstr "کدام مجموعه باید این باشد؟"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
 #: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
-msgstr "変数"
+msgstr "متغیرها"
 
 #: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
-msgstr "データについて詳しく見る"
+msgstr "درباره دادههای خود اطلاعاتی کسب کنید"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:460
 msgid "Alerts are on"
-msgstr "アラートはオンです"
+msgstr "هشدارها روشن هستند"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:522
 msgid "started from"
-msgstr "から開始"
+msgstr "از شروع شد"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:48
 msgid "SQL"
@@ -5129,168 +5156,168 @@ msgstr "SQL"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:48
 msgid "native query"
-msgstr "ネイティブクエリ"
+msgstr "پرس و جو بومی"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:52
 msgid "Not Supported"
-msgstr "サポートされていません"
+msgstr "پشتیبانی نشده"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:58
 msgid "View the {0}"
-msgstr "{0}を見る"
+msgstr "مشاهده {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:59
 msgid "Switch to {0}"
-msgstr "{0}に切り換える"
+msgstr "تغییر به {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:62
 msgid "Switch to Builder"
-msgstr "ビルダーに切り換える"
+msgstr "به سازنده بروید"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:87
 msgid "{0} for this question"
-msgstr "この質問の{0}"
+msgstr "{0} برای این سوال"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:111
 msgid "Convert this question to {0}"
-msgstr "この質問を{0}に転換する"
+msgstr "این سوال را به {0} تبدیل کنید"
 
 #: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
-msgstr "この質問は更新に約{0}かかります"
+msgstr "این سوال تقریبا {0} را برای تازه کردن انجام خواهد داد"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
-msgstr "{0}をアップデートしました"
+msgstr "به روز شده {0}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:141
 msgid "row"
 msgid_plural "rows"
-msgstr[0] "行"
+msgstr[0] "ردیف"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:148
 msgid "Showing first {0} {1}"
-msgstr "最初の{0} {1}を表示する"
+msgstr "نمایش {0} {1} اول"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:151
 msgid "Showing {0} {1}"
-msgstr "{0} {1}を表示する"
+msgstr "نمایش {0} {1}"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
-msgstr "実験中"
+msgstr "انجام علم"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
-msgstr "お見せしたいものがあります。データを入力し、 是非クエリを実行してください！"
+msgstr "اگر شما برخی از داده ها را به من بدهید، می توانم چیزی را باهم نشان دهم. یک پرس و جو را اجرا کنید"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:299
 msgid "How do I use this thing?"
-msgstr "どのように使いますか？"
+msgstr "چطور از این چیزی استفاده کنم؟"
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
-msgstr "回答を得る"
+msgstr "دریافت پاسخ"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:12
 msgid "It's okay to play around with saved questions"
-msgstr "保存された質問で自由に操作していただいて構いません"
+msgstr "خوب است که با سوالات ذخیره شده بازی کنید"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:14
 msgid "You won't make any permanent changes to a saved question unless you click the edit icon in the top-right."
-msgstr "右上の編集アイコンをクリックしない限り、保存された質問に変更は反映されません"
+msgstr "شما هیچ تغییری دائمی در یک سوال ذخیره نخواهید کرد مگر اینکه روی آیکون ویرایش در بالا سمت راست کلیک کنید."
 
 #: frontend/src/metabase/query_builder/components/SearchBar.jsx:28
 msgid "Search for"
-msgstr "を探す"
+msgstr "جستجو برای"
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:158
 msgid "Advanced..."
-msgstr "高度な..."
+msgstr "پیشرفته ..."
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:167
 msgid "Sorry. Something went wrong."
-msgstr "申し訳ありません、問題が発生しました"
+msgstr "متاسف. چیزی اشتباه رفت"
 
 #: frontend/src/metabase/query_builder/components/TimeGroupingPopover.jsx:40
 msgid "Group time by"
-msgstr "で時間をグループ化する"
+msgstr "زمان گروهی توسط"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
-msgstr "質問に時間がかかりすぎました"
+msgstr "سوال شما خیلی طول کشید"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
-msgstr "データベースから時間内に回答を得られなかったため、動作を終了しました。時間をおいて再度お試しいただくか、問題が続く場合は管理者にメールでお問い合わせください。"
+msgstr "ما در زمان پاسخی از پایگاه داده خود دریافت نکردیم، بنابراین مجبور شدیم متوقف شویم. میتوانید بعد از یک دقیقه دوباره تلاش کنید یا اگر مشکل باقی بماند، میتوانید یک مدیر را برای اطلاع از آنها ایمیل کنید."
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
-msgstr "サーバーの問題が発生しています"
+msgstr "ما مشکالت سرور را تجربه می کنیم"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
-msgstr "数分後にページを再読み込みしてください。問題が続く場合は、管理者へお問い合わせください。"
+msgstr "پس از یک دقیقه یا دو دقیقه یک صفحه را تمیز کنید. اگر مشکل باقی می ماند، توصیه می کنیم با یک مدیر تماس بگیرید."
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
-msgstr "質問で問題が発生しました"
+msgstr "مشکلی با سوال شما وجود داشت"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
-msgstr "これは無効な選択または無効な入力値であるために発生することがあります。 入力を再度確認して、クエリを再試行してください。"
+msgstr "اغلب اوقات این مسئله ناشی از انتخاب نامعتبر یا ارزش ورودی بد است. دو ورودی خود را بررسی کنید و درخواست خود را دوباره امتحان کنید."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
-msgstr "お探しの回答ですか？そうではない場合は、回答が特定されすぎないように、フィルターを削除または変更してください。"
+msgstr "این ممکن است پاسخ شما به دنبال آن هستید. اگر نه، سعی کنید فیلتر ها را از بین ببرید یا تغییر دهید تا آنها را کمتر مشخص کنید."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
-msgstr "結果がある場合は、{0}もできます。"
+msgstr "شما همچنین می توانید {0} زمانی که برخی نتایج وجود دارد."
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
-msgstr "アラートを受け取る"
+msgstr "هشدار بده"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:77
 msgid "Back to last run"
-msgstr "最後の実行に戻る"
+msgstr "بازگشت به آخرین اجرا"
 
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
-msgstr "ビジュアライゼーション"
+msgstr "تجسم"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
-msgstr "まだ説明がありません"
+msgstr "بدون شرح"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Use for current question"
-msgstr "現在の質問で使用する"
+msgstr "برای سوال فعلی استفاده کنید"
 
 #: frontend/src/metabase/reference/components/UsefulQuestions.jsx:16
 msgid "Potentially useful questions"
-msgstr "役立つかもしれない質問"
+msgstr "سوالات بالقوه مفید"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
-msgstr "{0}でグループ化する"
+msgstr "گروه توسط {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:165
 msgid "Sum of all values of {0}"
-msgstr "{0}の全値の合計"
+msgstr "مجموع تمام مقادیر {0}"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:63
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:51
 msgid "All distinct values of {0}"
-msgstr "{0}の全ての重複を除いた値"
+msgstr "تمام مقادیر متمایز {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
-msgstr "{1}でグループ化された{0}の数"
+msgstr "تعداد {0} گروه بندی شده توسط {1}"
 
 #: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
@@ -5302,338 +5329,338 @@ msgstr "{1}でグループ化された{0}の数"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:24
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:23
 msgid "Data Reference"
-msgstr "データ一覧"
+msgstr "مرجع داده"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:13
 msgid "Learn more about your data structure to ask more useful questions"
-msgstr "さらに役立つ質問をするためにデータ構成を詳しく知る"
+msgstr "درباره ساختار داده های خود بیشتر بدانید تا سؤالات مفیدتری را بیاموزید"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
-msgstr "質問作成前にテーブルメタデータが見つかりませんでした"
+msgstr "قبل از ایجاد یک سوال جدید، ابرداده جدول یافت نشد"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
-msgstr "{0}を見る"
+msgstr "{0} را ببینید"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
-msgstr "メトリクスの定義"
+msgstr "تعریف متریک"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
-msgstr "{0}でフィルターをかける"
+msgstr "فیلتر توسط {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
-msgstr "{0}の数"
+msgstr "تعداد {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
-msgstr "全ての{0}を見る"
+msgstr "مشاهده تمام {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
-msgstr "セグメントの定義"
+msgstr "تعریف بخش"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
 msgid "An error occurred loading the table"
-msgstr "テーブルの読み込み中にエラーが発生しました"
+msgstr "هنگام بارگیری جدول خطایی روی داد"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:74
 msgid "See the raw data for {0}"
-msgstr "{0}のローデータを見る"
+msgstr "داده های خام برای {0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
-msgstr "さらに"
+msgstr "بیشتر"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:201
 msgid "Invalid expression"
-msgstr "無効な表現"
+msgstr "عبارت نادرست"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:276
 msgid "unknown error"
-msgstr "不明なエラー"
+msgstr "خطای ناشناخته"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
-msgstr "フィールド計算式"
+msgstr "فرمول فیلد"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
-msgstr "これは、スプレッドシートプログラムで数式を書くようなものだとお考えください。数値、この表のフィールド、+などの数学記号、その他一部の機能を使用できます。そのため、Subtotal - Costのようなものを入力することができます。"
+msgstr "از این به عنوان نوعی از نوشتن یک فرمول در یک برنامه صفحه گسترده استفاده کنید. میتوانید از اعداد، فیلدها در این جدول، نمادهای ریاضی مانند + و برخی از توابع استفاده کنید. بنابراین شما می توانید چیزی مانند Subtotal - Cost را تایپ کنید."
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
-msgstr "詳しく見る"
+msgstr "بیشتر بدانید"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
-msgstr "名前を付ける"
+msgstr "نام آن را بدهید"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
-msgstr "分かりやすい説明"
+msgstr "چیزی خوب و توصیفی"
 
 #: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:60
 msgid "Add a custom field"
-msgstr "カスタムフィールドを追加する"
+msgstr "یک فیلد سفارشی اضافه کنید"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:17
 msgid "Include {0}"
-msgstr "{0}を含む"
+msgstr "شامل {0}"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:19
 msgid "Case sensitive"
-msgstr "大文字/小文字を区別する"
+msgstr "مورد حساس"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:23
 msgid "today"
-msgstr "本日"
+msgstr "امروز"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:24
 msgid "this week"
-msgstr "今週"
+msgstr "این هفته"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:25
 msgid "this month"
-msgstr "今月"
+msgstr "این ماه"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:26
 msgid "this year"
-msgstr "今年"
+msgstr "امسال"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:27
 msgid "this minute"
-msgstr "現在の分"
+msgstr "این لحظه"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:28
 msgid "this hour"
-msgstr "現在の時間"
+msgstr "این ساعت"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:290
 msgid "not implemented {0}"
-msgstr "未実装の{0}"
+msgstr "اجرا نشده {0}"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:291
 msgid "true"
-msgstr "正"
+msgstr "درست است"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:291
 msgid "false"
-msgstr "誤"
+msgstr "نادرست"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
-msgstr "フィルターを追加する"
+msgstr "اضافه کردن فیلتر"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
 msgid "Item"
-msgstr "アイテム"
+msgstr "مورد"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
-msgstr "前回"
+msgstr "قبلی"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
-msgstr "現在"
+msgstr "جاری"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
-msgstr "オン"
+msgstr "بر"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx:47
 msgid "Enter desired number"
-msgstr "希望の番号を入力する"
+msgstr "شماره مورد نظر را وارد کنید"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
-msgstr "空"
+msgstr "خالی"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
 msgid "Find a value"
-msgstr "値を探す"
+msgstr "ارزش را پیدا کنید"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:113
 msgid "Hide calendar"
-msgstr "カレンダーを非表示にする"
+msgstr "پنهان کردن تقویم"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:113
 msgid "Show calendar"
-msgstr "カレンダーを表示する"
+msgstr "نمایش تقویم"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx:97
 msgid "You can enter multiple values separated by commas"
-msgstr "コンマ(,)で区切ることで、複数の値を入力できます"
+msgstr "شما می توانید چندین عدد را با کاما وارد کنید"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx:38
 msgid "Enter desired text"
-msgstr "希望のテキストを入力する"
+msgstr "متن دلخواه را وارد کنید"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
-msgstr "試してみる"
+msgstr "آن را امتحان کنید"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
-msgstr "何に使いますか？"
+msgstr "این چیست؟"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
-msgstr "ネイティブクエリの変数を用いることで、フィルターウィジェットまたはURLを使用したクエリの値を置き換えることができます。"
+msgstr "متغیرها در نمایشهای بومی شما به صورت پویا ارزشها را در نمایشهای خود با استفاده از ویدجت فیلتر یا از طریق URL جایگزین می کنند."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
-msgstr "{0}は、このSQLテンプレートで変数名 \"variable_name\"を作成します。 サイドパネルに変数を指定すると、その動作が変わります。 \"フィールドフィルター\"以外の全ての変数タイプは、この質問に自動的にフィルターウィジェットを配置します。 フィールドフィルターでは、これはオプションです。 このフィルターウィジェットが入力されると、その値がSQLテンプレートの変数に置き換えられます。"
+msgstr "{0} یک متغیر در این قالب SQL ایجاد می کند که نام \"متغیر_ نام\" است. متغیرها می توانند در پانل سمت چپ انواع داده شوند که رفتار آنها را تغییر می دهد. همه انواع متغیر غیر از فیلد فیلد به صورت خودکار باعث می شود ویجت فیلتر بر روی این سوال قرار گیرد. با فیلتر فیلدها، این اختیاری است. وقتی این ویجت فیلتر پر شده است، آن مقدار متغیری را در قالب SQL جایگزین می کند."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
-msgstr "フィルターを探す"
+msgstr "فیلترهای فیلد"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
-msgstr "変数に \"フィールドフィルター\"タイプを指定すると、SQLカードをダッシュボードフィルターウィジェットにリンクしたり、SQL質問にさらに多くのタイプのフィルターウィジェットを使用することができます。 フィールドフィルター変数は、既存の列にフィルターを追加するときにGUIクエリビルダーによって生成されたものと同様のSQLを挿入します。"
+msgstr "دادن یک متغیر نوع فیلد فیلد اجازه می دهد تا کارت های SQL را به ویدجت های فیلتر دسکتاپ پیوند دهید یا از انواع بیشتر ویدجت های فیلتر در سوال SQL خود استفاده کنید. یک فیلد فیلد فیلد SQL را همانند آنچه که توسط سازنده پرس و جو GUI ایجاد شده است در هنگام اضافه کردن فیلتر در ستون های موجود اضافه می کند."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
-msgstr "フィールドフィルター変数を追加するときは、特定のフィールドにマップする必要があります。 質問にフィルターウィジェットを表示させるか選択できますが、そうでない場合でも、この質問をダッシュボードに追加するときに、フィールドフィルター変数をダッシュボードフィルターにマッピングすることが可能です。 フィールドフィルターは \"WHERE\"節の中で使用する必要があります。"
+msgstr "هنگام اضافه کردن متغیر فیلد فیلد، باید آن را به یک فیلد مشخص کنید. سپس می توانید یک ویجت فیلتر را روی سوال خود انتخاب کنید، اما حتی اگر این کار را نکنید، می توانید در هنگام اضافه کردن این سوال به داشبورد، فیلد فیلد فیلد خود را به فیلد داشبورد نشان دهید. فیلدهای فیلد باید در داخل یک «WHERE» قرار گیرد."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
-msgstr "選択条項"
+msgstr "مقررات اختیاری"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:132
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr "{0}を囲む括弧は、テンプレート内に任意の句を作成します。 \"変数\"が設定されている場合は、節全体がテンプレートに配置されます。 そうでない場合、節全体が無視されます。"
+msgstr "براکت در اطراف یک {0} یک بند اختیاری در قالب ایجاد کنید. اگر \"متغیر\" تنظیم شده باشد، کل عبارت در قالب قرار می گیرد. اگر نه، پس کل عبارت نادیده گرفته می شود."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
-msgstr "複数の任意の句を使用するには、最低1つの任意でないWHERE句と、その後に「AND」で始まる任意の句を含めてください。"
+msgstr "برای استفاده از چندین پارامتر اختیاری می توانید حداقل یک عبارت WHERE غیر اختیاری همراه با پاراگراف های اختیاری را با «AND» وارد کنید."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
-msgstr "全文を読む"
+msgstr "مستندات کامل را بخوانید"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
-msgstr "フィルターラベル"
+msgstr "برچسب فیلتر"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
-msgstr "値タイプ"
+msgstr "نوع متغیر"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:143
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
-msgstr "テキスト"
+msgstr "متن"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:119
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
-msgstr "日付"
+msgstr "تاریخ"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
-msgstr "フィールドフィルター"
+msgstr "فیلتر فیلد"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
-msgstr "マップするためのフィールド"
+msgstr "فیلد برای نقشه"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
-msgstr "フィルターウィジェットタイプ"
+msgstr "نوع ویجت فیلتر"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
-msgstr "必要ですか？"
+msgstr "ضروری؟"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
-msgstr "デフォルトのフィルターウィジェット値"
+msgstr "مقدار ویجت فیلتر پیش فرض"
 
 #: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
-msgstr "この質問をアーカイブしますか？"
+msgstr "بایگانی این سوال؟"
 
 #: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
-msgstr "この質問は関連したダッシュボードやパルスから削除されます"
+msgstr "این سوال از هر داشبورد یا پالس از آن حذف خواهد شد."
 
 #: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
-msgstr "質問"
+msgstr "سوال"
 
 #: frontend/src/metabase/questions/containers/AddToDashboard.jsx:11
 msgid "Pick a question to add"
-msgstr "追加する質問を選ぶ"
+msgstr "یک سوال برای اضافه کردن انتخاب کنید"
 
 #: frontend/src/metabase/reference/components/EditHeader.jsx:19
 msgid "You are editing this page"
-msgstr "このページを編集中です"
+msgstr "شما در حال ویرایش این صفحه هستید"
 
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:101
 #: frontend/src/metabase/reference/components/ReferenceHeader.jsx:63
 msgid "See this {0}"
-msgstr "この{0}を見る"
+msgstr "این را ببینید {0}"
 
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
-msgstr "のサブセット"
+msgstr "زیر مجموعه ای از"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
-msgstr "フィールドタイプを選択する"
+msgstr "یک نوع فیلد را انتخاب کنید"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
-msgstr "フィールドタイプがありません"
+msgstr "نوع فیلد نیست"
 
 #: frontend/src/metabase/reference/components/FieldToGroupBy.jsx:22
 msgid "by"
-msgstr "で"
+msgstr "توسط"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
 #: frontend/src/metabase/reference/databases/FieldList.jsx:155
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
-msgstr "フィールドタイプ"
+msgstr "نوع فیلد"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
-msgstr "外部キーを選択する"
+msgstr "یک کلید خارجی را انتخاب کنید"
 
 #: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
-msgstr "{0}計算式を見る"
+msgstr "فرمول {0} را ببینید"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:80
 msgid "Why this {0} is important"
-msgstr "なぜこの{0}は重要ですか？"
+msgstr "چرا این {0} مهم است"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:81
 msgid "Why this {0} is interesting"
-msgstr "なぜこの{0}は興味深いですか？"
+msgstr "چرا این {0} جالب است"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:87
 msgid "Nothing important yet"
-msgstr "重要なデータはまだありません"
+msgstr "هیچ چیز مهم نیست"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
@@ -5643,11 +5670,11 @@ msgstr "重要なデータはまだありません"
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
-msgstr "興味深いデータはまだありません"
+msgstr "هیچ چیز جالب نیست"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:93
 msgid "Things to be aware of about this {0}"
-msgstr "この{0}関して知っておくべきこと"
+msgstr "چیزهایی که در مورد این آگاه هستند {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
@@ -5657,78 +5684,78 @@ msgstr "この{0}関して知っておくべきこと"
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
-msgstr "知っておくべきことはまだありません"
+msgstr "هیچ چیز از قبل هنوز آگاه نیست"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:103
 msgid "Explore this metric"
-msgstr "このメトリクスを調査する"
+msgstr "کاوش این متریک"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:105
 msgid "View this metric"
-msgstr "メトリクスを見る"
+msgstr "مشاهده این متریک"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:112
 msgid "By {0}"
-msgstr "{0}で"
+msgstr "توسط {0}"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:146
 msgid "Remove item"
-msgstr "アイテムを削除する"
+msgstr "حذف مورد"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:155
 msgid "Why is this dashboard the most important?"
-msgstr "なぜこのダッシュボードが最重要ですか？"
+msgstr "چرا این داشبورد مهمترین است؟"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:156
 msgid "What is useful or interesting about this {0}?"
-msgstr "{0}の何が役立つまたは興味深いですか？"
+msgstr "در مورد این {0} مفید یا جالب است؟"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:160
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:174
 msgid "Write something helpful here"
-msgstr "役立つ情報をご記入ください"
+msgstr "اینجا چیزی بنویسید"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:169
 msgid "Is there anything users of this dashboard should be aware of?"
-msgstr "このダッシュボードのユーザーが知っておくべきことはありますか？"
+msgstr "آیا کاربرانی که از این داشبورد استفاده می کنند باید آگاه باشند؟"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:170
 msgid "Anything users should be aware of about this {0}?"
-msgstr "{0}に関してユーザーが知っておくべきことはありますか？"
+msgstr "هر چیزی که کاربران باید در مورد این {0} آگاه باشند؟"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:182
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:26
 msgid "Which 2-3 fields do you usually group this metric by?"
-msgstr "このメトリクスをグループ化するにあたりよく使うフィールド2〜3個はどれですか？"
+msgstr "کدام 2-3 فیلد آیا شما معمولا این متریک را با گروه بندی می کنید؟"
 
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:23
 msgid "This is the perfect place to start if you’re new to your company’s data, or if you just want to check in on what’s going on."
-msgstr "企業のデータにアクセスするのが初めての場合や、まずはどんな感じか見てみたい場合は、ここから始めると良いでしょう"
+msgstr "این محل مناسب برای شروع است اگر شما به اطلاعات شرکت خود جدید هستید یا اگر فقط می خواهید در آنچه که در جریان است، بررسی کنید."
 
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:65
 msgid "Most useful fields to group this metric by"
-msgstr "このメトリクスをグループ化するのに最も役立つフィールド"
+msgstr "بیشترین زمینه های مفید برای گروه بندی این متریک توسط"
 
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:32
 msgid "Reason for changes"
-msgstr "変更理由"
+msgstr "دلیل تغییرات"
 
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:36
 msgid "Leave a note to explain what changes you made and why they were required"
-msgstr "変更箇所と変更理由を記入してください"
+msgstr "یک یادداشت را برای توضیح آنچه که تغییراتی ایجاد کرده اید و چرا آنها مورد نیاز بود را ترک کنید"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
-msgstr "なぜこのデータベースは興味深いですか？"
+msgstr "چرا این پایگاه جالب است؟"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
-msgstr "このデータベースに関して知っておくべきこと"
+msgstr "چیزهایی که باید درباره این پایگاه اطلاعات بدانند"
 
 #: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
-msgstr "データベースとテーブル"
+msgstr "پایگاه های داده و جداول"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
@@ -5742,1672 +5769,1674 @@ msgstr "データベースとテーブル"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
-msgstr "詳細"
+msgstr "جزئیات"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
 #: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
-msgstr "{0}のテーブル"
+msgstr "جداول در {0}"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:203
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
-msgstr "データベース上の実際の名前"
+msgstr "نام واقعی در پایگاه داده"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
-msgstr "なぜこのフィールドは興味深いですか？"
+msgstr "چرا این زمینه جالب است"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
-msgstr "このフィールドに関して知っておくべきこと"
+msgstr "چیزهایی که در مورد این زمینه آگاهی دارند"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
 #: frontend/src/metabase/reference/databases/FieldList.jsx:158
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
-msgstr "データタイプ"
+msgstr "نوع داده"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:39
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:39
 msgid "Fields in this table will appear here as they're added"
-msgstr "このテーブルのフィールドは追加されるとここに表示されます"
+msgstr "فیلدها در این جدول در اینجا به نظر میرسند زیرا آنها اضافه شدهاند"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:137
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
-msgstr "{0}のフィールド"
+msgstr "فیلدها در {0}"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:152
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
-msgstr "フィールド名"
+msgstr "نام زمینه"
 
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:49
 msgid "X-ray this field"
-msgstr "このフィールドを自動探査(X-ray)する"
+msgstr "اشعه ایکس این میدان"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:8
 msgid "Metabase is no fun without any data"
-msgstr "Metabaseを使用するにはデータが必要です"
+msgstr "Metabase بدون هیچ گونه اطلاعاتی سرگرم کننده است"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:9
 msgid "Your databases will appear here once you connect one"
-msgstr "データベースは一度接続するとここに表示されます"
+msgstr "پایگاه های داده شما هنگامی که یکی از آنها را وصل می کنید، در اینجا ظاهر می شوند"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:10
 msgid "Databases will appear here once your admins have added some"
-msgstr "データベースは一度管理者が追加するとここに表示されます"
+msgstr "پایگاه های داده در اینجا ظاهر خواهد شد، هنگامی که مدیران شما تعدادی را اضافه کرده اند"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:12
 msgid "Connect a database"
-msgstr "データベースを接続する"
+msgstr "یک پایگاه داده را وصل کنید"
 
 #. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
 #. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
-msgstr "{0}のカウント"
+msgstr "تعداد {0}"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:47
 msgid "See raw data for {0}"
-msgstr "{0}のローデータを見る"
+msgstr "اطلاعات خام را برای {0} مشاهده کنید"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
-msgstr "なぜこのテーブルは興味深いですか？"
+msgstr "چرا این جدول جالب است"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
-msgstr "このテーブルに関して知っておくべきこと"
+msgstr "چیزهایی که باید در مورد این جدول آگاه باشند"
 
 #: frontend/src/metabase/reference/databases/TableList.jsx:30
 msgid "Tables in this database will appear here as they're added"
-msgstr "このデータベースのテーブルは追加されるとここに表示れます"
+msgstr "جداول در این پایگاه داده در اینجا به همان شکل اضافه می شوند"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
 msgid "Questions about this table will appear here as they're added"
-msgstr "このテーブルに関する質問は追加されるとここに表示されます"
+msgstr "سوالات در مورد این جدول در اینجا به عنوان آنها اضافه شده است"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
-msgstr "{0}に関する質問"
+msgstr "سوالات در مورد {0}"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
-msgstr "{1}で{0}を作成しました"
+msgstr "{0} توسط {1} ایجاد شد"
 
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:40
 msgid "Fields in this table"
-msgstr "このテーブルのフィールド"
+msgstr "زمینه های این جدول"
 
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:48
 msgid "Questions about this table"
-msgstr "このテーブルに関する質問"
+msgstr "سوالات در مورد این جدول"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
-msgstr "チームとデータを共有する"
+msgstr "کمک به تیم خود را با داده های خود را آغاز کنید."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
-msgstr "トップにくるダッシュボード、メトリクス、セグメントを選択し、チームに重要事項を提示しましょう"
+msgstr "تیم خود را با انتخاب مهمترین داشبورد، معیارها و بخشهای خود مهم تر کنید."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
-msgstr "開始する"
+msgstr "شروع کنید"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
-msgstr "最重要ダッシュボード"
+msgstr "مهم ترین داشبورد ما"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
-msgstr "注視すべき数値"
+msgstr "اعدادی که به آن توجه می کنیم"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
-msgstr "メトリクスは企業が重視する数値です。ビジネスが上手くいっているかどうかを示すものです。"
+msgstr "معیارهای مهم هستند که شرکت شما در مورد آن اهمیت دارد. آنها اغلب نشان دهنده شاخص اصلی عملکرد کسب و کار هستند."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
-msgstr "全メトリクスを見る"
+msgstr "تمام معیارها را ببینید"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
-msgstr "セグメントとテーブル"
+msgstr "بخش ها و جداول"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:83
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
-msgstr "テーブル"
+msgstr "جداول"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
-msgstr "セグメントやテーブルは、会社データの基礎的要素です。 テーブルはローデータをまとめた情報であり、セグメントは{0}など特定の意味を持つ特定の情報です。"
+msgstr "بخش ها و جداول بلوک های داده های شرکت شما هستند. جداول مجموعه ای از اطلاعات خام است در حالی که بخش ها برش های خاصی با معانی خاصی مانند {0}"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
-msgstr "テーブルは、会社データの基礎的要素です。"
+msgstr "جداول بلوک های داده های شرکت شما هستند."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
-msgstr "全セグメントを見る"
+msgstr "تمام بخشها را ببینید"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
-msgstr "全てのテーブルを見る"
+msgstr "تمام جداول را ببینید"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
-msgstr "データに関して他に知っておくべきこと"
+msgstr "چیزهای دیگر در مورد اطلاعات ما می دانیم"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
-msgstr "詳細を見る"
+msgstr "اطلاعات بیشتر"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
-msgstr "他のテーブルや情報をもっと見ることで、自身のデータをより詳しく知ることができます。時間がかかるかもしれませんが、名前やその意味について理解を深めることができるでしょう。"
+msgstr "یک راه خوب برای شناختن اطلاعات شما با صرف کمی وقت است که از جداول مختلف و سایر اطلاعات موجود برای شما استفاده کنید. ممکن است کمی طول بکشد، اما در طول زمان، اسامی و معانی را خواهید فهمید."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
-msgstr "データを調査する"
+msgstr "کاوش داده های ما"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
-msgstr "質問はありますか？"
+msgstr "سوالی دارید؟"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
-msgstr "{0}に問い合わせる"
+msgstr "تماس بگیرید {0}"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
-msgstr "新しいユーザーをヘルプする"
+msgstr "کمک به کاربران جدید Metabase راه خود را پیدا می کنند."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
-msgstr "スタートガイドは、ダッシュボード、メトリクス、セグメントやテーブル等の重要事項に焦点を当て、ユーザーが実際にデータを扱い始める前に知っておくべきことを説明しています。"
+msgstr "راهنمای شروع به کار، داشبورد، متریک ها، بخش ها و جداول را مهم تر می کند و کاربران را از موارد مهم که باید قبل از حفر نمودن آنها به داده ها اطلاع دهند، اطلاع می دهد."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
-msgstr "チームに重要なダッシュボードはありますか？"
+msgstr "آیا داشبورد مهم برای تیم شما وجود دارد؟"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
-msgstr "今すぐダッシュボードを作成する"
+msgstr "اکنون داشبورد را ایجاد کنید"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
-msgstr "最重要ダッシュボードはどれですか？"
+msgstr "مهمترین داشبورد مهم شما چیست؟"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
-msgstr "よく参照するメトリクスはありますか？"
+msgstr "آیا شما معیارهای رایج را دارید؟"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
-msgstr "メトリクスの定義づけ方法を確認する"
+msgstr "یاد بگیرید که چگونه یک متریک را تعریف کنید"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
-msgstr "よく参照するメトリクス3〜5個は何ですか？"
+msgstr "3-5 معیارهای رایج ترین معیار شما چیست؟"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
-msgstr "他のメトリクスを追加する"
+msgstr "یک متریک دیگر اضافه کنید"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
-msgstr "よく参照するセグメントやテーブルはありますか"
+msgstr "آیا شما هر بخش یا جداول رایج را دارید؟"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
-msgstr "セグメントの作成方法を確認する"
+msgstr "یاد بگیرید چگونه یک بخش ایجاد کنید"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
-msgstr "オーディエンスに役立つであろう、よく参照するセグメントやテーブル3〜5個は何ですか？"
+msgstr "3-6 بخش یا جدول جداگانه که معمولا برای این مخاطب مفید است، 3-5 هستند."
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
-msgstr "他のセグメントやテーブルを追加する"
+msgstr "یک بخش یا جدول دیگر اضافه کنید"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
-msgstr "データへのアクセスを開始する前に、ユーザーが理解し知っておくべきことはありますか？"
+msgstr "آیا قبل از شروع به دسترسی به داده ها، کاربران باید قبل از شروع دسترسی به آنها، باید بدانند یا بدانند؟"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
-msgstr "データへのアクセスを開始する前に、ユーザーが知っておくべきことは何ですか？"
+msgstr "قبل از شروع دسترسی به این اطلاعات باید یک کاربر از این اطلاعات بداند؟"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
-msgstr "例: データのプライバシーと使用に関する危険性や誤解、データウェアハウスのパフォーマンスに関する情報、法的通知など"
+msgstr "به عنوان مثال، انتظارات در مورد حریم خصوصی و استفاده از داده ها، مشکلات رایج یا سوء تفاهم ها، اطلاعات مربوط به عملکرد انبار داده، اعلامیه های قانونی و غیره"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
-msgstr "このガイドで不明点があった際にユーザーがコンタクトできる方はいますか？"
+msgstr "آیا کسی وجود دارد که کاربران شما می توانند برای کمک در صورت بروز این اشتباه در مورد این راهنما چاره کنند؟"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
-msgstr "このデータで不明点があった際にユーザーは誰にコンタクトすべきですか？"
+msgstr "اگر در مورد این اطلاعات اشتباه گرفته شود، کاربران باید برای کمک تماس بگیرند؟"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:75
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:95
 msgid "Please enter a revision message"
-msgstr "履歴メッセージを入力してください"
+msgstr "لطفا یک پیام تجدید نظر را وارد کنید"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
-msgstr "なぜこのメトリクスは興味深いですか？"
+msgstr "چرا این متریک جالب است"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
-msgstr "このメトリクスに関して知っておくべきこと"
+msgstr "چیزهایی که در مورد این متریال آگاه هستند"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
-msgstr "このメトリクスの計算方法"
+msgstr "چگونه این متریک محاسبه شده است"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
-msgstr "計算方法はまだありません"
+msgstr "هیچ چیز در مورد چگونگی محاسبه هنوز"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
-msgstr "このメトリクスをグループ化する他のフィールド"
+msgstr "دیگر زمینه های شما می توانید این متریک با گروه"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
-msgstr "このメトリクスをグループ化するフィールド"
+msgstr "زمینه های شما می توانید این متریک با گروه"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
-msgstr "メトリクスはチームが重視する公式な数値です"
+msgstr "معیارهای رسمی اعداد رسمی است که تیم شما در مورد آن مورد توجه قرار گرفته است"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
-msgstr "メトリクスは管理者が作成次第ここに表示されます"
+msgstr "پس از اینکه مدیران شما برخی از آنها ایجاد کرد، معیارها در اینجا ظاهر می شوند"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
-msgstr "メトリクスの作成方法を詳しく見る"
+msgstr "یاد بگیرید چگونه برای ایجاد معیارها"
 
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
 msgid "Questions about this metric will appear here as they're added"
-msgstr "このメトリクスに関する質問は追加されるとここに表示されます"
+msgstr "سوالاتی درباره این معیار در اینجا به عنوان آنها اضافه شده است"
 
 #: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:29
 msgid "There are no revisions for this metric"
-msgstr "このメトリクスには履歴がありません"
+msgstr "برای این متریک تجدیدنظر وجود ندارد"
 
 #: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
-msgstr "{0}の履歴"
+msgstr "تاریخچه ویرایش برای {0}"
 
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:43
 msgid "X-ray this metric"
-msgstr "このメトリクスを自動探査(X-ray)する"
+msgstr "اشعه ایکس این متریک"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
-msgstr "なぜこのセグメントは興味深いですか？"
+msgstr "چرا این بخش جالب است"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
-msgstr "このセグメントに関して知っておくべきこと"
+msgstr "چیزهایی که در مورد این بخش آگاهی دارند"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
-msgstr "セグメントはテーブルのサブセットです"
+msgstr "بخش ها بخش های جالب از جداول هستند"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
-msgstr "共通のセグメントについて定義するとチームがより質問しやすくなります"
+msgstr "تعریف بخش های عادی برای تیم شما، باعث می شود که سؤالات بیشتری از شما بپرسید"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
-msgstr "セグメントは管理者が作成次第ここに表示されます"
+msgstr "Segments در اینجا ظاهر خواهد شد، هنگامی که مدیران شما برخی را ایجاد کرده اند"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
-msgstr "セグメントの作成方法について詳しく見る"
+msgstr "یاد بگیرید چگونه برای ایجاد بخش"
 
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
 msgid "Questions about this segment will appear here as they're added"
-msgstr "このセグメントに関する質問は追加されるとここに表示されます"
+msgstr "سوالات در مورد این بخش در اینجا به عنوان آنها اضافه می شود"
 
 #: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:29
 msgid "There are no revisions for this segment"
-msgstr "このセグメントには履歴がありません"
+msgstr "برای این بخش تجدیدنظر وجود ندارد"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:36
 msgid "Fields in this segment"
-msgstr "このセグメントのフィールド"
+msgstr "زمینه های این بخش"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:42
 msgid "Questions about this segment"
-msgstr "このセグメントに関する質問"
+msgstr "سوالات در مورد این بخش"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:49
 msgid "X-ray this segment"
-msgstr "このセグメントを自動探査(X-ray)する"
+msgstr "اشعه ایکس این بخش"
 
 #: frontend/src/metabase/routes.jsx:182
 msgid "Login"
-msgstr "ログイン"
+msgstr "ورود"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
-msgstr "検索"
+msgstr "جستجو کردن"
 
 #: frontend/src/metabase/routes.jsx:217
 msgid "Dashboard"
-msgstr "ダッシュボード"
+msgstr "داشبورد"
 
 #: frontend/src/metabase/routes.jsx:228
 msgid "New Question"
-msgstr "新しい質問"
+msgstr "سوال جدید"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:125
 msgid "Select the type of Database you use"
-msgstr "使用するデータベースタイプを選択する"
+msgstr "نوع پایگاه داده ای که استفاده می کنید را انتخاب کنید"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
-msgstr "データを追加する"
+msgstr "اطلاعات خود را اضافه کنید"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
-msgstr "あとでデータを追加する"
+msgstr "بعدا داده های خودم را اضافه خواهم کرد"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
-msgstr "{0}に接続中"
+msgstr "اتصال به {0}"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
-msgstr "ユーザー名やパスワード等データベースに関する情報が必要です。"
+msgstr "شما به اطلاعاتی درباره پایگاه داده خود نیاز دارید، مانند نام کاربری و رمز عبور. اگر شما آن را در حال حاضر ندارید، Metabase همچنین با مجموعه داده های نمونه ای که می توانید از آن استفاده کنید."
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
-msgstr "あとでデータを追加する"
+msgstr "بعدا داده هایم را اضافه خواهم کرد"
 
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
-msgstr "自動スキャンを設定する"
+msgstr "کنترل اسکن خودکار"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
-msgstr "データ使用の優先度"
+msgstr "تنظیمات داده استفاده"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
-msgstr "ご協力ありがとうございます"
+msgstr "با تشکر برای کمک به بهبود ما"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
-msgstr "Usage eventに関する情報は収集いたしません"
+msgstr "ما هر گونه رویداد استفاده را جمع آوری نخواهیم کرد"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
-msgstr "Metabaseサービスを向上させるため、Google Analyticsを通じてデータ使用に関する情報を収集いたします"
+msgstr "به منظور کمک به بهبود Metabase، ما می خواهیم اطلاعات خاصی در مورد استفاده از طریق Google Analytics جمع آوری کنیم."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
-msgstr "収集する情報とその理由についてはこちらをご確認ください"
+msgstr "در اینجا یک لیست کامل از همه چیز ما پیگیری و به همین دلیل است."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
-msgstr "Metabaseが匿名の情報収集をすることに同意する"
+msgstr "اجازه دهید Metabase به صورت ناشناس رویدادهای استفاده را جمع آوری کند"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
-msgstr "Metabase {0}はデータや質問結果に関する情報を収集します"
+msgstr "Metabase {0} اطلاعاتی درباره نتایج یا نتایج شما را جمع آوری می کند."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
-msgstr "しない"
+msgstr "هرگز"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
-msgstr "情報収集は全て匿名です"
+msgstr "تمام مجموعه کاملا ناشناس است."
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
-msgstr "情報収集による設定は管理者設定からいつでも変更することができます"
+msgstr "مجموعه را می توانید در هر نقطه از تنظیمات مدیریت خود خاموش کنید."
 
 #: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
-msgstr "お困りの場合"
+msgstr "اگر احساس می کنید گیر کرده اید"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
-msgstr "スタートガイド"
+msgstr "راهنمای شروع به کار ما"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
-msgstr "クリックするだけ"
+msgstr "فقط یک کلیک دور است"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
-msgstr "Metabaseへようこそ"
+msgstr "به Metabase خوش آمدید"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
-msgstr "すべて正常に動作しています。使用を開始し、データを接続して回答を探しましょう。"
+msgstr "به نظر می رسد همه چیز در حال کار است اکنون اجازه دهید شما را بشناسیم، با داده هایتان ارتباط برقرار کنید و برخی از پاسخ ها را پیدا کنید!"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
-msgstr "開始しましょう"
+msgstr "بیا شروع کنیم"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
-msgstr "準備ができました！"
+msgstr "همه شما تنظیم شده اند!"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
-msgstr "Metabaseを使い始める"
+msgstr "من را به Metabase ببر"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:155
 msgid "What should we call you?"
-msgstr "何とお呼びしましょうか？"
+msgstr "ما باید با شما تماس بگیریم؟"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:156
 msgid "Hi, {0}. nice to meet you!"
-msgstr "やあ {0} さん、はじめまして！"
+msgstr "سلام {0} از ملاقات شما خوشبختم!"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:243
 msgid "Create a password"
-msgstr "パスワードを作成する"
+msgstr "یک رمز عبور ایجاد کنید"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
-msgstr "シーッ"
+msgstr "شیخ ..."
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:269
 msgid "Confirm password"
-msgstr "パスワード確認"
+msgstr "رمز عبور را تایید کنید"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:278
 msgid "Shhh... but one more time so we get it right"
-msgstr "もう一度お試しください"
+msgstr "شوش ... اما یک بار دیگر، بنابراین ما آن را درست می گیریم"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:287
 msgid "Your company or team name"
-msgstr "企業名またはチーム名"
+msgstr "نام شرکت یا تیم شما"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:296
 msgid "Department of awesome"
-msgstr "部署名"
+msgstr "بخش بسیار جذاب"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:26
 msgid "Metabot is admiring your integers…"
-msgstr "MetaBot処理中..."
+msgstr "Metabot عواقب صحیح شما را تحسین می کند ..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:27
 msgid "Metabot is performing billions of differential equations…"
-msgstr "MetaBot処理中..."
+msgstr "Metabot در حال انجام میلیاردها معادلات دیفرانسیل است ..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:28
 msgid "Metabot is doing science…"
-msgstr "MetaBot処理中..."
+msgstr "متابوت در حال انجام علم ..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:29
 msgid "Metabot is checking out your metrics…"
-msgstr "MetaBotはメトリクスを確認中..."
+msgstr "متابوت چک کردن معیارهای شما ..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:30
 msgid "Metabot is looking for trends and outliers…"
-msgstr "MetaBot処理中..."
+msgstr "Metabot به دنبال روندهایی و ریزگردها است ..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:31
 msgid "Metabot is consulting the quantum abacus…"
-msgstr "MetaBot処理中..."
+msgstr "Metabot مشاوره کوانتومی ..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:32
 msgid "Metabot is feeling pretty good about all this…"
-msgstr "MetaBot処理中..."
+msgstr "متابوت در مورد همه اینها خیلی خوب است ..."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:52
 msgid "We’ll show you some interesting explorations of your data in\n"
 "just a few minutes."
-msgstr "わずか数分であなたのデータに関する興味深い探索結果を提示します。"
+msgstr "ما به شما برخی از کاوشهای جالب داده های شما را نشان خواهیم داد\n"
+"فقط چند دقیقه"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:72
 msgid "This seems to be taking a while. In the meantime, you can check out one of these example explorations to see what Metabase can do for you."
-msgstr "しばらく時間がかかります。その間、これらの探索結果のサンプルを見てMetabaseで何ができるか知ることができます。"
+msgstr "این به نظر می رسد که در حال مصرف است. در ضمن، می توانید یکی از این نمونه های نمونه را چک کنید تا ببینید چه چیزی Metabase می تواند برای شما انجام دهد."
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:86
 msgid "I took a look at the data you just connected, and I have some explorations of interesting things I found. Hope you like them!"
-msgstr "今接続されたデータに基づく、興味深い探索結果がいくつかあります。気に入っていただけると嬉しいです。"
+msgstr "من نگاهی به اطلاعاتی که به تازگی متصل کرده اید نگاه کردم، و من برخی از کاوشهای جالب توجه را پیدا کردم. امیدوارم که آنها را دوست داشته باشید"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:98
 msgid "I'm done exploring for now"
-msgstr "調査を終了する"
+msgstr "من اکنون در حال جستجو هستم"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:20
 msgid "Welcome to the Query Builder!"
-msgstr "クエリビルダーへようこそ"
+msgstr "به Query Builder خوش آمدید!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:22
 msgid "The Query Builder lets you assemble questions (or \"queries\") to ask about your data."
-msgstr "クエリビルダーを使用すると、データに関する質問（またはクエリ）を作成することができます"
+msgstr "Query Builder به شما اجازه می دهد سوالات (یا «نمایش ها») را برای جمع آوری اطلاعات در مورد خود بسازید."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:26
 msgid "Tell me more"
-msgstr "さらに詳しく"
+msgstr "بیشتر بگو"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:43
 msgid "Start by picking the table with the data that you have a question about."
-msgstr "質問のあるデータを含むテーブルを選ぶことから開始する"
+msgstr "با جمع آوری جدول با داده هایی که در مورد یک سوال دارید شروع کنید."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:45
 msgid "Go ahead and select the \"Orders\" table from the dropdown menu."
-msgstr "ドロップダウンメニューから \"Orders\" テーブルを選択する"
+msgstr "پیش بروید و جدول \"سفارشات\" را از منوی کشویی انتخاب کنید."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:78
 msgid "Filter your data to get just what you want."
-msgstr "ご希望の情報を得るためにフィルターをかける"
+msgstr "اطلاعات خود را فیلتر کنید تا آنچه را که میخواهید دریافت کنید."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:79
 msgid "Click the plus button and select the \"Created At\" field."
-msgstr "＋ボタンをクリックして、「作成日時」フィールドを選択する"
+msgstr "روی دکمه plus کلیک کنید و فیلد \"ایجاد شده در\" را انتخاب کنید."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:93
 msgid "Here we can pick how many days we want to see data for, try 10"
-msgstr "何日間のデータを見たいか選ぶことができます。10日から見てみてはいかがですか？"
+msgstr "در اینجا می توانیم چند روزی که می خواهیم داده ها را ببینیم انتخاب کنیم، 10 را امتحان کنید"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:116
 msgid "Here's where you can choose to add or average your data, count the number of rows in the table, or just view the raw data."
-msgstr "こちらでデータを追加したり平均したり、テーブル内の行数を数えたり、またはローデータを見たりできます"
+msgstr "در اینجا می توانید انتخاب کنید که اطلاعات خود را اضافه یا به طور متوسط، تعداد ردیف ها در جدول را شمارش کنید یا فقط دادههای خام را مشاهده کنید."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:118
 msgid "Try it: click on <strong>Raw Data</strong> to change it to <strong>Count of rows</strong> so we can count how many orders there are in this table."
-msgstr "お試しください: <Strong>ローデータ</strong>をクリックして設定を<strong>行数</strong>に変更すると、このテーブル内のオーダー数を確認することができます。"
+msgstr "آن را امتحان کنید: بر روی <strong> دادههای خام </ strong> کلیک کنید تا آن را به <strong> تعداد ردیفها </ strong> تغییر دهید تا بتوانیم تعداد زیادی سفارش را در این جدول داشته باشیم."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:142
 msgid "Add a grouping to break out your results by category, day, month, and more."
-msgstr "グルーピングを追加して、結果をカテゴリー、日、月等で分ける"
+msgstr "گروهی را اضافه کنید تا نتایج خود را بر اساس طبقه بندی، روز، ماه و موارد دیگر برطرف کنید."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:144
 msgid "Let's do it: click on <strong>Add a grouping</strong>, and choose <strong>Created At: by Week</strong>."
-msgstr "やってみましょう: <strong>グルーピングを追加する</strong>をクリックして、<strong>作成日時: 週別</strong>を選択しましょう"
+msgstr "اجازه دهید این کار را انجام دهیم: روی <strong> افزودن یک گروه </ strong> کلیک کنید و <strong> ایجاد شده در: توسط هفته </ strong> را انتخاب کنید."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:152
 msgid "Click on \"by day\" to change it to \"Week.\""
-msgstr "「1日ごと」をクリックして「週」に変更する"
+msgstr "روی «روز» کلیک کنید تا آن را به «هفته» تغییر دهید."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:173
 msgid "Run Your Query."
-msgstr "クエリを実行する"
+msgstr "درخواست خود را اجرا کنید"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:175
 msgid "You're doing so well! Click <strong>Run query</strong> to get your results!"
-msgstr "その調子です！<strong>クエリを実行する</strong>をクリックして結果を表示させましょう。"
+msgstr "شما خیلی خوب کار میکنید برای رسیدن به نتایج خود، روی <strong> اجرای درخواست </ strong> کلیک کنید"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:192
 msgid "You can view your results as a chart instead of a table."
-msgstr "テーブルではなくチャートとして結果を見ることができます"
+msgstr "شما می توانید نتایج خود را به عنوان یک نمودار به جای یک جدول مشاهده کنید."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:194
 msgid "Everbody likes charts! Click the <strong>Visualization</strong> dropdown and select <strong>Line</strong>."
-msgstr "チャートを使うと便利です！<strong>ビジュアライゼーション</strong>のドロップダウンをクリックして、<strong>線</strong>を選択しましょう"
+msgstr "Everbody نمودار ها را دوست دارد! روی منوی کشویی <strong> تجسم </ strong> کلیک کنید و <strong> خط </ strong> را انتخاب کنید."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:216
 msgid "Well done!"
-msgstr "よくできました！"
+msgstr "آفرین!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:218
 msgid "That's all! If you still have questions, check out our"
-msgstr "以上です！ご不明な点がありましたら、こちらをご確認ください"
+msgstr "این همه! اگر هنوز سوالی دارید، از ما بخواهید"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "User's Guide"
-msgstr "ユーザーガイド"
+msgstr "راهنمای کاربر"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "Have fun exploring your data!"
-msgstr "データ調査をお楽しみください！"
+msgstr "لذت بردن از اطلاعات خود را کاوش کنید!"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:226
 msgid "Thanks"
-msgstr "ありがとうございました"
+msgstr "با تشکر"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:235
 msgid "Save Your Questions"
-msgstr "質問を保存する"
+msgstr "سوالات خود را ذخیره کنید"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:237
 msgid "By the way, you can save your questions so you can refer to them later. Saved Questions can also be put into dashboards or Pulses."
-msgstr "質問を保存することで、あとからでも参照することができます。保存された質問はダッシュボードやパルスでも確認できます。"
+msgstr "به هر حال، شما می توانید سوالات خود را ذخیره کنید تا بعدا بتوانید به آنها مراجعه کنید. سوالات ذخیره شده را می توان در داشبورد یا پالس قرار داد."
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:241
 msgid "Sounds good"
-msgstr "確認しました"
+msgstr "به نظر می رسد خوب است"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:248
 msgid "Whoops!"
-msgstr "おっと！"
+msgstr "هوس"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:249
 msgid "Sorry, it looks like something went wrong. Please try restarting the tutorial in a minute."
-msgstr "申し訳ありません、問題が発生しました。時間をおいてから再度チュートリアルを再生してください。"
+msgstr "با عرض پوزش، به نظر می رسد چیزی اشتباه رفت. لطفا یک دقیقه پس از اتمام آموزش دوباره امتحان کنید."
 
 #: frontend/src/metabase/user/actions.js:34
 msgid "Password updated successfully!"
-msgstr "パスワードがアップデートされました！"
+msgstr "گذرواژه با موفقیت بهروز شد"
 
 #: frontend/src/metabase/user/actions.js:53
 msgid "Account updated successfully!"
-msgstr "アカウントがアップデートされました！"
+msgstr "حساب با موفقیت به روز شد!"
 
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:107
 msgid "Current password"
-msgstr "現在のパスワード"
+msgstr "رمز عبور فعلی"
 
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:137
 msgid "Sign in with Google Email address"
-msgstr "Googleメールアドレスでサインインする"
+msgstr "با آدرس ایمیل Google وارد شوید"
 
 #: frontend/src/metabase/user/components/UserSettings.jsx:65
 msgid "User Details"
-msgstr "ユーザー詳細"
+msgstr "اطلاعات کاربر"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
-msgstr "デフォルトに戻す"
+msgstr "بازنشانی به پیش فرضها"
 
 #: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
-msgstr "不明なマップ"
+msgstr "نقشه ناشناخته"
 
 #: frontend/src/metabase/visualizations/components/LeafletGridHeatMap.jsx:26
 msgid "Grid map requires binned longitude/latitude."
-msgstr "グリッドマップには経度/緯度がビニングされている必要があります"
+msgstr "نقشه شبکه نیازمند طول جغرافیایی / عرض جغرافیایی است."
 
 #: frontend/src/metabase/visualizations/components/LegendVertical.jsx:112
 msgid "more"
-msgstr "さらに"
+msgstr "بیشتر"
 
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
-msgstr "X軸、Y軸にどのフィールドを使用しますか？"
+msgstr "کدام زمینه ها برای محورهای X و Y مورد استفاده قرار می گیرد؟"
 
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
-msgstr "フィールドを選択する"
+msgstr "زمینه ها را انتخاب کنید"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
-msgstr "デフォルトビューとして保存する"
+msgstr "نمایش به صورت پیش فرض ذخیره شود"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
-msgstr "フィルターにボックスを描く"
+msgstr "جعبه قرعه کشی برای فیلتر کردن"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
-msgstr "フィルターをキャンセルする"
+msgstr "لغو فیلتر"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:47
 msgid "Pin Map"
-msgstr "マップを固定する"
+msgstr "نقشه پین"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
-msgstr "解除する"
+msgstr "گمشده"
 
 #: frontend/src/metabase/visualizations/components/TableSimple.jsx:253
 msgid "Rows {0}-{1} of {2}"
-msgstr "{2}の行{0}〜{1}"
+msgstr "ردیف {0} - {1} از {2}"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
-msgstr "{0}行に切り捨てされたデータ"
+msgstr "داده های کوتاه شده به {0} ردیف."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
-msgstr "ビジュアライゼーションが見つかりませんでした"
+msgstr "تجسم یافت نشد"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
-msgstr "このデータではチャートが表示できません"
+msgstr "این نمودار را نمیتوان با این اطلاعات نمایش داد."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
-msgstr "結果が見つかりませんでした"
+msgstr "هیچ نتیجه ای!"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
-msgstr "待機中..."
+msgstr "هنوز منتظرم..."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
-msgstr "通常約{0}かかります"
+msgstr "این معمولا طول می کشد به طور متوسط ​​{0}."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
-msgstr "（通常のダッシュボード処理より時間がかかっています）"
+msgstr "(این کمی طولانی برای داشبورد است)"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:503
 msgid "This is usually pretty fast but seems to be taking awhile right now."
-msgstr "通常より時間がかかっています"
+msgstr "این معمولا خیلی سریع است اما به نظر می رسد در حال حاضر به مدت طولانی مصرف شود."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:36
 msgid "Select a field"
-msgstr "フィールドを選択する"
+msgstr "یک فیلد را انتخاب کنید"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:45
 msgid "error"
-msgstr "エラー"
+msgstr "خطا"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
-msgstr "順番を変えるにはクリックしてドラッグしてください"
+msgstr "برای تغییر سفارش خود روی بکشید و بکشید"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
-msgstr "以下リストからフィールドを追加する"
+msgstr "فیلدهای را از لیست زیر اضافه کنید"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:24
 msgid "less than"
-msgstr "より小さい"
+msgstr "کمتر از"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:25
 msgid "greater than"
-msgstr "より大きい"
+msgstr "بزرگتر از"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "less than or equal to"
-msgstr "以下"
+msgstr "کمتر از یا برابر است"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "greater than or equal to"
-msgstr "以上"
+msgstr "بزرگتر یا مساوی با"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:28
 msgid "equal to"
-msgstr "同等"
+msgstr "مساوی با"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:29
 msgid "not equal to"
-msgstr "同等ではない"
+msgstr "برابر نیست با"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:191
 msgid "Conditional formatting"
-msgstr "条件付書式"
+msgstr "قالب بندی مشروط"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:193
 msgid "You can add rules to make the cells in this table change color if\n"
 "they meet certain conditions."
-msgstr "条件にあったテーブルのセルの色を変更するためのルールを追加することができます"
+msgstr "شما می توانید قوانین را برای ایجاد سلول ها در این جدول تغییر رنگ اگر\n"
+"آنها شرایط خاصی را برآورده می کنند."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:203
 msgid "Add a rule"
-msgstr "ルールを追加する"
+msgstr "یک قانون را اضافه کنید"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:208
 msgid "Rules will be applied in this order"
-msgstr "この順番でルールが適用されます"
+msgstr "قوانین به این منظور اعمال خواهد شد"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:209
 msgid "Click and drag to reorder."
-msgstr "順番を変更するにはクリックしてドラッグしてください"
+msgstr "برای ترتیب دوباره، روی کلیک کنید و بکشید"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:242
 msgid "No columns selected"
-msgstr "列が選択されていません"
+msgstr "ستونها انتخاب نشده اند"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:290
 msgid "Cells in this column will be tinted based on their values."
-msgstr "この列のセルは値によって色付けされます"
+msgstr "سلولهای این ستون بر اساس مقادیرشان رنگ میشوند."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:279
 msgid "When a cell in these columns is {0} it will be tinted this color."
-msgstr "この列のセルが{0}のとき、この色に色付けされます"
+msgstr "هنگامی که یک سلول در این ستون {0} باشد، این رنگ آن رنگ می شود."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:313
 msgid "Which columns should be affected?"
-msgstr "どの列に適用しますか？"
+msgstr "کدام ستون باید تحت تاثیر قرار گیرد؟"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:335
 msgid "Formatting style"
-msgstr "フォーマットスタイル"
+msgstr "سبک فرمت"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:339
 msgid "Single color"
-msgstr "単色"
+msgstr "تنها رنگ"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:340
 msgid "Color range"
-msgstr "色の範囲"
+msgstr "محدوده رنگ"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:312
 msgid "When a cell in this column is…"
-msgstr "この列のセルが...のとき"
+msgstr "یک سلول در این ستون ..."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:376
 msgid "…turn its background this color:"
-msgstr "背景がこの色になる:"
+msgstr "... پس زمینه این رنگ را عوض کنید:"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:382
 msgid "Highlight the whole row"
-msgstr "全行をハイライトする"
+msgstr "تمام سطر را برجسته کنید"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
-msgstr "色"
+msgstr "رنگ ها"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:404
 msgid "Start the range at"
-msgstr "範囲をここから指定する"
+msgstr "محدوده را در شروع کنید"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:409
 msgid "Smallest value in this column"
-msgstr "この列の最小値"
+msgstr "کوچکترین مقدار در این ستون"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:411
 msgid "Smallest value in each column"
-msgstr "各列の最小値"
+msgstr "کوچکترین مقدار در هر ستون"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:413
 msgid "Smallest value in all of these columns"
-msgstr "これらの列の最小値"
+msgstr "کوچکترین مقدار در همه این ستون ها"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:417
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:441
 msgid "Custom value"
-msgstr "カスタム値"
+msgstr "ارزش سفارشی"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:428
 msgid "End the range at"
-msgstr "範囲をここまでに指定する"
+msgstr "محدوده را در پایان"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:433
 msgid "Largest value in this column"
-msgstr "この列の最大値"
+msgstr "بزرگترین مقدار در این ستون"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:435
 msgid "Largest value in each column"
-msgstr "各列の最大値"
+msgstr "بزرگترین مقدار در هر ستون"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:437
 msgid "Largest value in all of these columns"
-msgstr "これらの列の最大値"
+msgstr "بزرگترین ارزش در همه این ستون ها"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:471
 msgid "Add rule"
-msgstr "ルールを追加する"
+msgstr "اضافه کردن قانون"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:471
 msgid "Update rule"
-msgstr "ルールをアップデートする"
+msgstr "به روز رسانی قانون"
 
 #: frontend/src/metabase/visualizations/index.js:33
 msgid "Visualization is null"
-msgstr "ビジュアライゼーションはnullです。"
+msgstr "تجسم صفر است"
 
 #: frontend/src/metabase/visualizations/index.js:38
 msgid "Visualization must define an 'identifier' static variable: "
-msgstr "ビジュアライゼーションでは、'識別子'スタティック変数を定義する必要があります: "
+msgstr "تجسم باید متغیر ایستا 'شناسه' را تعریف کند:"
 
 #: frontend/src/metabase/visualizations/index.js:44
 msgid "Visualization with that identifier is already registered: "
-msgstr "この識別子を用いたビジュアライゼーションはすでに存在します: "
+msgstr "تجسم با آن شناسه قبلا ثبت شده است:"
 
 #: frontend/src/metabase/visualizations/index.js:72
 msgid "No visualization for {0}"
-msgstr "{0}のビジュアライゼーションがありません"
+msgstr "هیچ تصویری برای {0}"
 
 #: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
-msgstr "「{0}」は属性のないフィールドです。X軸上に複数の値がある場合、値は合計値となります。"
+msgstr "\"{0}\" یک فیلد جمع نشده است: در صورتی که دارای مقدار بیش از یک مقدار در یک محور x باشد، مقادیر جمع می شوند."
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
-msgstr "このチャートタイプでは最低2列が必要です"
+msgstr "این نوع نمودار نیاز به حداقل 2 ستون دارد."
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
-msgstr "このチャートタイプは、{0}個以上のデータをサポートしていません。"
+msgstr "این نوع نمودار بیش از {0} سری داده ها را پشتیبانی نمی کند."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:297
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
-msgstr "目標値"
+msgstr "هدف"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
-msgstr "クエリのデータが、選択した表示選択に適合しません。 このビジュアライゼーションには少なくとも{0} {1}のデータが必要です。"
+msgstr "دوو! داده های درخواست شما متناسب با انتخاب انتخاب صفحه نمایش نیست. این تجسم نیاز به حداقل {0} {1} داده دارد."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
 msgid_plural "columns"
-msgstr[0] "列"
+msgstr[0] "ستون"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "No dice. We have {0} data {1} to show and that's not enough for this visualization."
-msgstr "{0}データ{1}が表示可能ですが、このビジュアライゼーションには不十分です。"
+msgstr "بدون تاس. ما {0} داده {1} را برای نشان دادن داریم و برای این تجسم کافی نیست."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "point"
 msgid_plural "points"
-msgstr[0] "点"
+msgstr[0] "نقطه"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:35
 msgid "Bummer. We can't actually do a pin map for this data because we require both a latitude and longitude column."
-msgstr "緯度と経度の両方の列が必要なため、このデータのピンマップを作成できません。"
+msgstr "آزاردهنده. ما نمی توانیم برای این داده ها نقشه پین ​​را انجام دهیم، زیرا ما نیاز به ستون طول و عرض جغرافیایی داریم."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:55
 msgid "Please configure this chart in the chart settings"
-msgstr "チャート設定でこのチャートを設定してください"
+msgstr "لطفا این نمودار را در تنظیمات نمودار تنظیم کنید"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:57
 msgid "Edit Settings"
-msgstr "編集設定"
+msgstr "ویرایش تنظیمات"
 
 #: frontend/src/metabase/visualizations/lib/fill_data.js:37
 msgid "xValues missing!"
-msgstr "x値がありません"
+msgstr "xValues ​​گم شده!"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
-msgstr "X軸"
+msgstr "محور X"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
-msgstr "ブレークアウトのシリーズを追加する..."
+msgstr "شکستن سریال اضافه کنید ..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
-msgstr "Y軸"
+msgstr "محور Y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
-msgstr "別のシリーズを追加する..."
+msgstr "یک سری دیگر اضافه کنید ..."
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
-msgstr "吹き出しサイズ"
+msgstr "اندازه حباب"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:16
 msgid "Line"
-msgstr "線"
+msgstr "خط"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:72
 msgid "Curve"
-msgstr "曲線"
+msgstr "منحنی"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
-msgstr "ステップ"
+msgstr "گام"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:170
 msgid "Show point markers on lines"
-msgstr "線上にポイントマーカーを表示する"
+msgstr "نشانگرهای نقطه در خطوط"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
-msgstr "スタック中"
+msgstr "پشتهسازی"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
-msgstr "スタックしない"
+msgstr "پشته نکن"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
-msgstr "スタック"
+msgstr "پشته"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
-msgstr "スタック - 100%"
+msgstr "پشته - 100٪"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
-msgstr "目標値を表示する"
+msgstr "نمایش هدف"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
-msgstr "目標値"
+msgstr "ارزش هدف"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:103
 msgid "Replace missing values with"
-msgstr "欠測値を置き換える"
+msgstr "ارزش های گمشده را با"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:107
 msgid "Zero"
-msgstr "0"
+msgstr "صفر"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:108
 msgid "Nothing"
-msgstr "なし"
+msgstr "هیچ چی"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:109
 msgid "Linear Interpolated"
-msgstr "線形補間"
+msgstr "خطی Interpolated"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
-msgstr "X軸目盛"
+msgstr "مقیاس محور X"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
-msgstr "時系列"
+msgstr "سری زمانی"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:381
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
-msgstr "線形"
+msgstr "خطی"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:383
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
-msgstr "累乗"
+msgstr "قدرت"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:384
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
-msgstr "ログ"
+msgstr "ورود"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
-msgstr "ヒストグラム"
+msgstr "هیستوگرام"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
-msgstr "序数"
+msgstr "Ordinal"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
-msgstr "Y軸目盛"
+msgstr "مقیاس محور Y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
-msgstr "X軸線とマークを表示する"
+msgstr "نمایش خط x محور و علائم"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
-msgstr "コンパクト"
+msgstr "فشرده"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
-msgstr "45°回転"
+msgstr "چرخش 45 درجه"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
-msgstr "90°回転"
+msgstr "چرخش 90 درجه"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
-msgstr "Y軸線とマークを表示する"
+msgstr "نمایش خط محور y و علائم"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
-msgstr "自動Y軸範囲"
+msgstr "محدوده ی محدوده ی خودکار"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
-msgstr "必要に応じて分割したY軸を使用する"
+msgstr "در صورت لزوم از محور y تقسیم استفاده کنید"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
-msgstr "X軸にラベルを表示する"
+msgstr "برچسب را روی محور x نشان دهید"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
-msgstr "X軸ラベル"
+msgstr "برچسب محور X"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
-msgstr "Y軸のラベルを表示する"
+msgstr "نمایش برچسب در محور y"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
-msgstr "Y軸ラベル"
+msgstr "برچسب محور Y"
 
 #: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
-msgstr "標準偏差"
+msgstr "انحراف معیار"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
-msgstr "範囲"
+msgstr "حوزه"
 
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
-msgstr "範囲図"
+msgstr "نمودار منطقه"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
-msgstr "棒"
+msgstr "بار"
 
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
-msgstr "棒グラフ"
+msgstr "نمودار میله ای"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
-msgstr "どのフィールドを利用しますか？"
+msgstr "کدام فیلدها را می خواهید استفاده کنید؟"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
-msgstr "ファネル"
+msgstr "کانال"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
-msgstr "測定"
+msgstr "اندازه گرفتن"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
-msgstr "ファネルタイプ"
+msgstr "نوع قیف"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
-msgstr "棒グラフ"
+msgstr "نمودار میله ای"
 
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:19
 msgid "line chart"
-msgstr "折れ線グラフ"
+msgstr "نمودار خط"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
-msgstr "チャート設定で緯度と経度を選択してください"
+msgstr "لطفا ستون طول و عرض جغرافیایی را در تنظیمات نمودار انتخاب کنید."
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
-msgstr "地域マップを選択してください"
+msgstr "لطفا یک نقشه منطقه را انتخاب کنید"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 msgid "Please select region and metric columns in the chart settings."
-msgstr "チャート設定で地域とメトリクス列を選択してください"
+msgstr "لطفا ستون های منطقه و متریک را در تنظیمات نمودار انتخاب کنید."
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
-msgstr "マップ"
+msgstr "نقشه"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
-msgstr "マップタイプ"
+msgstr "نوع نقشه"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
-msgstr "地域マップ"
+msgstr "نقشه منطقه"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
-msgstr "ピンマップ"
+msgstr "نقشه پین"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
-msgstr "ピンタイプ"
+msgstr "نوع پین"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
-msgstr "タイル"
+msgstr "کاشی"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
-msgstr "マーカー"
+msgstr "نشانگرها"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
-msgstr "緯度"
+msgstr "زمینه عرض"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
-msgstr "経度"
+msgstr "میدان طول جغرافیایی"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
-msgstr "メトリクスフィールド"
+msgstr "زمینه متریک"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
-msgstr "地域フィールド"
+msgstr "زمینه منطقه"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
-msgstr "半径"
+msgstr "شعاع"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
-msgstr "ぼかし"
+msgstr "تاری"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
-msgstr "最小不透明度"
+msgstr "حداقل ابعاد"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
-msgstr "最大ズーム"
+msgstr "حداکثر زوم"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
-msgstr "関係は見つかりませんでした"
+msgstr "هیچ روابطی پیدا نشد"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
-msgstr "{0}経由"
+msgstr "از طریق {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
-msgstr "この{0}は接続していません:"
+msgstr "این {0} به متصل است:"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
-msgstr "オブジェクト詳細"
+msgstr "جزئیات شیء"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
-msgstr "オブジェクト"
+msgstr "هدف - شی"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
-msgstr "合計"
+msgstr "جمع"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
-msgstr "どの列を使用しますか？"
+msgstr "کدام ستون ها می خواهید استفاده کنید؟"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
-msgstr "円"
+msgstr "پای"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
-msgstr "ディメンション"
+msgstr "بعد، ابعاد، اندازه"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
-msgstr "凡例"
+msgstr "نمایش افسانه"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
-msgstr "凡例にパーセンテージを表示する"
+msgstr "نمایش درصد در افسانه"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
-msgstr "最小パーセンテージ"
+msgstr "حداقل قطعه قطعه"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
-msgstr "目標値に到達しました"
+msgstr "هدف ملاقات کرد"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
-msgstr "目標値を達成しました"
+msgstr "هدف بیش از حد است"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
-msgstr "目標値{0}"
+msgstr "هدف {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
-msgstr "進行状況のビジュアライゼーションには数値が必要です。"
+msgstr "تجسم پیشرفت نیاز به یک عدد دارد"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:27
 msgid "Progress"
-msgstr "プログレス"
+msgstr "پیش رفتن"
 
 #: frontend/src/metabase/entities/collections.js:109
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
-msgstr "色"
+msgstr "رنگ"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row Chart"
-msgstr "行グラフ"
+msgstr "نمودار ردیف"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
-msgstr "行グラフ"
+msgstr "نمودار ردیف"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
-msgstr "桁区切りスタイル"
+msgstr "سبک جداساز"
 
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:88
 msgid "Number of decimal places"
-msgstr "小数点以下の桁数"
+msgstr "تعداد اعشاری"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
-msgstr "接頭辞をつける"
+msgstr "افزودن یک پیشوند"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
-msgstr "接尾辞をつける"
+msgstr "یک پسوند را اضافه کنید"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
-msgstr "掛ける"
+msgstr "ضرب به یک عدد"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
-msgstr "散布"
+msgstr "پراکنده"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
-msgstr "散布図"
+msgstr "طرح پراکنده"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
-msgstr "テーブルをピボットする"
+msgstr "جدول را محکم بگیرید"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:73
 msgid "Visible fields"
-msgstr "表示されるフィールド"
+msgstr "زمینه های قابل مشاهده"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
 #, fuzzy
 msgid "Write here, and use Markdown if you'd like"
-msgstr "書き込みをし、ご自由にMarkdownをご利用ください"
+msgstr "اینجا بنویسید و از Markdown استفاده کنید اگر دوست دارید"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
 msgid "Vertical Alignment"
-msgstr "垂直配向"
+msgstr "چیدمان عمودی"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:77
 msgid "Top"
-msgstr "上"
+msgstr "بالا"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:78
 msgid "Middle"
-msgstr "中"
+msgstr "میانه"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:79
 msgid "Bottom"
-msgstr "下"
+msgstr "پایین"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:86
 msgid "Horizontal Alignment"
-msgstr "平行配向"
+msgstr "ترازبندی افقی"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:126
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:90
 msgid "Left"
-msgstr "左"
+msgstr "ترک کرد"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:91
 msgid "Center"
-msgstr "中央"
+msgstr "مرکز"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:127
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:92
 msgid "Right"
-msgstr "右"
+msgstr "درست"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:99
 msgid "Show background"
-msgstr "背景を表示する"
+msgstr "نمایش پس زمینه"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
-msgstr[0] "{0}ビン"
+msgstr[0] "{0} بن"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:731
 msgid "Auto binned"
-msgstr "自動ビニングされた"
+msgstr "خودکار متصل"
 
 #: src/metabase/api/alert.clj
 msgid "DELETE /api/alert/:id is deprecated. Instead, change its `archived` value via PUT /api/alert/:id."
-msgstr "DELETE /api/alert/:idは推奨されていません。 代わりに、'archived'値をPUT /api/alert/:idで変更してください。"
+msgstr "DELETE / api / alert /: id غیرفعال است در عوض، مقدار `archived 'خود را از طریق PUT / api / alert /: id تغییر دهید."
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid show value"
-msgstr "無効な表示値"
+msgstr "ارزش نشان دهنده نامعتبر است"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid value for prefix"
-msgstr "無効な敬称の値"
+msgstr "ارزش نامعتبر برای پیشوند"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid value for rule name"
-msgstr "無効なルール名の値"
+msgstr "نامعتبر برای نام قانون"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "value couldn''t be parsed as base64 encoded JSON"
-msgstr "値をbase64でエンコードされたJSONとして解析できませんでした"
+msgstr "ارزش نمی تواند به عنوان base64 کدگذاری شده JSON تجزیه شود"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid entity type"
-msgstr "無効なエンティティタイプ"
+msgstr "نوع موجودیت نامعتبر است"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid comparison entity type. Can only be one of \"table\", \"segment\", or \"adhoc\""
-msgstr "無効な比較エンティティタイプです。「テーブル」「セグメント」または「アドホック」のうち一つのみが選択可能です。"
+msgstr "نوع موجودیت مقایسه نادرست فقط می تواند یکی از \"جدول\"، \"بخش\" یا \"adhoc\" باشد"
 
 #: src/metabase/query_processor/async.clj
 msgid "Error running query to determine Card result metadata:"
-msgstr "カードの結果メタデータを測定するためのクエリ実行中にエラーが発生しました:"
+msgstr "خطا در اجرای پرس و جو برای تعیین Metadata نتیجه کارت:"
 
 #: src/metabase/api/card.clj
 msgid "DELETE /api/card/:id is deprecated. Instead, change its `archived` value via PUT /api/card/:id."
-msgstr "DELETE /api/card/:id は廃止されました。代わりに、PUT /api/card/:id を使用して`archived`の値を変更してください。"
+msgstr "DELETE / api / card /: id خسته شده است در عوض، مقدار `archived` خود را از طریق PUT / api / card /: id تغییر دهید."
 
 #: src/metabase/api/common.clj src/metabase/api/common/internal.clj
 msgid "Invalid field: {0}"
-msgstr "無効なフィールド: {0}"
+msgstr "فیلد نامعتبر: {0}"
 
 #: src/metabase/api/common.clj
 msgid "Invalid value ''{0}'' for ''{1}'': {2}"
-msgstr "{1}に対する無効な値「{0}」: {2}"
+msgstr "' {0} '' برای '' {1} '': {2} مقدار نامعتبر است"
 
 #: src/metabase/api/common.clj
 msgid "must be one of: {0}"
-msgstr "{0}の1つでなければならない"
+msgstr "باید یکی از موارد زیر باشد: {0}"
 
 #: src/metabase/api/common.clj
 msgid "Invalid Request."
-msgstr "無効なリクエスト"
+msgstr "درخواست نامعتبر"
 
 #: src/metabase/api/common.clj
 msgid "Not found."
-msgstr "見つかりませんでした"
+msgstr "پیدا نشد."
 
 #: src/metabase/api/common.clj
 msgid "You don''t have permissions to do that."
-msgstr "権限がありません"
+msgstr "شما این اجازه را ندارید."
 
 #: src/metabase/api/common.clj
 msgid "Internal server error."
-msgstr "サーバー内部エラー"
+msgstr "خطای سرور داخلی"
 
 #: src/metabase/api/common.clj
 msgid "Warning: endpoint {0}/{1} does not have a docstring."
-msgstr "警告: エンドポイント{0}/{1}はdocstringがありません"
+msgstr "هشدار: نقطه پایانی {0} / {1} دایرکتوری را ندارد"
 
 #: src/metabase/api/common.clj
 msgid "starting streaming request"
-msgstr "ストリーミングリクエスト開始中"
+msgstr "با شروع درخواست جریان"
 
 #: src/metabase/async/api_response.clj
 msgid "connection closed, canceling request"
-msgstr "接続が閉じられ、リクエストをキャンセルしています"
+msgstr "اتصال بسته، لغو درخواست"
 
 #. a newline padding character as it's harmless and will allow us to check if the client is connected. If
 #. sending this character fails because the connection is closed, the chan will then close.  Newlines are
 #. no-ops when reading JSON which this depends upon.
 #: src/metabase/async/api_response.clj
 msgid "Response not ready, writing one byte & sleeping..."
-msgstr "準備中..."
+msgstr "پاسخ آماده نیست، نوشتن یک بایت و خواب ..."
 
 #: src/metabase/api/common.clj
 msgid "Public sharing is not enabled."
-msgstr "公開は有効化されていません"
+msgstr "به اشتراک گذاری عمومی فعال نیست"
 
 #: src/metabase/api/common.clj
 msgid "Embedding is not enabled."
-msgstr "埋め込みは有効化されていません"
+msgstr "تعویض فعال نیست"
 
 #: src/metabase/api/common.clj
 msgid "The object has been archived."
-msgstr "対象がアーカイブされました"
+msgstr "این شیء بایگانی شده است."
 
 #: src/metabase/api/common/internal.clj
 msgid "Attempted to return a boolean as an API response. This is not allowed!"
-msgstr "API応答として真偽値を返そうとしました。 これは許可されていない処理です！"
+msgstr "تلاش برای بازگرداندن یک Boolean به عنوان پاسخ API. این مجاز نیست"
 
 #: src/metabase/api/dataset.clj
 msgid "Source query for this query is Card {0}"
-msgstr "このクエリのソースクエリは、カード{0}です。"
+msgstr "پرس و جو منبع برای این سوال کارت {0}"
 
 #: src/metabase/api/dataset.clj
 msgid "Invalid export format: {0}"
-msgstr "無効なエクスポートフォーマット: {0}"
+msgstr "قالب صادرات نامعتبر: {0}"
 
 #: src/metabase/api/geojson.clj
 msgid "Invalid JSON URL or resource: {0}"
-msgstr "無効なJSON URLまたはリソース: {0}"
+msgstr "URL یا منبع JSON نامعتبر است: {0}"
 
 #: src/metabase/api/geojson.clj
 msgid "JSON containing information about custom GeoJSON files for use in map visualizations instead of the default US State or World GeoJSON."
-msgstr "JSONには、米国または世界GeoJSONのデフォルトの代わりに、マップビジュアライゼーションで使用するカスタムGeoJSONファイルに関する情報が含まれています。"
+msgstr "JSON حاوی اطلاعاتی درباره فایل های GeoJSON سفارشی برای استفاده در تصویر برداری های نقشه به جای پیش فرض ایالات متحده یا جهان GeoJSON است."
 
 #: src/metabase/api/geojson.clj
 msgid "Invalid custom GeoJSON key: {0}"
-msgstr "無効なカスタムGeoJSONキー: {0}"
+msgstr "کلید GeoJSON سفارشی نامعتبر است: {0}"
 
 #. ...but if we *still* couldn't find a match, throw an Exception, because we don't want people
 #. trying to inject new params
 #: src/metabase/api/public.clj
 msgid "Invalid param: {0}"
-msgstr "無効なパラメータ―: {0}"
+msgstr "پارامتر نامعتبر: {0}"
 
 #: src/metabase/api/pulse.clj
 msgid "DELETE /api/pulse/:id is deprecated. Instead, change its `archived` value via PUT /api/pulse/:id."
-msgstr "DELETE /api/pulse/:idは推奨されていません。 代わりに、'archived'値をPUT /api/pulse/:idで変更してください。"
+msgstr "DELETE / api / pulse /: id تخفیف است در عوض، مقدار `archived` خود را از طریق PUT / api / pulse /: id تغییر دهید."
 
 #: src/metabase/api/routes.clj
 msgid "API endpoint does not exist."
-msgstr "APIエンドポイントが存在しません"
+msgstr "پایان نقطه API موجود نیست"
 
 #: src/metabase/api/session.clj
 msgid "Password did not match stored password."
-msgstr "保存されたパスワードと一致しませんでした"
+msgstr "رمز عبور با رمز ذخیره شده مطابقت ندارد."
 
 #: src/metabase/api/session.clj
 msgid "did not match stored password"
-msgstr "保存されたパスワードと一致しませんでした"
+msgstr "با رمز ذخیره شده مطابقت نداشت"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fallback to local authentication {0}"
-msgstr "LDAPサーバーへの接続中に問題が発生しました。ローカル認証{0}にフォールバックします。"
+msgstr "مشکل اتصال به سرور LDAP، اعتبار احراز هویت محلی خواهد بود {0}"
 
 #: src/metabase/api/session.clj
 msgid "Invalid reset token"
-msgstr "無効なリセットトークン"
+msgstr "نشانگر مجدد نامعتبر است"
 
 #: src/metabase/api/session.clj
 msgid "Client ID for Google Auth SSO. If this is set, Google Auth is considered to be enabled."
-msgstr "Google Auth SSOのクライアントID。こちらが設定されている場合、Google Authは有効化されていると見なされます"
+msgstr "شناسه مشتری برای Google Auth SSO اگر این تنظیم شده باشد، Google Auth در نظر گرفته شود که فعال باشد."
 
 #: src/metabase/api/session.clj
 msgid "When set, allow users to sign up on their own if their Google account email address is from this domain."
-msgstr "設定されていると、Googleメールアドレスがこのドメインを使用している場合ユーザーは自分でサインアップすることができます"
+msgstr "هنگام تنظیم، کاربران را مجبور به ثبت نام در صورتی که آدرس ایمیل حساب Google خود از این دامنه است."
 
 #: src/metabase/api/session.clj
 msgid "Invalid Google Auth token."
-msgstr "無効なGoogle Authトークン"
+msgstr "نام مستعار Google Auth نامعتبر است"
 
 #: src/metabase/api/session.clj
 msgid "Email is not verified."
-msgstr "メールが確認されていません"
+msgstr "ایمیل تایید نشده است."
 
 #: src/metabase/api/session.clj
 msgid "You''ll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Googleを利用してログインするには、事前に管理者がMetabaseアカウントを作成する必要があります"
+msgstr "قبل از اینکه بتوانید از Google برای ورود به سیستم، یک حساب کاربری Metabase ایجاد کنید، به یک مدیر نیاز خواهید داشت."
 
 #: src/metabase/api/session.clj
 msgid "Successfully authenticated Google Auth token for: {0} {1}"
-msgstr "{0} {1}のGoogle Authトークンの認証に成功しました"
+msgstr "Google Auth Token برای گواهی موفقیت آمیز: {0} {1}"
 
 #: src/metabase/api/setup.clj
 msgid "Add a database"
-msgstr "データベースを追加する"
+msgstr "یک پایگاه داده اضافه کنید"
 
 #: src/metabase/api/setup.clj
 msgid "Get connected"
-msgstr "接続する"
+msgstr "متصل شوید"
 
 #: src/metabase/api/setup.clj
 msgid "Connect to your data so your whole team can start to explore."
-msgstr "チームの全員がデータを見れるようにしましょう"
+msgstr "به داده های خود متصل شوید، بنابراین کل تیم شما می تواند شروع به کشف کند."
 
 #: src/metabase/api/setup.clj
 msgid "Set up email"
-msgstr "メールの設定"
+msgstr "ایمیل را تنظیم کنید"
 
 #: src/metabase/api/setup.clj
 msgid "Add email credentials so you can more easily invite team members and get updates via Pulses."
-msgstr "メールの資格情報を追加すると、チームメンバーをより簡単に招待し、パルスを通じて更新情報を入手することができます。"
+msgstr "افزودن اعتبارنامه ایمیل، بنابراین شما می توانید به راحتی اعضای تیم را دعوت کنید و از Pulses به روز رسانی کنید."
 
 #: src/metabase/api/setup.clj
 msgid "Set Slack credentials"
-msgstr "Slackの認証情報をセットする"
+msgstr "مدارک Slack را تنظیم کنید"
 
 #: src/metabase/api/setup.clj
 msgid "Does your team use Slack? If so, you can send automated updates via pulses and ask questions with MetaBot."
-msgstr "チームはSlackを使用していますか？使用している場合、自動アップデートをパルスで送信し、MetaBotで質問することができます。"
+msgstr "آیا تیم شما از Slack استفاده می کند؟ اگر چنین است، شما می توانید به روز رسانی خودکار از طریق پالس ها ارسال کنید و سوالات را با MetaBot بپرسید."
 
 #: src/metabase/api/setup.clj
 msgid "Invite team members"
-msgstr "チームメンバーを招待する"
+msgstr "دعوت از اعضای تیم"
 
 #: src/metabase/api/setup.clj
 msgid "Share answers and data with the rest of your team."
-msgstr "チームと回答やデータを共有する"
+msgstr "به اشتراک گذاشتن پاسخ ها و اطلاعات با بقیه تیم خود."
 
 #: src/metabase/api/setup.clj
 msgid "Hide irrelevant tables"
-msgstr "無関係なテーブルを非表示にする"
+msgstr "پنهان کردن جداول نامناسب"
 
 #: src/metabase/api/setup.clj
 msgid "Curate your data"
-msgstr "データを公開する"
+msgstr "داده های شما را خراب می کند"
 
 #: src/metabase/api/setup.clj
 msgid "If your data contains technical or irrelevant info you can hide it."
-msgstr "データが技術的または無関係な情報を含む場合、非表示にすることができます"
+msgstr "اگر اطلاعات شما حاوی اطلاعات فنی یا بی اهمیت باشد، می توانید آن را پنهان کنید."
 
 #: src/metabase/api/setup.clj
 msgid "Organize questions"
-msgstr "質問を管理する"
+msgstr "سازماندهی سوالات"
 
 #: src/metabase/api/setup.clj
 msgid "Have a lot of saved questions in {0}? Create collections to help manage them and add context."
-msgstr "{0}に保存された質問が多数ありますか？整理するのにコレクションを使用しましょう。"
+msgstr "سوالهای ذخیره شده زیادی در {0} دارید؟ ایجاد مجموعه برای کمک به مدیریت آنها و اضافه کردن زمینه."
 
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
@@ -7418,1660 +7447,1660 @@ msgstr "Metabase"
 
 #: src/metabase/api/setup.clj
 msgid "Create metrics"
-msgstr "メトリクスを作成する"
+msgstr "ایجاد معیارها"
 
 #: src/metabase/api/setup.clj
 msgid "Define canonical metrics to make it easier for the rest of your team to get the right answers."
-msgstr "チームが正しい回答を得られるよう標準的なメトリクスを定義する"
+msgstr "معیارهای کانونی را تعریف کنید تا بقیه تیم خود را برای دریافت پاسخ مناسب آسانتر کنید."
 
 #: src/metabase/api/setup.clj
 msgid "Create segments"
-msgstr "セグメントを作成する"
+msgstr "ایجاد بخش ها"
 
 #: src/metabase/api/setup.clj
 msgid "Keep everyone on the same page by creating canonical sets of filters anyone can use while asking questions."
-msgstr "質問をする際に誰でも使用できる標準的なフィルターを作成し、利用者全員に共通認識を持たせましょう。"
+msgstr "هر کس را در همان صفحه نگه دارید، با ایجاد مجموعه ای از فیلترهایی که هرکسی می تواند هنگام سوال کردن استفاده کند."
 
 #: src/metabase/api/table.clj
 msgid "Table ''{0}'' is now visible. Resyncing."
-msgstr "テーブル \"{0}\" は表示設定されています。再同期中。"
+msgstr "جدول '' {0} '' در حال حاضر قابل مشاهده است Resyncing"
 
 #: src/metabase/api/table.clj
 msgid "Auto bin"
-msgstr "自動ビン"
+msgstr "بنز اتوماتیک"
 
 #: src/metabase/api/table.clj
 msgid "Don''t bin"
-msgstr "ビニングしない"
+msgstr "نه بیرون"
 
 #: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
-msgstr[0] "日"
+msgstr[0] "روز ها"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
 #: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
-msgstr[0] "分"
+msgstr[0] "دقیقه ها"
 
 #: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
-msgstr[0] "時間"
+msgstr[0] "ساعت ها"
 
 #: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
-msgstr[0] "四半期"
+msgstr[0] "ربع"
 
 #: src/metabase/api/table.clj
 msgid "Minute of Hour"
-msgstr "1時間のうち1分"
+msgstr "دقیقه ساعت"
 
 #: src/metabase/api/table.clj
 msgid "Hour of Day"
-msgstr "1日のうち1時間"
+msgstr "ساعت از روز"
 
 #: src/metabase/api/table.clj
 msgid "Day of Week"
-msgstr "1週間のうち1日"
+msgstr "روز هفته"
 
 #: src/metabase/api/table.clj
 msgid "Day of Month"
-msgstr "1か月のうち1日"
+msgstr "روز ماه"
 
 #: src/metabase/api/table.clj
 msgid "Day of Year"
-msgstr "1年のうち1日"
+msgstr "روز سال"
 
 #: src/metabase/api/table.clj
 msgid "Week of Year"
-msgstr "1年のうち1週間"
+msgstr "هفته سال"
 
 #: src/metabase/api/table.clj
 msgid "Month of Year"
-msgstr "1年のうち1か月"
+msgstr "ماه سال"
 
 #: src/metabase/api/table.clj
 msgid "Quarter of Year"
-msgstr "1年の4分の1"
+msgstr "چهارم سال"
 
 #: src/metabase/api/table.clj
 msgid "10 bins"
-msgstr "10ビン"
+msgstr "10 سطل"
 
 #: src/metabase/api/table.clj
 msgid "50 bins"
-msgstr "50ビン"
+msgstr "50 مخزن"
 
 #: src/metabase/api/table.clj
 msgid "100 bins"
-msgstr "100ビン"
+msgstr "100 مخزن"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 0.1 degrees"
-msgstr "0.1度ごとにビニングする"
+msgstr "بن هر 0.1 درجه"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 1 degree"
-msgstr "1度ごとにビニングする"
+msgstr "بن هر 1 درجه"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 10 degrees"
-msgstr "10度ごとにビニングする"
+msgstr "بن هر 10 درجه"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 20 degrees"
-msgstr "20度ごとにビニングする"
+msgstr "بن هر 20 درجه"
 
 #. returns `true` if successful -- see JavaDoc
 #: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
-msgstr "最適なイメージライターが見つかりませんでした"
+msgstr "هیچ نویسنده تصویر مناسب پیدا نشد!"
 
 #: src/metabase/api/user.clj
 msgid "Email address already in use."
-msgstr "メールアドレスはすでに使用されています"
+msgstr "آدرس ایمیل در حال استفاده است"
 
 #: src/metabase/api/user.clj
 msgid "Email address already associated to another user."
-msgstr "メールアドレスは他ユーザーがすでに使用しています"
+msgstr "آدرس ایمیل در حال حاضر به کاربر دیگری مرتبط است"
 
 #: src/metabase/api/user.clj
 msgid "Not able to reactivate an active user"
-msgstr "アクティブユーザーを再有効化することはできません"
+msgstr "قادر به فعال کردن یک کاربر فعال نیست"
 
 #: src/metabase/api/user.clj
 msgid "Invalid password"
-msgstr "無効なパスワード"
+msgstr "رمز عبور نامعتبر"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "All {0}"
-msgstr "全{0}"
+msgstr "همه {0}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "{0}, all {1}"
-msgstr "{0}、全{1}"
+msgstr "{0}، همه {1}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "Comparison of {0} and {1}"
-msgstr "{0}と{1}の比較"
+msgstr "مقایسه {0} و {1}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "Automatically generated comparison dashboard comparing {0} and {1}"
-msgstr "{0}と{1}を比較する比較ダッシュボードが自動作成されました"
+msgstr "داشبورد مقایسه به صورت خودکار ایجاد شده در مقایسه با {0} و {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "sum"
-msgstr "合計"
+msgstr "مجموع"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "average"
-msgstr "平均"
+msgstr "میانگین"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "minumum"
-msgstr "最低"
+msgstr "کمترین"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "maximum"
-msgstr "最大"
+msgstr "بیشترین"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "distinct count"
-msgstr "重複を除いたカウント"
+msgstr "تعداد مجزا"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "standard deviation"
-msgstr "標準偏差"
+msgstr "انحراف معیار"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative count"
-msgstr "累積カウント"
+msgstr "شمارش تجمعی"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative sum"
-msgstr "累積和"
+msgstr "جمع تجمعی"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} and {1}"
-msgstr "{0}と{1}"
+msgstr "{0} و {1}"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
-msgstr "{1}の{0}"
+msgstr "{0} از {1}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
-msgstr "{1}で{0}"
+msgstr "{0} توسط {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} in the {1} segment"
-msgstr "{1}セグメントの{0}"
+msgstr "{0} در بخش {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} segment"
-msgstr "{0}セグメント"
+msgstr "{0} بخش"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
 msgid_plural "{0} metrics"
-msgstr[0] "{0}メトリクス"
+msgstr[0] "{0} متریک"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
-msgstr "{0}フィールド"
+msgstr "{0} فیلد"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "\"{0}\" question"
-msgstr "\"{0}\"質問"
+msgstr "\"{0}\" سوال"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Compare with {0}"
-msgstr "{0}と比較する"
+msgstr "مقایسه با {0}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Compare with entire dataset"
-msgstr "全データセットと比較する"
+msgstr "مقایسه با مجموعه داده های کل"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Applying heuristic %s to %s."
-msgstr "ヒューリスティック%sを%sに適用しています"
+msgstr "اعمال٪ s به٪ s."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Dimensions bindings:n%s"
-msgstr "ディメンションのバインディング: n%s"
+msgstr "اتصالات ابعاد: n٪ s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Using definitions:nMetrics:n%snFilters:n%s"
-msgstr "定義を使用中:nMetrics:n%snFilters:n%s"
+msgstr "با استفاده از تعاریف: nMetrics: n٪ snFilters: n٪ s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Can''t create dashboard for {0}"
-msgstr "{0}のダッシュボードが作成できません"
+msgstr "نمیتوان داشبورد را برای {0} ایجاد کرد"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}st"
-msgstr "{0}番目"
+msgstr "{0} خیابان"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}nd"
-msgstr "{0}番目"
+msgstr "{0} nd"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}rd"
-msgstr "{0}番目"
+msgstr "{0} rd"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}th"
-msgstr "{0}番目"
+msgstr "{0} th"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "at {0}"
-msgstr "{0}で"
+msgstr "در {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "on {0}"
-msgstr "{0}で"
+msgstr "در {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in {0} week - {1}"
-msgstr "{0}週 - {1}"
+msgstr "در {0} هفته - {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in {0}"
-msgstr "{0}で"
+msgstr "در {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in Q{0} - {1}"
-msgstr "Q{0} - {1}で"
+msgstr "در Q {0} - {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Q{0}"
-msgstr "Ｑ{0}"
+msgstr "Q {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is {1}"
-msgstr "{0}は{1}"
+msgstr "{0} {1} است"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is between {1} and {2}"
-msgstr "{0}は{1}と{2}の間"
+msgstr "{0} بین {1} و {2}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is between {1} and {2}; and {3} is between {4} and {5}"
-msgstr "{0}は{1}と{2}の間、{3}は{4}と{5}の間"
+msgstr "{0} بین {1} و {2} است و {3} بین {4} و {5}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "where {0}"
-msgstr "{0}で"
+msgstr "جایی که {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "A closer look at {0}"
-msgstr "{0}を詳しく見る"
+msgstr "یک نگاه نزدیک به {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "A closer look at the {0}"
-msgstr "{0}を詳しく見る"
+msgstr "نگاهی نزدیک به {0}"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding %s cards to dashboard %s:n%s"
-msgstr "%sカードをダッシュボード%s:n%sに追加中"
+msgstr "افزودن٪ s کارت به داشبورد٪ s: n٪ s"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "0 <= score <= {0}"
-msgstr "0 <= スコア <= {0}"
+msgstr "0 <= score <= {0}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "1 <= width <= {0}"
-msgstr "1 <= 幅 <= {0}"
+msgstr "1 <= عرض <= {0}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid metrics references"
-msgstr "有効なメトリクス参照"
+msgstr "مراجع معتبر معیارهای"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid filters references"
-msgstr "有効なフィルター参照"
+msgstr "منابع معتبر فیلتر شده"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid group references"
-msgstr "有効なグループ参照"
+msgstr "مراجع معتبر گروه"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid order_by references"
-msgstr "有効なorder_by参照"
+msgstr "مدارک معتبر سفارشات"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid dashboard filters references"
-msgstr "有効なダッシュボードフィルター参照"
+msgstr "داشبورد معتبر فیلترهای مراجع"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid dimension references"
-msgstr "有効なディメンション参照"
+msgstr "ارجاع ابعاد معتبر"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid card dimension references"
-msgstr "有効なカードディメンション参照"
+msgstr "مراجع ابعاد کارت معتبر"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Error parsing %s:n%s"
-msgstr "%s:n%sを解析中にエラーが発生しました。"
+msgstr "خطا در تجزیه٪ s: n٪ s"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "No user found with email address ''{0}''. "
-msgstr "メールアドレス\"{0}\"のユーザーが見つかりませんでした"
+msgstr "هیچ کاربر با آدرس ایمیل '' {0} '' یافت نشد"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Please check the spelling and try again."
-msgstr "スペルを確認し再度お試しください"
+msgstr "لطفا املای خود را بررسی کنید و دوباره امتحان کنید."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Resetting password for {0}..."
-msgstr "{0}のパスワードをリセットしています..."
+msgstr "تنظیم مجدد رمز عبور برای {0} ..."
 
 #: src/metabase/cmd/reset_password.clj
 msgid "OK [[[{0}]]]"
-msgstr "成功 [[[{0}]]]"
+msgstr "OK [[[{0}]]]"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "FAIL [[[{0}]]]"
-msgstr "失敗 [[[{0}]]]"
+msgstr "فايل [[[{0}]]]"
 
 #: src/metabase/core.clj
 msgid "Please use the following URL to setup your Metabase installation:"
-msgstr "Metabaseインストールを設定するには次のURLを使用してください:"
+msgstr "لطفا برای نصب Metabase Metabase از URL زیر استفاده کنید:"
 
 #: src/metabase/core.clj
 msgid "Metabase Shutting Down ..."
-msgstr "Metabaseをシャットダウン中..."
+msgstr "متاباز خاموش کردن ..."
 
 #: src/metabase/core.clj
 msgid "Metabase Shutdown COMPLETE"
-msgstr "Metabaseのシャットダウンが完了しました"
+msgstr "Metabase Shutdown COMPLETE"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase version {0} ..."
-msgstr "Metabaseバージョン{0}を起動中..."
+msgstr "شروع نسخه Metabase {0} ..."
 
 #: src/metabase/core.clj
 msgid "System timezone is ''{0}'' ..."
-msgstr "システムタイムゾーンは\"{0}\"です..."
+msgstr "منطقه زمانی سیستم است '' {0} '' ..."
 
 #. startup database.  validates connection & runs any necessary migrations
 #: src/metabase/core.clj
 msgid "Setting up and migrating Metabase DB. Please sit tight, this may take a minute..."
-msgstr "Metabase DBのセットアップとマイグレーション中。これには時間がかかることがあります。"
+msgstr "راه اندازی و مهاجرت Metabase DB. لطفا کمی تنگ بشوید، ممکن است یک دقیقه طول بکشد ..."
 
 #: src/metabase/core.clj
 msgid "Looks like this is a new installation ... preparing setup wizard"
-msgstr "新規インストールのようです。セットアップウィザードを準備中。"
+msgstr "به نظر می رسد این یک نصب جدید است ... آماده سازی جادوگر راه اندازی"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization COMPLETE"
-msgstr "Metabaseの初期化が完了しました"
+msgstr "شروع اولیه Metabase"
 
 #: src/metabase/server.clj
 msgid "Launching Embedded Jetty Webserver with config:"
-msgstr "埋め込みJetty Webserverを起動中 設定:"
+msgstr "راه اندازی جاسازی شده جتتی وب سرور با پیکربندی:"
 
 #: src/metabase/server.clj
 msgid "Shutting Down Embedded Jetty Webserver"
-msgstr "埋め込みJetty Webserverをシャットダウン中"
+msgstr "وب سایت جتتی جاسازی شده را خاموش می کند"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase in STANDALONE mode"
-msgstr "MetabaseをSTANDALONEモードで起動中"
+msgstr "شروع Metabase در حالت STANDALONE"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization FAILED"
-msgstr "Metabaseの初期化に失敗しました"
+msgstr "ابتدایی Metabase ناپدید شد"
 
 #: src/metabase/db.clj
 msgid "Database has migration lock; cannot run migrations."
-msgstr "データベースはマイグレーションロックされています。マイグレーションを実行できません。"
+msgstr "پایگاه داده دارای قفل مهاجرت است. نمی توان مهاجرت کرد"
 
 #: src/metabase/db.clj
 msgid "You can force-release these locks by running `java -jar metabase.jar migrate release-locks`."
-msgstr "`java -jar metabase.jar migrate release-locks`を実行することでこのロックを強制解除することができます"
+msgstr "شما می توانید این قفل ها را با اجرای `java -jar metabase.jar migrate release-locks 'باز کنید."
 
 #: src/metabase/db.clj
 msgid "Checking if Database has unrun migrations..."
-msgstr "データベースがマイグレーションを取り消したか確認中..."
+msgstr "بررسی اینکه آیا بانک اطلاعاتی مهاجرت نشده است ..."
 
 #: src/metabase/db.clj
 msgid "Database has unrun migrations. Waiting for migration lock to be cleared..."
-msgstr "データベースはマイグレーションを取り消しました。 マイグレーションロックが解除されるのを待っています..."
+msgstr "بانک اطلاعاتی مهاجرت نشده است. منتظر قفل مهاجرت هستیم ..."
 
 #: src/metabase/db.clj
 msgid "Migration lock is cleared. Running migrations..."
-msgstr "マイグレーションロックが解除されました。マイグレーションを実行中..."
+msgstr "قفل مهاجرت پاک شده است. مهاجرت در حال اجرا ..."
 
 #: src/metabase/db.clj
 msgid "Migration lock cleared, but nothing to do here! Migrations were finished by another instance."
-msgstr "マイグレーションロックは解除されましたが、ここでは処理されません！ マイグレーションは別のインスタンスで終了しました。"
+msgstr "قفل مهاجرت پاک شده است، اما هیچ چیز برای انجام این کار وجود ندارد! مهاجرت به وسیله یک نمونه دیگر انجام شد."
 
 #. Set up liquibase and let it do its thing
 #: src/metabase/db.clj
 msgid "Setting up Liquibase..."
-msgstr "Liquibaseの設定中..."
+msgstr "راه اندازی Liquibase ..."
 
 #: src/metabase/db.clj
 msgid "Liquibase is ready."
-msgstr "Liquibaseの準備ができました"
+msgstr "Liquibase آماده است"
 
 #: src/metabase/db.clj
 msgid "Verifying {0} Database Connection ..."
-msgstr "{0}データベース接続を確認中..."
+msgstr "بررسی {0} اتصال به پایگاه داده ..."
 
 #: src/metabase/db.clj
 msgid "Verify Database Connection ... "
-msgstr "データベース接続を確認... "
+msgstr "اتصال پایگاه داده را بررسی کنید ..."
 
 #: src/metabase/db.clj
 msgid "Running Database Migrations..."
-msgstr "データベースマイグレーションを実行中..."
+msgstr "مهاجرت پایگاه داده در حال اجرا ..."
 
 #: src/metabase/db.clj
 msgid "Database Migrations Current ... "
-msgstr "データベースマイグレーションは現在... "
+msgstr "..."
 
 #: src/metabase/driver/common.clj
 msgid "Hmm, we couldn''t connect to the database."
-msgstr "データベースに接続できませんでした"
+msgstr "هوم، ما نمی توانیم به پایگاه داده وصل شویم."
 
 #: src/metabase/driver/common.clj
 msgid "Make sure your host and port settings are correct"
-msgstr "ホストとポート設定が正しいことをお確かめください"
+msgstr "اطمینان حاصل کنید که تنظیمات میزبان و پورت شما صحیح است"
 
 #: src/metabase/driver/common.clj
 msgid "We couldn''t connect to the ssh tunnel host."
-msgstr "SSHトンネルホストに接続できませんでした"
+msgstr "ما نمی توانیم به میزبان تونل ssh متصل شویم."
 
 #: src/metabase/driver/common.clj
 msgid "Check the username, password."
-msgstr "ユーザーネームとパスワードをお確かめください"
+msgstr "نام کاربری، رمز عبور را بررسی کنید."
 
 #: src/metabase/driver/common.clj
 msgid "Check the hostname and port."
-msgstr "ホスト名とポートをお確かめください"
+msgstr "نام میزبان و پورت را بررسی کنید."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like the database name is incorrect."
-msgstr "データベース名が間違っているようです"
+msgstr "به نظر می رسد نام پایگاه داده نادرست است."
 
 #: src/metabase/driver/common.clj
 msgid "It looks like your host is invalid."
-msgstr "ホストが無効のようです"
+msgstr "به نظر می رسد میزبان شما نامعتبر است"
 
 #: src/metabase/driver/common.clj
 msgid "Please double-check it and try again."
-msgstr "再度ご確認の上お試しください"
+msgstr "لطفا آن را بررسی کنید و دوباره امتحان کنید."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like your password is incorrect."
-msgstr "パスワードが間違っているようです"
+msgstr "به نظر می رسد رمز عبور شما اشتباه است"
 
 #: src/metabase/driver/common.clj
 msgid "Looks like you forgot to enter your password."
-msgstr "パスワードが入力されていないようです"
+msgstr "به نظر می رسد که رمز عبور خود را فراموش کرده اید."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like your username is incorrect."
-msgstr "ユーザー名が間違っているようです"
+msgstr "به نظر می رسد نام کاربری شما نادرست است."
 
 #: src/metabase/driver/common.clj
 msgid "Looks like the username or password is incorrect."
-msgstr "ユーザーネームまたはパスワードが間違っているようです"
+msgstr "به نظر می رسد که نام کاربری یا رمز عبور نادرست است."
 
 #. ## CONFIG
 #: src/metabase/driver.clj
 msgid "Connection timezone to use when executing queries. Defaults to system timezone."
-msgstr "クエリを実行するときに使用する接続タイムゾーン。 デフォルトはシステムタイムゾーンです。"
+msgstr "زمان اتصال اتصال برای استفاده در هنگام اجرای پرس و جو. به طور پیش فرض به منطقه زمانی سیستم"
 
 #: src/metabase/driver.clj
 msgid "Registered driver {0} {1}"
-msgstr "登録されたドライバー{0} {1}"
+msgstr "راننده ثبت شده {0} {1}"
 
 #: src/metabase/driver.clj
 msgid "No -init-driver function found for ''{0}''"
-msgstr "\"{0}\"の初期ドライバー機能が見つかりません。"
+msgstr "هیچ تابع راننده برای '' {0} '' یافت نشد"
 
 #: src/metabase/driver/common.clj
 msgid "Unable to parse date string ''{0}'' for database engine ''{1}''"
-msgstr "データベースエンジン\"{1}\"の日付文字列\"{0}\"を解析できません。"
+msgstr "قادر به تجزیه تاریخ رشته '' {0} '' برای موتور پایگاه داده '' {1} ''"
 
 #. all-NULL columns in DBs like Mongo w/o explicit types
 #: src/metabase/driver/common.clj
 msgid "Don''t know how to map class ''{0}'' to a Field base_type, falling back to :type/*."
-msgstr "クラス\"{0}\"をフィールドbase_typeにマップする方法が不明です。:type/*.にお戻りください。"
+msgstr "نمی دانید که چگونه کلاس '' {0} '' را به یک فیلد base_type ارجاع دهید، به نوع: / *."
 
 #: src/metabase/driver/util.clj
 msgid "Failed to connect to database: {0}"
-msgstr "データベースへの接続が失敗しました: {0}"
+msgstr "اتصال به پایگاه داده نشد: {0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Invalid BigQuery identifier: ''{0}''"
-msgstr "無効なBigQuery識別子: \"{0}\""
+msgstr "شناسه BigQuery نامعتبر است: '' {0} ''"
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can't be parameterized!"
-msgstr "BigQueryステートメントをパラメーター化することはできません。"
+msgstr "اظهارات BigQuery نمی تواند پارامتر شود!"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone:"
-msgstr "タイムゾーンの設定に失敗しました:"
+msgstr "تنظیم منطقه زمانی تنظیم نشد"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "You must enable the Google Analytics API. Use this link to go to the Google Developers Console: {0}"
-msgstr "Google Analytics APIを有効化する必要があります。こちらのリンクを利用しGoogle Developers Consoleにアクセスしてください: {0}"
+msgstr "شما باید API Google Analytics را فعال کنید. برای رفتن به کنسول Google Developers Console از این لینک استفاده کنید: {0}"
 
 #: src/metabase/driver/h2.clj
 msgid "Running SQL queries against H2 databases using the default (admin) database user is forbidden."
-msgstr "デフォルトの（管理者）データベースユーザーを使用してH2データベースに対してSQLクエリを実行することは禁じられています。"
+msgstr "در حال انجام پرس و جو SQL در برابر پایگاه داده های H2 با استفاده از کاربر پایگاه داده به طور پیش فرض (admin) ممنوع است."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Error: metabase.driver.FixedHiveDriver is registered, but JDBC does not seem to be using it."
-msgstr "エラー: metabase.driver.FixedHiveDriverは登録されていますが、JDBCがそれを使用していないようです。"
+msgstr "خطا: metabase.driver.FixedHiveDriver ثبت شده است، اما JDBC به نظر نمی رسد از آن استفاده کند."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Found metabase.driver.FixedHiveDriver."
-msgstr "metabase.driver.FixedHiveDriverが見つかりました。"
+msgstr "metabase.driver.FixedHiveDriver یافت شد"
 
 #: src/metabase/driver/sparksql.clj
 msgid "Successfully registered metabase.driver.FixedHiveDriver with JDBC."
-msgstr "metabase.driver.FixedHiveDriverが正常にJDBCに登録されました。"
+msgstr "Metabase.driver.FixedHiveDriver با JDBC ثبت نام شده است."
 
 #. CONFIG
 #. TODO - smtp-port should be switched to type :integer
 #: src/metabase/email.clj
 msgid "Email address you want to use as the sender of Metabase."
-msgstr "Metabaseの送信者として使用したいメールアドレス"
+msgstr "آدرس ایمیل شما می خواهید به عنوان فرستنده Metabase استفاده کنید."
 
 #: src/metabase/email.clj
 msgid "The address of the SMTP server that handles your emails."
-msgstr "メール管理をするSMTPサーバーのアドレス"
+msgstr "آدرس سرور SMTP که ایمیل های شما را مدیریت می کند."
 
 #: src/metabase/email.clj
 msgid "SMTP username."
-msgstr "SMTPユーザー名"
+msgstr "نام کاربری SMTP"
 
 #: src/metabase/email.clj
 msgid "SMTP password."
-msgstr "SMTPパスワード"
+msgstr "رمز عبور SMTP"
 
 #: src/metabase/email.clj
 msgid "The port your SMTP server uses for outgoing emails."
-msgstr "メール送信に使用するSMTPサーバーのポート"
+msgstr "پورت سرور SMTP شما برای ایمیل های خروجی استفاده می کند."
 
 #: src/metabase/email.clj
 msgid "SMTP secure connection protocol. (tls, ssl, starttls, or none)"
-msgstr "SMTP接続プロトコル（TLS、SSL、STARTTLS、または該当なし）"
+msgstr "پروتکل اتصال ایمن SMTP (tls، ssl، starttls، یا none)"
 
 #: src/metabase/email.clj
 msgid "none"
-msgstr "なし"
+msgstr "هیچ یک"
 
 #: src/metabase/email.clj
 msgid "SMTP host is not set."
-msgstr "SMTPホストが設定されていません"
+msgstr "میزبان SMTP تنظیم نشده است."
 
 #: src/metabase/email.clj
 msgid "Failed to send email"
-msgstr "メールの送信に失敗しました"
+msgstr "ایمیل ارسال نشد"
 
 #: src/metabase/email.clj
 msgid "Error testing SMTP connection"
-msgstr "SMTP接続テストエラー"
+msgstr "خطا در اتصال به SMTP"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Enable LDAP authentication."
-msgstr "LDAP認証を有効化する"
+msgstr "تأیید هویت LDAP را فعال کنید"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Server hostname."
-msgstr "サーバーホスト名"
+msgstr "نام میزبان سرور"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Server port, usually 389 or 636 if SSL is used."
-msgstr "サーバーポート、SSLを使用している場合は通常389または636です"
+msgstr "پورت سرور، معمولا 389 یا 636 اگر SSL استفاده شود."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Use SSL, TLS or plain text."
-msgstr "SSL、TLSまたはプレーンテキストを使用する"
+msgstr "از SSL، TLS یا متن ساده استفاده کنید."
 
 #: src/metabase/integrations/ldap.clj
 msgid "The Distinguished Name to bind as (if any), this user will be used to lookup information about other users."
-msgstr "バインドの識別名（ある場合）。このユーザーは、他のユーザーに関する情報を参照するために使用されます。"
+msgstr "نام متمایز برای اتصال (به عنوان مثال)، این کاربر برای جستجوی اطلاعات در مورد سایر کاربران استفاده خواهد شد."
 
 #: src/metabase/integrations/ldap.clj
 msgid "The password to bind with for the lookup user."
-msgstr "検索ユーザー用にバインドするパスワード"
+msgstr "رمز عبور برای اتصال کاربر برای جستجو."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Search base for users. (Will be searched recursively)"
-msgstr "ユーザーのための検索ベース。 （繰り返し検索されます）"
+msgstr "پایگاه جستجوی کاربران (به صورت بازگشتی جستجو می شود)"
 
 #: src/metabase/integrations/ldap.clj
 msgid "User lookup filter, the placeholder '{login}' will be replaced by the user supplied login."
-msgstr "ユーザー検索フィルター。プレースホルダー '{login}'はユーザーが入力したログインに置き換えられます。"
+msgstr "فیلد جستجوگر کاربر، جادوگر {login} با کاربر وارد شده توسط کاربر جایگزین خواهد شد."
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user's email. (usually ''mail'', ''email'' or ''userPrincipalName'')"
-msgstr "ユーザーのメールに使用する属性。（通常は、\"メール\"、\"Eメール\"、\"userPrincipalName\"など）"
+msgstr "مشخصه برای استفاده از ایمیل کاربر. (معمولا '' پست الکترونیکی ''، '' ایمیل '' یا '' userPrincipalName '')"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user''s first name. (usually ''givenName'')"
-msgstr "ユーザーの名に使用する属性。（通常は、\"givenName\"）"
+msgstr "مشخصه برای نام کاربری کاربر استفاده می شود. (معمولا '' givenName '')"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user''s last name. (usually ''sn'')"
-msgstr "ユーザーの姓に使用する属性。（通常は、\"sn\"）"
+msgstr "مشخصه برای نام کاربری کاربر استفاده می شود. (معمولا '' sn '')"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Enable group membership synchronization with LDAP."
-msgstr "LDAPとのグループ同期を有効化する"
+msgstr "همگام سازی عضویت گروه با LDAP را فعال کنید"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Search base for groups, not required if your LDAP directory provides a ''memberOf'' overlay. (Will be searched recursively)"
-msgstr "グループの検索ベース。LDAPディレクトリが\"memberOf”オーバーレイを提供する場合は不要です。（繰り返し検索されます）"
+msgstr "پایگاه جستجوی برای گروه ها، مورد نیاز نیست، اگر دایرکتوری LDAP یک پوشه '' memberOf '' را فراهم می کند. (به صورت بازگشتی جستجو می شود)"
 
 #. Should be in the form: {"cn=Some Group,dc=...": [1, 2, 3]} where keys are LDAP groups and values are lists of MB groups IDs
 #: src/metabase/integrations/ldap.clj
 msgid "JSON containing LDAP to Metabase group mappings."
-msgstr "LDAPとMetabaseのグループマッピングを含むJSON"
+msgstr "JSON حاوی LDAP به گروه بندی Metabase گروه."
 
 #. Define a setting which captures our Slack api token
 #: src/metabase/integrations/slack.clj
 msgid "Slack API bearer token obtained from https://api.slack.com/web#authentication"
-msgstr "https://api.slack.com/web#authenticationから入手したSlack APIベアラートークン"
+msgstr "نشانه حامل Slack API از https://api.slack.com/web#authentication به دست آمده است"
 
 #: src/metabase/metabot.clj
 msgid "Enable MetaBot, which lets you search for and view your saved questions directly via Slack."
-msgstr "MetaBotを有効化すると、Slackで保存された質問を直接検索したり見たりすることができます"
+msgstr "فعال کردن MetaBot، که به شما اجازه می دهد به طور مستقیم از طریق Slack جستجو و مشاهده سوالات ذخیره شده خود را مشاهده کنید."
 
 #: src/metabase/metabot/instance.clj
 msgid "Last MetaBot checkin was {0} ago."
-msgstr "MetaBotへの最後のチェックインは{0}前でした。"
+msgstr "آخرین چک چک MetaBot {0} پیش بود."
 
 #: src/metabase/metabot/instance.clj
 msgid "This instance will now handle MetaBot duties."
-msgstr "このインスタンスはMetaBotのタスクを処理しています。"
+msgstr "این مثال اکنون وظایف MetaBot را انجام خواهد داد."
 
 #: src/metabase/metabot.clj
 msgid "Here''s what I can {0}:"
-msgstr "ここに {0} できるものがあります:"
+msgstr "در اینجا چیزی است که می توانم {0}:"
 
 #: src/metabase/metabot.clj
 msgid "I don''t know how to {0} `{1}`.n{2}"
-msgstr "'{1}と{2}の{0}方法が不明です。"
+msgstr "من نمی دانم چگونه {0} `{1}` .n {2}"
 
 #: src/metabase/metabot/slack.clj
 msgid "Uh oh! :cry:n> {0}"
-msgstr ":cry:n> {0}"
+msgstr "اوه آه! : گریه: n> {0}"
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s your {0} most recent cards:n{1}"
-msgstr "最新{0}のカードがあります: n{1}"
+msgstr "در اینجا آخرین کارت های {0} شما وجود دارد: n {1}"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific? I found these cards with names that matched:n{0}"
-msgstr "より詳細に誤入力ください。名前が一致するカードが見つかりました: n{0}"
+msgstr "می توانید کمی بیشتر مشخص کنید؟ من این کارت ها را با نام هایی یافتم که با هم مطابقت داشتند: n {0}"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know what Card `{0}` is. Give me a Card ID or name."
-msgstr "カード'{0}'が不明です。カードIDかカード名をご入力ください。"
+msgstr "من نمی دانم چه کارت {0} `است. یک شناسه یا نام کارت را به من بدهید"
 
 #: src/metabase/metabot/command.clj
 msgid "Show which card? Give me a part of a card name or its ID and I can show it to you. If you don''t know which card you want, try `metabot list`."
-msgstr "どのカードを表示しますか？ カード名やカードIDの一部を入力していただくと、ご希望のカードを表示することができます。 どのカードが必要なのかわからない場合は、「MetaBotリスト」をお試しください。"
+msgstr "نمایش کدام کارت بخشی از یک نام کارت یا شناسه آن را به من بدهید و می توانم آن را به شما نشان دهم. اگر شما نمی دانید که کدام کارت را می خواهید، سعی کنید به لیست متابوت بپردازید."
 
 #: src/metabase/metabot/command.clj
 msgid "Ok, just a second..."
-msgstr "少々お待ちください..."
+msgstr "خوب، فقط یک ثانیه ..."
 
 #: src/metabase/metabot/command.clj
 msgid "Not Found"
-msgstr "見つかりませんでした"
+msgstr "پیدا نشد"
 
 #: src/metabase/metabot/command.clj
 msgid "Loading Kanye quotes..."
-msgstr "処理中..."
+msgstr "Loading Kanye نقل قول ..."
 
 #: src/metabase/metabot/events.clj
 msgid "Evaluating Metabot command:"
-msgstr "MetaBotコマンドを診断中:"
+msgstr "ارزیابی فرمان Metabot:"
 
 #: src/metabase/metabot.clj
 msgid "Go home websocket, you're drunk."
-msgstr "WebSocketで問題が発生しました"
+msgstr "به وب سایت ما بپیوندید، شما مست هستید"
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error launching metabot:"
-msgstr "MetaBot起動中にエラーが発生しました:"
+msgstr "خطا در راه اندازی متابوت:"
 
 #: src/metabase/metabot/websocket.clj
 msgid "MetaBot WebSocket is closed. Reconnecting now."
-msgstr "MetaBot WebSocketが終了しました。再接続中。"
+msgstr "MetaBot WebSocket بسته است در حال اتصال مجدد"
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error connecting websocket:"
-msgstr "WebSocketへの接続中にエラーが発生しました。:"
+msgstr "خطا در اتصال websocket:"
 
 #: src/metabase/metabot/instance.clj
 msgid "This instance is performing MetaBot duties."
-msgstr "このインスタンスはMetaBotのタスクを処理しています。"
+msgstr "این مثال انجام وظایف MetaBot است."
 
 #: src/metabase/metabot/instance.clj
 msgid "Another instance is already handling MetaBot duties."
-msgstr "別のインスタンスが既にMetaBotのタスクを処理しています。"
+msgstr "مثال دیگر در حال حاضر با وظایف MetaBot کار می کند."
 
 #: src/metabase/metabot.clj
 msgid "Starting MetaBot threads..."
-msgstr "MetaBotスレッドを開始中..."
+msgstr "شروع موضوعات MetaBot ..."
 
 #: src/metabase/metabot.clj
 msgid "Stopping MetaBot...  🤖"
-msgstr "MetaBotを停止しています...  🤖"
+msgstr "متوقف سازی ربات متا... 🤖"
 
 #: src/metabase/metabot.clj
 msgid "MetaBot already running. Killing the previous WebSocket listener first."
-msgstr "MetaBotは既に実行中です。 前のWebSocketリスナーを強制終了します。"
+msgstr "ربات متا درحال اجرا می باشد. اول شنونده وبسوکت قبلی را متوقف سازید."
 
 #: src/metabase/middleware/security.clj
 msgid "Base-64 encoded public key for this site's SSL certificate."
-msgstr "このサイトのSSL証明書のBase-64でエンコードされた公開キー"
+msgstr "Base-64 رمزگذاری شده برای کلید عمومی برای گواهی SSL این سایت."
 
 #: src/metabase/middleware/security.clj
 msgid "Specify this to enable HTTP Public Key Pinning."
-msgstr "これを指定すると、HTTP公開キーのピン設定が有効になります。"
+msgstr "این را برای فعال کردن پین کردن کلید عمومی HTTP فعال کنید."
 
 #: src/metabase/middleware/security.clj
 msgid "See {0} for more information."
-msgstr "詳細は{0}を参照してください。"
+msgstr "{0} را برای اطلاعات بیشتر ببینید"
 
 #: src/metabase/models/card.clj
 msgid "Cannot save Question: source query has circular references."
-msgstr "質問が保存できません: ソースクエリに循環参照があります"
+msgstr "نتوانست سوال را نجات دهد: پرس و جو منبع دارای مراجع دایره ای است."
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
-msgstr "カード{0}は存在しません。"
+msgstr "کارت {0} وجود ندارد."
 
 #: src/metabase/models/card.clj
 msgid "You do not have permissions to run ad-hoc native queries against Database {0}."
-msgstr "データベース{0}に対してアドホックネイティブクエリを実行する権限がありません。"
+msgstr "شما مجوزهای لازم برای نمایش درخواستهای بومی خاص خود را در برابر بانک اطلاعاتی {0} ندارید"
 
 #: src/metabase/models/collection.clj
 msgid "Invalid color"
-msgstr "無効な色"
+msgstr "رنگ نامعتبر"
 
 #: src/metabase/models/collection.clj
 msgid "must be a valid 6-character hex color code"
-msgstr "有効な6文字の16進数カラーコードでなければなりません"
+msgstr "باید کد رنگ هگزسیده 6 کاراکتری معتبر باشد"
 
 #: src/metabase/models/collection.clj
 msgid "Collection name cannot be blank!"
-msgstr "コレクション名は空欄にできません！"
+msgstr "اسم مجموعه نمیتواند خالی باشد."
 
 #: src/metabase/models/collection.clj
 msgid "cannot be blank"
-msgstr "空欄にできません"
+msgstr "نمی‌تونه خالی باشه"
 
 #: src/metabase/models/collection.clj
 msgid "Invalid Collection location: path is invalid."
-msgstr "無効なコレクションの場所: パスが無効です。"
+msgstr "محل مجموعه غیر معتبر: آدرس نامعتبر می باشد."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Personal Collection."
-msgstr "パーソナルコレクションは移動できません。"
+msgstr "شما نمیتوانید یک مجموعه شخصی را جا به جا کنید."
 
 #: src/metabase/models/collection.clj
 msgid "Invalid Collection location: some or all ancestors do not exist."
-msgstr "無効なコレクションの場所: 一部またはすべての先祖が存在しません。"
+msgstr "محل جمع آوری نامعتبر: برخی یا همه اجداد وجود ندارد."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot archive the Root Collection."
-msgstr "ルートコレクションはアーカイブできません。"
+msgstr "شما نمی توانید مجموعه ریشه را بایگانی کنید."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot archive a Personal Collection."
-msgstr "パーソナルコレクションはアーカイブできません。"
+msgstr "شما نمیتوانید یک مجموعه شخصی را بایگانی کنید"
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move the Root Collection."
-msgstr "ルートコレクションは移動できません。"
+msgstr "شما نمیتوانید مجموعه ریشه ای را جا به جا کنید"
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection into itself or into one of its descendants."
-msgstr "コレクションをそれ自身または子孫の1つに移動することはできません。"
+msgstr "شما نمی توانید مجموعه را به خود و یا به یکی از فرزندان خود منتقل کنید."
 
 #. first move this Collection
 #: src/metabase/models/collection.clj
 msgid "Moving Collection {0} and its descendants from {1} to {2}"
-msgstr "コレクション{0}およびその子孫を{1}から{2}に移動中"
+msgstr "مجموعه حرکت {0} و فرزندان آن از {1} تا {2}"
 
 #: src/metabase/models/collection.clj
 msgid "You're not allowed to change the owner of a Personal Collection."
-msgstr "パーソナルコレクションの所有者は変更できません。"
+msgstr "شما مجاز به تغییر صاحب یک مجموعه شخصی نیستید."
 
 #: src/metabase/models/collection.clj
 msgid "You're not allowed to move a Personal Collection."
-msgstr "パーソナルコレクションは移動できません。"
+msgstr "شما مجاز به انتقال یک مجموعه شخصی نیستید."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection and archive it at the same time."
-msgstr "コレクションを移動し同時にアーカイブすることはできません。"
+msgstr "شما نمیتوانید یک مجموعه را حرکت دهید و آن را همزمان ذخیره کنید."
 
 #: src/metabase/models/collection.clj
 msgid "You cannot delete a Personal Collection!"
-msgstr "パーソナルコレクションを削除することはできません。"
+msgstr "شما نمی توانید یک مجموعه شخصی را حذف کنید!"
 
 #: src/metabase/models/collection.clj
 msgid "{0} {1}''s Personal Collection"
-msgstr "{0} {1}さんのパーソナルコレクション"
+msgstr "{0} {1} مجموعه شخصی"
 
 #: src/metabase/models/collection_revision.clj
 msgid "You cannot update a CollectionRevision!"
-msgstr "コレクション履歴をアップデートすることはできません。"
+msgstr "شما نمی توانید CollectionRevision را به روز کنید!"
 
 #: src/metabase/models/field_values.clj
 msgid "Field {0} was previously automatically set to show a list widget, but now has {1} values."
-msgstr "フィールド{0}は以前は自動的にリストウィジェットを表示するよう設定されていましたが、現在は{1}の値を持っています。"
+msgstr "فیلد {0} قبلا به طور خودکار برای نمایش یک ویجت لیست تنظیم شده است، اما در حال حاضر دارای {1} مقدار است."
 
 #: src/metabase/models/field_values.clj
 msgid "Switching Field to use a search widget instead."
-msgstr "検索ウィジェットを代わりに使用するようフィールド切り替え中。"
+msgstr "سوئیچینگ فیلد به جای استفاده از ویجت جستجو."
 
 #: src/metabase/models/field_values.clj
 msgid "Storing updated FieldValues for Field {0}..."
-msgstr "フィールド{0}の更新されたフィールド値を保存中..."
+msgstr "ذخیرۀ FieldValues ​​به روز شده برای فیلد {0} ..."
 
 #: src/metabase/models/field_values.clj
 msgid "Storing FieldValues for Field {0}..."
-msgstr "フィールド{0}のフィールド値を保存中..."
+msgstr "ذخیره فیلد فیلد برای فیلد {0} ..."
 
 #: src/metabase/models/humanization.clj
 msgid "Metabase can attempt to transform your table and field names into more sensible, human-readable versions, e.g. \"somehorriblename\" becomes \"Some Horrible Name\"."
-msgstr "Metabaseはテーブルとフィールド名をより理に適った、読みやすい名前に変更することができます。例: 「somehorriblename」を「Some Horrible Name」へ変更する"
+msgstr "Metabase می تواند تلاش کند نام جدول و فیلدهای خود را به نسخه های قابل اعتماد تر و قابل خواندن با انسانی تبدیل کند، برای مثال \"somehorriblename\" می شود \"برخی از نام وحشتناک\"."
 
 #: src/metabase/models/humanization.clj
 msgid "This doesn’t work all that well if the names are in a language other than English, however."
-msgstr "しかし、英語以外の言語の名前の場合はうまく動作しません。"
+msgstr "با این حال، این کار همه کارها را به خوبی انجام نمی دهد، اگر این نام ها در زبان دیگری غیر از زبان انگلیسی باشد."
 
 #: src/metabase/models/humanization.clj
 msgid "Do you want us to take a guess?"
-msgstr "予想したいですか？"
+msgstr "میخوای ما برات حدس بزنیم؟"
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot create or revoke permissions for the 'Admin' group."
-msgstr "「管理者」グループの権限を作成または取り消すことはできません。"
+msgstr "شما نمیتوانید مجوزهای گروه مدیریت را ایجاد یا لغو کنید."
 
 #: src/metabase/models/permissions.clj
 msgid "Invalid permissions object path: ''{0}''."
-msgstr "無効な権限のオブジェクトパス: \"{0}\""
+msgstr "مسیر شیء مجوزهای معتبر: '' {0} ''."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot update a permissions entry!"
-msgstr "権限エントリーを更新することはできません！"
+msgstr "شما نمی توانید ورود مجوز را به روز کنید!"
 
 #: src/metabase/models/permissions.clj
 msgid "Delete it and create a new one."
-msgstr "削除して新しく作成する"
+msgstr "حذفش کن و یه جدیدش رو بساز"
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot edit permissions for a Personal Collection or its descendants."
-msgstr "パーソナルコレクションまたはその子孫の権限を編集することはできません。"
+msgstr "شما نمیتوانید مجوزهای یک مجموعه شخصی یا نسلهای آن را ویرایش کنید."
 
 #: src/metabase/models/permissions.clj
 msgid "Looks like someone else edited the permissions and your data is out of date."
-msgstr "他ユーザーが権限を編集したようです。そのため、あなたのデータは最新ではありません。"
+msgstr "به نظر می رسد شخص دیگری ویرایش مجوز ها را داشته و داده های شما از بین رفته است."
 
 #: src/metabase/models/permissions.clj
 msgid "Please fetch new data and try again."
-msgstr "新しいデータを取得し、再度お試しください。"
+msgstr "لطفا داده جدید را دریافت کنید و مجددا تلاش کنید"
 
 #: src/metabase/models/permissions_group.clj
 msgid "Created magic permissions group ''{0}'' (ID = {1})"
-msgstr "特別な権限のグループ\"{0}\"（ID = {1}）が作成されました。"
+msgstr "گروه مجوز جادویی '' {0} '' (ID = {1})"
 
 #: src/metabase/models/permissions_group.clj
 msgid "A group with that name already exists."
-msgstr "同じ名前のグループが既に存在します。"
+msgstr "گروهی با این نام در حال حاضر وجود دارد."
 
 #: src/metabase/models/permissions_group.clj
 msgid "You cannot edit or delete the ''{0}'' permissions group!"
-msgstr "\"{0}\"権限グループを編集または削除することはできません！"
+msgstr "شما نمی توانید گروه مجوز '' {0} '' را ویرایش یا حذف کنید!"
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'MetaBot' group."
-msgstr "「MetaBot」グループへユーザーを追加したりユーザーを削除することはできません"
+msgstr "شما نمیتوانید کاربران را به / از گروه MetaBot اضافه یا حذف کنید."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'All Users' group."
-msgstr "'All Users'グループへユーザーを追加したりユーザーを削除することはできません"
+msgstr "شما نمیتوانید کاربران را به / از گروه «همه کاربران» اضافه یا حذف کنید."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the 'Admin' group!"
-msgstr "「管理者」グループの最後のメンバーを削除することはできません！"
+msgstr "شما نمیتوانید آخرین عضو گروه مدیریت را حذف کنید"
 
 #: src/metabase/models/permissions_revision.clj
 msgid "You cannot update a PermissionsRevision!"
-msgstr "権限履歴をアップデートすることはできません！"
+msgstr "شما نمی توانید PermissionsRevision را به روز کنید!"
 
 #. if there's still not a Card, throw an Exception!
 #: src/metabase/models/pulse.clj
 msgid "Invalid Alert: Alert does not have a Card assoicated with it"
-msgstr "無効なアラート: アラートにはカードが関連付けられていません"
+msgstr "هشدار نامعتبر: هشدار یک کارت مرتبط با آن ندارد"
 
 #: src/metabase/models/pulse.clj
 msgid "value must be a map with the keys `{0}`, `{1}`, and `{2}`."
-msgstr "値は、キー'{0}'、'{1}'、'{2}'を含むマップでなければなりません。"
+msgstr "ارزش باید یک نقشه با کلید `{0}`، `{1}`، و `{2}` باشد."
 
 #: src/metabase/models/pulse.clj
 msgid "value must be a map with the following keys `({0})`"
-msgstr "値は次のキーを含むマップでなければなりません: `({0})`"
+msgstr "ارزش باید یک نقشه با کلیدهای زیر {(0)) `باشد"
 
 #: src/metabase/models/query/permissions.clj
 msgid "Error calculating permissions for query: {0}"
-msgstr "クエリの権限を処理中にエラーが発生しました: {0}"
+msgstr "خطا در محاسبه مجوزها برای پرس و جو: {0}"
 
 #: src/metabase/models/query/permissions.clj
 msgid "Invalid query type: {0}"
-msgstr "無効なクエリタイプ: {0}"
+msgstr "نوع پرس و جو نامعتبر: {0}"
 
 #: src/metabase/models/query_execution.clj
 msgid "You cannot update a QueryExecution!"
-msgstr "クエリ実行をアップデートすることはできません！"
+msgstr "شما نمی توانید QueryExecution را به روز کنید!"
 
 #: src/metabase/models/revision.clj
 msgid "You cannot update a Revision!"
-msgstr "履歴をアップデートできません！"
+msgstr "شما نمی توانید یک نسخه را به روز کنید!"
 
 #: src/metabase/models/setting.clj
 msgid "Setting {0} does not exist.nFound: {1}"
-msgstr "設定{0}は存在しません: {1}"
+msgstr "تنظیم {0} وجود ندارد. نکته: {1}"
 
 #: src/metabase/models/setting/cache.clj
 msgid "Updating value of settings-last-updated in DB..."
-msgstr "データベース内で最後に更新された値をアップデート中..."
+msgstr "به روز رسانی ارزش تنظیمات - آخرین به روز رسانی در DB ..."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Checking whether settings cache is out of date (requires DB call)..."
-msgstr "キャッシュ設定が最新か確認中（データベースコースが必要）..."
+msgstr "بررسی اینکه آیا حافظه پنهان تنظیم شده است (نیاز به تماس DB) ..."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Settings have been changed on another instance, and will be reloaded here."
-msgstr "別のインスタンスで変更された設定は、ここで再読み込みされます。"
+msgstr "تنظیمات در مثال دیگری تغییر کرده است و در اینجا دوباره بارگیری خواهد شد."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Refreshing Settings cache..."
-msgstr "設定キャッシュを更新中..."
+msgstr "حافظه تنظیمات بازخوانی ..."
 
 #: src/metabase/models/setting.clj
 msgid "Invalid value for string: must be either \"true\" or \"false\" (case-insensitive)."
-msgstr "文字列の値が無効です: \"true\"または \"false\"（大文字小文字を区別しない）である必要があります。"
+msgstr "مقدار نامعتبر برای رشته: باید \"درست\" یا \"غلط\" (حساس به حروف) باشد."
 
 #: src/metabase/models/setting.clj
 msgid "You cannot update `settings-last-updated` yourself! This is done automatically."
-msgstr "'最後に更新された設定'を手動でアップデートすることはできません。これは自動でアップデートされます。"
+msgstr "شما نمیتوانید تنظیمات خود را بهروزرسانی کنید! این به صورت خودکار انجام می شود."
 
 #. go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
 #: src/metabase/models/setting.clj
 msgid "Error inserting a new Setting:"
-msgstr "新設定の適用中にエラーが発生しました:"
+msgstr "خطا در افزودن یک تنظیم جدید:"
 
 #: src/metabase/models/setting.clj
 msgid "Assuming Setting already exists in DB and updating existing value."
-msgstr "設定が既にデータベースに存在すると仮定し、既存の値を更新中"
+msgstr "فرض کنید تنظیم در حال حاضر در DB وجود دارد و به روز رسانی مقدار موجود است."
 
 #: src/metabase/models/user.clj
 msgid "value must be a map with each value either a string or number."
-msgstr "値は、各値が文字列または数値のいずれかを含むマップでなければなりません。"
+msgstr "ارزش باید یک نقشه با هر مقدار یا رشته یا عدد باشد."
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in directory {0}..."
-msgstr "ディレクトリ{0}のプラグインを読込中..."
+msgstr "بارگیری پلاگین ها در دایرکتوری {0} ..."
 
 #: src/metabase/plugins.clj
 msgid "Loading plugin {0}... "
-msgstr "プラグイン{0}を読込中... "
+msgstr "بارگیری پلاگین {0} ..."
 
 #: src/metabase/plugins.clj
 msgid "It looks like you have some external dependencies in your Metabase plugins directory."
-msgstr "Metabaseプラグインディレクトリに、外部依存関係があるようです。"
+msgstr "به نظر می رسد که شما در وابستگی های خارجی خود در دایرکتوری پلاگین Metabase خود دارید."
 
 #: src/metabase/plugins.clj
 msgid "With Java 9 or higher, Metabase cannot automatically add them to your classpath."
-msgstr "Java 9以降では、Metabaseはクラスパスに自動的に追加できません。"
+msgstr "با جاوا 9 یا بالاتر، Metabase نمی تواند به طور خودکار آنها را به مسیر کلاس شما اضافه کند."
 
 #: src/metabase/plugins.clj
 msgid "Instead, you should include them at launch with the -cp option. For example:"
-msgstr "代わりに、起動時に-cpオプションを使用して含める必要があります。 例:"
+msgstr "در عوض، شما باید آنها را در راه اندازی با گزینه -cp وارد کنید. مثلا:"
 
 #: src/metabase/plugins.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#java-versions for more details."
-msgstr "詳しくは、 https://metabase.com/docs/latest/operations-guide/start.html#java-versions を見てください"
+msgstr "برای اطلاعات بیشتر به https://metabase.com/docs/latest/operations-guide/start.html#java-versions مراجعه کنید"
 
 #: src/metabase/plugins.clj
 msgid "(If you're already running Metabase this way, you can ignore this message.)"
-msgstr "（すでにこの方法でMetabaseを実行している場合は、このメッセージを無視してください。）"
+msgstr "(اگر شما در حال حاضر Metabase را در این راه اجرا می کنید، می توانید این پیام را نادیده بگیرید.)"
 
 #: src/metabase/public_settings.clj
 msgid "Identify when new versions of Metabase are available."
-msgstr "Metabaseの新しいバージョンがいつ入手可能かを確認する"
+msgstr "شناسایی زمانی که نسخه های جدید Metabase در دسترس هستند."
 
 #: src/metabase/public_settings.clj
 msgid "Information about available versions of Metabase."
-msgstr "Metabaseの利用可能なバージョンに関する情報"
+msgstr "اطلاعات در مورد نسخه های موجود Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "The name used for this instance of Metabase."
-msgstr "このMetabaseのインスタンスの名前"
+msgstr "نام مورد استفاده برای این مثال Metabase."
 
 #: src/metabase/public_settings.clj
 msgid "The base URL of this Metabase instance, e.g. \"http://metabase.my-company.com\"."
-msgstr "このMetabaseインスタンスのベースURL、例: \"http://metabase.my-company.com\""
+msgstr "آدرس پایه این نمونه متاباز، به عنوان مثال \"http://metabase.my-company.com\"."
 
 #: src/metabase/public_settings.clj
 msgid "The default language for this Metabase instance."
-msgstr "このMetabaseインスタンスのデフォルトの言語です。"
+msgstr "زبان پیشفرض برای این نمونه متابیس"
 
 #: src/metabase/public_settings.clj
 msgid "This only applies to emails, Pulses, etc. Users'' browsers will specify the language used in the user interface."
-msgstr "これはメール、パルス等だけに適用されます。ブラウザーの言語は、ユーザーが使用しているインターフェイスの言語が適用されます"
+msgstr "این فقط در مورد ایمیل ها، پالس ها و غیره استفاده می شود. مرورگرهای کاربران زبان مورد استفاده در رابط کاربری را مشخص می کنند."
 
 #: src/metabase/public_settings.clj
 msgid "The email address users should be referred to if they encounter a problem."
-msgstr "問題が発生した場合に、ユーザーが参照すべきメールアドレス"
+msgstr "اگر با یک مشکل مواجه شدید، کاربران آدرس ایمیل باید مراجعه کنند."
 
 #: src/metabase/public_settings.clj
 msgid "Enable the collection of anonymous usage data in order to help Metabase improve."
-msgstr "Metabaseのサービス向上のため、匿名の使用状況データの収集を許可する。"
+msgstr "مجموعه ای از داده های استفاده ناشناس را برای کمک به بهبود Metabase فعال کنید."
 
 #: src/metabase/public_settings.clj
 msgid "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox."
-msgstr "マップのビジュアライゼーションで使用されるマップタイルサーバーのURLテンプレート（例: OpenStreetMaps、MapBoxなど）。"
+msgstr "الگو URL الگو سرور کاشی مورد استفاده در تصورات نقشه، به عنوان مثال از OpenStreetMaps یا MapBox."
 
 #: src/metabase/public_settings.clj
 msgid "Enable admins to create publicly viewable links (and embeddable iframes) for Questions and Dashboards?"
-msgstr "管理者が質問とダッシュボード用に公開閲覧リンク（および埋め込み可能なiframe）を作成できるようにしますか？"
+msgstr "فعال کردن مدیران برای ایجاد لینک های قابل مشاهده قابل مشاهده (و قاب های قابل جاسازی) برای سوالات و داشبورد ها؟"
 
 #: src/metabase/public_settings.clj
 msgid "Allow admins to securely embed questions and dashboards within other applications?"
-msgstr "管理者が質問やダッシュボードを他のアプリケーションに安全に埋め込めるよう許可しますか？"
+msgstr "به مدیران اجازه دهید ایمن سوالات و داشبورد ها را در برنامه های دیگر قرار دهند؟"
 
 #: src/metabase/public_settings.clj
 msgid "Allow using a saved question as the source for other queries?"
-msgstr "保存された質問を他のクエリのソースとして使用することを許可しますか？"
+msgstr "اجازه استفاده از یک سؤال ذخیره شده به عنوان منبع برای سایر نمادها؟"
 
 #: src/metabase/public_settings.clj
 msgid "Enabling caching will save the results of queries that take a long time to run."
-msgstr "キャッシングを有効にすると、実行に時間がかかるクエリの結果が保存されます。"
+msgstr "فعال کردن ذخیره سازی، نتایجی از نمایش داده ها را ذخیره می کند که مدت زمان زیادی طول می کشد تا اجرا شوند."
 
 #: src/metabase/public_settings.clj
 msgid "The maximum size of the cache, per saved question, in kilobytes:"
-msgstr "保存された質問ごとのキャッシュの最大サイズ（キロバイト）:"
+msgstr "حداکثر اندازه حافظه پنهان، در هر سوال ذخیره شده، در کیلوبایت:"
 
 #: src/metabase/public_settings.clj
 msgid "The absolute maximum time to keep any cached query results, in seconds."
-msgstr "キャッシュされたクエリの結果を保持する最長時間（秒単位）"
+msgstr "حداکثر حداکثر زمان برای حفظ هر گونه نتایج پرس و جو ذخیره شده در ثانیه."
 
 #: src/metabase/public_settings.clj
 msgid "Metabase will cache all saved questions with an average query execution time longer than this many seconds:"
-msgstr "Metabaseは、保存された全ての質問を、平均クエリ実行時間内にキャッシュします。:"
+msgstr "Metabase تمام سوالات ذخیره شده را با میانگین زمان اجرای پرس و جو بیشتر از این چند ثانیه مخفی نگه می دارد:"
 
 #: src/metabase/public_settings.clj
 msgid "To determine how long each saved question''s cached result should stick around, we take the query''s average execution time and multiply that by whatever you input here."
-msgstr "クエリの平均実行時間を取得し、ここに入力した値で乗算することで、保存された各質問のキャッシュ結果の保存期間を判断します。"
+msgstr "برای تعیین مدت زمانی که هر نتیجه ذخیره شده ذخیره شده در سؤال باید در اطراف نگه داشته شود، ما میانگین زمان اجرای اجرای پرس و جو را افزایش می دهیم و آن را با آنچه شما در اینجا وارد کردید می کنید."
 
 #: src/metabase/public_settings.clj
 msgid "So if a query takes on average 2 minutes to run, and you input 10 for your multiplier, its cache entry will persist for 20 minutes."
-msgstr "したがって、クエリの実行に平均2分かかる場合、乗数に10を入力すると、そのキャッシュエントリは20分間保持されます。"
+msgstr "بنابراین اگر یک پرس و جو برای اجرا به طور متوسط ​​2 دقیقه طول بکشد، و شما 10 برای چندتایی خود را وارد کنید، ورودی حافظه پنهان آن تا 20 دقیقه ادامه خواهد یافت."
 
 #: src/metabase/public_settings.clj
 msgid "When using the default binning strategy and a number of bins is not provided, this number will be used as the default."
-msgstr "デフォルトのビニング設定を使用しており、かつビンが入力されていない場合には、この数値がデフォルトとして使用されます。"
+msgstr "هنگام استفاده از استراتژی پیشفرض به طور پیش فرض و تعدادی از سطل ها ارائه نشده است، این شماره به عنوان پیش فرض مورد استفاده قرار می گیرد."
 
 #: src/metabase/public_settings.clj
 msgid "When using the default binning strategy for a field of type Coordinate (such as Latitude and Longitude), this number will be used as the default bin width (in degrees)."
-msgstr "座標タイプ（緯度と経度など）のフィールドにデフォルトのビニング設定を使用する場合、この数値はデフォルトビン幅（度）として使用されます。"
+msgstr "هنگام استفاده از استراتژی پیشفرض پیش فرض برای یک فیلد از نوع مختصات (مانند طول و عرض جغرافیایی)، این شماره به عنوان عرض باین پیش فرض (در درجه) استفاده می شود."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token."
-msgstr "トークンを検証できません"
+msgstr "قادر به تأیید نشانه نیست"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error fetching token status:"
-msgstr "トークンステータスの取得中にエラーが発生しました:"
+msgstr "خطا در دریافت وضعیت توکن"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid."
-msgstr "このトークンの有効性を確認中にエラーが発生しました。"
+msgstr "یک خطا در بررسی اینکه آیا این نشانه معتبر بود، وجود داشت."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token validation timed out."
-msgstr "トークンの検証がタイムアウトしました。"
+msgstr "تأیید اعتبار سنجی زمان به پایان رسیده است"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Invalid token: token isn't in the right format."
-msgstr "トークンが不正です。トークンが正しいフォーマットではありません。"
+msgstr "نشانه نامعتبر: نشانه در فرمت مناسب نیست."
 
 #. attempt to query the metastore API about the status of this token. If the request doesn't complete in a
 #. reasonable amount of time throw a timeout exception
 #: src/metabase/public_settings/metastore.clj
 msgid "Checking with the MetaStore to see whether {0} is valid..."
-msgstr "{0}の有効性を確認するためにMetaStoreをチェック中..."
+msgstr "بررسی با MetaStore برای دیدن اینکه {0} معتبر است ..."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium embedding. Go to the MetaStore to get yours!"
-msgstr "プレミアム埋め込みのためのトークン。 是非あなたもMetaStoreから入手してください！"
+msgstr "برچسب برای تعبیه حق بیمه. برو به MetaStore برای به دست آوردن شما!"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token is valid."
-msgstr "トークンは有効です"
+msgstr "توکن معتبر می باشد"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error setting premium embedding token"
-msgstr "プレミアム埋め込みトークンの設定中にエラーが発生しました。"
+msgstr "خطا در تعیین تعرفه حق بیمه"
 
 #: src/metabase/pulse.clj
 msgid "Unable to compare results to goal for alert."
-msgstr "結果と目標を比較できませんでした"
+msgstr "نمیتوان مقایسه نتایج را به هدف برای هشدار داد."
 
 #: src/metabase/pulse.clj
 msgid "Question ID is ''{0}'' with visualization settings ''{1}''"
-msgstr "ビジュアライゼーション設定が \"{1}\"の質問IDは\"{0}\"です。"
+msgstr "سوال ID '' {0} '' با تنظیمات تجسم است '' {1} ''"
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized alert with condition ''{0}''"
-msgstr "状態\"{0}\"の認識できないアラート"
+msgstr "هشدار ناشناخته با وضعیت '' {0} ''"
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized channel type {0}"
-msgstr "認識できないチャンネルタイプ{0}"
+msgstr "نوع کانال نامشخص {0}"
 
 #: src/metabase/pulse.clj
 msgid "Error sending notification!"
-msgstr "通知送信中にエラーが発生しました！"
+msgstr "خطا در ارسال اعلان!"
 
 #: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
-msgstr "\"{0}\"にJSカラーセレクタが見つかりません。"
+msgstr "می توانید انتخاب رنگ JS را در '' {0} '' پیدا کنید"
 
 #: src/metabase/pulse/render.clj
 msgid "Card has errors: {0}"
-msgstr "カードにエラーがあります: {0}"
+msgstr "کارت دارای خطا است: {0}"
 
 #: src/metabase/pulse/render.clj
 msgid "Pulse card render error"
-msgstr "パルスカードレンダリングエラー"
+msgstr "کارت پالس رندر خطا"
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Trimming trailing comment from card with id {0}"
-msgstr "ID{0}のカードの後続コメントをトリミング中"
+msgstr "ترتیب پیشنویس از کارت با شناسه {0}"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Can't find field with ID: {0}"
-msgstr "ID {0}のフィールドが見つかりません"
+msgstr "فیلد با شناسه پیدا نشد: {0}"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "''{0}'' is a required param."
-msgstr "\"{0}\"は必須パラメータ―です"
+msgstr "' {0} '' پارامتر مورد نیاز است."
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Found ''{0}'' with no terminating ''{1}'' in query ''{2}''"
-msgstr "クエリ\"{2}\"に\"{1}\"が終了していない\"{0}\"が見つかりました。"
+msgstr "' {0} '' بدون تعطیل '' {1} '' در پرس و جو '' {2} ''"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Unable to substitute ''{0}'': param not specified.nFound: {1}"
-msgstr "\"{0}\"を置換できません: パラメーターは指定されていないため見つかりませんでした: {1}"
+msgstr "قادر به جایگزینی '' {0} '': param not specified.nFound: {1}"
 
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "You do not have permissions to view Card {0}."
-msgstr "カード{0}の閲覧権限がありません"
+msgstr "شما مجوز هایی برای مشاهده کارت {0} ندارید."
 
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "You do not have permissions to run this query."
-msgstr "このクエリを実行する権限がありません"
+msgstr "شما برای اجرای این پرس و جو مجوز ندارید."
 
 #: src/metabase/sync/analyze.clj
 msgid "Fingerprint updates attempted {0}, updated {1}, no data found {2}, failed {3}"
-msgstr "{0}のフィンガープリントを更新しようとし、{1}件更新、{2}件はデータが見つからず、{3}件は失敗しました"
+msgstr "به روز رسانی اثر انگشت تلاش {0}، بهروز {1}، هیچ اطلاعاتی یافت نشد {2}، شکست خورد {3}"
 
 #: src/metabase/sync/analyze.clj
 msgid "Total number of fields classified {0}, {1} failed"
-msgstr "合計{0}フィールドが分類され、{1}件が失敗しました"
+msgstr "تعداد کل فیلدها دسته بندی شده {0}، {1} شکست خورده است"
 
 #: src/metabase/sync/analyze.clj
 msgid "Total number of tables classified {0}, {1} updated"
-msgstr "合計{0}テーブルが分類され、{1}件が失敗しました "
+msgstr "تعداد کل جداول طبقه بندی شده {0}، {1} به روز شد"
 
 #: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
 msgid "Error generating fingerprint for {0}"
-msgstr "{0}のフィンガープリント生成中にエラーが発生しました。"
+msgstr "خطا در ایجاد اثر انگشت برای {0}"
 
 #: src/metabase/sync/field_values.clj
 msgid "Updated {0} field value sets, created {1}, deleted {2} with {3} errors"
-msgstr "{0}件のフィールド値セットを更新、{1}件作成、{2}件削除、{3}件エラー"
+msgstr "به روز شده {0} مجموعه مقادیر فیلد، ایجاد {1}، حذف {2} با خطاهای {3}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of fields sync''d {0}, number of fields updated {1}"
-msgstr "合計{0}フィールドが同期され、{1}フィールドが更新されました"
+msgstr "تعداد کل فیلدها sync''d {0}، تعداد فیلدها به روز شده {1}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of tables sync''d {0}, number of tables updated {1}"
-msgstr "合計{0}テーブルが同期され、{1}テーブルが更新されました"
+msgstr "تعداد کل جداول sync''d {0}، تعداد جداول به روز شده {1}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Found timezone id {0}"
-msgstr "タイムゾーンID{0}が見つかりました。"
+msgstr "شناسه منطقه زمانی یافت شد {0}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of foreign keys sync''d {0}, {1} updated and {2} tables failed to update"
-msgstr "合計{0}の外部キーが同期され、{1}件更新、{2}テーブルが更新に失敗しました"
+msgstr "مجموع کل کلید های خارجی sync''d {0}، {1} به روز شد و {2} جداول نتوانست به روز رسانی شود"
 
 #: src/metabase/sync/util.clj
 msgid "{0} Database {1} ''{2}''"
-msgstr "{0}データベース{1} ''{2}''"
+msgstr "{0} پایگاه داده {1} '' {2} ''"
 
 #: src/metabase/sync/util.clj
 msgid "Table {0} ''{1}''"
-msgstr "テーブル {0} \"{1}\""
+msgstr "جدول {0} '' {1} ''"
 
 #: src/metabase/sync/util.clj
 msgid "Field {0} ''{1}''"
-msgstr "フィールド{0} ''{1}''"
+msgstr "فیلد {0} '' {1} ''"
 
 #: src/metabase/sync/util.clj
 msgid "Field ''{0}''"
-msgstr "フィールド\"{0}\""
+msgstr "فیلد '' {0} ''"
 
 #: src/metabase/sync/util.clj
 msgid "step ''{0}'' for {1}"
-msgstr "{1}のステップ\"{0}\""
+msgstr "گام \"'{0}' 'برای {1}"
 
 #: src/metabase/sync/util.clj
 msgid "Completed {0} on {1}"
-msgstr "{1}で{0}を完了しました"
+msgstr "تکمیل شده {0} در {1}"
 
 #: src/metabase/sync/util.clj
 msgid "Start: {0}"
-msgstr "開始: {0}"
+msgstr "شروع: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "End: {0}"
-msgstr "終了: {0}"
+msgstr "پایان: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "Duration: {0}"
-msgstr "期間: {0}"
+msgstr "مدت زمان: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "Completed step ''{0}''"
-msgstr "ステップ\"{0}\"が完了しました"
+msgstr "گام کامل '' {0} ''"
 
 #: src/metabase/task.clj
 msgid "Loading tasks namespace:"
-msgstr "タスクのネームスペースを読込中:"
+msgstr "بارگذاری وظایف فضای نام:"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler"
-msgstr "Quartz Schedulerを開始中"
+msgstr "شروع برنامه زمانبندی کوارتز"
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler"
-msgstr "Quartz Schedulerを停止中"
+msgstr "توقف کوارتز زمانبند"
 
 #: src/metabase/task.clj
 msgid "Job already exists:"
-msgstr "ジョブが既に存在します:"
+msgstr "وظیفه در حال حاضر وجود دارد:"
 
 #. This is the very first log message that will get printed.  It's here because this is one of the very first
 #. namespaces that gets loaded, and the first that has access to the logger It shows up a solid 10-15 seconds before
 #. the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
 #: src/metabase/util.clj
 msgid "Loading Metabase..."
-msgstr "Metabaseを読込中..."
+msgstr "در حال بارگیری متابیس ..."
 
 #: src/metabase/util/date.clj
 msgid "Possible timezone conflict found on database {0}."
-msgstr "データベース{0}でタイムゾーンのコンフリクトが検出されました"
+msgstr "درگیری احتمالی منطقه در پایگاه داده {0} یافت شد."
 
 #: src/metabase/util/date.clj
 msgid "JVM timezone is {0} and detected database timezone is {1}."
-msgstr "JVMのタイムゾーンは{0}で、検出されたデータベースのタイムゾーンは{1}です。"
+msgstr "منطقه زمانی JVM {0} است و منطقه زمانی داده شده را شناسایی کرده است {1}."
 
 #: src/metabase/util/date.clj
 msgid "Configure a report timezone to ensure proper date and time conversions."
-msgstr "レポートのタイムゾーンを構成して、適切な日時変換が行われるようにします。"
+msgstr "منطقه زمانی گزارش را پیکربندی کنید تا تبدیلات تاریخ و زمان مناسب را تضمین کنید."
 
 #: src/metabase/util/embed.clj
 msgid "Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints."
-msgstr "`/ api / embed`エンドポイントへのリクエストに対してJSON Webトークンに署名するために使用される秘密キー。"
+msgstr "کلید مخفی برای امضای JSON Web Tokens برای درخواست به نقطه انتهایی `/ api / embed 'استفاده می شود."
 
 #: src/metabase/util/encryption.clj
 msgid "MB_ENCRYPTION_SECRET_KEY must be at least 16 characters."
-msgstr "MB_ENCRYPTION_SECRET_KEYは16文字以上にしてください。"
+msgstr "MB_ENCRYPTION_SECRET_KEY باید حداقل 16 حرف باشد."
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is ENABLED for this Metabase instance."
-msgstr "このMetabaseインスタンスに対して、保存された資格情報の暗号化が有効になっています。"
+msgstr "رمزگذاری اعتبار ذخیره شده برای این مثال متاباز فعال می شود."
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is DISABLED for this Metabase instance."
-msgstr "保存された資格情報は、このMetabase Instanceでは無効化されています"
+msgstr "رمزگذاری داده های ذخیره شده برای این مثال Metabase غیرفعال است."
 
 #: src/metabase/util/encryption.clj
 msgid "nFor more information, see"
-msgstr "詳細はこちらを参照してください。"
+msgstr "n برای اطلاعات بیشتر، دیدن کنید"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer."
-msgstr "値は整数値でなくてはなりません"
+msgstr "مقدار آن باید یک عدد صحیح باشد."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a string."
-msgstr "値は文字列でなくてはなりません"
+msgstr "مقدار آن باید یک رشته باشد."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a boolean."
-msgstr "値は真偽値でなくてはなりません"
+msgstr "مقدار باید یک Boolean باشد."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a string that matches the regex `{0}`."
-msgstr "値は正規表現'{0}'に一致する文字列にしてください。"
+msgstr "مقدار باید یک رشته باشد که با regex {{0}} منطبق باشد."
 
 #: src/metabase/util/schema.clj
 msgid "value must satisfy one of the following requirements: "
-msgstr "値は、次のいずれかの要件を満たす必要があります: "
+msgstr "ارزش باید یکی از الزامات زیر را برآورده کند:"
 
 #: src/metabase/util/schema.clj
 msgid "value may be nil, or if non-nil, {0}"
-msgstr "値はnilでも良いし、non-nilの場合には{0}"
+msgstr "مقدار ممکن است صفر باشد، یا اگر غیر صفر باشد، {0}"
 
 #: src/metabase/util/schema.clj
 msgid "value must be one of: {0}."
-msgstr "値は次のいずれかにしてください: {0}"
+msgstr "مقدار باید از {0} باشد."
 
 #: src/metabase/util/schema.clj
 msgid "value must be an array."
-msgstr "値は配列でなくてはなりません"
+msgstr "مقدار آن باید یک آرایه باشد."
 
 #: src/metabase/util/schema.clj
 msgid "Each {0}"
-msgstr "各{0}"
+msgstr "هر {0}"
 
 #: src/metabase/util/schema.clj
 msgid "The array cannot be empty."
-msgstr "配列は空欄にできません。"
+msgstr "آرایه نمی‌تواند خالی باشد."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a non-blank string."
-msgstr "値は空欄のない文字列でなければなりません"
+msgstr "مقدار باید یک رشته غیر خالی باشد."
 
 #: src/metabase/util/schema.clj
 msgid "Integer greater than zero"
-msgstr "ゼロより大きい整数"
+msgstr "عدد صحیح بزرگتر از صفر"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer greater than zero."
-msgstr "値はゼロより大きい整数でなければなりません"
+msgstr "مقدار باید عدد صحیحی بزرگتر از صفر باشد"
 
 #: src/metabase/util/schema.clj
 msgid "Number greater than zero"
-msgstr "ゼロより大きい数値"
+msgstr "عدد بزرگتر از صفر"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a number greater than zero."
-msgstr "値はゼロより大きい数値でなければなりません"
+msgstr "مقدار باید عددی بزرگتر از صفر باشد"
 
 #: src/metabase/util/schema.clj
 msgid "Keyword or string"
-msgstr "キーワードや文字列"
+msgstr "کلید واژه یا رشته"
 
 #: src/metabase/util/schema.clj
 msgid "Valid field type"
-msgstr "有効なフィールドタイプ"
+msgstr "نوع فیلد معتبر"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid field type."
-msgstr "値は有効なフィールドタイプでなければなりません"
+msgstr "مقدار باید یک نوع فیلد معتبر باشد."
 
 #: src/metabase/util/schema.clj
 msgid "Valid field type (keyword or string)"
-msgstr "有効なフィールドタイプ（キーワードや文字列）"
+msgstr "نوع فیلد معتبر (کلید واژه یا رشته)"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid field type (keyword or string)."
-msgstr "値は有効なフィールドタイプ（キーワードや文字列）でなければなりません"
+msgstr "مقدار باید یک نوع فیلد معتبر باشد (کلید واژه یا رشته)."
 
 #: src/metabase/util/schema.clj
 msgid "Valid entity type (keyword or string)"
-msgstr "有効なエンティティタイプ（キーワードや文字列）"
+msgstr "نوع موجودیت معتبر (کلید واژه یا رشته)"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid entity type (keyword or string)."
-msgstr "値は有効なエンティティタイプ（キーワードや文字列）でなければなりません"
+msgstr "مقدار باید یک نوع نهایی معتبر باشد (کلید واژه یا رشته)."
 
 #: src/metabase/util/schema.clj
 msgid "Valid map"
-msgstr "有効なマップ"
+msgstr "نقشه معتبر"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a map."
-msgstr "値はマップでなければなりません"
+msgstr "ارزش باید یک نقشه باشد"
 
 #: src/metabase/util/schema.clj
 msgid "Valid email address"
-msgstr "有効なメールアドレス"
+msgstr "آدرس ایمیل معتبر"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid email address."
-msgstr "値は有効なメールアドレスでなければなりません"
+msgstr "مقدار باید یک آدرس ایمیل معتبری باشد"
 
 #: src/metabase/util/schema.clj
 msgid "Insufficient password strength"
-msgstr "パスワードの強度が足りません"
+msgstr "قدرت رمز عبور ناکافی"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer."
-msgstr "値は有効な整数でなければなりません"
+msgstr "مقدار باید یک عدد صحیح معتبر باشد"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer greater than zero."
-msgstr "値はゼロより大きい有効な整数でなければなりません"
+msgstr "مقدار آن باید عدد صحیح و‌ بزرگتر از صفر باشد."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid boolean string (''true'' or ''false'')."
-msgstr "valueは有効な真偽値の文字列（ '' true ''または '' false ''）でなければなりません。"
+msgstr "مقدار آن باید رشته ‘true’ یا ‘false’ باشد."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid JSON string."
-msgstr "値は有効なJSON文字列でなければなりません。"
+msgstr "مقدار آن باید رشته JSON باشد."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid embedding params map."
-msgstr "値は有効な埋め込みパラメーターマップでなければなりません。"
+msgstr "ارزش باید یک نقشه پارامتر تعبیه معتبر باشد."
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx:12
 msgid "Data permissions"
-msgstr "データ権限"
+msgstr "دسترسی‌های داده"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx:13
 msgid "Collection permissions"
-msgstr "コレクション権限"
+msgstr "مجوزهای مجموعه"
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
-msgstr "全てのコレクション権限を見る"
+msgstr "تمام مجوزهای مجموعه را مشاهده کنید"
 
 #: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
-msgstr "サブコレクションを変更することもできます"
+msgstr "همچنین زیر مجموعه ها را تغییر دهید"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
-msgstr "このコレクションとコンテンツを編集することができます"
+msgstr "می توانید این مجموعه و محتویات آن را ویرایش کنید"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
-msgstr "このコレクション内のアイテムを見ることができます"
+msgstr "می توانید آیتم های موجود در این مجموعه را مشاهده کنید"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
-msgstr "コレクションアクセス"
+msgstr "دسترسی به مجموعه"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
-msgstr "このグループには、コレクション内の最低一つのサブコレクションの閲覧権限があります"
+msgstr "این گروه اجازه می دهد حداقل یک زیر مجموعه از این مجموعه را مشاهده کنید."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
-msgstr "このグループは、このコレクションの最低1つのサブコレクションを編集する権限があります"
+msgstr "این گروه اجازه ویرایش حداقل یک زیر مجموعه از این مجموعه را دارد."
 
 #: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
-msgstr "サブコレクションを見る"
+msgstr "مشاهده زیر مجموعه ها"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
-msgstr "記憶する"
+msgstr "مرا به خاطر بسپار"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
-msgstr "このスキーマを自動探査(X-ray)する"
+msgstr "اشعه ایکس این طرح"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:258
 msgid "Edit the permissions for this collection"
-msgstr "このコレクションの権限を編集する"
+msgstr "ویرایش مجوزهای این مجموعه"
 
 #: frontend/src/metabase/containers/AddToDashSelectDashModal.jsx:55
 msgid "Add this question to a dashboard"
-msgstr "ダッシュボードにこの質問を追加する"
+msgstr "این سوال را به یک داشبورد اضافه کنید"
 
 #: frontend/src/metabase/containers/AddToDashSelectDashModal.jsx:65
 msgid "Create a new dashboard"
-msgstr "新ダッシュボードを作成する"
+msgstr "ساخت داشبورد جدید"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:45
 msgid "The page you asked for couldn't be found."
-msgstr "リクエストしたページが見つかりませんでした"
+msgstr "صفحه درخواستی شما یافت نشد"
 
 #: frontend/src/metabase/containers/ItemSelect.jsx:30
 msgid "Select a {0}"
-msgstr "{0}を選択する"
+msgstr "یک {0} را انتخاب کنید"
 
 #: frontend/src/metabase/containers/Overworld.jsx:185
 msgid "Save dashboards, questions, and collections in \"{0}\""
-msgstr "\"{0}\"にダッシュボード、質問、コレクションを保存する"
+msgstr "ذخیره داشبورد ها، سوالات و مجموعه ها در \"{0}\""
 
 #: frontend/src/metabase/containers/Overworld.jsx:188
 msgid "Access dashboards, questions, and collections in \"{0}\""
-msgstr "\"{0}\"のダッシュボード、質問、コレクションにアクセスする"
+msgstr "دسترسی به داشبورد ها، سوالات و مجموعه ها در \"{0}\""
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
-msgstr "比較"
+msgstr "مقایسه"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
-msgstr "ズームアウト"
+msgstr "کوچک‌نمایی"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
-msgstr "関連"
+msgstr "مربوط"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
-msgstr "さらに自動探査(X-ray)"
+msgstr "اشعه X بیشتر"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:40
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
-msgstr "結果がありません"
+msgstr "بدون نتیجه"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
-msgstr "検索結果が見つかりませんでした"
+msgstr "Metabase نمی تواند برای جستجوی شما هیچ نتیجه ای پیدا کند."
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
-msgstr "メトリクスがありません"
+msgstr "بدون معیارهای"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
 msgid "Aggregations"
-msgstr "集約"
+msgstr "انباشتگی"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
 msgid "Operators"
-msgstr "オペレーター"
+msgstr "عمل‌گرها"
 
 #: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
 msgid "Custom fields"
-msgstr "カスタムフィールド"
+msgstr "موضوعات سفارشی"
 
 #. 2. Create the new collections.
 #: src/metabase/db/migrations.clj
 msgid "Migrated Dashboards"
-msgstr "マイグレーションされたダッシュボード"
+msgstr "داشبورد مهاجرت"
 
 #: src/metabase/db/migrations.clj
 msgid "Migrated Pulses"
-msgstr "マイグレーションされたパルス"
+msgstr "پالس های مهاجرت"
 
 #: src/metabase/db/migrations.clj
 msgid "Migrated Questions"
-msgstr "マイグレーションされた質問"
+msgstr "سوالات مهاجرت شده"
 
 #. 4. move everything not in this Collection to a new Collection
 #: src/metabase/db/migrations.clj
 msgid "Moving instances of {0} that aren't in a Collection to {1} Collection {2}"
-msgstr "コレクションにない{0}のインスタンスを{1}コレクション{2}にマイグレーションする"
+msgstr "حرکت نمونه هایی از {0} که در مجموعه نیستند {1} مجموعه {2}"
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions: {0}"
-msgstr "権限を付与できませんでした: {0}"
+msgstr "مجوزها مجاز نبود: {0}"
 
 #: src/metabase/util/encryption.clj
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
-msgstr "暗号化された文字列を復号化できません。 MB_ENCRYPTION_SECRET_KEYを変更または設定しましたか？"
+msgstr "رشته رمزنگاری را نمی توان رمزگشایی کرد. آیا تغییر کرده اید یا فراموش کرده اید MB_ENCRYPTION_SECRET_KEY را تنظیم کنید؟"
 
 #: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
-msgstr "全てのパーソナルコレクション"
+msgstr "همه مجموعه های شخصی"
 
 #: src/metabase/driver/common.clj
 msgid "Host"
-msgstr "ホスト"
+msgstr "میزبان"
 
 #: src/metabase/driver/common.clj
 msgid "Port"
-msgstr "ポート"
+msgstr "پورت"
 
 #: src/metabase/driver/common.clj
 msgid "Database username"
-msgstr "データベースユーザー名"
+msgstr "نام کاربری پایگاه داده"
 
 #: src/metabase/driver/common.clj
 msgid "What username do you use to login to the database?"
-msgstr "データベースへのログインにどのユーザー名を使用しますか？"
+msgstr "از چه نام کاربری ای برای ورود به پایگاه داده استفاده می‌ کنید؟"
 
 #: src/metabase/driver/common.clj
 msgid "Database password"
-msgstr "データベースパスワード"
+msgstr "رمز پایگاه داده"
 
 #: src/metabase/driver/common.clj
 msgid "Database name"
-msgstr "データベース名"
+msgstr "نام پایگاه داده"
 
 #: src/metabase/driver/common.clj
 msgid "birds_of_the_world"
@@ -9079,59 +9108,59 @@ msgstr "birds_of_the_world"
 
 #: src/metabase/driver/common.clj
 msgid "Use a secure connection (SSL)?"
-msgstr "セキュア接続（SSL）を使用しますか？"
+msgstr "آیا از اتصال امن (SSL) استفاده می کنید؟"
 
 #: src/metabase/driver/common.clj
 msgid "Additional JDBC connection string options"
-msgstr "追加のJDBC接続文字列オプション"
+msgstr "گزینه های رشته اتصال JDBC اضافی"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Project ID"
-msgstr "プロジェクトID"
+msgstr "شناسه پروژه"
 
 #: src/metabase/driver/bigquery.clj
 msgid "praxis-beacon-120871"
-msgstr "プラクシスビーコン-120871"
+msgstr "praxis-beacon-120871"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Dataset ID"
-msgstr "データセットID"
+msgstr "شناسه داده"
 
 #: src/metabase/driver/bigquery.clj
 msgid "toucanSightings"
-msgstr "toucanSightings"
+msgstr "تانک ها"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Client ID"
-msgstr "クライアントID"
+msgstr "شناسه مشتری"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Client Secret"
-msgstr "クライアントシークレット"
+msgstr "مشتری راز"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Auth Code"
-msgstr "認証コード"
+msgstr "کد تایید"
 
 #: src/metabase/driver/crate.clj
 msgid "Hosts"
-msgstr "ホスト"
+msgstr "میزبانان"
 
 #: src/metabase/driver/druid.clj
 msgid "Broker node port"
-msgstr "ブローカーノードポート"
+msgstr "پورت گره کارگزار"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "Google Analytics Account ID"
-msgstr "Google AnalyticsアカウントID"
+msgstr "شناسه حساب Google Analytics"
 
 #: src/metabase/driver/h2.clj
 msgid "Connection String"
-msgstr "接続文字列"
+msgstr "رشته اتصال"
 
 #: src/metabase/driver/h2.clj
 msgid "Users/camsaul/bird_sightings/toucans"
-msgstr "Users/camsaul/bird_sightings/toucans"
+msgstr "کاربران / camsaul / bird_sightings / toucans"
 
 #: src/metabase/driver/mongo.clj
 msgid "carrierPigeonDeliveries"
@@ -9139,39 +9168,39 @@ msgstr "carrierPigeonDeliveries"
 
 #: src/metabase/driver/mongo.clj
 msgid "Authentication Database"
-msgstr "認証データベース"
+msgstr "پایگاه داده احراز هویت"
 
 #: src/metabase/driver/mongo.clj
 msgid "Optional database to use when authenticating"
-msgstr "認証時に使用する任意のデータベース"
+msgstr "پایگاه داده اختیاری برای استفاده هنگام تأیید اعتبار"
 
 #: src/metabase/driver/mongo.clj
 msgid "Additional Mongo connection string options"
-msgstr "追加のMongo接続文字列オプション"
+msgstr "گزینه های رشته اتصال اضافی Mongo"
 
 #: src/metabase/driver/oracle.clj
 msgid "Oracle system ID (SID)"
-msgstr "OracleシステムID（SID）"
+msgstr "شناسه سیستم اوراکل (SID)"
 
 #: src/metabase/driver/oracle.clj
 msgid "Usually something like ORCL or XE."
-msgstr "通常ORCLやXE等。"
+msgstr "معمولا چیزی شبیه ORCL یا XE است."
 
 #: src/metabase/driver/oracle.clj
 msgid "Optional if using service name"
-msgstr "サービス名を使用している場合は任意です"
+msgstr "در صورتی که از نام سرور استفاده می‌کنید، اختیاری است."
 
 #: src/metabase/driver/oracle.clj
 msgid "Oracle service name"
-msgstr "Oracleサービス名"
+msgstr "نام سرویس اوراکل"
 
 #: src/metabase/driver/oracle.clj
 msgid "Optional TNS alias"
-msgstr "任意のTNSエイリアス"
+msgstr "نام مستعار TNS اختیاری"
 
 #: src/metabase/driver/presto.clj
 msgid "hive"
-msgstr "ハイブ"
+msgstr "کندو"
 
 #: src/metabase/driver/redshift.clj
 msgid "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
@@ -9183,62 +9212,63 @@ msgstr "toucan_sightings"
 
 #: src/metabase/driver/sparksql.clj
 msgid "default"
-msgstr "デフォルト"
+msgstr "پیش‌فرض"
 
 #: src/metabase/driver/sqlite.clj
 msgid "Filename"
-msgstr "ファイル名"
+msgstr "اسم فایل"
 
 #: src/metabase/driver/sqlite.clj
 msgid "/home/camsaul/toucan_sightings.sqlite 😋"
-msgstr "/home/camsaul/toucan_sightings.sqlite 😋"
+msgstr "/home/camsaul/toucan_sightings.sqlite"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "BirdsOfTheWorld"
-msgstr "BirdsOfTheWorld"
+msgstr "پرندگان جهان"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "Database instance name"
-msgstr "データベースインスタンス名"
+msgstr "نام نمونه پایگاه داده"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "N/A"
-msgstr "該当なし"
+msgstr "ناموجود"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "Windows domain"
-msgstr "ウィンドウズドメイン"
+msgstr "دامین ویندوز"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:490
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:499
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
-msgstr "ラベル"
+msgstr "برچسب ها"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
+#, fuzzy
 msgid "Add members"
-msgstr "メンバーを追加する"
+msgstr "افزودن عضو"
 
 #: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
-msgstr "保存先のコレクション"
+msgstr "مجموعه آن ذخیره شده است"
 
 #: frontend/src/metabase/lib/groups.js:4
 msgid "All Users"
-msgstr "All Users"
+msgstr "همه کاربران"
 
 #: frontend/src/metabase/lib/groups.js:5
 msgid "Administrators"
-msgstr "管理者"
+msgstr "مدیران"
 
 #: frontend/src/metabase/lib/groups.js:6
 msgid "MetaBot"
-msgstr "MetaBot"
+msgstr "مِتا بات"
 
 #: frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx:290
 msgid "Sharing"
-msgstr "共有"
+msgstr "اشتراک گذاری"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:218
@@ -9259,7 +9289,7 @@ msgstr "共有"
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
-msgstr "表示"
+msgstr "نمایش دادن"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:358
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:393
@@ -9270,228 +9300,229 @@ msgstr "表示"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:447
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
-msgstr "軸"
+msgstr "محورها"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
 #: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
-msgstr "書式"
+msgstr "در حال پاک‌سازی"
 
 #: frontend/src/metabase/containers/Overworld.jsx:102
 msgid "Try these x-rays based on your data."
-msgstr "データに基づく自動探査(X-ray)を試す"
+msgstr "با استفاده از داده های خود این اشعه ایکس را امتحان کنید."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:36
 msgid "There was a problem displaying this chart."
-msgstr "チャートの表示で問題が発生しました"
+msgstr "مشکلی در نمایش نمودار وجود دارد."
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:37
 msgid "Sorry, you don't have permission to see this card."
-msgstr "申し訳ありません、このカードの閲覧権限がありません。"
+msgstr "شرمنده، شما اجازه مشاهده این کارت را ندارید."
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:55
 msgid "Just a heads up:"
-msgstr "注意喚起:"
+msgstr "فقط یک سر:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:63
 msgid "{0} without the Sample Dataset, the Query Builder tutorial won't work. You can always restore the Sample Dataset, but any questions you've saved using this data will be lost."
-msgstr "サンプルデータセットのない{0}では、クエリビルダーのチュートリアルは機能しません。 サンプルデータセットはいつでも復元できますが、このデータを使用して保存した質問は失われます。"
+msgstr "{0} بدون مجموعه داده های نمونه، آموزش Query Builder کار نخواهد کرد. شما همیشه می توانید مجموعه داده های نمونه را بازگردانید، اما هر سوالی که با استفاده از این داده ها ذخیره کرده اید، از بین می رود."
 
 #: frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx:33
 msgid "X-ray"
-msgstr "自動探査(X-ray)"
+msgstr "اشعه X"
 
 #: frontend/src/metabase/modes/components/drill/CompareToRestDrill.js:34
 msgid "Compare to the rest"
-msgstr "残りと比較する"
+msgstr "با بقیه مقایسه کن."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
-msgstr "JVMのタイムゾーンを使う"
+msgstr "از منطقه زمانی ماشین مجازی جاوا استفاده کن."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
-msgstr "もしほとんどのクエリで手動でタイムゾーンのキャストをしていない限り、この設定はそのままにしておくことをおすすめします"
+msgstr "ما پیشنهاد می کنیم که این کار را ترک کنید مگر اینکه در حال انجام مراحل مربوط به زمان بندی کاربر هستید\n"
+"بسیاری از یا بیشتر از پرس و جو خود را با این داده ها."
 
 #: frontend/src/metabase/containers/Overworld.jsx:312
 msgid "Your team's most important dashboards go here"
-msgstr "あなたのチームの最も重要なダッシュボードがここに表示されます"
+msgstr "مهمترین داشبورد تیم شما در اینجا قرار دارد"
 
 #: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
-msgstr "他の人も閲覧できるようこの場所に表示させるため、ダッシュボードを{0}でピン留めする"
+msgstr "پانل داشبورد در {0} برای اینکه آنها در این فضا برای همه ظاهر شوند"
 
 #: src/metabase/db.clj
 msgid "Unable to release the Liquibase lock after a migration failure"
-msgstr "マイグレーション失敗後、Liquibaseのロックを解放できません"
+msgstr "پس از انتقال ناموفق، امکان آزادسازی قفل Liquibase وجود ندارد"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Use JVM Time Zone"
-msgstr "JVMのタイムゾーンを使う"
+msgstr "استفاده از منطقه زمانی JVM"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:29
 msgid "We're currently analyzing the tables and fields to help you explore your data."
-msgstr "あなたがデータ分析を簡単にできるようテーブルとフィールドを解析中です・・"
+msgstr "برای کمک به  در حال تحلیل جداول و "
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
-msgstr "ヒント: "
+msgstr "نکته:"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
-msgstr "通貨単位を選択"
+msgstr "یک واحد پول انتخاب کنید"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
-msgstr "フィールドタイプ"
+msgstr "نوع فیلد"
 
 #: frontend/src/metabase/admin/routes.jsx:109
 #: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
-msgstr "トラブルシューティング"
+msgstr "عیب‌یابی"
 
 #: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
-msgstr "自動探査(X-ray)機能を有効化"
+msgstr "فعال‌کردن ویژگی X-ray"
 
 #: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
-msgstr "書式オプション"
+msgstr "گزینه های قالب بندی"
 
 #: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
-msgstr "タスク詳細"
+msgstr "جزییات کار"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:29
 msgid "Troubleshooting logs"
-msgstr "トラブルシューティングログ"
+msgstr "لاگ‌های عیب‌یابی"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:31
 msgid "Trying to get to the bottom of something? This section shows logs of Metabase's background tasks, which can help shed light on what's going on."
-msgstr "何かの原因究明をしようとしていますか？このセクションではMetabaseのバックグラウンドタスクのログを表示しています。これを見れば何が起こっているかを知る助けになるでしょう。"
+msgstr "سعی می کنید به ته چیزی برسید؟ در این بخش log های مربوط به کارهای پس زمینه Metabase را نشان می دهد ، که می تواند به روشنایی آنچه در جریان است کمک کند."
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:56
 msgid "Task"
-msgstr "タスク"
+msgstr "کار"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:57
 msgid "DB ID"
-msgstr "データベースID"
+msgstr "شناسه پایگاه‌داده"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:58
 msgid "Started at"
-msgstr "に開始"
+msgstr "زمان شروع"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:59
 msgid "Ended at"
-msgstr "に終了"
+msgstr "زمان پایان"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:60
 msgid "Duration (ms)"
-msgstr "実行時間(ms)"
+msgstr "دیرش (میلی ثانیه)"
 
 #: frontend/src/metabase/lib/core.js:45
 msgid "Currency"
-msgstr "通貨"
+msgstr "واحد پول"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
-msgstr "ユーザーかチャンネルを選ぶ..."
+msgstr "یک کاربر یا کانال را انتخاب کنید..."
 
 #: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
-msgstr "フォーマット設定はありません"
+msgstr "بدون تنظیمات قالب بندی"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:81
 msgid "Label for this range (optional)"
-msgstr "範囲のラベル（任意）"
+msgstr "برچسب برای این بازه (اختیاری)"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:93
 msgid "Add a range"
-msgstr "範囲を追加"
+msgstr "یک بازه اضافه کنید"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "is less than"
-msgstr "未満"
+msgstr "کمتر از"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "is greater than"
-msgstr "大きい"
+msgstr "بزرگتر از"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:28
 msgid "is less than or equal to"
-msgstr "以下"
+msgstr "کمتر از یا برابر با"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:29
 msgid "is greater than or equal to"
-msgstr "以上"
+msgstr "بزرگتر از یا برابر با"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:37
 msgid "is equal to"
-msgstr "等しい"
+msgstr "برابر با"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:31
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:38
 msgid "is not equal to"
-msgstr "等しくない"
+msgstr "مساوی نیست با"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:32
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:39
 msgid "is null"
-msgstr "null値"
+msgstr "تهی هست"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:33
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:40
 msgid "is not null"
-msgstr "null値でない"
+msgstr "تهی نیست"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:41
 msgid "contains"
-msgstr "含む"
+msgstr "شامل می شود"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:42
 msgid "does not contain"
-msgstr "含まない"
+msgstr "شامل نمی شود"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:43
 msgid "starts with"
-msgstr "接頭辞"
+msgstr "شروع با"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:44
 msgid "ends with"
-msgstr "接尾辞"
+msgstr "پایان با"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:292
 msgid "When a cell in these columns {0} it will be tinted this color."
-msgstr "この列のセルが{0}のとき、この色に色付けされます"
+msgstr "وقتی سلول در این ستون ها {0} باشد ، این رنگ را رنگی می کند."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:351
 msgid "When a cell in this column…"
-msgstr "この列のセルが…したとき"
+msgstr "وقتی سلول در این ستون…"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:42
 msgid "This visualization requires you to group by a field."
-msgstr "表示にはグループ化するためのフィールドが必要です。"
+msgstr "برای نمایش باید داده های خود را بر اساس یک فیلد گروه کنید. "
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:178
 msgid "Date style"
-msgstr "日付の形式"
+msgstr "استایل تاریخ"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:196
 msgid "Date separators"
-msgstr "日付の区切り文字"
+msgstr "جداکننده تاریخ"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:215
 msgid "Abbreviate names of days and months"
-msgstr "日と月の略称"
+msgstr "نام اختصاری روزها و ماه‌ها"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:225
 msgid "Show the time"
-msgstr "時間を表示"
+msgstr "زمان را نشان بده"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:232
 msgid "HH:MM"
@@ -9499,383 +9530,384 @@ msgstr "HH:MM"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:240
 msgid "HH:MM:SS"
-msgstr "HH:MM:SS"
+msgstr "HH:MM:SS\n"
+""
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:243
 msgid "HH:MM:SS.MS"
-msgstr "HH:MM:SS.MS"
+msgstr "HH:MM:SS.MS\n"
+""
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:254
 msgid "Time style"
-msgstr "時刻の形式"
+msgstr "سبک زمان"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:300
 msgid "Unit of currency"
-msgstr "通貨単位"
+msgstr "واحد پول"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
-msgstr "通貨単位の表示形式"
+msgstr "سبک برچسب ارز"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
-msgstr "通貨単位の表示場所"
+msgstr "واحد پول را از کجا نمایش دهیم"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
-msgstr "小数点の最小桁数"
+msgstr "حداقل تعداد اعشار"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
-msgstr "積み上げグラフ形式"
+msgstr "نوع نمودار انباشته"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
-msgstr "ゴールラベル"
+msgstr "برچسب هدف"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
-msgstr "傾向線を表示"
+msgstr "نمایش خط روند"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:67
 msgid "Line style"
-msgstr "線の形式"
+msgstr "سبک خط"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:84
 msgid "Show dots on lines"
-msgstr "点線で表示"
+msgstr "نمایش نقاط بر روی خط"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
-msgstr "自動"
+msgstr "خودکار"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:120
 msgid "Which axis?"
-msgstr "どちらの軸？"
+msgstr "کدام محور؟"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
 msgid "Line + Bar"
-msgstr "折れ線＋棒"
+msgstr "خط + نوار"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:19
 msgid "line and bar chart"
-msgstr "折れ線＋棒グラフ"
+msgstr "نمودار خط و نوار"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
-msgstr "ゲージビジュアライゼーションには数値が必要です"
+msgstr "تجسم سنج به تعدادی نیاز دارد."
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:60
-#, fuzzy
 msgid "Gauge"
-msgstr "ゲージ"
+msgstr "سنج"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
-#, fuzzy
 msgid "Gauge ranges"
-msgstr "ゲージの範囲"
+msgstr "محدوده سنج"
 
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
-msgstr "表示するフィールド"
+msgstr "زمینه برای نشان دادن"
 
-#. 「前{0}」はどうでしょう。前日、前月、…
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
-msgstr "前{0}"
+msgstr "آخرین {0}"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
-msgstr "{0} は {1} {2}でした"
+msgstr "{0} بود {1} {2}"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
-msgstr "時間経過と共にどのように変化したか見るため時間のフィールドでグルーピング"
+msgstr "گروهی را با یک فیلد زمانی برای دیدن چگونگی تغییر این موضوع در طول زمان ، گروه بندی کنید"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
-msgstr "＋/ーの色を入れ替える？"
+msgstr "تغییر رنگ های مثبت / منفی؟"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
-msgstr "ピボット項目"
+msgstr "ستون محوری"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
-msgstr "セル項目"
+msgstr "ستون سلول"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
-msgstr "表示列"
+msgstr "ستونهای قابل مشاهده"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
-msgstr "条件付き書式"
+msgstr "قالب بندی شرطی"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
-msgstr "項目名"
+msgstr "عنوان ستون"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
-msgstr "ミニバーを表示"
+msgstr "نمایش نمودار نوار"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
-msgstr "リンク"
+msgstr "لینک"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
-msgstr "メールアドレス"
+msgstr "لینک ایمیل"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
-msgstr "イメージ"
+msgstr "تصویر"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
-msgstr "自動"
+msgstr "اتوماتیک"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
-msgstr "リンクまたは画像として表示"
+msgstr "به عنوان لینک یا تصویر مشاهده کنید"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
-msgstr "リンクテキスト"
+msgstr "لینک متن"
 
 #: src/metabase/api/common/internal.clj
 msgid "Not a valid integer: ''{0}''"
-msgstr "有効な数値ではありません: \"{0}\""
+msgstr "یک عدد صحیح معتبر نیست: '' {0} ''"
 
 #: src/metabase/api/embed.clj
+#, fuzzy
 msgid "Embedding is not enabled for this object."
-msgstr "このオブジェクトは埋め込み可能になっていません。"
+msgstr "جاسازی برای این شی فعال نیست."
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fallback to local authentication: {0}"
-msgstr "LDAPサーバー接続に失敗し、ローカルで認証します: {0}"
+msgstr "اتصال به سرور LDAP به تأیید اعتبار محلی بازگردد: {0}"
 
 #: src/metabase/api/task.clj
 msgid "When including an offset, a limit must also be included."
-msgstr "オフセットを含む場合、上限も含まないといけません"
+msgstr "هنگام اضافه کردن یک افست ، محدودیتی نیز باید درج شود."
 
 #: src/metabase/api/task.clj
 msgid "When including a limit, an offset must also be included."
-msgstr "上限を含む場合、オフセットも含まないといけません"
+msgstr "هنگام اضافه کردن محدودیت ، یک جبران خسارت نیز باید درج شود."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Applying heuristic {0} to {1}."
-msgstr ""
+msgstr "درخواست اکتشافی {0} تا {1}."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Dimensions bindings:n{0}"
-msgstr ""
+msgstr "اتصالات ابعاد: {n {0"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Using definitions:nMetrics:n{0}nFilters:n{1}"
-msgstr ""
+msgstr "با استفاده از تعاریف: n اندازه گیری: n {0} n فیلترها: {n {1"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "minute"
-msgstr "分"
+msgstr "دقیقه"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "hour"
-msgstr "時"
+msgstr "ساعت"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of week"
-msgstr "曜日"
+msgstr "روز هفته"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of month"
-msgstr "日"
+msgstr "روز ماه"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of year"
-msgstr "年間通算日"
+msgstr "روز سال"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "week"
-msgstr "週"
+msgstr "هفته"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "month"
-msgstr "月"
+msgstr "ماه"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "quarter"
-msgstr "四半期"
+msgstr "ربع"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding {0} cards to dashboard {1}:n{2}"
-msgstr "{0}カードをダッシュボード{1}:n{2}に追加中"
+msgstr "افزودن کارت {0} به داشبورد {1}: {n {2"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Error parsing {0}:n{1}"
-msgstr ""
+msgstr "خطا در تجزیه {0}: {n {1"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Filtering only works on dimensions! ''{0}'' is a metric. Ignoring filter."
-msgstr "警告: フィルタリングはディメンションでのみ機能します！ ''{0}''はメトリックです。フィルターを無視します。"
+msgstr "هشدار: فیلتر کردن فقط در ابعاد کار می کند! '' {0} '\"یک متریک است. نادیده گرفتن فیلتر."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: A date can't belong to multiple discrete intervals, so ANDing them together doesn't make sense."
-msgstr "警告: 日付は複数の連続しない区間に属することはないので、それらの条件をAND条件でつなぐことは意味を成しません。"
+msgstr "اخطار: تاریخ نمی تواند به چندین فواصل گسسته تعلق داشته باشد ، بنابراین کنار آمدن با یکدیگر معنی ندارد."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Ignoring these intervals: {0}"
-msgstr "これらの間隔を無視: {0}"
+msgstr "نادیده گرفتن این فواصل: {0}"
 
 #. We should never get to this point since the all non-string negations should get automatically rewritten
 #. by the query expander.
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Don't know how to negate: {0}"
-msgstr "警告: 無効にする方法がわからない: {0}"
+msgstr "اخطار: نمی دانید چگونه نفی کنید: {0}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Sorting with Druid is only allowed in queries that have one or more breakout columns. Ignoring :order-by clause."
-msgstr "Druid によるソートは、1つ以上のブレークアウト列があるクエリでのみ許可されます。 :order-by 句を無視します。"
+msgstr "مرتب سازی با Druid فقط در سؤالات نمایش داده شده که دارای یک یا چند ستون Breakout هستند ، مجاز است. نادیده گرفتن: بند سفارش."
 
 #. TODO - this is not really true, is it
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: It only makes sense to specify :fields for a query with no aggregation. Ignoring the clause."
-msgstr "警告: 集計のないクエリには :fields を指定することだけが意味があります。句を無視します。"
+msgstr "اخطار: فقط منطقی است كه زمینه ها را برای پرس و جو بدون تجمعات مشخص كنید. نادیده گرفتن بند."
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid doenst allow limitSpec in timeseries queries. Ignoring the LIMIT clause."
-msgstr "警告: Druid は時系列クエリで limitSpec を許可しません。 LIMIT 句を無視します。"
+msgstr "اخطار: Druid در نمایش داده های سری زمانی limitSpec را مجاز نمی کند. نادیده گرفتن بند LIMIT."
 
 #: src/metabase/driver/sql/query_processor.clj
 msgid "HoneySQL Form:"
-msgstr "HoneySQLフォーム:"
+msgstr "فرم HoneySQL:"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Unable to parse date ''{0}''"
-msgstr "日付として解析できません: \"{0}\""
+msgstr "تجزیه تاریخ '' {0} '' امکان پذیر نیست"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, cancelling query"
-msgstr "クライアントは切断しました。クエリをキャンセルしています。"
+msgstr "اتصال بسته مشتری ، جستجوی لغو"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Setting timezone with statement: {0}"
-msgstr "ステートメントでタイムゾーンを設定: {0}"
+msgstr "تنظیم منطقه زمانی با بیانیه: {0}"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid "Multiple date filters are not supported"
-msgstr "複数の日付フィルターはサポートされていません"
+msgstr "فیلترهای تاریخ چندگانه پشتیبانی نمی شوند"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid ":not is not yet implemented"
-msgstr ":not はまだ実装されていません"
+msgstr ": هنوز اجرا نشده است"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid "Only one Google Analytics segment allowed at a time."
-msgstr "同時に複数のGoogle Analyticsセグメントは利用できません。"
+msgstr "فقط یک بخش Google Analytics به طور همزمان مجاز است."
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "MONGO AGGREGATION PIPELINE:"
-msgstr "MongoDB集約パイプライン："
+msgstr "MONGO AGGREGATION PIPELINE:\n"
+""
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "Error: mismatched columns in results! Expected: {0} Got: {1}"
-msgstr "エラー: 結果に整合しない項目があります！ 想定は {0} 、結果は {1} でした"
+msgstr "خطا: ستون ها در نتایج ناسازگار است! پیش بینی شده: {0} رسید: {1}"
 
 #: src/metabase/email/messages.clj
 msgid "Unable to create temp file in `{0}` for email attachments "
-msgstr "`{0}` にメール添付のための一時ファイルを作成できません"
+msgstr "امکان ایجاد پرونده موقت در {0} برای پیوست های ایمیل وجود ندارد"
 
 #: src/metabase/events/activity_feed.clj
 msgid "Error preprocessing query:"
-msgstr "クエリ処理に失敗:"
+msgstr "خطا در پردازش خطا:"
 
 #: src/metabase/mbql/normalize.clj
 msgid "Illegal filter clause: {0}"
-msgstr "不正なフィルター条件: {0}"
+msgstr "بند فیلتر غیرقانونی: {0}"
 
 #: src/metabase/mbql/normalize.clj
 msgid "Invalid clause:"
-msgstr "不正な条件:"
+msgstr "بند نامعتبر:"
 
 #: src/metabase/mbql/util.clj
 msgid "Error: query's source query has not been resolved. You probably need to `preprocess` the query first."
-msgstr "エラー: クエリに使われているソースクエリを特定できません。恐らく初めに事前処理する必要があります。"
+msgstr "خطا: پرس و جو منبع پرس و جو برطرف نشده است. احتمالاً ابتدا باید query را پردازش کنید."
 
 #: src/metabase/mbql/util.clj
 msgid "No expression named ''{0}''"
-msgstr "\"{0}\" という名前はありません"
+msgstr "هیچ عبارتی به نام '' {0} ''"
 
 #: src/metabase/mbql/util.clj
 msgid "No aggregation at index: {0}"
-msgstr "{0} のインデックスに集合はありません"
+msgstr "هیچ شاخصی در شاخص: {0}"
 
 #: src/metabase/models/field_values.clj
 msgid "Field values total length is {0} (max {1})."
-msgstr "フィールド値の長さが {0} です。(最大 )"
+msgstr "طول کل مقادیر میدان {0} است (حداکثر{1})."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues are allowed for this Field."
-msgstr "FieldValues はこのフィールドに設定できます"
+msgstr "FieldValues برای این قسمت مجاز است."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues are NOT allowed for this Field."
-msgstr "FieldValues はこのフィールドに設定できません"
+msgstr "FieldValues برای این قسمت مجاز نیست."
 
 #: src/metabase/models/field_values.clj
 msgid "Field {0} ''{1}'' should have FieldValues and belongs to a Database with On-Demand FieldValues updating."
-msgstr ""
+msgstr "قسمت {0} '' {1} '' باید دارای FieldValues باشد و به یک بانک اطلاعاتی با به روزرسانی FieldValues On-Demand تعلق دارد."
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot create or revoke permissions for the ''Admin'' group."
-msgstr "Adminグループの権限の作成または取り消しはできません"
+msgstr "شما نمی توانید مجوزها را برای گروه \"مدیر\" ایجاد یا لغو کنید."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the ''MetaBot'' group."
-msgstr "MetaBotグループのユーザーは変更できません"
+msgstr "شما قادر به حذف یا اضافه کردن کاربر به گروه \"MetaBot\" نیستید."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the ''All Users'' group."
-msgstr "All Usersグループのユーザーは変更できません"
+msgstr "شما نمی توانید کاربران را به گروه \"همه کاربران\" اضافه یا حذف کنید."
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the ''Admin'' group!"
-msgstr "Adminグループには最低１人のメンバーを残さないといけません！"
+msgstr "شما نمی توانید آخرین عضو گروه \"مدیر\" را حذف کنید!"
 
 #. go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
 #: src/metabase/models/setting/cache.clj
 msgid "Error inserting a new Setting: {0}"
-msgstr "新しい設定の追加に失敗: {0}"
+msgstr "خطا در وارد کردن یک تنظیم جدید: {0}"
 
 #: src/metabase/models/setting.clj
 msgid "defsetting descriptions strings must be `:internal?` or internationalized, found: `{0}`"
-msgstr ""
+msgstr "رشته های توصیف ناپیوسته باید \"داخلی\" یا بین المللی یافت شده ، یافت شوند: \"{0}\""
 
 #: src/metabase/plugins.clj
 msgid "Loading plugin {0}... {1}"
-msgstr "プラグインを読み込み中 {0}... {1}"
+msgstr "بارگیری افزونه {0} ... {1}"
 
 #: src/metabase/public_settings.clj
 msgid "Object keyed by type, containing formatting settings"
-msgstr ""
+msgstr "کلید بسته شده بر اساس نوع ، حاوی تنظیمات قالب بندی"
 
 #: src/metabase/public_settings.clj
 msgid "Allow users to explore data using X-rays"
-msgstr "自動探査(X-ray)を使ってデータの探索を許可する"
+msgstr "به کاربران اجازه دهید داده ها را با استفاده از اشعه X اکتشاف کنند"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Using this URL to check token: {0}"
-msgstr "トークンのチェックにこのURLを使います: {0}"
+msgstr "با استفاده از این URL برای بررسی توکن: {0}"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token: 404 not found."
-msgstr "トークンを検証できません: 404"
+msgstr "تأیید اعتبار نمیتواند: 404 یافت نشد."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid:"
-msgstr "トークンの有効性チェックでエラー:"
+msgstr "هنگام بررسی صحت این نشان خطایی رخ داد:"
 
 #. +----------------------------------------------------------------------------------------------------------------+
 #. |                                             SETTING & RELATED FNS                                              |
@@ -9883,292 +9915,295 @@ msgstr "トークンの有効性チェックでエラー:"
 #. TODO - rename this to premium-features-token?
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium features. Go to the MetaStore to get yours!"
-msgstr "プレミアム機能のトークン取得のためMetaStoreに行きましょう！"
+msgstr "بیان ویژگی های حق بیمه برو به MetaStore برای گرفتن مال شما!"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token format is invalid. Token should be 64 hexadecimal characters."
-msgstr "トークンの形式が不正です。トークンは64文字の16進数です。"
+msgstr "قالب گفتاری نامعتبر است. توکن باید 64 کاراکتر شش ضلعی باشد."
 
 #: src/metabase/public_settings/metastore.clj
+#, fuzzy
 msgid "Error setting premium features token"
-msgstr "プレミアム機能トークンの設定に失敗"
+msgstr "خطا در تنظیم توکن های حق بیمه"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error validating token:"
-msgstr "トークンの検証エラー:"
+msgstr "خطا در تأیید اعتبار:"
 
 #: src/metabase/query_processor.clj
 msgid "Error preprocessing query"
-msgstr "クエリの処理エラー"
+msgstr "خطا در پردازش پرس و جو خطا"
 
 #: src/metabase/query_processor.clj
 msgid "No native form returned."
-msgstr "ネイティブフォームは返されません。"
+msgstr "هیچ شکل بومی برگشت نداد."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
-msgstr "データベースドライバーから不正な応答: ステータスを確認できません"
+msgstr "پاسخ نامعتبر از درایور پایگاه داده. خیر: وضعیت ارائه شده"
 
 #: src/metabase/query_processor.clj
 msgid "General error"
-msgstr "一般的なエラー"
+msgstr "خطای عمومی"
 
 #: src/metabase/query_processor.clj
 msgid "Missing query hash!"
-msgstr "クエリハッシュが不足しています"
+msgstr "هش پرس و جو وجود ندارد!"
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Table ''{0}'' has no Fields associated with it."
-msgstr "テーブル \"{0}\" には指定されたフィールドに関連するフィールドはありません。"
+msgstr "در جدول \"\" {0} \"هیچ فیلد مرتبط با آن وجود ندارد."
 
 #: src/metabase/query_processor/middleware/add_query_throttle.clj
 msgid "Max concurrent query limit reached"
-msgstr "最大同時クエリ数に達しました"
+msgstr "حداکثر حد سؤال همزمان رسیده است"
 
 #. we should never reach this if our patterns are written right so this is more to catch code mistakes than
 #. something the user should expect to see
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Don't know how to get information about Field:"
-msgstr "フィールドの情報を取得する方法を知りません:"
+msgstr "نمی دانید چگونه می توانید اطلاعات مربوط به زمینه را بدست آورید:"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "metabase.query-processor.interface/*driver* is unbound."
-msgstr ""
+msgstr "درایور metabase.query-processor.interface / * محدود نیست."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: mismatched number of columns in query and results."
-msgstr "クエリプロセッサエラー：クエリと結果におけるコラム数が一致していません"
+msgstr "خطای پردازنده پرس و جو: تعداد ستونها در پرس و جو و نتایج ناسازگار است."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} fields, got {1}"
-msgstr "{0} のフィールドのうち {1} を取得しました"
+msgstr "توقع {0} فیلد , بدست امدن {1}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected: {0}"
-msgstr "予定: {0}"
+msgstr "توقع :  {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Actual: {0}"
-msgstr "結果: {0}"
+msgstr "واقعی: {0}"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Unable to bin Field without a min/max value"
-msgstr "最小値、最大値なしにフィールドを格納できません"
+msgstr "bin Field بدون ارزش حداقل / حداکثر امکان پذیر نیست"
 
 #: src/metabase/query_processor/middleware/check_features.clj
 msgid "{0} is not supported by this driver."
-msgstr "{0} はこのドライバーでサポートされていません"
+msgstr "{0} توسط این درایور پشتیبانی نمی شود."
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Segment {0} does not exist, or is invalid."
-msgstr "セグメント {0} は存在しないか無効です。"
+msgstr "قطعه {0} وجود ندارد ، یا نامعتبر است."
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Metric {0} does not exist, or is invalid."
-msgstr "メトリック {0} は存在しないか無効です。"
+msgstr "متریک {0} وجود ندارد ، یا نامعتبر است."
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Missing source query in Card {0}"
-msgstr "カード {0} にはソースクエリが不足しています"
+msgstr "جستجوی منبع موجود در کارت {0}"
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Fetched source query from Card {0}:"
-msgstr "カード {0} から取得されたソースクエリ"
+msgstr "جستجوی منبع دریافت شده از کارت {0}:"
 
 #: src/metabase/query_processor/middleware/mbql_to_native.clj
 msgid "Error transforming MBQL query to native:"
-msgstr "MBQLクエリからネイティブクエリに変換中にエラーが起こりました:"
+msgstr "خطا در تبدیل درخواست MBQL به بومی:"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Cannot run query: could not find source table {0}."
-msgstr "クエリを実行できません: ソーステーブル {0} が見つかりません"
+msgstr "جستجوی جستجو امکان پذیر نیست: جدول منبع یافت نشد {0}."
 
 #: src/metabase/query_processor/middleware/results_metadata.clj
 msgid "Error recording results metadata for query:"
-msgstr ""
+msgstr "خطا در ثبت فوق داده های نتایج برای پرس و جو:"
 
 #: src/metabase/query_processor/store.clj
+#, fuzzy
 msgid "Error: Query Processor store is not initialized."
-msgstr "エラー: クエリ処理ストアが初期化されていません。"
+msgstr "خطا: فروشگاه Query پردازنده آغازین نشده است."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Table {0} is not present in the Query Processor Store."
-msgstr "エラー: テーブル{0}がクエリ処理ストアに存在しません。"
+msgstr "خطا: جدول {0} فروشگاه Query پردازنده موجود نیست."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Field {0} is not present in the Query Processor Store."
-msgstr "エラー: フィールド{0}がクエリ処理ストアに存在しません。"
+msgstr "خطا: قسمت {0} در فروشگاه Query پردازنده موجود نیست."
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were {0}deleted"
-msgstr "タスク履歴の削除は成功しました。{0}行が削除されました。"
+msgstr "پاک سازی سابقه کار با موفقیت انجام شد ، ردیف ها {0} حذف شدند"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "not"
-msgstr "でない"
+msgstr "نه"
 
 #: src/metabase/util/encryption.clj
 msgid "For more information, see"
-msgstr "詳細はこちら"
+msgstr "برای اطلاعات بیش‌تر مشاهده کنید :"
 
 #: src/metabase/util/schema.clj
 msgid "Integer greater than or equal to zero"
-msgstr "0以上の整数"
+msgstr "عدد صحیح بیشتر از یا برابر صفر است"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer greater than or equal to zero."
-msgstr "値は0以上の整数でないといけません"
+msgstr "مقدار باید عدد صحیحی بزرگتر یا مساوی صفر باشد."
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer zero or greater."
-msgstr "値は0かそれより大きな整数でないといけません"
+msgstr "مقدار باید صفر یا بیشتر از عدد صحیح باشد."
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer greater than or equal to zero."
-msgstr "値は0以上の有効な整数でないといけません"
+msgstr "مقدار باید یک عدد صحیح معتبر بزرگتر از یا برابر با صفر باشد."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "New users per state in the last 30 days"
-msgstr "過去30日の状態ごとの新規ユーザー"
+msgstr "کاربران جدید در هر ایالت در 30 روز گذشته"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by day of the week"
-msgstr "曜日別の作成日時"
+msgstr "ایجاد شده توسط روز هفته"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by quarter of the year"
-msgstr "四半期別の作成日時"
+msgstr "ایجاد شده در سه ماهه سال"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per country"
-msgstr "国ごとの [[this.short-name]]"
+msgstr "[[this.short-name]] در هر کشور"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Users per source"
-msgstr "ソースごとのユーザー"
+msgstr "کاربران در هر منبع"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "The top external pages that brought users to your site"
-msgstr "ユーザーを最も呼び込んでいる外部ページ"
+msgstr "صفحات برتر خارجی که کاربران را به سایت شما رسانده است"
 
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
-msgstr ""
+msgstr "چگونگی توزیع [[this]] و موارد دیگر."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "The [[this]] over time"
-msgstr "[[this]] の時間推移"
+msgstr "[[this]] با گذشت زمان"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "User growth"
-msgstr "ユーザー増加"
+msgstr "رشد کاربر"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Whether or not there are any patterns to when they happen."
-msgstr "いつ発生したかに何らかのパターンがあるかどうか"
+msgstr "چه الگویی در مورد وقوع آنها وجود داشته باشد یا نه."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Users per state"
-msgstr "状態ごとのユーザー"
+msgstr "کاربران در هر ایالت"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions"
-msgstr "セッション"
+msgstr "نشست ها"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How some of the numbers in [[this]] relate to each other"
-msgstr ""
+msgstr "چگونه برخی از اعداد موجود در [[this]] به یکدیگر مربوط می شوند"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per country"
-msgstr "国ごとの売上"
+msgstr "فروش ها به ازای هر کشور"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by month of the year"
-msgstr "月別の登録日"
+msgstr "تاریخ عضویت ماه سال"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by hour of the day"
-msgstr "時間別の [[Timestamp]]"
+msgstr "[[Timestamp]] ساعتی از روز"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "A look at the [[this]]"
-msgstr "[[this]] の概要"
+msgstr "نگاهی به [[this]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Bottom 5 per category"
-msgstr "カテゴリーごとの下位5位"
+msgstr "پایین 5 در هر گروه"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Number of orders"
-msgstr "注文数"
+msgstr "تعداد سفارشات"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Event growth"
-msgstr "イベント増加"
+msgstr "رشد رویداد"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "Total [[GenericTable]]"
-msgstr "[[GenericTable]] 合計"
+msgstr "تعداد [[GenericTable]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Income growth"
-msgstr "収益の増加"
+msgstr "رشد درآمد"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales in the last 30 days"
-msgstr "過去30日の売上上位10位の国"
+msgstr "10 کشور برتر با فروش در 30 روز گذشته"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by month of the year"
-msgstr "月別の [[this]]"
+msgstr "[[این]] ماه سال"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per day of the week"
-msgstr "曜日毎のトランザクション"
+msgstr "معاملات روزانه هفته"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by device type"
-msgstr "デバイスタイプ別のセッション"
+msgstr "جلسات بر اساس نوع دستگاه"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Transactions per country"
-msgstr "国ごとのトランザクション"
+msgstr "معاملات در هر کشور"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by quarter of the year"
-msgstr "四半期別の登録日"
+msgstr "تاریخ عضویت در سه ماهه سال است"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per hour of the day"
-msgstr "時間帯ごとのイベント"
+msgstr "رویدادها در هر ساعت از روز"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Singleton]]"
-msgstr "[[Singleton]]"
+msgstr "[[Singleton]]\n"
+""
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Top 5 [[this]]"
-msgstr "[[this]] の上位5つ"
+msgstr "5 مورد برتر [[this]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Bottom 5 [[this]]"
-msgstr "[[this]] の下位5つ"
+msgstr "پایین 5 [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by day of the month"
-msgstr "日別の [[Timestamp]]"
+msgstr "[[Timestamp]] تا روز ماه"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[GenericCategoryLarge]]"
-msgstr "[[GenericCategoryLarge]] ごと"
+msgstr "در هر [[GenericCategorLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10176,335 +10211,337 @@ msgstr "[[GenericCategoryLarge]] ごと"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Null values"
-msgstr "Null値"
+msgstr "مقادیر تهی"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Total events"
-msgstr "総イベント数"
+msgstr "کل رویدادها"
 
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "A look at [[GenericTable]] across your [[this]], and how it changes over time."
-msgstr ""
+msgstr "نگاهی به [[GenericTable]] در [[this]] شما ، و اینکه چگونه با گذشت زمان تغییر می کند."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryMedium]]"
-msgstr "[[GenericCategoryMedium]] ごとの [[this]]"
+msgstr "[[this]] به ازای [[GenericCategorMedium]]"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] changes with time"
-msgstr "[[this]]が時間とともにどのように変化するか"
+msgstr "چگونه [[this]] با زمان تغییر می کند"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "How they compare by seasonality"
-msgstr "季節ごとの比較"
+msgstr "چگونگی مقایسه آنها با فصلی"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average income per transaction"
-msgstr "トランザクションごとの平均収益"
+msgstr "درآمد متوسط در هر تراکنش"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per country"
-msgstr "国ごとの [[this]]"
+msgstr "[[this]] در هر کشور"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Income per state"
-msgstr "州ごとの収益"
+msgstr "درآمد در هر ایالت"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[GenericCategoryMedium]]"
-msgstr "[[GenericCategoryMedium]] ごとの"
+msgstr "در هر [[GenericCategorMedium]]"
 
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "A closer look at your [[this]]"
-msgstr "あなたの [[this]] を詳しく見る"
+msgstr "نگاه دقیق تر به [[this]] شما"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "How [[GenericNumber]] is distributed"
-msgstr "[[GenericNumber]] の分散"
+msgstr "نحوه توزیع [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by quarter of year"
-msgstr "四半期別の [[Timestamp]]"
+msgstr "[[Timestamp]] تا ربع سال"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per country"
-msgstr "国ごとのイベント"
+msgstr "رویدادها در هر کشور"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Weekdays when [[this.short-name]] were added"
-msgstr "[[this.short-name]] が追加された曜日"
+msgstr "روزهای هفته که [[this.short-name]] اضافه شد"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Months when [[this.short-name]] were added"
-msgstr "[[this.short-name]] が追加された月"
+msgstr "روزهای هفته که [[this.short-name]] اضافه شد"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across different categories"
-msgstr "異なるカテゴリーを比較する方法"
+msgstr "نحوه مقایسه آنها در گروههای مختلف"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30"
-msgstr "直近30件のうちソースごとの新規ユーザー"
+msgstr "کاربران جدید در هر منبع در 30 منبع اخیر"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per quarter of the year"
-msgstr "四半期毎のイベント"
+msgstr "وقایع در هر سه ماه سال"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Heres a quick look at your [[this]]"
-msgstr "これが [[this]] の概要です"
+msgstr "نگاهی گذرا به [[this]] شما"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryLarge]], top 5"
-msgstr "[[GenericCategoryLarge]] ごとの [[this]] 上位5つ"
+msgstr "[[this]] برای [[GenericCategorLarge]] ، 5 مورد برتر"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Days when [[this.short-name]] were added"
-msgstr "[[this.short-name]] が追加されて経過した日数"
+msgstr "روزهایی که [[this.short-name]] اضافه شد"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Total orders per source"
-msgstr "ソースごとの総オーダー数"
+msgstr "کل سفارشات در هر منبع"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by quarter of the year"
-msgstr "四半期別の [[this]]"
+msgstr "[[this]] تا ربع سال"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per [[GenericCategoryMedium]]"
-msgstr "[[GenericCategoryMedium]] ごとのイベント"
+msgstr "رویدادها برای [[GenericCategorMedium]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
+#, fuzzy
 msgid "Events per state"
-msgstr "状態ごとのイベント"
+msgstr "وقایع در هر حالت"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#, fuzzy
 msgid "Top landing pages"
-msgstr "人気のページ"
+msgstr "بالای صفحات معرفی"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Heres a closer look at your [[this]] over time"
-msgstr "経時的に [[this]] を詳しく見てみましょう"
+msgstr "با نگاهی دقیق تر به [[this]] شما در طول زمان نگاه می کنید"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Sum of [[this]] by [[Country]]"
-msgstr "[[Country]] 別の [[this]] 合計"
+msgstr "جمع [[this]] توسط [[Country]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "States that are performing best"
-msgstr "最もパフォーマンスが良い州"
+msgstr "کشورهایی که بهترین عملکرد را دارند"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by month of the year"
-msgstr "月別の作成日時"
+msgstr "ایجاد شده توسط ماه سال"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Sum of [[this]] by [[State]]"
-msgstr "[[State]] 別の [[this]] の合計"
+msgstr "جمع [[this]] توسط [[State]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Sum of [[GenericNumber]] per [[this]]"
-msgstr "[[this]] ごとの [[GenericNumber]] の合計"
+msgstr "مجموع [[GenericNumber]] به ازای [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by coordinates"
-msgstr "座標別のイベント"
+msgstr "رویدادها توسط مختصات"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top referral pages"
-msgstr "最も参照されたページ"
+msgstr "صفحات ارجاع برتر"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "An exploration of your users to get you started."
-msgstr ""
+msgstr "کاوش در مورد کاربران خود برای شروع کار."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "An overview of your [[this]] and how its distributed across time, place, and categories."
-msgstr ""
+msgstr "مروری بر [[this]] شما و نحوه توزیع آن در طول زمان ، مکان و دسته بندی ها."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average income per state"
-msgstr "州ごとの平均収益"
+msgstr "درآمد متوسط در هر ایالت"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
-msgstr "[[GenericCategoryMedium]] 別の [[this]]"
+msgstr "[[this]] توسط [[GenericCategorMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total transactions"
-msgstr "総トランザクション数"
+msgstr "کل معاملات"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] that have joined over time"
-msgstr "[[this.short-name]] の参加数推移"
+msgstr "[[this.short-name]] که به مرور زمان پیوسته اند"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "The [[this]] by location"
-msgstr "場所別の [[this]]"
+msgstr "[[this]] توسط مکان"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per month of the year"
-msgstr "月毎のイベント"
+msgstr "رویدادها در هر ماه از سال"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] by [[GenericNumber]]"
-msgstr "[[GenericNumber]] 別の [[this]]"
+msgstr "[[this]] توسط [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] were added"
-msgstr "[[this.short-name]] が追加された四半期"
+msgstr "چهارم وقتی [[this.short-name]] اضافه شد"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "How these [[this.short-name]] are distributed"
-msgstr "[[this.short-name]] がどのように拡散したか"
+msgstr "نحوه توزیع این [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by [[GenericNumber]]"
-msgstr "[[GenericNumber]] 別の [[this.short-name]]"
+msgstr "[[this.short-name]] توسط [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where users are coming from"
-msgstr "ユーザーがどこから来たか"
+msgstr "از کجا کاربران می آیند"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "[[this]] comparisons and correlations"
-msgstr "[[this]] の比較と相関"
+msgstr "[[this]] مقایسه و همبستگی"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income"
-msgstr "総収益"
+msgstr "درآمد کلی"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income per month"
-msgstr "月毎の全収益"
+msgstr "درآمد کل در هر ماه"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Number of users per source"
-msgstr "ソースごとのユーザー数"
+msgstr "تعداد کاربران در هر منبع"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Transactions per state"
-msgstr "状態ごとのトランザクション"
+msgstr "معاملات در هر ایالت"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "[[this]] by [[Timestamp]]"
-msgstr "[[Timestamp]] 別の [[this]]"
+msgstr "[[this]] توسط [[Timestamp]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30 days"
-msgstr "過去30日のソースごとのユーザー"
+msgstr "کاربران جدید در هر منبع در 30 روز گذشته"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the month"
-msgstr "日別の登録日"
+msgstr "تاریخ عضویت روز به ماه"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount %"
-msgstr "平均値引率"
+msgstr "متوسط تخفیف٪"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Autogenerated metrics about [[GenericTable]]."
-msgstr "[[GenericTable]]に関して自動生成されたメトリクス"
+msgstr "اندازه گیری خودکار در مورد [[GenericTable]]."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per day of the month"
-msgstr "日毎の [[this]]"
+msgstr "[[this]] در هر روز از ماه"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions in each country"
-msgstr "国別の総セッション数"
+msgstr "کل جلسات در هر کشور"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per month of the year"
-msgstr "月毎のトランザクション数"
+msgstr "معاملات در هر ماه از سال"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per product"
-msgstr "製品ごとの売上"
+msgstr "فروش در هر محصول"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Users in each country"
-msgstr "国ごとのユーザー"
+msgstr "کاربران در هر کشور"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by hour of the day"
-msgstr "時間別の [[this]]"
+msgstr "[[this]] ساعت ساعت روز"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events in the last 30 days"
-msgstr "過去30日のイベント"
+msgstr "رویدادها در 30 روز گذشته"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Transactions per source"
-msgstr "ソースごとのトランザクション"
+msgstr "معاملات در هر منبع"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where youve acquired your users"
-msgstr "あなたがどこで顧客を獲得したのか"
+msgstr "جایی که کاربران خود را به دست آورده اید"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare acrosss location"
-msgstr "場所を超えて比較する方法"
+msgstr "چگونه آنها در سراسر مکان مقایسه می کنند"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "[[this]] per product"
-msgstr "製品ごとの [[this]]"
+msgstr "[[this]] در هر محصول"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per month of the year"
-msgstr "月毎の [[this]]"
+msgstr "[[this]] در هر ماه سال"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per country"
-msgstr "国ごと"
+msgstr "در هر کشور"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "A deeper look at how different countries are performing for you."
-msgstr ""
+msgstr "نگاهی عمیق تر به نحوه عملکرد کشورهای مختلف برای شما."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per state"
-msgstr "州ごとの売上"
+msgstr "فروش در هر ایالت"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by [[GenericNumber]]"
-msgstr "[[GenericNumber]] 別のイベント"
+msgstr "رویدادها توسط [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales per product [[ProductCategoryMedium]]"
-msgstr "[[ProductCategoryMedium]] 製品ごとの売上"
+msgstr "فروش برای هر محصول [[ProductCategorMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "User acquisition by country"
-msgstr "国ごとのユーザー獲得"
+msgstr "کسب کاربر توسط کشور"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "[[this]] per source"
-msgstr "ソースごとの [[this]]"
+msgstr "[[this]] در هر منبع"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by day of the week"
-msgstr "曜日別の [[this]]"
+msgstr "[[this]] در هر منبع"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Days of the month when [[this.short-name]] joined"
-msgstr "その月の[[this.short-name]]が参加した日"
+msgstr "روزهایی که به [[this.short-name]] پیوست"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Heres an overview of the people in your [[this]]"
-msgstr "あなたの [[this]] の人々の概要はここにあります"
+msgstr "در اینجا مروری بر افراد موجود در [[this]] شما"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "How [[GenericTable]] are distributed across this time field, and if it has any seasonal patterns."
-msgstr ""
+msgstr "چگونه [[GenericTable]] در این زمینه زمانی توزیع می شود ، و اگر دارای الگوهای فصلی باشد."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10515,200 +10552,201 @@ msgstr ""
 #: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Overview"
-msgstr "概要"
+msgstr "بررسی اجمالی"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How this metric is distributed across different categories"
-msgstr "このメトリックがさまざまなカテゴリーにどのように分布しているか"
+msgstr "نحوه توزیع این متریک در دسته های مختلف"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per state"
-msgstr "州ごとの [[this.short-name]]"
+msgstr "[[this.short-name]] در هر ایالت"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Weekdays when [[this.short-name]] joined"
-msgstr "[[this.short-name]] が加わった曜日"
+msgstr "روزهای هفته وقتی [[this.short-name]] پیوست"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Hours when [[this.short-name]] joined"
-msgstr ""
+msgstr "ساعتهایی که [[this.short-name]] پیوست"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Total income by month"
-msgstr "月別の総収益"
+msgstr "درآمد کل ماه"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "A breakdown of your [[this]] over time, and its min, max, average and more."
-msgstr "[[this]] の時系列分析および最小、最大、平均など"
+msgstr "تفکیک [[this]] شما با گذشت زمان و حداقل ، حداکثر ، میانگین و بیشتر آن."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average quantity per state"
-msgstr "ソースごとの平均数量"
+msgstr "مقدار متوسط در هر ایالت"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare by across different numbers"
-msgstr ""
+msgstr "چگونه می توان آنها را با اعداد مختلف مقایسه کرد"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "New users per country in the last 30 days"
-msgstr "過去30日の国ごとの新規ユーザー"
+msgstr "کاربران جدید در هر کشور در 30 روز گذشته"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions over time"
-msgstr ""
+msgstr "معاملات با گذشت زمان"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategorySmall]]"
-msgstr "[[GenericCategorySmall]]ごとの[[this]]"
+msgstr "[[this]] به ازای [[GenericCategorSmall]]"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Some breakdown"
-msgstr "いくつかの分析"
+msgstr "برخی از شکست"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Average of [[this]] by [[State]]"
-msgstr "[[State]] 別の [[this]] の平均"
+msgstr "میانگین [[this]] توسط [[State]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per quarter of the year"
-msgstr "四半期毎のトランザクション数"
+msgstr "معاملات در هر سه ماه سال"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "By coordinates"
-msgstr "座標別"
+msgstr "توسط مختصات"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Heres a closer look at your [[this]] by products"
-msgstr "商品別に [[this]] を詳しく見てみましょう"
+msgstr "نگاه دقیق تری به [[this]] محصولات شما دارد"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per quarter of the year"
-msgstr "四半期毎の [[this]]"
+msgstr "[[this]] در هر سه ماه سال"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Heres an overview of your [[this]] data from Google Analytics"
-msgstr "Google Analyticsから得られた[[this]]のデータの概要です"
+msgstr "مروری بر داده های [[this]] شما از Google Analytics دارد"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] joined"
-msgstr "[[this.short-name]] が加わった四半期"
+msgstr "چهارم وقتی [[this.short-name]] پیوست"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "New [[this.short-name]] in the last 30 days"
-msgstr "過去30日の新しい[[this.short-name]] "
+msgstr "[[this.short-name] جدید در 30 روز گذشته"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions by desktop, mobile, or tablet"
-msgstr "デスクトップ、モバイル、またはタブレットごとの合計セッション"
+msgstr "کل جلسات توسط دسک تاپ ، موبایل یا تبلت"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "Indepth example"
-msgstr "詳細な例"
+msgstr "به عنوان مثال"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average income per source"
-msgstr "ソースごとの平均収益"
+msgstr "درآمد متوسط در هر منبع"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by day of week"
-msgstr "曜日別の [[Timestamp]]"
+msgstr "[[Timestamp]] تا روز هفته"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "Heres a closer look at your [[this]]"
-msgstr "[[this]] を詳しく見てみましょう"
+msgstr "نگاه دقیق تری به [[this]] شما"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Heres a closer look at your [[this]] field"
-msgstr "[[this]] フィールドを詳しく見てみましょう"
+msgstr "نگاه دقیق تری به زمینه [[this]] شما دارد"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Summary"
-msgstr "要約"
+msgstr "خلاصه"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] is distributed geographically"
-msgstr "[[this]]は地理的にどのように分布しているのか"
+msgstr "نحوه توزیع [[this]] جغرافیایی"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "The pages with the most pageviews"
-msgstr "最大のビュー数があるページ"
+msgstr "صفحات دارای بیشترین بازدید از صفحه"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How [[Number1]] is correlated with [[Number2]]"
-msgstr "[[Number1]]は[[Number2]]とどのように相関しているのか"
+msgstr "چگونه [[Number1]] با [[Number2]] ارتباط دارد"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales in the last 30 days"
-msgstr "過去30日の売上トップ10の州"
+msgstr "10 کشور برتر با فروش در 30 روز گذشته"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales"
-msgstr "売上トップ10の州"
+msgstr "10 کشور برتر با فروش"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Timestamp]]"
-msgstr "[[Timestamp]]"
+msgstr "[[Timestamp]]\n"
+""
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Where these transactions happened"
-msgstr "これらのトランザクションが発生した場所"
+msgstr "جایی که این معاملات اتفاق افتاده است"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales"
-msgstr "売上トップ10の国"
+msgstr "10 کشور برتر با فروش"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by state"
-msgstr "州別の売上"
+msgstr "فروش توسط دولت"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Where most of your sessions originate from"
-msgstr "最も多くセッションが発生したのはどこか"
+msgstr "جایی که بیشتر جلسات شما از آنجا شروع می شود"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top acquisition channels"
-msgstr "トップの顧客獲得チャンネル"
+msgstr "کانال های برتر کسب"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "These [[this.short-name]] across time"
-msgstr ""
+msgstr "اینها [[this.short-name]] در طول زمان"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity"
-msgstr "国ごとの平均数量"
+msgstr "مقدار متوسط"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per source"
-msgstr "ソースごとの売上"
+msgstr "فروش در هر منبع"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average income per country"
-msgstr "国別の平均収益"
+msgstr "درآمد متوسط در هر کشور"
 
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed"
-msgstr "どのように[[this]]が分布しているか"
+msgstr "چگونه [[this]] توزیع می شود"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Distinct [[FK]]"
-msgstr ""
+msgstr "متمایز [[FK]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "How these transactions are distributed"
-msgstr "これらのトランザクションの分散方法"
+msgstr "نحوه توزیع این معاملات"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per state"
-msgstr "州ごと"
+msgstr "در هر ایالت"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "Count of [[GenericCategoryMedium]] by [[this]]"
-msgstr ""
+msgstr "تعداد [[GenericCategorMedium]] توسط [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10723,68 +10761,68 @@ msgstr ""
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "A look at your [[this]]"
-msgstr ""
+msgstr "نگاهی به [[this]] شما"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "[[GenericNumber]] by [[this]]"
-msgstr ""
+msgstr "[[GenericNumber]] توسط [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Sum of [[GenericNumber]] by [[this]]"
-msgstr "[[this]] ごとの [[GenericNumber]] の合計"
+msgstr "جمع [[GenericNumber]] توسط [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A look at your [[this]] table"
-msgstr ""
+msgstr "نگاهی به جدول [[this]] شما"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "How many [[GenericTable]] there are per state, and how each state is represented across other categories."
-msgstr ""
+msgstr "چه تعداد [[GenericTable]] در هر ایالت وجود دارد ، و چگونه هر ایالت در دسته های دیگر نشان داده می شود."
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Most-viewed pages"
-msgstr "最もビュー数の多いページ"
+msgstr "صفحات پر بازدید"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Example exploration"
-msgstr "探索の例"
+msgstr "اکتشاف نمونه"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales vs. rating"
-msgstr "売上高対評価"
+msgstr "فروش در مقابل امتیاز"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per hour of the day"
-msgstr ""
+msgstr "[[this]] در هر ساعت از روز"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Where your [[this.short-name]] are"
-msgstr ""
+msgstr "[[this.short-name]] شما کجاست"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "These are the same for all your [[this.short-name]]"
-msgstr ""
+msgstr "اینها برای همه [[this.short-name]] شما یکسان هستند"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by different categories"
-msgstr "さまざまなカテゴリーのイベント"
+msgstr "رویدادها بر اساس دسته بندی های مختلف"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Where these [[this.short-name]] are"
-msgstr ""
+msgstr "جایی که این [[this.short-name]] هستند"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Over time"
-msgstr ""
+msgstr "اضافه کاری"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A summary of the events in your [[this]] table"
-msgstr ""
+msgstr "خلاصه ای از وقایع موجود در جدول [[this]] شما"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Transactions per source over time"
-msgstr "ソースごとのトランザクション推移"
+msgstr "معاملات در هر منبع با گذشت زمان"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10792,223 +10830,221 @@ msgstr "ソースごとのトランザクション推移"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "How the [[this]] is distributed"
-msgstr ""
+msgstr "نحوه توزیع [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Total income per source"
-msgstr "ソースごとの総収益"
+msgstr "درآمد کل در هر منبع"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Total [[this.short-name]]"
-msgstr "合計[[this.short-name]]"
+msgstr "تعداد [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#, fuzzy
 msgid "Some metrics we found about your transactions."
-msgstr "あなたのトランザクションに関して、あるメトリクスを見つけました。"
+msgstr "برخی از معیارهایی که در مورد معاملات شما پیدا کردیم."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "How your different products are performing."
-msgstr ""
+msgstr "نحوه عملکرد محصولات مختلف شما"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Where these events are happening"
-msgstr "これらのイベントがどこで起きているか"
+msgstr "جایی که این وقایع اتفاق می افتد"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Which US states are bringing you the most business."
-msgstr "どの米国州が最も大きな業績をもたらしているか"
+msgstr "کدام کشورهای ایالات متحده بیشترین تجارت را به شما ارائه می دهند."
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
-msgstr ""
+msgstr "چگونه آنها در طول زمان مقایسه می کنند"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#, fuzzy
 msgid "Average transaction income per month"
-msgstr "月毎の平均トランザクション収益"
+msgstr "متوسط درآمد معاملات در هر ماه"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity per month"
-msgstr "月毎の平均数量"
+msgstr "مقدار متوسط در هر ماه"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "Seasonal patterns in the [[this]]"
-msgstr "[[this]] の季節変動パターン"
+msgstr "الگوهای فصلی در [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events over time"
-msgstr ""
+msgstr "حوادث با گذشت زمان"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Orders and income per source"
-msgstr "ソースごとの注文と収益"
+msgstr "سفارشات و درآمد در هر منبع"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per hour of the day"
-msgstr "その日の時間ごとのトランザクション数"
+msgstr "معاملات در هر ساعت از روز"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where most of your traffic is coming from."
-msgstr "最大のトラフィックがどこから来ているか"
+msgstr "جایی که بیشتر ترافیک شما از آنجا شروع می شود."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Heres a quick look at the [[this]]"
-msgstr ""
+msgstr "نگاهی گذرا به [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "It looks like your [[this]] has transactions, so heres a look at them"
-msgstr ""
+msgstr "به نظر می رسد [[this]] شما معاملات دارد ، بنابراین نگاهی به آنها می اندازد"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount per month"
-msgstr "月毎の平均割引"
+msgstr "متوسط تخفیف در هر ماه"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by month of the year"
-msgstr "月別の [[Timestamp]]"
+msgstr "[[Timestamp]] بر اساس ماه سال"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategorySmall]] over time"
-msgstr ""
+msgstr "[[this]] به ازای [[GenericCategorSmall]] با گذشت زمان"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Distribution by coordinates"
-msgstr "座標別の分布"
+msgstr "توزیع توسط مختصات"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by source"
-msgstr "ソース別の売上"
+msgstr "فروش توسط منبع"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales for each product category"
-msgstr "各製品カテゴリーの売上"
+msgstr "فروش برای هر دسته از محصولات"
 
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "A closer look at the metrics and dimensions used in this saved question."
-msgstr "この保存された質問で使用されるメトリックとディメンションの詳細。"
+msgstr "نگاهی دقیق تر به معیارها و ابعاد بکار رفته در این سوال ذخیره شده."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryMedium]]"
-msgstr ""
+msgstr "[[this.short-name]] به ازای [[GenericCategorMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Sales per product [[ProductCategoryLarge]]"
-msgstr "[[ProductCategoryLarge]] 製品ごとの売上"
+msgstr "فروش برای هر محصول [[ProductCategorLarge]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average quantity per country"
-msgstr "国別平均数量"
+msgstr "مقدار متوسط در هر کشور"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per [[GenericCategoryLarge]]"
-msgstr ""
+msgstr "[[[this.short-name]] به ازای [[GenericCategorLarge]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Heres a closer look at your [[this]] per source"
-msgstr "ソース毎の [[this]] を詳しく見てみましょう"
+msgstr "نگاه دقیق تری به [[this]] شما در هر منبع دارد"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the month"
-msgstr "日毎のイベント"
+msgstr "رویدادها در هر روز از ماه"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If youre into correlations, this is the x-ray for you."
-msgstr "もしもあなたが相関に興味があるのならば、これはおすすめのX-Rayです。"
+msgstr "رویدادها در هر روز از ماه"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by Country"
-msgstr "国別セッション"
+msgstr "جلسات کشور"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Some interesting metrics about your GA stats to get you started."
-msgstr ""
+msgstr "برخی از معیارهای جالب در مورد آمار GA برای شروع کار."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per state"
-msgstr "州ごとの [[this]]"
+msgstr "[[this]] در هر ایالت"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by quarter of the year"
-msgstr "四半期別の [[Timestamp]]"
+msgstr "[[Timestamp]] تا چهارم سال"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How its distributed across time and other categories."
-msgstr "時間や他のカテゴリーにどのように分布しているか。"
+msgstr "نحوه توزیع آن در طول زمان و مقوله های دیگر."
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A look at your events over time and by several categories."
-msgstr ""
+msgstr "نگاهی به رویدادهای شما با گذشت زمان و چند دسته."
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "[[GenericTable]] per [[this]]"
-msgstr ""
+msgstr "[[GenericTable]] به ازای [[this]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average quantity per source"
-msgstr "ソース別平均数量"
+msgstr "مقدار متوسط در هر منبع"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Top 5 per category"
-msgstr "カテゴリーごとの上位5位"
+msgstr "5 رده برتر در هر گروه"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the week"
-msgstr "曜日毎のイベント"
+msgstr "رویدادهای روزانه هفته"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "New [[this.short-name]] per month"
-msgstr "月毎の新しい[[this.short-name]]"
+msgstr "[[this.short-name] جدید در هر ماه"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top performers"
-msgstr "業績優秀者"
+msgstr "نوازندگان برتر"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Transactions in the last 30 days"
-msgstr "過去30日のトランザクション数"
+msgstr "معاملات در 30 روز گذشته"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[GenericTable]] by [[this]]"
-msgstr ""
+msgstr "[[GenericTable]] توسط [[this]]"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Overview of your [[this]] data from Google Analytics"
-msgstr "Google Analyticsの[[this]]データの概要"
+msgstr "نمای کلی داده های [[this]] شما از Google Analytics"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by hour of the day"
-msgstr "時間別の作成日時"
+msgstr "در ساعتی از روز ایجاد شده است"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by month"
-msgstr "月別の売上"
+msgstr "فروش ماه"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] is distributed across categories"
-msgstr ""
+msgstr "نحوه توزیع [[this]] در دسته ها"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by month of year"
-msgstr "月別の [[Timestamp]]"
+msgstr "[[Timestamp]] بر اساس ماه سال"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "How many total sessions vs. how many individual users you had each day."
-msgstr "合計セッション数と毎日の個別ユーザー数。"
+msgstr "چه تعداد جلسه در کل vs چه تعداد کاربر جداگانه شما هر روز."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How this metric is distributed across different numbers"
-msgstr "このメトリックが異なる数値にどのように分布しているか"
+msgstr "نحوه توزیع این متریک در اعداد مختلف"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by page where the session began"
-msgstr "ページ別の開始されたセッション"
+msgstr "جلسات براساس صفحه ای که جلسه شروع شده است"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -11016,20 +11052,20 @@ msgstr "ページ別の開始されたセッション"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Distinct values"
-msgstr "重複のない値"
+msgstr "مقادیر متمایز"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Hours when [[this.short-name]] were added"
-msgstr "[[this.short-name]] が追加された時間"
+msgstr "ساعت هایی که [[this.short-name]] اضافه شد"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by day of the week"
-msgstr "曜日別の [[Timestamp]]"
+msgstr "[[Timestamp]] تا روز هفته"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[GenericNumber]] over time"
-msgstr "[[GenericNumber]] の推移"
+msgstr "[[GenericNumber]] با گذشت زمان"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
@@ -11038,43 +11074,44 @@ msgstr "[[GenericNumber]] の推移"
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Heres an overview of your [[this]]"
-msgstr "あなたの[[this]]の概要はこちらです"
+msgstr "مروری بر [[this]] شما"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by coordinates"
-msgstr "座標別の[[this.short-name]]"
+msgstr "[[this.short-name]] توسط مختصات"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Heres a closer look at your [[this]] per state"
-msgstr "州毎の [[this]] を詳しく見てみましょう"
+msgstr "نگاه دقیق تری به [[this]] شما در هر ایالت دارد"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by day of the month"
-msgstr "日別の作成日時"
+msgstr "ایجاد شده توسط روز ماه"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales by coordinates"
-msgstr "座標別の売上"
+msgstr "فروش توسط مختصات"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "New [[this.short-name]] over time"
-msgstr "時系列の新しい[[this.short-name]]"
+msgstr "جدید [[this.short-name]] با گذشت زمان"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "Join date by hour of the day"
-msgstr "時間別の登録日"
+msgstr "ساعت تاریخ عضویت"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by hour of day"
-msgstr "時間別の [[Timestamp]]"
+msgstr "[[Timestamp]] ساعت روز"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions and unique users per day"
-msgstr "1日あたりのセッションとユニークユーザー"
+msgstr "جلسات و کاربران منحصر به فرد در روز"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per [[GenericCategoryLarge]]"
-msgstr ""
+msgstr "رویدادها برای [[GenericCategorLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -11083,395 +11120,396 @@ msgstr ""
 #: resources/automagic_dashboards/field/GenericField.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
-msgstr ""
+msgstr "چگونه آنها با توزیع مقایسه می شوند"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Income per country"
-msgstr "国別の収益"
+msgstr "درآمد در هر کشور"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Heres a closer look at your [[this]] per country"
-msgstr "国毎の [[this]] を詳しく見てみましょう"
+msgstr "نگاه دقیق تری به [[this]] شما در هر کشور دارد"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by product [[ProductCategory]]"
-msgstr "[[ProductCategory]] の製品別の売上"
+msgstr "فروش براساس محصول [[ProductCategory]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryLarge]], bottom 5"
-msgstr ""
+msgstr "[[this]] برای [[GenericCategLarge]] ، پایین 5"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] added in the last 30 days"
-msgstr "過去30日に追加された [[this.short-name]]"
+msgstr "[[this.short-name]] در 30 روز گذشته اضافه شد"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[Source]]"
-msgstr "[[Source]] ごと"
+msgstr "در هر [[Source]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average item quantity per month"
-msgstr "月毎の平均項目数"
+msgstr "مقدار متوسط کالا در هر ماه"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "The number of [[GenericTable]] per country, and how each country is represented in different categories."
-msgstr ""
+msgstr "تعداد [[GenericTable]] در هر کشور و نحوه نمایش هر کشور در دسته های مختلف."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per day of the week"
-msgstr "曜日毎の [[this]]"
+msgstr "[[this]] در هر روز در هفته"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average qunatity per source"
-msgstr "ソースごとの平均数量"
+msgstr "مقدار متوسط در هر منبع"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by [[Timestamp]]"
-msgstr ""
+msgstr "[[this.short-name]] توسط [[Timestamp]]"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Summary statistics"
-msgstr "要約統計"
+msgstr "آمار خلاصه"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per month"
-msgstr "月毎の売上"
+msgstr "فروش در هر ماه"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[GenericNumber]] by join date"
-msgstr "登録日別の [[GenericNumber]]"
+msgstr "[[GenericNumber]] تا تاریخ عضویت"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Average of [[this]] by [[Country]]"
-msgstr "[[Country]] 別の [[this]] の平均"
+msgstr "میانگین [[this]] توسط [[Country]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[this]] over time"
-msgstr "[[this]] の推移"
+msgstr "[[this]] با گذشت زمان"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the week"
-msgstr "曜日別の登録日"
+msgstr "تاریخ روز به روز هفته بپیوندید"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "We crunched the numbers for your [[this]]"
-msgstr "[[this]]の数値を計算しました"
+msgstr "ما اعداد را برای [[this]] شما خرد کردیم"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Months when [[this.short-name]] joined"
-msgstr "[[this.short-name]]が加わった月"
+msgstr "ماه هایی که [[this.short-name]] پیوست"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to parse resource `{0}` as JSON"
-msgstr "`{0}` のリソースをJSONとして解析できません"
+msgstr "تجزیه منابع \"0` \"به عنوان JSON امکان پذیر نیست"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to find JSON via relative path `{0}`"
-msgstr "`{0}` の相対パスにJSONを見つけられません"
+msgstr "JSON از طریق مسیر نسبی امکان پذیر نیست. {0}"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection to host timed out for URL `{0}`"
-msgstr "`{0}` のURLへの接続はタイムアウトしました"
+msgstr "اتصال به میزبان برای URL به پایان رسیده است `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to connect to unknown host at URL `{0}`"
-msgstr "`{0}` のURLで未知のホストへの接続ができません"
+msgstr "اتصال به هاست ناشناس در URL `{0}` امکان پذیر نیست"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to connect to host at URL `{0}`"
-msgstr "`{0}` のURLでホストへの接続ができません"
+msgstr "اتصال به میزبان در URL `{0}` امکان پذیر نیست"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection refused by host at for URL `{0}`"
-msgstr "`{0}` のURLでホストへの接続が拒否されました"
+msgstr "اتصال توسط میزبان برای URL `{0}` رد شد"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to retrieve resource at URL `{0}`"
-msgstr "`{0}` のURLでリソースの取得ができません"
+msgstr "بازیابی منابع در URL امکان پذیر نیست. {0}"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to parse resource at URL `{0}` as JSON"
-msgstr "`{0}` のURLのリソースをJSONとして解析できません"
+msgstr "تجزیه منابع در URL `{0}` به عنوان JSON امکان پذیر نیست"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fall back to local authentication: {0}"
-msgstr "LDAPサーバーへの接続に問題が起こりました。ローカルでの認証へフォールバックします: {0}"
+msgstr "اتصال به سرور LDAP به تأیید اعتبار محلی برمی گردد: {0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can''t be parameterized!"
-msgstr "BigQueryステートメントはパラメーター化できません！"
+msgstr "گفته های BigQuery را نمی توان پارامتر کرد!"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid does not allow limitSpec in time series queries. Ignoring the LIMIT clause."
-msgstr "警告: Druid は時系列クエリで limitSpec を許可しません。 LIMIT 句を無視します。"
+msgstr "اخطار: Druid در نمایش داده های سری زمانی limitSpec را مجاز نمی کند. نادیده گرفتن بند LIMIT."
 
 #: src/metabase/driver/snowflake.clj
 msgid "Invalid Snowflake connection details: missing DB name."
-msgstr "無効なSnowflakeへの接続の詳細：データベース名が指定されていません"
+msgstr "جزئیات اتصال Snowflake نامعتبر: نام DB موجود نیست."
 
 #: src/metabase/email/messages.clj
 msgid "We’d love your feedback."
-msgstr "フィードバックは大歓迎です"
+msgstr "ما نظرات شما را دوست داریم."
 
 #: src/metabase/email/messages.clj
 msgid "It looks like Metabase wasn’t quite a match for you."
-msgstr "Metabaseはあなたに合わなかったようです。"
+msgstr "به نظر می رسد که Metabase کاملاً مناسب شما نبود."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 5 question survey to help the Metabase team understand why and make things better in the future?"
-msgstr "Metabaseチームがその理由を理解し、将来的に物事を改善するのを助けるために、5問の高速アンケートに回答していただけますか"
+msgstr "آیا می خواهید یک بررسی سریع 5 سؤالی داشته باشید تا به تیم Metabase کمک کنید درک کند که چرا و در آینده شرایط را بهتر می کند؟"
 
 #: src/metabase/email/messages.clj
 msgid "We hope you''ve been enjoying Metabase."
-msgstr "Metabaseを楽しんでくださいね"
+msgstr "امیدواریم که از Metabase لذت برده باشید."
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 6 question survey to tell us how it’s going?"
-msgstr "どのような感じだったか私たちが知るため簡単な6つの質問に答えてくれませんか？"
+msgstr "آیا فکر می کنید یک نظرسنجی سریع با 6 سوال انجام دهید تا به ما بگویید که چگونه این کار را انجام می دهد؟"
 
 #: src/metabase/email/messages.clj
 msgid "{0} created a Metabase account"
-msgstr "{0} はMetabaseアカウントを作成しました"
+msgstr "{0} یک حساب Metabase ایجاد کرد"
 
 #: src/metabase/email/messages.clj
 msgid "{0} accepted their Metabase invite"
-msgstr "{0} はMetabaseへの招待を受付けました"
+msgstr "{0} دعوتنامه Metabase خود را پذیرفتند"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Password Reset Request"
-msgstr "[Metabase] パスワードリセット申告"
+msgstr "[Metabase] درخواست بازنشانی گذرواژه"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Notification"
-msgstr "[Metabase] 通知"
+msgstr "[Metabase] اعلان"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Help make Metabase better."
-msgstr "[Metabase] Metabaseの改善にご協力ください"
+msgstr "[Metabase] به بهتر شدن Metabase کمک کنید."
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Tell us how things are going."
-msgstr "[Metabase] 感想をお聞かせください"
+msgstr "[Metabase] به ما بگویید که اوضاع چگونه پیش می رود."
 
 #: src/metabase/mbql/util.clj
 msgid "Error: query''s source query has not been resolved. You probably need to `preprocess` the query first."
-msgstr ""
+msgstr "خطا: پرس و جو منبع پرس و جو حل نشده است. احتمالاً ابتدا باید query را پردازش کنید."
 
 #: src/metabase/models/params.clj
 msgid "Don't know what to do with:"
-msgstr "何をすべきかわからない:"
+msgstr "نمی دانم با چه کارهایی باید کرد:"
 
 #: src/metabase/models/params.clj
 msgid "Don't know how to wrap:"
-msgstr "ラップする方法がわからない:"
+msgstr "نمی دانم چگونه بسته بندی کنید:"
 
 #: src/metabase/public_settings.clj
 msgid "Failed setting `query-caching-max-kb` to {0}."
-msgstr "`query-caching-max-kb`を{0}に設定するのに失敗しました。"
+msgstr "تنظیم \"query-caching-max-kb\" تا {0} انجام نشد."
 
 #: src/metabase/public_settings.clj
 msgid "Values greater than {1} are not allowed."
-msgstr "{1} より大きな値は指定できません。"
+msgstr "مقادیر بیشتر از {1}مجاز نیست."
 
 #: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
-msgstr "データベース {0} は存在しません。"
+msgstr "بانک اطلاعاتی {0} وجود ندارد."
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Database is not present in the Query Processor Store."
-msgstr "エラー: データベース{0}がクエリ処理ストアに存在しません。"
+msgstr "خطا: بانک اطلاعات در فروشگاه Query پردازنده موجود نیست."
 
 #: src/metabase/util/embed.clj
 msgid "Invalid embedding-secret-key! Secret key must be a hexadecimal-encoded 256-bit key (i.e., a 64-character string)."
-msgstr ""
+msgstr "تعبیه نامعتبر-کلید مخفی! کلید مخفی باید یک کلید 256 بیتی رمزگذاری شده hexadecimal باشد (یعنی یک رشته 64 کاراکتر)."
 
 #: src/metabase/util/embed.clj
 msgid "JWT is missing `alg`."
-msgstr "JWTには`alg`がありません。"
+msgstr "JWT گم شده است 'alg'."
 
 #: src/metabase/util/embed.clj
 msgid "JWT `alg` cannot be `none`."
-msgstr "JWT `alg`は`none`にはできません。"
+msgstr "JWT \"alg\" نمی تواند \"هیچ\" باشد."
 
 #: src/metabase/util/embed.clj
 msgid "The embedding secret key has not been set."
-msgstr "埋め込み秘密鍵が設定されていません。"
+msgstr "کلید مخفی تعبیه نشده است."
 
 #: src/metabase/util/embed.clj
 msgid "Token is missing value for keypath"
-msgstr "トークンにキーパスの値がありません"
+msgstr "توکن ارزش برای صفحه کلید نیست"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "In-depth example"
-msgstr ""
+msgstr "مثال عمیق"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:29
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:17
 msgid "Key"
-msgstr "キー"
+msgstr "کلید"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:30
 msgid "Class"
-msgstr "クラス"
+msgstr "کلاس"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:32
 msgid "Triggers"
-msgstr "トリガー"
+msgstr "ماشه ها\n"
+""
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:48
 msgid "View triggers"
-msgstr ""
+msgstr "نمایش محرکها"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
-msgstr "スケジューラ情報"
+msgstr "اطلاعات برنامه ریز"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:20
 msgid "Priority"
-msgstr "優先度"
+msgstr "اولویت"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:21
 msgid "Last Fired"
-msgstr ""
+msgstr "آخرین اخراج"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:22
 msgid "Next Fire Time"
-msgstr "次回実行時間"
+msgstr "زمان بعدی آتش"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:23
 msgid "Start Time"
-msgstr "開始時間"
+msgstr "زمان شروع"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:24
 msgid "End Time"
-msgstr "終了時間"
+msgstr "زمان پایان"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:25
 msgid "Final Fire Time"
-msgstr "最終実行時間"
+msgstr "زمان آتش سوزی نهایی"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:26
 msgid "May Fire Again?"
-msgstr ""
+msgstr "ممکن است دوباره آتش بگیریم؟"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
-msgstr "{0}へのトリガー"
+msgstr "شروع برای {0}"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:25
 msgid "Tasks"
-msgstr "タスク"
+msgstr "وظایف"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:30
 msgid "Jobs"
-msgstr "ジョブ"
+msgstr "شغل ها"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
-msgstr ""
+msgstr "کپی شده {0}"
 
 #: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
-msgstr "このアイテムを複製する"
+msgstr "این مورد را کپی کنید"
 
 #: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
-msgstr "このアイテムをアーカイブする"
+msgstr "بایگانی این مورد"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
-msgstr "ダッシュボードを複製する"
+msgstr "داشبورد کپی"
 
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:16
 msgid "Duplicate \"{0}\""
-msgstr "“{0}”を複製"
+msgstr "کپی کردن \"{0}\""
 
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
-msgstr "複製"
+msgstr "کپی کردن"
 
 #: frontend/src/metabase/lib/query_time.js:115
 msgid "Tomorrow"
-msgstr "明日"
+msgstr "فردا"
 
 #: frontend/src/metabase/lib/query_time.js:129
 #: frontend/src/metabase/lib/query_time.js:143
 msgid "This {0}"
-msgstr "現在の{0}"
+msgstr "این {0}"
 
 #: frontend/src/metabase/lib/query_time.js:132
 msgid "Next {0}"
-msgstr "次の{0}"
+msgstr "بعدی {0}"
 
 #: frontend/src/metabase/lib/query_time.js:135
 msgid "Previous {0}"
-msgstr "前の{0}"
+msgstr "قبلی {0}"
 
 #: frontend/src/metabase/lib/query_time.js:139
 msgid "Previous {0} {1}"
-msgstr "前の {0} {1}"
+msgstr "قبلی {0 {1}"
 
 #: frontend/src/metabase/lib/query_time.js:141
 msgid "Next {0} {1}"
-msgstr "次の {0} {1}"
+msgstr "بعدی {0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:171
 msgid "Now"
-msgstr "今"
+msgstr "اکنون"
 
 #: frontend/src/metabase/lib/query_time.js:174
 msgid "{0} {1} ago"
-msgstr "{0}{1}前"
+msgstr "{0} {1} پیش"
 
 #: frontend/src/metabase/lib/query_time.js:175
 msgid "{0} {1} from now"
-msgstr "今から{0}{1}"
+msgstr "{0} {1} از حالا"
 
 #: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
-msgstr[0] ""
+msgstr[0] "دوره های پیش فرض"
 
 #: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
-msgstr[0] ""
+msgstr[0] "دقیقه ساعت"
 
 #: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
-msgstr[0] ""
+msgstr[0] "ساعت روز"
 
 #: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
-msgstr[0] ""
+msgstr[0] "روز هفته"
 
 #: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
-msgstr[0] ""
+msgstr[0] "روز ماه"
 
 #: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
-msgstr[0] ""
+msgstr[0] "روز سال"
 
 #: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
-msgstr[0] ""
+msgstr[0] "هفته سال"
 
 #: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
-msgstr[0] ""
+msgstr[0] "ماه سال"
 
 #: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
-msgstr[0] ""
+msgstr[0] "ربع سال"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
@@ -11479,7 +11517,7 @@ msgstr[0] ""
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
 msgid "{0} selection"
 msgid_plural "{0} selections"
-msgstr[0] ""
+msgstr[0] "{0} انتخاب"
 
 #: frontend/src/metabase/parameters/components/widgets/DateQuarterYearWidget.jsx:11
 msgid "[Q]Q"
@@ -11487,220 +11525,221 @@ msgstr "[Q]Q"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:28
 msgid "This"
-msgstr ""
+msgstr "این"
 
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
-msgstr "無効"
+msgstr "بی اعتبار"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
-msgstr "時間を追加する"
+msgstr "زمان اضافه کنید"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
-msgstr ""
+msgstr "هیچ چیز برای مقایسه قبلی نیست {0}"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:678
 msgid "by {0}"
-msgstr ""
+msgstr "توسط {0}"
 
 #: src/metabase/api/database.clj
 msgid "value must be a valid database engine."
-msgstr "値は有効なデータベースエンジンである必要があります。"
+msgstr "مقدار باید یک موتور پایگاه داده معتبر باشد."
 
 #: src/metabase/api/geojson.clj
 msgid "Connection refused by host for URL `{0}`"
-msgstr "`{0}`のURLでホストへの接続が拒否されました"
+msgstr "اتصال توسط میزبان برای URL `{0}` رد شد"
 
 #: src/metabase/db.clj
 msgid "Warning: Postgres connection string with `ssl=true` detected."
-msgstr "警告: `ssl=true`のPostgres接続文字列が検出されました。"
+msgstr "هشدار: رشته اتصال Postgres با 'ssl = true' شناسایی شده است."
 
 #: src/metabase/db.clj
 msgid "You may need to add `?sslmode=require` to your application DB connection string."
-msgstr "アプリケーションのDB接続文字列に `?sslmode=require`を追加する必要がある場合があります。"
+msgstr "ممکن است شما نیاز به اضافه کردن \"؟ sslmode = نیاز\" به رشته اتصال DB برنامه خود داشته باشید."
 
 #: src/metabase/db.clj
 msgid "If Metabase fails to launch, please add it and try again."
-msgstr "Metabaseが起動に失敗したときは、これを加えて再試行をお願いします。"
+msgstr "اگر Metabase نتواند راه اندازی شود ، لطفاً آن را اضافه کنید و دوباره امتحان کنید."
 
 #: src/metabase/db.clj
 msgid "See https://github.com/metabase/metabase/issues/8908 for more details."
-msgstr "詳細については、 https://github.com/metabase/metabase/issues/8908 を参照してください。"
+msgstr "برای اطلاعات بیشتر به https://github.com/metabase/metabase/issues/8908 مراجعه کنید."
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recomended for production deployments."
-msgstr "警告: 本番環境で、MetabaseをH2アプリケーションデータベースと共に使用することはお勧めできません。"
+msgstr "اخطار: استفاده از Metabase با بانک اطلاعاتی برنامه H2 برای استقرار تولید توصیه نمی شود."
 
 #: src/metabase/db.clj
 msgid "For production deployments, we highly recommend using Postgres, MySQL, or MariaDB instead."
-msgstr "本番環境の場合は、代わりにPostgres、MySQL、またはMariaDBを使用することを強くお勧めします。"
+msgstr "برای استقرار تولید ، ما به جای استفاده از Postgres ، MySQL یا MariaDB توصیه می کنیم."
 
 #: src/metabase/db.clj
 msgid "If you decide to continue to use H2, please be sure to back up the database file regularly."
-msgstr "H2の使用を継続する場合は、データベースファイルを定期的にバックアップしてください。"
+msgstr "اگر تصمیم به ادامه استفاده از H2 دارید ، لطفاً از فایل پایگاه داده بطور منظم تهیه کنید."
 
 #: src/metabase/db.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres for more information."
-msgstr "詳細については、 https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres を参照してください。"
+msgstr "برای اطلاعات بیشتر به https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres مراجعه کنید."
 
 #: src/metabase/db.clj
 msgid "Unable to connect to Metabase {0} DB."
-msgstr "Metabase {0} DBに接続できません。"
+msgstr "اتصال به دیتابیس {0} Metabase امکان پذیر نیست"
 
 #: src/metabase/db/migrations.clj
 msgid "Error adding legacy SQL directive to BigQuery saved Question"
-msgstr ""
+msgstr "خطا در اضافه کردن بخشنامه SQL میراث به BigQuery ذخیره شده سؤال"
 
 #: src/metabase/driver.clj
 msgid "Failed to notify {0} Database {1} updated"
-msgstr ""
+msgstr "به روزرسانی {0} پایگاه داده {1} انجام نشد"
 
 #: src/metabase/driver.clj
 msgid "Loading driver {0} {1}"
-msgstr "{0} {1} ドライバーを読込中"
+msgstr "بارگیری درایور {0} {1}"
 
 #: src/metabase/driver.clj
 msgid "Load driver {0}"
-msgstr "{0} ドライバーを読込"
+msgstr "راننده بار {0}"
 
 #: src/metabase/driver.clj
 msgid "Driver not registered after loading: {0}"
-msgstr "ロード後にドライバーが登録されていません: {0}"
+msgstr "راننده بعد از بارگیری ثبت نشده است: {0}"
 
 #: src/metabase/driver.clj
 msgid "Error: attempting to change {0} property `:abstract?` from {1} to {2}."
-msgstr ""
+msgstr "خطا: تلاش برای تغییر {0} ویژگی `: انتزاعی؟` از {1} به {2}"
 
 #: src/metabase/driver.clj
 msgid "Registered abstract driver {0}"
-msgstr "抽象ドライバー {0} を登録しました"
+msgstr "راننده انتزاعی ثبت شده {0}"
 
 #: src/metabase/driver.clj
 msgid "Registered driver {0}"
-msgstr "ドライバー {0} を登録しました"
+msgstr "راننده ثبت شده {0}"
 
 #: src/metabase/driver.clj
 msgid "(parents: {0})"
-msgstr ""
+msgstr "(والدین: {0})"
 
 #: src/metabase/driver.clj
 msgid "Initializing driver {0}..."
-msgstr "ドライバー{0}の初期化中です..."
+msgstr "درایور اولیه {0} ..."
 
 #: src/metabase/driver.clj
 msgid "Reason:"
-msgstr "理由:"
+msgstr "دلیل:"
 
 #: src/metabase/driver.clj
 msgid "Invalid driver feature: {0}"
-msgstr "無効なドライバー機能: {0}"
+msgstr "ویژگی نامعتبر راننده: {0}"
 
 #: src/metabase/driver/sql/query_processor.clj
 msgid "Invalid HoneySQL form:"
-msgstr "不正なHoney SQLの形式:"
+msgstr "فرم HoneySQL نامعتبر:"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing connection pool for database {0} ..."
-msgstr "データベース {0} へのコネクションプールを切断中です..."
+msgstr "بستن استخر اتصال برای دیتابیس{0} ..."
 
 #: src/metabase/driver/util.clj
 msgid "Error loading namespace"
-msgstr "名前空間の読み込みエラー"
+msgstr "خطا در بارگیری فضای نام"
 
 #: src/metabase/events.clj
 msgid "Starting events listener:"
-msgstr "イベントリスナーを開始しています:"
+msgstr "شروع شنونده رویدادها:"
 
 #: src/metabase/events.clj
 msgid "Unexpected error listening on events"
-msgstr "イベントをリッスンする際の予期しないエラー"
+msgstr "خطای غیرمنتظره هنگام گوش دادن به رویدادها"
 
 #: src/metabase/events/sync_database.clj
 msgid "Error syncing Database {0}"
-msgstr "データベース {0} の同期に失敗しました"
+msgstr "خطا در همگام سازی بانک اطلاعاتی {0}"
 
 #: src/metabase/events/sync_database.clj
 msgid "Failed to process sync-database event."
-msgstr "データベース同期イベントの実行に失敗しました"
+msgstr "پردازش رویداد همگام سازی با پایگاه داده انجام نشد."
 
 #: src/metabase/mbql/util.clj
 msgid "Bad nested-query-level: query does not have a source query"
-msgstr ""
+msgstr "Bad-Nest-query-level: query منبع پرس و جو ندارد"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know how to `{0}`."
-msgstr ""
+msgstr "من نمی دانم چگونه می توانم `{0}`."
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s what I can do: "
-msgstr ""
+msgstr "در اینجا کارهایی که می توانم انجام دهم وجود دارد:"
 
 #: src/metabase/metabot/slack.clj
 msgid "Error in Metabot command"
-msgstr "MetaBotコマンドのエラー"
+msgstr "خطا در دستور Metabot"
 
 #: src/metabase/metabot/websocket.clj
 msgid "Websocket associated with this Slack event is different from the websocket we're currently using."
-msgstr "このSlackイベントに関連付けられているWebSocketは、現在使用しているWebSocketとは異なります。"
+msgstr "صفحه‌نمایش مرتبط با این رویداد Slack با صفحه‌بندی که در حال حاضر از آن استفاده می‌کنیم متفاوت است."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues for Field {0} remain unchanged. Skipping..."
-msgstr ""
+msgstr "FieldValues برای {0} بدون تغییر باقی می ماند. پرش ..."
 
 #: src/metabase/models/interface.clj
 msgid "Unable to normalize:"
-msgstr "正規化できません:"
+msgstr "امکان عادی سازی وجود ندارد:"
 
 #: src/metabase/models/params.clj
 msgid "Could not find matching Field ID for target:"
-msgstr "ターゲットに一致するフィールドIDが見つかりませんでした:"
+msgstr "یافتن شناسه فیلد منطبق برای هدف یافت نشد:"
 
 #: src/metabase/plugins.clj
 msgid "Metabase does not have permissions to write to plugins directory {0}"
-msgstr "Metabaseはプラグインディレクトリへの書き込み権限を持っていません"
+msgstr "Metabase مجوز نوشتن در فهرست افزونه ها {0} را ندارد"
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot use the plugins directory {0}"
-msgstr "Metabaseはプラグインディレクトリ {0} を使用できません"
+msgstr "بانک اطلاعاتی نمی توانند از فهرست پلاگین ها استفاده کنند{0}"
 
 #: src/metabase/plugins.clj
 msgid "Please make sure the directory exists and that Metabase has permission to write to it."
-msgstr "ディレクトリが存在するか、Metabaseに書き込み権限があるか確認してください。"
+msgstr "لطفاً اطمینان حاصل کنید که فهرست موجود است و Metabase اجازه نوشتن آن را دارد."
 
 #: src/metabase/plugins.clj
 msgid "You can change the directory Metabase uses for modules by setting the environment variable MB_PLUGINS_DIR."
-msgstr "環境変数 MB_PLUGINS_DIR を設定することにより、Metabaseがモジュールに使用するディレクトリを変更できます。"
+msgstr "با تنظیم متغیر محیط MB_PLUGINS_DIR می توانید دایرکتوری مورد استفاده Metabase برای ماژول ها را تغییر دهید."
 
 #: src/metabase/plugins.clj
 msgid "Falling back to a temporary directory for now."
-msgstr "今のところ一時ディレクトリにフォールバックしています。"
+msgstr "در حال حاضر به یک فهرست راهنما موقت تبدیل می شوید."
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot write to temporary directory. Please set MB_PLUGINS_DIR to a writable directory and restart Metabase."
-msgstr "Metabaseは一時ディレクトリに書き込めません。 MB_PLUGINS_DIR を書き込み可能なディレクトリに設定し、Metabaseを再起動してください。"
+msgstr "بانک اطلاعاتی نمی توانند در دایرکتوری موقت بنویسند. لطفاً MB_PLUGINS_DIR را در یک فهرست قابل ویرایش قرار دهید و Metabase را مجدداً راه اندازی کنید."
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory."
-msgstr "spark-deeps.jarはMetabase 1.0以降では必要ありません。プラグインディレクトリから削除して構いません。"
+msgstr "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory.\n"
+""
 
 #: src/metabase/plugins.clj
 msgid "Failied to initialize plugin {0}"
-msgstr "プラグイン {0} の初期化に失敗しました"
+msgstr "تنظیم اولیه افزونه {0} انجام نشد"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in {0}..."
-msgstr "{0}のプラグインを読込中…"
+msgstr "بارگیری افزونه ها در {0} ..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using Clojure base loader as shared context classloader: {0}"
-msgstr "Clojureベースローダーを共有コンテキストクラスローダーとして使用: {0}"
+msgstr "استفاده از لودر پایه Clojure به عنوان یک کلاس زمینه ساز مشترک: {0}"
 
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to shared classloader {0}..."
-msgstr ""
+msgstr "تنظیم کلاس بارگذاری متن متن اصلی بر روی کلاس لودر مشترک {0} ..."
 
 #. it's important that we deref the promise again here instead of using the one we just created because it is
 #. possible thru a race condition that somebody else delivered the promise before we did; in that case,
@@ -11708,318 +11747,319 @@ msgstr ""
 #. value of it rather than one that ends up getting discarded
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to NEWLY CREATED classloader {0}..."
-msgstr ""
+msgstr "تنظیم کلاس بارگذاری متن متن فعلی بر روی بارگذاری کلاس کلاس جدید ساخته شده {0} ..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Added URL {0} to classpath"
-msgstr "URL {0} をクラスパスに追加しました"
+msgstr "URL به {0} به کلاس اضافه شد"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin {0} declares a dependency that Metabase does not understand: {1}"
-msgstr "プラグイン{0}はMetabaseが理解できない依存を宣言しています: {1}"
+msgstr "افزونه {0} وابستگی را اعلام می کند که Metabase آن را نمی فهمد: {1}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Refer to the plugin manifest reference for a complete list of valid plugin dependencies:"
-msgstr "有効なプラグインの依存関係の完全なリストについては、プラグインマニフェストリファレンスを参照してください:"
+msgstr "برای لیست کاملی از وابستگیهای معتبری به افزونه ، به مرجع آشکار پلاگین مراجعه کنید:"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Metabase cannot initialize plugin {0} due to required dependencies."
-msgstr "必要な依存性を満たしていないため、Metabaseはプラグイン{0}を初期化できません。"
+msgstr "به دلیل وابستگی های مورد نیاز ، پایگاه داده نمی تواند پلاگین {0} را آغاز کند."
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Class not found: {0}"
-msgstr "クラスが見つかりません: {0}"
+msgstr "کلاس یافت نشد: {0}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin ''{0}'' depends on plugin ''{1}''"
-msgstr "プラグイン ''{0}'' はプラグイン ''{1}'' に依存しています。"
+msgstr "افزونه '' {0} '' بستگی به افزونه '' {1} ''"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "{0} dependency {1} satisfied? {2}"
-msgstr ""
+msgstr "{0} وابستگی {1} راضی هستید؟ {2}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugins with unsatisfied deps: {0}"
-msgstr "満たされていない依存関係を持つプラグイン: {0}"
+msgstr "افزونه های دارای بخش ناراضی: {0}"
 
 #: src/metabase/plugins/files.clj
 msgid "Extract file {0} -> {1}"
-msgstr ""
+msgstr "استخراج پرونده {0} -> {1}"
 
 #: src/metabase/plugins/files.clj
 msgid "Resource does not exist."
-msgstr "リソースが存在しません。"
+msgstr "منبع وجود ندارد."
 
 #: src/metabase/plugins/init_steps.clj
 msgid "Loading plugin namespace {0}..."
-msgstr "ネームスペース{0}のプラグインを読込中..."
+msgstr "در حال بارگیری فضای نام پلاگین {0} ..."
 
 #: src/metabase/plugins/initialize.clj
 msgid "Dependencies satisfied; these plugins will now be loaded: {0}"
-msgstr "依存関係が満たされました。 これらのプラグインがロードされます: {0}"
+msgstr "وابستگی ها راضی است؛ این افزونه ها اکنون بارگیری می شوند: {0}"
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Registering JDBC proxy driver for {0}..."
-msgstr "{0}のJDBCプロキシドライバーを登録しています..."
+msgstr "ثبت درایور پروکسی JDBC با {0}..."
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Deregistering original JDBC driver {0}..."
-msgstr "これまで利用されていたJDBCドライバー{0}を登録解除しています..."
+msgstr "ثبت درایور پروکسی JDBC با {0}..."
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Default connection property {0} does not exist."
-msgstr ""
+msgstr "ویژگی اتصال پیش فرض {0} وجود ندارد."
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Invalid connection property {0}: not a string or map."
-msgstr "有効でない接続設定値{0}: 文字列またはマップではありません。"
+msgstr "ویژگی اتصال نامعتبر {0}: رشته یا نقشه نیست."
 
 #. ok, do the init steps listed in the plugin mainfest
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Load lazy loading driver {0}"
-msgstr ""
+msgstr "درایور بارگیری تنبل {0}"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Cannot initialize plugin: missing required property `driver-name`"
-msgstr "プラグインを初期化できません: driver-nameプロパティが設定されていません"
+msgstr "نمی توان ابتدا افزونه را تنظیم کرد: ویژگی مورد نیاز \"driver-name\" وجود ندارد"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Warning: plugin manifest for {0} does not include connection properties"
-msgstr "警告: {0}へのプラグインマニフェストに接続プロパティがありません"
+msgstr "هشدار: پلاگین مانیفست برای {0} شامل ویژگی های اتصال نیست"
 
 #. finally, register the Metabase driver
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Registering lazy loading driver {0}..."
-msgstr "遅延ロードドライバー {0} の登録中です..."
+msgstr "ثبت نام درایور بارگیری تنبل {0} ..."
 
 #: src/metabase/pulse.clj
 msgid "Error running query for Card {0}"
-msgstr "カード {0} のクエリ実行中にエラー"
+msgstr "خطایی در اجرای پرس و جو برای کارت {0}"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
-msgstr "先週"
+msgstr "هفته گذشته"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This week"
-msgstr "今週"
+msgstr "این هفته"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
-msgstr "先月"
+msgstr "ماه گذشته"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This month"
-msgstr "今月"
+msgstr "این ماه"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
-msgstr ""
+msgstr "سه ماهه گذشته"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
-msgstr "今四半期"
+msgstr "این ربع"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
-msgstr "昨年"
+msgstr "سال گذشته"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This year"
-msgstr "今年"
+msgstr "امسال"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "*driver* is unbound."
-msgstr ""
+msgstr "* driver * محدود نیست."
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Error syncing Fields for Table ''{0}''"
-msgstr ""
+msgstr "خطا در همگام سازی زمینه های جدول '' {0} ''"
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Hash of {0} matches stored hash, skipping Fields sync"
-msgstr ""
+msgstr "هش از {0} مطابقت دارد"
 
 #: src/metabase/sync/sync_metadata/fields/common.clj
 msgid "Field"
-msgstr "フィールド"
+msgstr "فیلد"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error checking if Fields {0} need to be created or reactivated"
-msgstr ""
+msgstr "خطا در بررسی اینکه آیا زمینه های {0} نیاز به ایجاد یا فعال سازی مجدد دارند"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Marking Field ''{0}'' as inactive."
-msgstr "''{0}'' フィールドを非アクティブとしてマークする"
+msgstr "علامت گذاری به عنوان \"\" {0} \"غیرفعال است."
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error retiring {0}"
-msgstr ""
+msgstr "خطا در بازنشستگی {0}"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Database type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "{0}のデータベースタイプが”{1}”から”{2}”に変更されました"
+msgstr "نوع بانک اطلاعاتی  {0} از '' {1} '' به '' {2} '' تغییر یافته است."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Base type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr ""
+msgstr "نوع پایه {0} از '' {1} '' به '' {2} '' تغییر کرده است."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Special type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "{0}の特別タイプは”{1}”から”{2}”に変更されました"
+msgstr "نوع ویژه {0} از '' {1} '' به '' {2} '' تغییر کرده است."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Comment has been added for {0}."
-msgstr "{0}へのコメントが追加されました。"
+msgstr "نظر برای {0} اضافه شده است."
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler {0}"
-msgstr "Quartzスケジューラ {0} を停止中です"
+msgstr "توقف زمانبند کوارتز {0}"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler {0}"
-msgstr "Quartzスケジューラ {0} を開始中です"
+msgstr "شروع برنامه ریزی کوارتز {0}"
 
 #: src/metabase/task.clj
 msgid "Error loading tasks namespace {0}"
-msgstr ""
+msgstr "خطا در بارگیری فضای نام کارها {0}"
 
 #. don't bother logging namespace for now, maybe in the future if there's tasks of the same name in multiple
 #. namespaces we can log it
 #: src/metabase/task.clj
 msgid "Initializing task {0}"
-msgstr "タスク {0} を初期化しています"
+msgstr "شروع کار {0}"
 
 #: src/metabase/task.clj
 msgid "Error initializing task {0}"
-msgstr "タスク {0} の初期化中にエラーが発生しました"
+msgstr "خطا در شروع کار {0}"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Problem sending abandonment email"
-msgstr "放棄メールの送信に関する問題"
+msgstr "ارسال ایمیل رها"
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Sending anonymous usage stats."
-msgstr "匿名の使用状況統計を送信します。"
+msgstr "ارسال آمار استفاده ناشناس."
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Error sending anonymous usage stats"
-msgstr "匿名の利用統計の送信に失敗しました"
+msgstr "خطا در ارسال آمار استفاده ناشناس"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Error sending Pulse {0}"
-msgstr "パルス {0} の送信に失敗しました"
+msgstr "خطا در ارسال پالس {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Sending scheduled pulses..."
-msgstr "スケジュールされたパルスを送信しています…"
+msgstr "در حال ارسال پالس های برنامه ریزی شده ..."
 
 #: src/metabase/task/send_pulses.clj
 msgid "SendPulses task failed"
-msgstr "SendPlusesタスクが失敗しました"
+msgstr "کار SendPulses انجام نشد"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to scheduler tasks for Database {0}"
-msgstr "データベース {0} のスケジューラタスクが失敗しました"
+msgstr "انجام وظایف برنامه ریزی برای بانک اطلاعات {0} انجام نشد"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Cleaning up task history"
-msgstr "タスク履歴の削除"
+msgstr "تمیز کردن تاریخچه کار"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were deleted"
-msgstr "タスク履歴の削除は成功しました。行が削除されました。"
+msgstr "پاک کردن سابقه کار با موفقیت انجام شد ، سطرها حذف شدند"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, no rows were deleted"
-msgstr "タスク履歴の削除は成功しました。削除された行はありませんでした。"
+msgstr "پاک سازی سابقه کار با موفقیت انجام شد ، هیچ سطر حذف نشد"
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Checking for new Metabase version info."
-msgstr "新しいバージョンのMetabaseの確認"
+msgstr "در حال بررسی اطلاعات نسخه جدید Metabase."
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Error fetching version info"
-msgstr "バージョン情報の取得に失敗しました"
+msgstr "خطا در واکشی اطلاعات نسخه"
 
 #: src/metabase/util.clj
 msgid "Maximum memory available to JVM: {0}"
-msgstr "JVMに割り当てられる最大メモリ量: {0}"
+msgstr "حداکثر حافظه در دسترس برای {JVM: {0"
 
 #: src/metabase/util.clj
 msgid "Not something with an ID: {0}"
-msgstr "IDのあるものではありません: {0}"
+msgstr "اطلاعاتی با این ID: {0}  وجود ندارد "
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by month of the year"
-msgstr "月別の [[CreateDate]]"
+msgstr "[[ایجاده داده]] بر اساس ماه"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Here's a quick look at your [[this]]"
-msgstr ""
+msgstr "نگاه سر سری و مختصری   [[this]] شما"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by hour of the day"
-msgstr "時間別の [[CreateTimestamp]]"
+msgstr "[ساخت تایم استمپ] بر اساس ساعت"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where you've acquired your users"
-msgstr "どこでユーザーを獲得したか"
+msgstr "جایی که کاربران خود را به دست آورده اید"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How it's distributed across time and other categories."
-msgstr ""
+msgstr "چگونگی توزیع داده بر اساس زمان و دیگر فاکتورها"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Here's a closer look at your [[this]] per source"
-msgstr "ソース毎の [[this]] を詳しく見てみましょう"
+msgstr "نگاه دقیق تر به [[this]]شما"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Here's a quick look at the [[this]]"
-msgstr ""
+msgstr "در اینجا نگاهی گذرا به [[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by day of the month"
-msgstr "日別の [[CreateTimestamp]]"
+msgstr "[[CreateTimestamp]] تا روز از ماه"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Here's an overview of the people in your [[this]]"
-msgstr ""
+msgstr "بررسی اجمالی افرادی که در [[this]] شما وجود دارند"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by quarter of the year"
-msgstr "四半期別の [[CreateTimestamp]]"
+msgstr "[[CreateTimestamp]] تا چهارم سال"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
-msgstr "場所を超えて比較する方法"
+msgstr "نحوه مقایسه انها در سراسر مکان یا نحوه مقایه انها بر اساس موقعیت مکانی\n"
+""
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "Here's a closer look at your [[this]] by products"
-msgstr "商品別に [[this]] を詳しく見てみましょう"
+msgstr "در اینجا نگاه دقیق تری به [[this]] محصولات خود می بینید"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by month of the year"
-msgstr "月別の [[CreateTimestamp]]"
+msgstr "[[CreateTimestamp]] بر اساس ماه سال"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "An overview of your [[this]] and how it's distributed across time, place, and categories."
-msgstr "[[this]]と、それが時間の経過、異なる場所やカテゴリでどのように分布しているかの概要です。"
+msgstr "مروری بر [[this]] شما و نحوه توزیع آن در طول زمان ، مکان و دسته ها."
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "Here's a closer look at your [[this]]"
-msgstr "[[this]] を詳しく見てみましょう"
+msgstr "در اینجا یک نگاه دقیق تر به [[this]] شما"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTimestamp]] by day of the week"
-msgstr "曜日別の [[CreateTimestamp]]"
+msgstr "[[CreateTimestamp]] تا روز هفته"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Here's an overview of your [[this]] data from Google Analytics"
-msgstr "Google Analyticsから得られた[[this]]のデータの概要です"
+msgstr "در اینجا مروری بر داده های [[this]] شما از Google Analytics ارائه شده است"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
@@ -12028,1087 +12068,1093 @@ msgstr "Google Analyticsから得られた[[this]]のデータの概要です"
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "Here's an overview of your [[this]]"
-msgstr "[[this]]の概要です"
+msgstr "در اینجا مروری بر [[this]] شما"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Here's a closer look at your [[this]] field"
-msgstr "[[this]] フィールドを詳しく見てみましょう"
+msgstr "در اینجا نگاه دقیق تری به قسمت [[this]] شما خواهیم داشت"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Here's a closer look at your [[this]] per country"
-msgstr "国毎の [[this]] を詳しく見てみましょう"
+msgstr "در اینجا نگاهی دقیق تر به [[this]] شما در هر کشور می اندازیم"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If you're into correlations, this is the x-ray for you."
-msgstr "もしもあなたが相関に興味があるのならば、これはおすすめのX-rayです。"
+msgstr "اگر به همبستگی دچار شوید ، این پرتونگاری برای شماست."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by day of the week"
-msgstr "曜日別の [[CreateDate]]"
+msgstr "[[CreatDate]] تا روز هفته"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "It looks like your [[this]] has transactions, so here's a look at them"
-msgstr ""
+msgstr "به نظر می رسد [[this]] شما معاملات دارد ، بنابراین در اینجا به آنها می پردازیم"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Here's a closer look at your [[this]] per state"
-msgstr "州毎の [[this]] を詳しく見てみましょう"
+msgstr "در اینجا نگاهی دقیق تر به [[this]] شما در هر ایالت می اندازیم"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by day of the month"
-msgstr "日別の [[CreateDate]]"
+msgstr "[[CreatDate]] تا روز ماه"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateTime]] by hour of the day"
-msgstr "時間別の [[CreateTime]]"
+msgstr "[[CreateTime]] ساعت ساعت روز"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Here's a closer look at your [[this]] over time"
-msgstr "経時的に [[this]] を詳しく見てみましょう"
+msgstr "در اینجا نگاه دقیق تری به [[this]] شما با گذشت زمان می اندازیم"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[CreateDate]] by quarter of the year"
-msgstr "四半期別の [[CreateDate]]"
+msgstr "[[CreatDate]] تا چهارم سال"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
-msgstr "ユーザーを編集"
+msgstr "ویرایش کاربر"
 
 #: frontend/src/metabase/admin/people/containers/NewUserModal.jsx:13
 msgid "New user"
-msgstr "新規ユーザー"
+msgstr "کاربر جدید"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
-msgstr "パスワードをリセットする"
+msgstr "بازنشانی گذرواژه"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
-msgstr "ユーザーを無効化"
+msgstr "غیرفعال کردن کاربر"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:47
 msgid "Reactivate {0}?"
-msgstr "{0}を再有効化しますか？"
+msgstr "فعال کردن {0}?"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:63
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
-msgstr "メールによる招待を送ることに失敗したので、{0}と自動で生成したこのパスワードを利用してログインするように招待者に伝えてください。"
+msgstr "ما نمی توانیم برای آنها یک ایمیل دعوت نامه ارسال کنیم ، بنابراین حتما به آنها بگویید که با استفاده از {0} و این رمز عبوری که برای آنها ایجاد کرده ایم وارد سیستم شوند:"
 
 #: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
-msgstr "コレクション"
+msgstr "مجموعه"
 
 #: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
-msgstr "コレクション"
+msgstr "مجموعه ها"
 
 #: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
-msgstr "ダッシュボード"
+msgstr "داشبورد"
 
 #: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
-msgstr "ダッシュボード"
+msgstr "داشبورد"
 
 #: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
-msgstr "名が必要です"
+msgstr "نام لازم است"
 
 #: frontend/src/metabase/entities/users.js:38
 #: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
-msgstr "100文字以下でなければなりません"
+msgstr "باید 100 نویسه یا کمتر باشد"
 
 #: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
-msgstr "姓は必須です"
+msgstr "نام خانوادگی لازم است"
 
 #: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
-msgstr "Emailアドレスは必須です"
+msgstr "ایمیل لازم است"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
-msgstr "アーカイブしたアイテムはここに現れます"
+msgstr "مواردی که بایگانی می کنید در اینجا ظاهر می شوند."
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:16
 msgid "No description"
-msgstr "説明がありません"
+msgstr "بدون توضیح"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
-msgstr "すべての値の合計"
+msgstr "جمع از همه ارزش ها"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
-msgstr "個別の値をすべて表示"
+msgstr "همه مقادیر مشخص را مشاهده کنید"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:12
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started"
-msgstr "データベース、テーブル、および列の内容を参照します。 開始するデータベースを選択してください"
+msgstr "محتویات پایگاه داده ها ، جداول و ستون ها را مرور کنید. برای شروع یک بانک اطلاعاتی انتخاب کنید"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is VALID. Thanks!"
-msgstr ""
+msgstr "ابرداده نتایج کارت منتقل شده به API معتبر است. با تشکر!"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is INVALID. Running query to fetch correct metadata."
-msgstr ""
+msgstr "ابرداده نتایج کارت منتقل شده به API INVALID است. در حال انجام درخواست برای واگذاری صحیح ابرداده."
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is  ISSING. Running query to fetch correct metadata."
-msgstr ""
+msgstr "داده های داده کارت که به API منتقل شده است MISSING است. در حال انجام درخواست برای واگذاری صحیح ابرداده."
 
 #: src/metabase/api/email.clj
 msgid "{0} was autocorrected to {1}"
-msgstr "{0}は{1}へオートコレクトされました"
+msgstr "{0} به اتمام رسید به {1}"
 
 #: src/metabase/api/metric.clj
 msgid "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id."
-msgstr "DELETE /api/metric/:idは推奨されていません。 代わりに、'archived'値をPUT /api/metric/:idで変更してください。"
+msgstr "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id.\n"
+""
 
 #: src/metabase/api/segment.clj
 msgid "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id."
-msgstr "DELETE /api/segment/:idは推奨されていません。 代わりに、'archived'値をPUT /api/segment/:idで変更してください。"
+msgstr "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id."
 
 #: src/metabase/api/user.clj
 msgid "Value of is_superuser must correspond to presence of Admin group ID in group_ids."
-msgstr "is_superuser の値は、 group_ids の管理グループIDの存在に対応する必要があります。"
+msgstr "مقدار is_superuser باید مطابق با حضور شناسه Admin Group در group_ids باشد."
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected error writing keepalive characters"
-msgstr "キープアライブ文字の書き込みで予期しないエラーが発生しました"
+msgstr "خطای غیرمنتظره در نوشتن شخصیت های نگهدارنده"
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected output in async API response"
-msgstr "非同期APIのレスポンスが予想外の出力です"
+msgstr "خروجی غیر منتظره در پاسخ API async"
 
 #: src/metabase/async/api_response.clj
 msgid "starting streaming response"
-msgstr "ストリーミング応答の開始"
+msgstr "پاسخ جریان را شروع کنید"
 
 #: src/metabase/async/api_response.clj
 msgid "Output chan closed, canceling keepalive request."
-msgstr "出力チャンネルが閉じられ、キープアライブ要求がキャンセルされました。"
+msgstr "زمان خروجی بسته است و درخواست نگهدارنده را لغو می کند."
 
 #: src/metabase/async/api_response.clj
 msgid "Async response finished, closing channels."
-msgstr "非同期通信が終了しました。チャンネルをクローズします。"
+msgstr "پاسخ Async به پایان رسید ، کانال ها را بستند."
 
 #: src/metabase/async/api_response.clj
 msgid "No response after waiting {0}. Canceling request."
-msgstr "{0} 待ちましたが応答がありません。問い合わせをキャンセルします"
+msgstr "هیچ پاسخی بعد از انتظار {0} نیست درخواست را لغو کنید."
 
 #: src/metabase/async/api_response.clj
 msgid "Input channel unexpectedly closed."
-msgstr "入力チャンネルが予期せず閉じられました。"
+msgstr "کانال ورودی به طور غیر منتظره بسته شد."
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "f finished, permit will be returned"
-msgstr ""
+msgstr "f به پایان رسید ، مجوز بازگردانده می شود"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "request canceled, permit will be returned"
-msgstr "リクエストはキャンセルされ、許可が返されます"
+msgstr "درخواست لغو شد ، مجوز بازگردانده می شود"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Unexpected error attempting to run function after obtaining permit"
-msgstr "許可を取得した後に関数を実行しようとすると予期しないエラーが発生しました"
+msgstr "خطای غیرمنتظره در تلاش برای اجرای عملکرد پس از اخذ مجوز"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Not running pending function call: output channel already closed."
-msgstr ""
+msgstr "در حال انجام فراخوانی عملکرد معلق نیست: کانال خروجی بسته شده است."
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Current thread already has a permit for {0}, will not wait to acquire another"
-msgstr ""
+msgstr "موضوع کنونی دارای مجوز برای {0} است ، منتظر نمی مانید تا مورد دیگری را بدست آورید"
 
 #: src/metabase/async/util.clj
 msgid "Output channel closed, will skip running {0}."
-msgstr ""
+msgstr "کانال خروجی بسته است ، در حال اجرا {0} خواهد شد."
 
 #: src/metabase/async/util.clj
 msgid "Running {0} on separate thread..."
-msgstr "{0}を複数のスレッドで実行中..."
+msgstr "در حال اجرا {0} در موضوع جداگانه ..."
 
 #: src/metabase/async/util.clj
 msgid "Caught error running {0}"
-msgstr "{0}の実行中にエラーが発生しました"
+msgstr "خطای مقصر در حال اجرا {0}"
 
 #: src/metabase/async/util.clj
 msgid "Request canceled, canceling future"
-msgstr "リクエストがキャンセルされたため、フューチャーをキャンセルしています"
+msgstr "درخواست لغو شد ، آینده را لغو می کند"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
 msgid "Closing old connection pool for database {0} ..."
-msgstr "データベース{0}への古いコネクションプールを閉じています..."
+msgstr "بستن استخر اتصال قدیمی برای پایگاه داده {0} ..."
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s your {0} most recent cards:"
-msgstr ""
+msgstr "جدیدترین کارتهای {0} شما در اینجا آمده است:"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
-msgstr ""
+msgstr "آیا می توانید کمی خاص تر باشید یا از شناسنامه استفاده کنید؟ این کارتها را با اسامی مطابقت داشتم:"
 
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
-msgstr "カード {0} が見つかりません"
+msgstr "کارت {0} یافت نشد."
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Exception in API call"
-msgstr "API呼び出しの例外"
+msgstr "استثناء در تماس API"
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Request canceled before finishing."
-msgstr "問い合わせは終了前にキャンセルされました"
+msgstr "درخواست قبل از اتمام لغو شد."
 
 #: src/metabase/middleware/json.clj
 msgid "Metabase only supports JSON requests."
-msgstr "MetabaseはJSONリクエストのみをサポートしています"
+msgstr "Metabase فقط از درخواستهای JSON پشتیبانی می کند."
 
 #: src/metabase/middleware/json.clj
 msgid "Make sure you set a 'Content-Type: application/json' header."
-msgstr "Content-Type: application/jsonのヘッダを設定したか確認してください"
+msgstr "اطمینان حاصل کنید که یک عنوان \"Content-Type: Application / json\" تنظیم کرده اید."
 
 #: src/metabase/middleware/misc.clj
 msgid "Setting Metabase site URL to {0}"
-msgstr "MetabaseのサイトURLを{0}に設定しています"
+msgstr "تنظیم URL سایت پایگاه داده در {0}"
 
 #: src/metabase/models/database.clj
 msgid "Error scheduling tasks for DB"
-msgstr "DBのタスクのスケジューリングエラー"
+msgstr "خطا در برنامه ریزی وظایف برای DB"
 
 #: src/metabase/models/database.clj
 msgid "Error unscheduling tasks for DB."
-msgstr "DBのタスクのスケジュール解除エラー。"
+msgstr "خطا در کارهای غیرقابل تنظیم برای DB."
 
 #: src/metabase/models/database.clj
 msgid "{0} Database ''{1}'' sync/analyze schedules have changed!"
-msgstr ""
+msgstr "{0} برنامه همگام سازی / تجزیه و تحلیل پایگاه داده '' {1} '' تغییر کرده است!"
 
 #: src/metabase/models/database.clj
 msgid "Sync metadata was: ''{0}'' is now: ''{1}''"
-msgstr ""
+msgstr "داده های همگام سازی همگام سازی شده بودند: '' {0} '' اکنون: '' {1} ''"
 
 #: src/metabase/models/database.clj
 msgid "Cache FieldValues was: ''{0}'', is now: ''{1}''"
-msgstr ""
+msgstr "Cache FieldValues این بود: '' {0} '' ، اکنون: '' {1} ''"
 
 #: src/metabase/models/metric.clj
 msgid "You cannot update the creator_id of a Metric."
-msgstr "メトリックの creator_id を更新することはできません。"
+msgstr "شما نمی توانید creator_id یک Metric را به روز کنید."
 
 #: src/metabase/models/permissions.clj
 msgid "MetaBot can only have Collection permissions."
-msgstr "MetaBotは、コレクションの権限のみを持つことができます。"
+msgstr "MetaBot فقط می تواند مجوزهای مجموعه را داشته باشد."
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions"
-msgstr "権限を付与できませんでした"
+msgstr "اعطای مجوزها انجام نشد"
 
 #: src/metabase/models/permissions.clj
 msgid "Changing permissions"
-msgstr "権限の変更"
+msgstr "تغییر مجوزها"
 
 #: src/metabase/models/permissions.clj
 msgid "FROM:"
-msgstr ""
+msgstr "از جانب:"
 
 #: src/metabase/models/permissions.clj
 msgid "TO:"
-msgstr ""
+msgstr "به:"
 
 #: src/metabase/models/segment.clj
 msgid "You cannot update the creator_id of a Segment."
-msgstr "セグメントの creator_id を更新することはできません。"
+msgstr "شما نمی توانید creator_id یک بخش را به روز کنید."
 
 #: src/metabase/models/setting.clj
 msgid "Attempted to set Setting {0} to obfuscated value. Ignoring change."
-msgstr ""
+msgstr "سعی در تنظیم مقدار {0} برای مقدار خراب شده است. نادیده گرفتن تغییر"
 
 #: src/metabase/models/setting.clj
 msgid "Using value of env var {0}"
-msgstr ""
+msgstr "استفاده از مقدار {env var {0"
 
 #: src/metabase/models/user.clj
 msgid "Adding User {0} to All Users permissions group..."
-msgstr "ユーザー {0} をAll Users権限グループに追加しています..."
+msgstr "افزودن کاربر {0} به گروه مجوزهای کاربران ..."
 
 #: src/metabase/models/user.clj
 msgid "Adding User {0} to Admin permissions group..."
-msgstr "ユーザー {0} を管理者権限グループに追加しています..."
+msgstr "افزودن کاربر {0} به گروه مجوزهای مدیریت ..."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
-msgstr "クエリの失敗"
+msgstr "عدم موفقیت پرس و جو"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
-msgstr "接続されたデータベースごとに許可する同時クエリの最大数。"
+msgstr "حداکثر تعداد نمایش داده های همزمان به هر پایگاه داده متصل اجازه می دهد."
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
-msgstr "{0} ミリ秒後にタイムアウトしました。"
+msgstr "به پایان رسید پس از {0} میلی ثانیه."
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
 msgid "Misfire Instruction"
-msgstr ""
+msgstr "دستورالعمل سوء استفاده"
 
 #: frontend/src/metabase/components/ArchiveModal.jsx:31
 msgid "Archive this?"
-msgstr "これをアーカイブしますか？"
+msgstr "بایگانی این؟"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:244
 msgid "Learn about our data"
-msgstr "データについて学ぶ"
+msgstr "درباره داده های ما اطلاعات کسب کنید"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
 msgid "Use DNS SRV when connecting"
-msgstr "接続時にDNS SRVを使用する"
+msgstr "هنگام اتصال از DNS SRV استفاده کنید"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
 msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
 "an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
 "leave this disabled."
-msgstr "このオプションを使用するには、提供されたホストがFQDNである必要があります。 Atlasクラスターに接続する場合は、このオプションを有効にする必要があります。 これが何を意味するのかわからない場合は、これを無効のままにします。"
+msgstr "استفاده از این گزینه مستلزم آن است که میزبان ارائه شده FQDN باشد. در صورت اتصال به\n"
+"ممکن است لازم باشد این گزینه را فعال کنید. اگر نمی دانید این به چه معنی است ،\n"
+"این را غیرفعال کنید."
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
 msgid "Automatically run queries when doing simple filtering and summarizing"
-msgstr "簡単なフィルタリングと要約を行うときに自動的にクエリを実行する"
+msgstr "هنگام انجام فیلتر کردن ساده و جمع بندی ساده ، نمایش داده شد"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
 msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "これを有効にすることにより、ユーザ―がテーブルやチャートを見るときに要約やフィルターボタンを利用して簡単な探索を行った場合に、Metabaseが自動的にクエリを実行するようになります。このデータベースへのクエリが遅い場合は、この設定を無効にすることができます。この設定によってドリルスルーやSQLクエリが影響を受けることはありません。"
+msgstr "هنگامی که این در Metabase است ، به طور خودکار هنگام نمایش جدول یا نمودار ، دکمه های Summarize و Filter را با استفاده از کاوش های ساده ، نمایش داده شد. اگر جستجوی این پایگاه داده کند است ، می توانید این را خاموش کنید. این تنظیم تأثیر نمی گذارد از طریق تمرین یا سؤالهای SQL."
 
 #: frontend/src/metabase/containers/Overworld.jsx:247
 msgid "Learn about this database"
-msgstr "このデータベースについて詳細を見る"
+msgstr "در مورد این پایگاه داده اطلاعات کسب کنید"
 
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
 msgid "Archive this dashboard?"
-msgstr "このダッシュボードをアーカイブしますか？"
+msgstr "بایگانی این داشبورد؟"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:113
 msgid "All results"
-msgstr "全ての結果"
+msgstr "همه نتایج"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:180
 msgid "Our Analytics"
-msgstr "我々の分析"
+msgstr "تحلیل ما"
 
 #: frontend/src/metabase/lib/schema_metadata.js:500
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
-msgstr ""
+msgstr "جمع اضافی از تمام مقادیر یک ستون. \\ ne.x. درآمد کل در طول زمان"
 
 #: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
-msgstr ""
+msgstr "تعداد افزودنی تعداد ردیف ها. \\ ne.x. تعداد کل فروش در طول زمان"
 
 #: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
 msgid "Filter"
-msgstr "フィルター"
+msgstr "فیلتر"
 
 #: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
 msgid "record"
 msgid_plural "records"
-msgstr[0] "レコード"
+msgstr[0] "رکورد"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:346
 msgid "Browse Data"
-msgstr "データを見る"
+msgstr "مرور داده ها"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:376
 msgid "Write SQL"
-msgstr "SQLを書く"
+msgstr "SQL بنویسید"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
 msgid "Simple question"
-msgstr "簡単な質問"
+msgstr "سوال ساده"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
-msgstr "データを選択し、見て、そして簡単にフィルタリングや集約をし、可視化します。"
+msgstr "برخی از داده ها را انتخاب کنید ، آن را مشاهده کنید و به راحتی آن را فیلتر ، خلاصه و تجسم کنید."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
 msgid "Custom question"
-msgstr "カスタム質問"
+msgstr "سوال سفارشی"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
-msgstr "高度なノートブックエディターを使用して、データの結合、カスタム列の作成、計算などを行います。"
+msgstr "از ویرایشگر نوت بوک پیشرفته برای پیوستن به داده ها ، ایجاد ستون های سفارشی ، انجام ریاضی و موارد دیگر استفاده کنید."
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
 msgid "Basic Metrics"
-msgstr "基本的なメトリクス"
+msgstr "اندازه گیری های اساسی"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
 msgid "Custom…"
-msgstr "カスタム…"
+msgstr "سفارشی…"
 
 #: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
 msgid "Add grouping"
-msgstr "グルーピングを追加する"
+msgstr "گروه بندی را اضافه کنید"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
 msgid "Pick a limit"
-msgstr ""
+msgstr "حد انتخاب کنید"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
 msgid "Show maximum"
-msgstr "最大を表示"
+msgstr "نمایش حداکثر"
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Preview"
-msgstr ""
+msgstr "پیش نمایش را دریافت کنید"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
 msgid "Back to previous results"
-msgstr "前の結果に戻る"
+msgstr "بازگشت به نتایج قبلی"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Sample values"
-msgstr "サンプル値"
+msgstr "مقادیر نمونه"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
-msgstr "データベース、テーブル、および列の内容を参照します。 データベースを選択して開始します。"
+msgstr "محتویات پایگاه داده ها ، جداول و ستون ها را مرور کنید. برای شروع یک بانک اطلاعاتی انتخاب کنید."
 
 #: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
 msgid "Visualize"
-msgstr "ビジュアライズ"
+msgstr "تجسم"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
 msgid "Join data"
-msgstr "結合"
+msgstr "اتصال داده ها"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
 msgid "Custom column"
-msgstr "カスタム列"
+msgstr "ستون سفارشی"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
 msgid "Summarize"
-msgstr "要約"
+msgstr "خلاصه کنید"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
 msgid "Aggregate"
-msgstr ""
+msgstr "تجمیع"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
 msgid "Breakout"
-msgstr "ブレークアウト"
+msgstr "Breakout\n"
+""
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
 msgid "Pick the metric you want to see"
-msgstr "見たいメトリクスを選ぶ"
+msgstr "متریک مورد نظر خود را انتخاب کنید"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
 #: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
 msgid "Pick a column to group by"
-msgstr "集約するためのキー列を選ぶ"
+msgstr "یک ستون را برای گروه انتخاب کنید"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
 msgid "Pick your starting data"
-msgstr "開始するデータを選択してください"
+msgstr "داده شروع را انتخاب کنید"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
 msgid "Select None"
-msgstr "選択解除"
+msgstr "هیچ کدام را انتخاب نکنید"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
 msgid "Select All"
-msgstr "すべて選択"
+msgstr "انتخاب همه"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
 msgid "Pick a table..."
-msgstr "テーブルを選ぶ..."
+msgstr "انتخاب یک جدول ..."
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
 msgid "Enter a limit"
-msgstr "最大行数を入力"
+msgstr "محدودیتی را وارد کنید"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
 msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr ""
+msgstr "براکت های اطراف {0} یک بند اختیاری در الگو ایجاد می کنند. اگر \"متغیر\" تنظیم شده باشد ، کل بند در قالب قرار می گیرد. اگر نه ، پس از آن کل بند نادیده گرفته می شود."
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
 msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
-msgstr "フィールドフィルターを使用する場合、列名をSQLに含めないでください。 代わりに、変数をサイドパネルのフィールドにマッピングする必要があります。"
+msgstr "هنگام استفاده از فیلد فیلد ، نام ستون نباید در SQL باشد. در عوض ، متغیر باید به یک قسمت در صفحه جانبی نقشه برداری شود."
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
 msgid "View the native query"
-msgstr "ネイティブクエリを表示する"
+msgstr "نمایش درخواست محلی"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
 msgid "Native query for this question"
-msgstr "この質問のネイティブクエリ"
+msgstr "جستجوی بومی برای این سوال"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
 msgid "Convert this question to a native query"
-msgstr "この質問をネイティブクエリに変換する"
+msgstr "این سؤال را به یک سؤال بومی تبدیل کنید"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
 msgid "SQL for this question"
-msgstr "この質問のSQL"
+msgstr "SQL برای این سوال"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
 msgid "Convert this question to SQL"
-msgstr "この質問をSQLに変換します"
+msgstr "این سوال را به SQL تبدیل کنید"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
 msgid "Get alerts"
-msgstr "アラートを受け取る"
+msgstr "دریافت هشدار"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
 msgid "{0} breakout"
 msgid_plural "{0} breakouts"
-msgstr[0] ""
+msgstr[0] "{0} breakout"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
 msgid "Hide filters"
-msgstr "フィルターを非表示"
+msgstr "فیلترها را مخفی کنید"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
 msgid "Show filters"
-msgstr "フィルターを表示する"
+msgstr "فیلترها را نشان دهید"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
 msgid "Started from"
-msgstr "から開始"
+msgstr "شروع شده از"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
 msgid "{0} row"
 msgid_plural "{0} rows"
-msgstr[0] "{0}行"
+msgstr[0] "{0} ردیف"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
 msgid "Show all rows"
-msgstr "全ての行を表示する"
+msgstr "نمایش تمام سطرها"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
 msgid "Show {0}"
-msgstr "{0}を表示する"
+msgstr "نمایش {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
 msgid "Showing first {0}"
-msgstr "最初の{0}を表示しています"
+msgstr "نمایش اول {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
 msgid "Showing {0}"
-msgstr "{0}を表示しています"
+msgstr "نمایش {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
 msgid "Summarized"
-msgstr "要約された"
+msgstr "خلاصه"
 
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
 msgid "Hide editor"
-msgstr "エディターを非表示にする"
+msgstr "ویرایشگر را مخفی کنید"
 
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
 msgid "Show editor"
-msgstr "エディターを表示する"
+msgstr "نمایش ویرایشگر"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
 msgid "Pick the metric you'd like to see"
-msgstr "あなたの見たい指標を選ぶ"
+msgstr "متریک مورد نظر خود را انتخاب کنید"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
 msgid "{0} options"
-msgstr ""
+msgstr "{0} گزینه ها"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
 msgid "Choose a visualization"
-msgstr "可視化方法を選択する"
+msgstr "تصویری را انتخاب کنید"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
 msgid "Filter by"
-msgstr "フィルター項目"
+msgstr "محدود شده توسط"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
 msgid "Summarize by"
-msgstr "集約方法"
+msgstr "خلاصه توسط"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
 msgid "Group by"
-msgstr "集約キー"
+msgstr "دسته بندی بر اساس"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
 msgid "Add a metric"
-msgstr "メトリクスを追加する"
+msgstr "متریک اضافه کنید"
 
 #: frontend/src/metabase/user/components/UserSettings.jsx:57
 msgid "Profile"
-msgstr "プロフィール"
+msgstr "مشخصات"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:548
 msgid "This is usually pretty fast but seems to be taking a while right now."
-msgstr "これはたいていの場合はとても速いですが、現在は時間がかかっているようです。"
+msgstr "این معمولاً خیلی سریع است اما به نظر می رسد اکنون مدتی طول می کشد."
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
 msgid "Combo"
-msgstr ""
+msgstr "Combo\n"
+""
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
-msgstr "行"
+msgstr "ردیف"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
 msgid "Trend"
-msgstr "トレンド"
+msgstr "روند"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:129
 msgid "Boolean"
-msgstr "真偽値"
+msgstr "Boolean"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
 msgid "Unknown Segment"
-msgstr "不明なセグメント"
+msgstr "بخش ناشناخته"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
 msgid "Unknown Filter"
-msgstr "不明なフィルター"
+msgstr "فیلتر ناشناخته"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
 msgid "Left outer join"
-msgstr "左外部結合"
+msgstr "پیوست بیرونی سمت چپ"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
 msgid "Right outer join"
-msgstr "右外部結合"
+msgstr "پیوست بیرونی راست"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
 msgid "Inner join"
-msgstr "内部結合"
+msgstr "پیوستن به درون"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
 msgid "Full outer join"
-msgstr "完全外部結合"
+msgstr "پیوستن بیرونی کامل"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
-msgstr ""
+msgstr "اطلاعات فوق داده نتایج کارت به API گم منتقل شده است. در حال انجام درخواست برای واگذاری صحیح ابرداده."
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fall back to local authentication"
-msgstr "LDAPサーバーへの接続に問題があり、ローカル認証にフォールバックします"
+msgstr "اتصال به سرور LDAP با تأیید اعتبار محلی برمی گردد"
 
 #: src/metabase/api/setup.clj
 msgid "Cannot create Database: cannot find driver {0}."
-msgstr "データベースが作成できません: {0} ドライバーが見つかりません"
+msgstr "ایجاد پایگاه داده امکان پذیر نیست: درایور {0} یافت نشد."
 
 #: src/metabase/api/tiles.clj
 msgid "Query failed"
-msgstr "クエリが失敗しました"
+msgstr "پرس و جو انجام نشد"
 
 #: src/metabase/async/util.clj
 msgid "Warning: {0} returned `nil`"
-msgstr "警告: {0} がnilを返しました"
+msgstr "هشدار: {0} `nil` برگشت داده شده است"
 
 #: src/metabase/async/util.clj
 msgid "Unexpected error writing result to output channel: already closed"
-msgstr "出力チャンネルへの結果の書き込みで予期しないエラーが発生しました: すでに閉じています"
+msgstr "نتیجه نوشتن خطای غیر منتظره به کانال خروجی: در حال حاضر بسته است"
 
 #: src/metabase/async/util.clj
 msgid "Unexpected error writing exception to output channel: already closed"
-msgstr "出力チャンネルへの例外の書き込み中に予期しないエラーが発生しました: すでに閉じています"
+msgstr "خطای غیر منتظره نوشتن استثناء کانال خروجی: در حال حاضر بسته است"
 
 #: src/metabase/async/util.clj
 msgid "Request canceled, canceling future."
-msgstr "リクエストがキャンセルされたため、フューチャーをキャンセルしています。"
+msgstr "درخواست لغو شد ، آینده را لغو می کند."
 
 #: src/metabase/cmd/load_from_h2.clj
 msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
-msgstr "MetabaseはH2からPostgresまたはMySQL/MariaDBへのデータ移行のみをサポートしています。"
+msgstr "Metabase فقط می تواند داده ها را از H2 به Postgres یا MySQL / MariaDB منتقل کند."
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
-msgstr "警告: 本番環境で、MetabaseをH2アプリケーションデータベースと共に使用することはお勧めできません。"
+msgstr "اخطار: استفاده از Metabase با پایگاه داده برنامه H2 برای استقرار تولید توصیه نمی شود."
 
 #: src/metabase/db.clj
 msgid "Application database setup"
-msgstr "アプリケーションデータベース セットアップ"
+msgstr "راه اندازی پایگاه داده برنامه"
 
 #: src/metabase/driver.clj
 msgid "Could not find {0} driver."
-msgstr "{0}のドライバーが見つかりませんでした"
+msgstr "درایور {0} یافت نشد."
 
 #: src/metabase/driver.clj
 msgid "Abstract drivers cannot derive from concrete parent drivers."
-msgstr ""
+msgstr "رانندگان چکیده نمی توانند از درایورهای والد والدین استخراج شوند."
 
 #: src/metabase/driver/mysql.clj
 msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
-msgstr "SSLで接続するには、追加の接続オプションに `trustServerCertificate=true` を追加する必要がある場合があります。"
+msgstr "برای اتصال به SSL ممکن است نیاز به افزودن \"trustServerCertificate = true\" به گزینه های اتصال اضافی داشته باشید."
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don't know how to alias {0}, expected an Identifer."
-msgstr ""
+msgstr "نمی دانید چگونه شناسه {0} ، انتظار می رود شناسه."
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, canceling query"
-msgstr "クライアントが接続を閉じ、クエリをキャンセルします"
+msgstr "اتصال بسته مشتری ، جستجوی لغو"
 
 #: src/metabase/integrations/ldap.clj
 msgid "{0} is not a valid DN."
-msgstr "{0}は有効なDNではありません"
+msgstr "{0} یک DN معتبر نیست."
 
 #: src/metabase/middleware/log.clj
 msgid "Error logging API request"
-msgstr "APIリクエストのロギングエラー"
+msgstr "خطا هنگام ثبت درخواست API"
 
 #: src/metabase/middleware/misc.clj
 msgid "Failed to set site-url"
-msgstr "サイトURLのセットに失敗しました"
+msgstr "تنظیم آدرس سایت انجام نشد"
 
 #: src/metabase/models/database.clj
 msgid "Error destroying thread pool for DB."
-msgstr "DBのスレッドプール終了エラー"
+msgstr "خطا در از بین بردن استخر موضوع برای DB."
 
 #: src/metabase/models/humanization.clj
 msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
-msgstr ""
+msgstr "به روزرسانی نام نمایشگر برای {0} '' {1} '': '' {2} '' -> '' {3} ''"
 
 #: src/metabase/models/humanization.clj
 msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
-msgstr ""
+msgstr "استراتژی انسانی نامعتبر \"\" {0} \"\". راهبردهای معتبر عبارتند از: {1}"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr ""
+msgstr "تغییر استراتژی انسان سازی جدول و زمینه از '' {0} '' 'به' '{1}' '"
 
 #: src/metabase/models/task_history.clj src/metabase/sync/util.clj
 msgid "Error saving task history"
-msgstr ""
+msgstr "خطا در ذخیره سابقه کار"
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
-msgstr "spark-deps.jarはMetabase 0.32.0以降では必要ありません。プラグインディレクトリから削除して構いません。"
+msgstr "جرقه-deps.jar دیگر مورد نیاز Metabase 0.32.0+ نیست. می توانید آن را از فهرست افزونه ها پاک کنید."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
-msgstr "「新しく作成された」クラスローダーを共有コンテキストクラスローダーとして使用: {0}"
+msgstr "با استفاده از لودر کلاس جديد ساخته شده به عنوان متن كلاس طبقه بندي مشترك: {0}"
 
 #: src/metabase/plugins/files.clj
 msgid "Failed to copy file"
-msgstr "ファイルのコピーに失敗しました"
+msgstr "کپی کردن پرونده انجام نشد"
 
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
-msgstr "無効なサイトURL: {0}"
+msgstr "URL سایت نامعتبر: {0}"
 
 #: src/metabase/public_settings.clj
 msgid "site-url is invalid; returning nil for now. Will be reset on next request."
-msgstr "サイトURLが無効です; 現在はnilを返しています。次のリクエストでリセットされます。"
+msgstr "آدرس اینترنتی نامعتبر است؛ فعلاً در صورت درخواست دوباره تنظیم مجدد خواهد شد."
 
 #: src/metabase/pulse/render/body.clj
 msgid "More results have been included as a file attachment"
-msgstr "より多くの結果が添付ファイルとして含まれています"
+msgstr "نتایج بیشتری به عنوان پیوست پرونده درج شده است"
 
 #: src/metabase/pulse/render/body.clj
 msgid "This question has been included as a file attachment"
-msgstr "この質問は添付ファイルとして含まれています"
+msgstr "این سوال به عنوان پیوست پرونده درج شده است"
 
 #: src/metabase/pulse/render/body.clj
 msgid "We were unable to display this Pulse."
-msgstr "このパルスを表示することができませんでした。"
+msgstr "ما قادر به نمایش این پالس نبودیم."
 
 #: src/metabase/pulse/render/body.clj
 msgid "Please view this card in Metabase."
-msgstr "このカードをMetabaseでご覧ください。"
+msgstr "لطفاً این کارت را در Metabase مشاهده کنید."
 
 #: src/metabase/pulse/render/body.clj
 msgid "An error occurred while displaying this card."
-msgstr "このカードの表示中にエラーが発生しました。"
+msgstr "هنگام نمایش این کارت خطایی روی داد."
 
 #: src/metabase/query_processor.clj
 msgid "Can only determine expected columns for MBQL queries."
-msgstr "MBQLクエリの予想列のみを決定できます。"
+msgstr "فقط می توانید ستون های مورد انتظار برای نمایش داده های MBQL را تعیین کنید."
 
 #: src/metabase/query_processor.clj
 msgid "No columns returned."
-msgstr "返される列はありません。"
+msgstr "هیچ ستونی برنگشته است."
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
-msgstr "警告: `source-metadata`も含めない限り、明示的な` source-query`のフィールドを決定できません。"
+msgstr "هشدار: نمی توانید زمینه هایی برای \"پرس و جو منبع\" صریح تعیین کنید ، مگر اینکه \"source-metadata\" نیز در آن قرار بگیرید."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
-msgstr "{0}を解決できません: フィールドが存在しないか、テーブルな異なるデータベースに属しています"
+msgstr "نمی توان {0} را حل کرد: فیلد وجود ندارد ، یا جدول آن به یک پایگاه داده دیگر تعلق دارد."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
-msgstr ""
+msgstr "حل نشد: درست به معنای واقعی در داخل: fk-> مگر اینکه در داخل با صریح پیوست: نام مستعار."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot find Table ID for {0}"
-msgstr "{0}に対するテーブルIDが見つかりません"
+msgstr "شناسه جدول برای {0} یافت نشد"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found."
-msgstr "合致する情報が見つかりません"
+msgstr "هیچ اطلاعات تطبیقی یافت نشد."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Could not resolve {0}"
-msgstr "{0}を解決できませんでした"
+msgstr "{0} حل نشد"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Invalid fk-> clause: nowhere to add corresponding join."
-msgstr ""
+msgstr "بند fk-> نامعتبر: جایی برای اضافه کردن پیوست مربوطه وجود ندارد."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "{0} driver does not support foreign keys."
-msgstr "{0}ドライバーは外部キーをサポートしていません"
+msgstr "{0} درایور از کلیدهای خارجی پشتیبانی نمی کند."
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
 msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
-msgstr ""
+msgstr "نمی توان استنباط کرد: منبع-ابرداده برای جستجوی منبع با پرس و جو منبع بومی و بدون ابرداده منبع."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: number of columns returned by driver does not match results."
-msgstr "クエリプロセッサエラー: ドライバーから返された列の数が結果と一致しません。"
+msgstr "خطای پردازنده پرس و جو: تعداد ستون هایی که توسط راننده برگشته است با نتایج مطابقت ندارد."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} columns, but first row of resuls has {1} columns."
-msgstr "{0}列の結果が期待されますが、結果の最初の行は{1}列有しています。"
+msgstr "ستون {0} پیش بینی شده است ، اما ردیف اول از اعاده مجدد ستون های {1} دارد."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "No expression named {0} found. Found: {1}"
-msgstr ""
+msgstr "هیچ عبارتی به نام {0} یافت نشد. یافت شده: {1}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Distinct values of {0}"
-msgstr "{0}の重複を除いた値"
+msgstr "مقادیر مشخص {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Average of {0}"
-msgstr "{0}の平均値"
+msgstr "میانگین {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0}"
-msgstr "{0}の合計値"
+msgstr "جمع {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "SD of {0}"
-msgstr "{0}の標準偏差"
+msgstr "SD of {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Min of {0}"
-msgstr "{0}の最小値"
+msgstr "Min of {0}\n"
+""
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Max of {0}"
-msgstr "{0}の最大値"
+msgstr "Max of {0}"
 
 #. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0} matching condition"
-msgstr "条件に合致する{0}の合計値"
+msgstr "مجموع شرط تطبیق {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Share of rows matching condition"
-msgstr ""
+msgstr "سهم شرط مطابقت ردیف ها"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of rows matching condition"
-msgstr "条件に合致する行の数"
+msgstr "تعداد ردیف شرایط مطابقت"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Request already canceled, will not run synchronous QP code."
-msgstr "要求はすでにキャンセルされており、同期QPコードは実行されません。"
+msgstr "درخواست قبلاً لغو شده ، کد QP همزمان را اجرا نمی کند."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unexpectedly got `nil` Query Processor response."
-msgstr "予期せず `nil`クエリプロセッサの応答がありました。"
+msgstr "به طور غیر منتظره پاسخ 'nil' پردازنده Query را دریافت کرد."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Got InterruptedException. Canceling query."
-msgstr "InterruptedException が発生しました。 クエリをキャンセルしています。"
+msgstr "InterpreException در حال لغو پرس و جو"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
-msgstr ""
+msgstr "استثناء بدون کنترل ، واسطه میانجی \"گرفتن استثناء\" را برای رسیدگی به آن انجام داد."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Query timed out after %s"
-msgstr ""
+msgstr "زمان پرس و جو بعد از %s پایان یافت"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Creating new query thread pool for Database {0}"
-msgstr "データベース{0}に対する新しいクエリスレッドプールを作成中です"
+msgstr "ایجاد استخر جدید برای جستجوی موضوعات برای پایگاه داده {0}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Destroying query thread pool for Database {0}"
-msgstr "データベース{0}に対するクエリスレッドプールを削除中です"
+msgstr "از بین بردن استخر موضوع جستجو برای بانک اطلاعات {0}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Request canceled, canceling pending query"
-msgstr "リクエストをキャンセルし、保留中のクエリをキャンセルします"
+msgstr "درخواست لغو شد ، جستجوی در حال انتظار لغو است"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: query is missing source-metadata"
-msgstr "ビニングされたフィールドを更新できません: クエリに source-metadata がありません"
+msgstr "می توانید زمینه binned را به روز نکنید: پرس و جو داده های منبع داده وجود ندارد"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
-msgstr "ビニングされたフィールドを更新できません: フィールド ''{0}''の一致するソースメタデータが見つかりませんでした"
+msgstr "زمینه بنه به روزرسانی نمی شود: یافت نشد. منبع داده منطبق با فیلد '' {0}''"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Using query processor cache backend: {0}"
-msgstr ""
+msgstr "با استفاده از پس زمینه حافظه نهان پردازنده پرس و جو: {0}"
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Invalid metric: {0} reason: {1}"
-msgstr "無効なメトリック: {0} 理由: {1}"
+msgstr "اندازه گیری نامعتبر: {0} دلیل: {1}"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unknown error"
-msgstr "未知のエラー"
+msgstr "خطای ناشناخته"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unexpected nil response from query processor."
-msgstr "クエリプロセッサからの予期しないnil応答。"
+msgstr "پاسخ صفر غیر منتظره از پردازنده پرس و جو."
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query canceled"
-msgstr "クエリがキャンセルされました"
+msgstr "پرس و جو لغو شد"
 
 #: src/metabase/query_processor/middleware/resolve_driver.clj
 msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
-msgstr "クエリのドライバーを解決できません: `:database` IDが見つからないか無効です。"
+msgstr "درایور برای پرس و جو امکان پذیر نیست: از بین رفته یا نامعتبر است: شناسه پایگاه داده."
 
 #: src/metabase/query_processor/middleware/resolve_driver.clj
 msgid "Unable to resolve driver for query: Database {0} does not exist."
-msgstr "クエリに対するドライバーを解決することができません: データベース{0}が存在しません。"
+msgstr "امکان حل کردن درایور برای پرس و جو وجود ندارد: بانک اطلاعات {0} وجود ندارد."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
-msgstr ""
+msgstr "استفاده از فیلدها امکان پذیر نیست: زمینه ها: همه در مقابل جستجوی منبع به هم پیوسته اند ، مگر اینکه دارای: منبع فرا داده باشد."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
-msgstr ""
+msgstr "بد: بند پیوستن به فیلد: پیوستن به نام مستعار '' {0} '' وجود ندارد. یافت شده: {1}"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
-msgstr ""
+msgstr "نامعتبر: جدول مبدأ '' {0} '' ': اکنون باید به شناسه جدول حل شود."
 
 #: src/metabase/query_processor/store.clj
 msgid "Cannot store Tables or Fields before Database is stored."
-msgstr "データベースが保存される前にテーブルまたはフィールドを保存できません。"
+msgstr "جداول یا فیلدها را قبل از ذخیره سازی پایگاه داده ذخیره نکنید."
 
 #: src/metabase/query_processor/store.clj
 msgid "Attempting to fetch second Database. Queries can only reference one Database."
-msgstr "2番目のデータベースを取得しようとしています。 クエリは1つのデータベースのみを参照できます。"
+msgstr "تلاش برای دستیابی به پایگاه داده دوم. نمایش داده شد فقط می تواند به یک بانک اطلاعاتی مراجعه کند."
 
 #: src/metabase/query_processor/store.clj
 msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
-msgstr "テーブル{0}のフェッチに失敗しました: テーブルが存在しないか、テーブルが異なるデータベースに属しています。"
+msgstr "جدول {0} انجام نشد: جدول وجود ندارد ، یا به یک پایگاه داده دیگر تعلق دارد."
 
 #: src/metabase/query_processor/store.clj
 msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
-msgstr "フィールド{0}のフェッチに失敗しました: フィールドが存在しないか、フィールドが異なるデータベースに属しています。"
+msgstr "واگذاری زمینه {0} انجام نشد: فیلد وجود ندارد ، یا به یک پایگاه داده دیگر تعلق دارد."
 
 #: src/metabase/routes/index.clj
 msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
-msgstr "テンプレート ''{0}''の読み込みに失敗しました。 Metabaseフロントエンドをビルドすることを覚えていましたか？"
+msgstr "الگوی '' {0} '' بارگیری نشد. یادتان هست که جبهه Metabase را بسازید؟"
 
 #: src/metabase/sample_data.clj
 msgid "Sample dataset DB file ''{0}'' cannot be found."
-msgstr "サンプルデータセットDBファイル ''{0}''が見つかりません。"
+msgstr "نمونه پرونده داده {DB '' {0'' یافت نشد."
 
 #: src/metabase/sample_data.clj
 msgid "Loading sample dataset..."
-msgstr "サンプルデータセットをロードしています..."
+msgstr "بارگیری مجموعه داده نمونه ..."
 
 #: src/metabase/sample_data.clj
 msgid "Failed to load sample dataset"
-msgstr "サンプルデータセットのロードに失敗しました"
+msgstr "بارگیری مجموعه داده نمونه انجام نشد"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Found new tables:"
-msgstr "新しいテーブルが見つかりました:"
+msgstr "جداول جدید یافت:"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Marking tables as inactive:"
-msgstr "テーブルを非アクティブとしてマークする:"
+msgstr "علامت گذاری جداول به عنوان غیرفعال:"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Updating description for tables:"
-msgstr "テーブルの説明の更新:"
+msgstr "به روزرسانی توضیحات برای جداول:"
 
 #: src/metabase/task.clj
 msgid "Rescheduling job {0}"
-msgstr ""
+msgstr "تنظیم مجدد کار {0}"
 
 #: src/metabase/task.clj
 msgid "Error rescheduling job"
-msgstr "ジョブのスケジュール変更エラー"
+msgstr "خطا در تنظیم مجدد کار"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Starting Pulse Execution: {0}"
-msgstr "パルスの実行を始めています: {0}"
+msgstr "شروع اجرای پالس: {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Finished Pulse Execution: {0}"
-msgstr "パルスの実行が終了しました: {0}"
+msgstr "اجرای پالس به پایان رسید: {0}"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to schedule tasks for Database {0}"
-msgstr "データベース{0}に対する定期タスクのスケジューリングに失敗しました"
+msgstr "برنامه ریزی وظایف برای بانک اطلاعات {0} انجام نشد"
 
 #: src/metabase/util/schema.clj
 msgid "All elements must be distinct."
-msgstr "全ての項目が一意でなければなりません"
+msgstr "همه عناصر باید مشخص باشند."
 
 #: 
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
-msgstr "含めたい列を選ぶ"
+msgstr "ستون هایی را که می خواهید گنجانید انتخاب کنید"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "これを有効にすることにより、ユーザーがチャートやテーブルを見るときに要約やフィルターボタンを利用して簡単な探索を行った場合に、Metabaseが自動的にクエリを実行するようになります。このデータベースへのクエリが遅い場合は、この設定を無効にすることができます。この設定によってドリルスルーやSQLクエリが影響を受けることはありません。"
+msgstr "هنگامی که این کار روشن است ، وقتی کاربر در هنگام مشاهده جدول یا نمودار ، دکمه های خلاصه و فیلتر را با استفاده از کاوش ساده انجام می دهد ، Metabase به صورت خودکار نمایش داده می شود. اگر جستجوی این پایگاه داده کند است ، می توانید این را خاموش کنید. این تنظیم تأثیر نمی گذارد از طریق مته یا سؤالهای SQL."
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
 msgid "Change join type"
-msgstr "JOINの形式を変える"
+msgstr "نوع پیوستن را تغییر دهید"
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don't know how to alias {0}, expected an Identifier."
-msgstr ""
+msgstr "نمی دانید چگونه شناسه {0} ، انتظار می رود شناسه."
 
 #: src/metabase/integrations/common.clj
 msgid "Error adding User {0} to Group {1}"
-msgstr "ユーザ{0}をグループ{1}に追加する際にエラーが発生しました"
+msgstr "خطا در افزودن کاربر {0} به گروه {1}"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr ""
+msgstr "تغییر استراتژی انسان سازی جدول و زمینه از '' {0} ''به ''{1}''"
 
 #: src/metabase/query_processor.clj
 msgid "Infinite loop detected: recursively preprocessed query {0} times."
-msgstr "無限ループが検知されました: クエリに対する再帰的な前処理が{0}回行われました。"
+msgstr "حلقه نامتناهی تشخیص داده شد: پرس و جو قبل از پردازش بازگشتی {0} بار."
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
-msgstr "警告: `source-metadata`も含めない限り、明示的な` source-query`のフィールドを決定できません。"
+msgstr "هشدار: نمی توانید زمینه هایی برای \"پرس و جو منبع\" صریح تعیین کنید ، مگر اینکه \"source-query\" نیز در آن قرار بگیرید."
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
 msgid "Error determining expected columns for query"
-msgstr "クエリの予想列の決定エラー"
+msgstr "خطا در تعیین ستون های مورد انتظار برای پرس و جو"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
-msgstr ""
+msgstr "استثناء نامحدود ، انتظار می رود واسطه میانجی \"گرفتن استثناء\" برای رسیدگی به آن."
 

--- a/locales/fa.po
+++ b/locales/fa.po
@@ -1061,8 +1061,8 @@ msgid "We couldn’t send them an email invitation,\n"
 "so make sure to tell them to log in using {0}\n"
 "and this password we’ve generated for them:"
 msgstr "ما نمی توانیم آنها را دعوت نامه ای بفرستیم\n"
-"بنابراین اطمینان حاصل کنید که آنها را وارد کنید با استفاده از {0}\n"
-"و این رمز عبور که برای آنها ایجاد کردیم:"
+"{بنابراین اطمینان حاصل کنید که آنها را وارد کنید با استفاده از {0"
+":و این رمز عبور که برای آنها ایجاد کردیم\n"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:73
 msgid "If you want to be able to send email invites, just go to the {0} page."
@@ -1086,7 +1086,7 @@ msgstr "هر گونه دعوتنامه ایمیل قبلی آنها دیگر ک�
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:31
 msgid "Deactivate {0}?"
-msgstr "غیر فعال کردن {0}"
+msgstr "{غیر فعال کردن {0"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:34
 msgid "{0} won't be able to log in anymore."
@@ -1410,7 +1410,7 @@ msgstr "این یک عدد صحیح معتبر نیست"
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:161
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:223
 msgid "Changes saved!"
-msgstr "تغییرات ذخیره شد!"
+msgstr "!تغییرات ذخیره شد"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:157
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:132
@@ -1423,11 +1423,11 @@ msgstr "ارسال ایمیل آزمایشی"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:13
 msgid "Sending..."
-msgstr "درحال ارسال..."
+msgstr "… درحال ارسال"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:14
 msgid "Sent!"
-msgstr "ارسال شد!"
+msgstr "!ارسال شد"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:82
 msgid "Clear"
@@ -1465,7 +1465,7 @@ msgstr "راه اندازی"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:106
 msgid "A few things you can do to get the most out of Metabase."
-msgstr "چند چیز که می توانید انجام دهید برای به دست آوردن بیشتر از Metabase."
+msgstr "Metabase چند چیز که می توانید انجام دهید برای به دست آوردن بیشتر از"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:115
 msgid "Recommended next step"
@@ -1505,7 +1505,7 @@ msgstr "شما Metabase {0} را اجرا می کنید که آخرین و بز�
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
-msgstr "Metabase {0} در دسترس است شما در حال اجرا {1}"
+msgstr "{در دسترس است. شما در حال اجرا {1 Metabase {0}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
@@ -1545,11 +1545,11 @@ msgstr "پاک کردن"
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
-msgstr "اتخاب..."
+msgstr "…اتخاب"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
-msgstr "متغیر نمونه"
+msgstr ":متغیر نمونه"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
@@ -1740,7 +1740,7 @@ msgstr "غیرفعال سازی"
 
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
-msgstr "تنظیم ناشناخته {0}"
+msgstr "{تنظیم ناشناخته {0"
 
 #: frontend/src/metabase/admin/settings/selectors.js:23
 msgid "Setup"
@@ -12991,15 +12991,15 @@ msgstr "می توانید زمینه binned را به روز نکنید: پرس 
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
-msgstr “''{زمینه بنه به روزرسانی نمی شود: یافت نشد. منبع داده منطبق با فیلد ''{0”
+msgstr "''{زمینه بنه به روزرسانی نمی شود: یافت نشد. منبع داده منطبق با فیلد ''{0"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Using query processor cache backend: {0}"
-msgstr "با استفاده از پس زمینه حافظه نهان پردازنده پرس و جو: {0}"
+msgstr "{با استفاده از پس زمینه حافظه نهان پردازنده پرس و جو: {0"
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Invalid metric: {0} reason: {1}"
-msgstr "اندازه گیری نامعتبر: {0} دلیل: {1}"
+msgstr "{اندازه گیری نامعتبر: {0} دلیل: {1"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unknown error"

--- a/locales/fa.po
+++ b/locales/fa.po
@@ -1061,8 +1061,8 @@ msgid "We couldn’t send them an email invitation,\n"
 "so make sure to tell them to log in using {0}\n"
 "and this password we’ve generated for them:"
 msgstr "ما نمی توانیم آنها را دعوت نامه ای بفرستیم\n"
-"{بنابراین اطمینان حاصل کنید که آنها را وارد کنید با استفاده از {0\n"
-":و این رمز عبور که برای آنها ایجاد کردیم"
+"بنابراین اطمینان حاصل کنید که آنها را وارد کنید با استفاده از {0}\n"
+"و این رمز عبور که برای آنها ایجاد کردیم:"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:73
 msgid "If you want to be able to send email invites, just go to the {0} page."
@@ -1086,7 +1086,7 @@ msgstr "هر گونه دعوتنامه ایمیل قبلی آنها دیگر ک�
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:31
 msgid "Deactivate {0}?"
-msgstr "{غیر فعال کردن {0"
+msgstr "غیر فعال کردن {0}"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:34
 msgid "{0} won't be able to log in anymore."
@@ -1423,7 +1423,7 @@ msgstr "ارسال ایمیل آزمایشی"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:13
 msgid "Sending..."
-msgstr "… درحال ارسال"
+msgstr "…درحال ارسال"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:14
 msgid "Sent!"
@@ -1465,7 +1465,7 @@ msgstr "راه اندازی"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:106
 msgid "A few things you can do to get the most out of Metabase."
-msgstr "Metabase چند چیز که می توانید انجام دهید برای به دست آوردن بیشتر از"
+msgstr "چند چیز که می توانید انجام دهید برای به دست آوردن بیشتر از Metabase."
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:115
 msgid "Recommended next step"
@@ -1505,7 +1505,7 @@ msgstr "شما Metabase {0} را اجرا می کنید که آخرین و بز�
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
-msgstr "{در دسترس است. شما در حال اجرا {1 Metabase {0}"
+msgstr "Metabase {0} در دسترس است شما در حال اجرا {1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
@@ -1549,7 +1549,7 @@ msgstr "…اتخاب"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
-msgstr ":متغیر نمونه"
+msgstr "متغیر نمونه"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
@@ -1740,7 +1740,7 @@ msgstr "غیرفعال سازی"
 
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
-msgstr "{تنظیم ناشناخته {0"
+msgstr "تنظیم ناشناخته {0}"
 
 #: frontend/src/metabase/admin/settings/selectors.js:23
 msgid "Setup"
@@ -12914,19 +12914,19 @@ msgstr "ستون {0} پیش بینی شده است ، اما ردیف اول ا�
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "No expression named {0} found. Found: {1}"
-msgstr "{هیچ عبارتی به نام {0} یافت نشد. یافت شده: {1"
+msgstr "هیچ عبارتی به نام {0} یافت نشد. یافت شده: {1}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Distinct values of {0}"
-msgstr "{مقادیر مشخص {0"
+msgstr "مقادیر مشخص {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Average of {0}"
-msgstr "{میانگین {0"
+msgstr "میانگین {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0}"
-msgstr "{جمع {0"
+msgstr "جمع {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "SD of {0}"
@@ -12943,7 +12943,7 @@ msgstr "{0} حداکثر از"
 #. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0} matching condition"
-msgstr "{مجموع شرط تطبیق {0"
+msgstr "مجموع شرط تطبیق {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Share of rows matching condition"
@@ -12975,11 +12975,11 @@ msgstr "زمان پرس و جو بعد از %s پایان یافت"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Creating new query thread pool for Database {0}"
-msgstr "{ایجاد استخر جدید برای جستجوی موضوعات برای پایگاه داده {0"
+msgstr "ایجاد استخر جدید برای جستجوی موضوعات برای پایگاه داده {0}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Destroying query thread pool for Database {0}"
-msgstr "{از بین بردن استخر موضوع جستجو برای بانک اطلاعات {0"
+msgstr "از بین بردن استخر موضوع جستجو برای بانک اطلاعات {0}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Request canceled, canceling pending query"
@@ -12991,15 +12991,15 @@ msgstr "می توانید زمینه binned را به روز نکنید: پرس 
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
-msgstr "''{زمینه بنه به روزرسانی نمی شود: یافت نشد. منبع داده منطبق با فیلد ''{0"
+msgstr "زمینه بنه به روزرسانی نمی شود: یافت نشد. منبع داده منطبق با فیلد '' {0}''"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Using query processor cache backend: {0}"
-msgstr "{با استفاده از پس زمینه حافظه نهان پردازنده پرس و جو: {0"
+msgstr "با استفاده از پس زمینه حافظه نهان پردازنده پرس و جو: {0}"
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Invalid metric: {0} reason: {1}"
-msgstr "{اندازه گیری نامعتبر: {0} دلیل: {1"
+msgstr "اندازه گیری نامعتبر: {0} دلیل: {1}"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unknown error"
@@ -13027,11 +13027,11 @@ msgstr "استفاده از فیلدها امکان پذیر نیست: زمین�
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
-msgstr "{بد: بند پیوستن به فیلد: پیوستن به نام مستعار ''{0}'' وجود ندارد. یافت شده: {1"
+msgstr "بد: بند پیوستن به فیلد: پیوستن به نام مستعار '' {0} '' وجود ندارد. یافت شده: {1}"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
-msgstr "نامعتبر: جدول مبدأ ''{0}'' ': اکنون باید به شناسه جدول حل شود."
+msgstr "نامعتبر: جدول مبدأ '' {0} '' ': اکنون باید به شناسه جدول حل شود."
 
 #: src/metabase/query_processor/store.clj
 msgid "Cannot store Tables or Fields before Database is stored."
@@ -13051,7 +13051,7 @@ msgstr "واگذاری زمینه {0} انجام نشد: فیلد وجود ند�
 
 #: src/metabase/routes/index.clj
 msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
-msgstr "الگوی ''{0}'' بارگیری نشد. یادتان هست که جبهه Metabase را بسازید؟"
+msgstr "الگوی '' {0} '' بارگیری نشد. یادتان هست که جبهه Metabase را بسازید؟"
 
 #: src/metabase/sample_data.clj
 msgid "Sample dataset DB file ''{0}'' cannot be found."
@@ -13059,7 +13059,7 @@ msgstr "نمونه پرونده داده DB ''{0}'' یافت نشد."
 
 #: src/metabase/sample_data.clj
 msgid "Loading sample dataset..."
-msgstr "بارگیری مجموعه داده نمونه ..."
+msgstr "…بارگیری مجموعه داده نمونه"
 
 #: src/metabase/sample_data.clj
 msgid "Failed to load sample dataset"
@@ -13074,12 +13074,12 @@ msgid "Marking tables as inactive:"
 msgstr ":علامت گذاری جداول به عنوان غیرفعال"
 
 #: src/metabase/sync/sync_metadata/tables.clj
-msgid "Updating description for tables:"
-msgstr ":به روزرسانی توضیحات برای جداول"
+msgid "Updating description for tables"
+msgstr ":به روزرسانی توضیحات برای جداول:"
 
 #: src/metabase/task.clj
 msgid "Rescheduling job {0}"
-msgstr "{تنظیم مجدد کار {0"
+msgstr "تنظیم مجدد کار {0}"
 
 #: src/metabase/task.clj
 msgid "Error rescheduling job"
@@ -13087,11 +13087,11 @@ msgstr "خطا در تنظیم مجدد کار"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Starting Pulse Execution: {0}"
-msgstr "{شروع اجرای پالس: {0"
+msgstr "شروع اجرای پالس: {0}"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Finished Pulse Execution: {0}"
-msgstr "{اجرای پالس به پایان رسید: {0"
+msgstr "اجرای پالس به پایان رسید: {0}"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to schedule tasks for Database {0}"
@@ -13120,13 +13120,13 @@ msgstr "نمی دانید چگونه شناسه {0} ، انتظار می رود 
 
 #: src/metabase/integrations/common.clj
 msgid "Error adding User {0} to Group {1}"
-msgstr "{خطا در افزودن کاربر {0} به گروه {1"
+msgstr "خطا در افزودن کاربر {0} به گروه {1}"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr "''{تغییر استراتژی انسان سازی جدول و زمینه از ''{0}'' به ''{1"
+msgstr "تغییر استراتژی انسان سازی جدول و زمینه از '' {0} ''به ''{1}''"
 
 #: src/metabase/query_processor.clj
 msgid "Infinite loop detected: recursively preprocessed query {0} times."

--- a/locales/fa.po
+++ b/locales/fa.po
@@ -1061,8 +1061,8 @@ msgid "We couldn’t send them an email invitation,\n"
 "so make sure to tell them to log in using {0}\n"
 "and this password we’ve generated for them:"
 msgstr "ما نمی توانیم آنها را دعوت نامه ای بفرستیم\n"
-"{بنابراین اطمینان حاصل کنید که آنها را وارد کنید با استفاده از {0"
-":و این رمز عبور که برای آنها ایجاد کردیم\n"
+"{بنابراین اطمینان حاصل کنید که آنها را وارد کنید با استفاده از {0\n"
+":و این رمز عبور که برای آنها ایجاد کردیم"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:73
 msgid "If you want to be able to send email invites, just go to the {0} page."

--- a/locales/fr.po
+++ b/locales/fr.po
@@ -13038,8 +13038,7 @@ msgstr "Incapable de mettre à jour le champ binné: la requête manque de méta
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
-msgstr "Dans l'incapacité de mttre à jour le champ binné: métadonnées correspondantes non trouvées pour le champ \"{0}\"\n"
-""
+msgstr "Dans l'incapacité de mttre à jour le champ binné: métadonnées correspondantes non trouvées pour le champ ''{0}''"
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Using query processor cache backend: {0}"
@@ -13149,7 +13148,7 @@ msgstr "Echec à la planification des tâches pour la base de données {0}"
 msgid "All elements must be distinct."
 msgstr "Tous les éléments doivent être distincts."
 
-#: 
+#:
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Choisissez les colonnes concernées"
@@ -13191,4 +13190,3 @@ msgstr "Erreur lors de la détermination des colonnes attendues pour la requête
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Exception non gérée, aurait du être prise en charge par le middleware `catch-exceptions`."
-

--- a/locales/fr.po
+++ b/locales/fr.po
@@ -13038,7 +13038,8 @@ msgstr "Incapable de mettre à jour le champ binné: la requête manque de méta
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
-msgstr "Dans l'incapacité de mttre à jour le champ binné: métadonnées correspondantes non trouvées pour le champ \"{0}\""
+msgstr "Dans l'incapacité de mttre à jour le champ binné: métadonnées correspondantes non trouvées pour le champ \"{0}\"\n"
+""
 
 #: src/metabase/query_processor/middleware/cache.clj
 msgid "Using query processor cache backend: {0}"
@@ -13148,7 +13149,7 @@ msgstr "Echec à la planification des tâches pour la base de données {0}"
 msgid "All elements must be distinct."
 msgstr "Tous les éléments doivent être distincts."
 
-#:
+#: 
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Choisissez les colonnes concernées"
@@ -13190,3 +13191,4 @@ msgstr "Erreur lors de la détermination des colonnes attendues pour la requête
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Exception non gérée, aurait du être prise en charge par le middleware `catch-exceptions`."
+

--- a/locales/it.po
+++ b/locales/it.po
@@ -12768,7 +12768,7 @@ msgstr "Richiesta annullata, annullamento futuro."
 
 #: src/metabase/cmd/load_from_h2.clj
 msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
-msgstr "2 "
+msgstr "Metabase può trasferire dati solo da database H2 a database Postgres o MySQL/MariaDB."
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
@@ -13075,7 +13075,8 @@ msgstr "Caricamento database di esempio..."
 
 #: src/metabase/sample_data.clj
 msgid "Failed to load sample dataset"
-msgstr "Caricamento del database di esempio fallito"
+msgstr "Caricamento del database di esempio fallito\n"
+""
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Found new tables:"
@@ -13111,9 +13112,10 @@ msgstr ""
 
 #: src/metabase/util/schema.clj
 msgid "All elements must be distinct."
-msgstr "All elements must be distinct."
+msgstr "All elements must be distinct.\n"
+""
 
-#:
+#: 
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Scegli le colonne che desideri includere"
@@ -13155,3 +13157,4 @@ msgstr ""
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr ""
+

--- a/locales/it.po
+++ b/locales/it.po
@@ -946,7 +946,8 @@ msgstr "Rimuovere questo gruppo?"
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:60
 msgid "Are you sure? All members of this group will lose any permissions settings they have based on this group.\n"
 "This can't be undone."
-msgstr "Sei sicuro? Tutti i membri di questo gruppo perderanno tutti i permessi basati su di esso. Operazione irreversibile."
+msgstr "Sei sicuro? Tutti i membri di questo gruppo perderanno tutti i permessi basati su di esso.\n"
+"Operazione irreversibile."
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
@@ -6583,7 +6584,8 @@ msgstr "Formattazione condizionale"
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:193
 msgid "You can add rules to make the cells in this table change color if\n"
 "they meet certain conditions."
-msgstr "Puoi aggiungere regole per fare in modo che le celle di questa tabella cambino colore se soddisfano determinate condizioni."
+msgstr "Puoi aggiungere regole per fare in modo che le celle di questa tabella cambino colore\n"
+"se soddisfano determinate condizioni."
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:203
 msgid "Add a rule"
@@ -13075,7 +13077,7 @@ msgstr "Caricamento database di esempio..."
 
 #: src/metabase/sample_data.clj
 msgid "Failed to load sample dataset"
-msgstr "Caricamento del database di esempio fallito\n"
+msgstr "Caricamento del database di esempio fallito"
 ""
 
 #: src/metabase/sync/sync_metadata/tables.clj
@@ -13112,10 +13114,10 @@ msgstr ""
 
 #: src/metabase/util/schema.clj
 msgid "All elements must be distinct."
-msgstr "All elements must be distinct.\n"
+msgstr "All elements must be distinct."
 ""
 
-#: 
+#:
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Scegli le colonne che desideri includere"
@@ -13157,4 +13159,3 @@ msgstr ""
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr ""
-

--- a/locales/nb.po
+++ b/locales/nb.po
@@ -11908,7 +11908,7 @@ msgstr ""
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error retiring {0}"
-msgstr ""
+msgstr "Feil ved arkivering av {0}"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Database type of {0} has changed from ''{1}'' to ''{2}''."
@@ -11924,15 +11924,15 @@ msgstr ""
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Comment has been added for {0}."
-msgstr ""
+msgstr "Kommentar ble lagt til for {0}"
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler {0}"
-msgstr ""
+msgstr "Stopper Quartz Scheduler {0}"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler {0}"
-msgstr ""
+msgstr "Starter Quartz Scheduler {0}"
 
 #: src/metabase/task.clj
 msgid "Error loading tasks namespace {0}"
@@ -11958,7 +11958,7 @@ msgstr "Sender anonym brukerstatistikk"
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Error sending anonymous usage stats"
-msgstr ""
+msgstr "Feil med å sende anonymt bruker statistikk"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Error sending Pulse {0}"
@@ -12140,11 +12140,11 @@ msgstr "Nullstill passord"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
-msgstr ""
+msgstr "Deaktiver bruker"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:47
 msgid "Reactivate {0}?"
-msgstr ""
+msgstr "Aktiver {0}?"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:63
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
@@ -12152,19 +12152,19 @@ msgstr ""
 
 #: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
-msgstr ""
+msgstr "kolleksjon"
 
 #: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
-msgstr ""
+msgstr "kolleksjoner"
 
 #: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
-msgstr ""
+msgstr "tavle"
 
 #: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
-msgstr ""
+msgstr "tavler"
 
 #: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"

--- a/locales/nl.po
+++ b/locales/nl.po
@@ -75,7 +75,8 @@ msgid "Metabase can scan the values present in each\n"
 "field in this database to enable checkbox filters in dashboards and questions. This\n"
 "can be a somewhat resource-intensive process, particularly if you have a very large\n"
 "database."
-msgstr "Metabase kan de waardes van elk veld in deze database scannen om de checkbox filters in dashboards en vragen weer te geven. Dit is een resource-intensief proces, voornamelijk indien je een grote database hebt."
+msgstr "Metabase kan de waardes van elk veld in deze database scannen om de checkbox filters in dashboards en vragen weer te geven. Dit is een resource-intensief proces, voornamelijk indien je een grote database hebt.\n"
+""
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
@@ -8782,7 +8783,8 @@ msgstr "JVM timezone is {0} and detected database timezone is {1}."
 
 #: src/metabase/util/date.clj
 msgid "Configure a report timezone to ensure proper date and time conversions."
-msgstr "Configure a report timezone to ensure proper date and time conversions."
+msgstr "Configure a report timezone to ensure proper date and time conversions.\n"
+""
 
 #: src/metabase/util/embed.clj
 msgid "Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints."
@@ -11307,7 +11309,8 @@ msgstr "Database {0} bestaat niet"
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Database is not present in the Query Processor Store."
-msgstr "Error: Database is not present in the Query Processor Store."
+msgstr "\n"
+"Error: Database is not present in the Query Processor Store."
 
 #: src/metabase/util/embed.clj
 msgid "Invalid embedding-secret-key! Secret key must be a hexadecimal-encoded 256-bit key (i.e., a 64-character string)."
@@ -11734,7 +11737,8 @@ msgstr "Plug-ins laden in {0} ..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using Clojure base loader as shared context classloader: {0}"
-msgstr "Using Clojure base loader as shared context classloader: {0}"
+msgstr "\n"
+"Using Clojure base loader as shared context classloader: {0}"
 
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to shared classloader {0}..."
@@ -12783,7 +12787,8 @@ msgstr "Kon driver {0} niet vinden."
 
 #: src/metabase/driver.clj
 msgid "Abstract drivers cannot derive from concrete parent drivers."
-msgstr "Abstract drivers cannot derive from concrete parent drivers."
+msgstr "\n"
+"Abstract drivers cannot derive from concrete parent drivers."
 
 #: src/metabase/driver/mysql.clj
 msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
@@ -12893,7 +12898,8 @@ msgstr "Cannot resolve :field-literal inside :fk-> unless inside join with expli
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot find Table ID for {0}"
-msgstr "Cannot find Table ID for {0}"
+msgstr "\n"
+"Cannot find Table ID for {0}"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found."
@@ -13034,7 +13040,8 @@ msgstr "Unable to resolve driver for query: Database {0} does not exist."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
-msgstr "Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr "\n"
+"Cannot use :fields :all in join against source query unless it has :source-metadata."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
@@ -13112,7 +13119,7 @@ msgstr "Kan taken voor database {0} niet plannen"
 msgid "All elements must be distinct."
 msgstr "Alle elementen moeten uniek zijn."
 
-#:
+#: 
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Kies de kolommen die je mee wilt nemen"
@@ -13154,3 +13161,4 @@ msgstr "Fout bij het bepalen van verwachte kolommen voor query"
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Onbehandelde exceptie, `catch-exceptions` middleware werd verwacht om dit af te handelen."
+

--- a/locales/nl.po
+++ b/locales/nl.po
@@ -75,8 +75,7 @@ msgid "Metabase can scan the values present in each\n"
 "field in this database to enable checkbox filters in dashboards and questions. This\n"
 "can be a somewhat resource-intensive process, particularly if you have a very large\n"
 "database."
-msgstr "Metabase kan de waardes van elk veld in deze database scannen om de checkbox filters in dashboards en vragen weer te geven. Dit is een resource-intensief proces, voornamelijk indien je een grote database hebt.\n"
-""
+msgstr "Metabase kan de waardes van elk veld in deze database scannen om de checkbox filters in dashboards en vragen weer te geven. Dit is een resource-intensief proces, voornamelijk indien je een grote database hebt."
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
@@ -8783,8 +8782,7 @@ msgstr "JVM timezone is {0} and detected database timezone is {1}."
 
 #: src/metabase/util/date.clj
 msgid "Configure a report timezone to ensure proper date and time conversions."
-msgstr "Configure a report timezone to ensure proper date and time conversions.\n"
-""
+msgstr "Configure a report timezone to ensure proper date and time conversions."
 
 #: src/metabase/util/embed.clj
 msgid "Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints."
@@ -11309,8 +11307,7 @@ msgstr "Database {0} bestaat niet"
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Database is not present in the Query Processor Store."
-msgstr "\n"
-"Error: Database is not present in the Query Processor Store."
+msgstr "Error: Database is not present in the Query Processor Store."
 
 #: src/metabase/util/embed.clj
 msgid "Invalid embedding-secret-key! Secret key must be a hexadecimal-encoded 256-bit key (i.e., a 64-character string)."
@@ -11737,8 +11734,7 @@ msgstr "Plug-ins laden in {0} ..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using Clojure base loader as shared context classloader: {0}"
-msgstr "\n"
-"Using Clojure base loader as shared context classloader: {0}"
+msgstr "Using Clojure base loader as shared context classloader: {0}"
 
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to shared classloader {0}..."
@@ -12787,8 +12783,7 @@ msgstr "Kon driver {0} niet vinden."
 
 #: src/metabase/driver.clj
 msgid "Abstract drivers cannot derive from concrete parent drivers."
-msgstr "\n"
-"Abstract drivers cannot derive from concrete parent drivers."
+msgstr "Abstract drivers cannot derive from concrete parent drivers."
 
 #: src/metabase/driver/mysql.clj
 msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
@@ -12898,8 +12893,7 @@ msgstr "Cannot resolve :field-literal inside :fk-> unless inside join with expli
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Cannot find Table ID for {0}"
-msgstr "\n"
-"Cannot find Table ID for {0}"
+msgstr "Kan tabel-ID niet vinden voor {0}"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found."
@@ -12907,23 +12901,23 @@ msgstr "Geen overeenkomende info gevonden."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Could not resolve {0}"
-msgstr "Could not resolve {0}"
+msgstr "Kan {0} niet oplossen"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Invalid fk-> clause: nowhere to add corresponding join."
-msgstr "Invalid fk-> clause: nowhere to add corresponding join."
+msgstr "Ongeldige fk-> -clausule: nergens om overeenkomstige join toe te voegen."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "{0} driver does not support foreign keys."
-msgstr "driver {0} ondersteund geen foreign keys."
+msgstr "Driver {0} ondersteund geen foreign keys."
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
 msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
-msgstr "Cannot infer `:source-metadata` for source query with native source query without source metadata."
+msgstr "Kan `: bron-metagegevens` voor bronquery met native bronquery zonder bronmetagegevens niet afleiden."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: number of columns returned by driver does not match results."
-msgstr "Query processor error: number of columns returned by driver does not match results."
+msgstr "Fout in queryprocessor: aantal kolommen dat door het stuurprogramma is geretourneerd, komt niet overeen met de resultaten."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} columns, but first row of resuls has {1} columns."
@@ -13040,8 +13034,7 @@ msgstr "Unable to resolve driver for query: Database {0} does not exist."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
-msgstr "\n"
-"Cannot use :fields :all in join against source query unless it has :source-metadata."
+msgstr "Kan niet :fields :all alles in join tegen bronquery tenzij deze beschikt over :source-metadata."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
 msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
@@ -13049,7 +13042,7 @@ msgstr "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found:
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
-msgstr "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
+msgstr "Ongeldig: brontabel ''{0}'': zou nu moeten zijn opgelost in een tabel-ID."
 
 #: src/metabase/query_processor/store.clj
 msgid "Cannot store Tables or Fields before Database is stored."
@@ -13069,15 +13062,15 @@ msgstr "Kan veld {0} niet ophalen: veld bestaat niet of behoort tot een andere d
 
 #: src/metabase/routes/index.clj
 msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
-msgstr "Kan template '' {0} '' niet laden. Heb je eraan gedacht om de Metabase-frontend te bouwen?"
+msgstr "Kan template ''{0}'' niet laden. Heb je eraan gedacht om de Metabase-frontend te bouwen?"
 
 #: src/metabase/sample_data.clj
 msgid "Sample dataset DB file ''{0}'' cannot be found."
-msgstr "Voorbeelddataset DB-bestand '' {0} '' kan niet worden gevonden."
+msgstr "Voorbeelddataset DB-bestand ''{0}'' kan niet worden gevonden."
 
 #: src/metabase/sample_data.clj
 msgid "Loading sample dataset..."
-msgstr "Voorbeeldgegevensset laden ..."
+msgstr "Voorbeeldgegevensset laden..."
 
 #: src/metabase/sample_data.clj
 msgid "Failed to load sample dataset"
@@ -13119,7 +13112,7 @@ msgstr "Kan taken voor database {0} niet plannen"
 msgid "All elements must be distinct."
 msgstr "Alle elementen moeten uniek zijn."
 
-#: 
+#:
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Kies de kolommen die je mee wilt nemen"
@@ -13161,4 +13154,3 @@ msgstr "Fout bij het bepalen van verwachte kolommen voor query"
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Onbehandelde exceptie, `catch-exceptions` middleware werd verwacht om dit af te handelen."
-

--- a/locales/pl.po
+++ b/locales/pl.po
@@ -11837,8 +11837,7 @@ msgstr "Wtyczka \"{0}\" zależy od wtyczki \"{1}\""
 
 #: src/metabase/plugins/dependencies.clj
 msgid "{0} dependency {1} satisfied? {2}"
-msgstr "{0} zależności {1} zadowolony? {2}\n"
-""
+msgstr "{0} zależności {1} zadowolony? {2}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugins with unsatisfied deps: {0}"
@@ -12885,8 +12884,7 @@ msgstr "Błąd podczas niszczenia puli wątków dla bazy danych."
 
 #: src/metabase/models/humanization.clj
 msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
-msgstr "Aktualizowanie nazwy wyświetlanej dla {0} ''{1}'': ''{2}'' -> ''{3}''\n"
-""
+msgstr "Aktualizowanie nazwy wyświetlanej dla {0} ''{1}'': ''{2}'' -> ''{3}''"
 
 #: src/metabase/models/humanization.clj
 msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
@@ -13183,7 +13181,7 @@ msgstr "Nie udało się zaplanować zadań dla bazy danych {0}"
 msgid "All elements must be distinct."
 msgstr "Wszystkie elementy muszą być unikalne."
 
-#: 
+#:
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Wybierz kolumny, które chcesz uwzględnić"
@@ -13225,4 +13223,3 @@ msgstr "Błąd podczas określania oczekiwanych kolumn dla zapytania"
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Nieobsługiwany wyjątek, oczekiwane oprogramowanie pośredniczące `catch-exceptions`  do obsługi."
-

--- a/locales/pl.po
+++ b/locales/pl.po
@@ -134,7 +134,7 @@ msgstr "Jeśli jesteś pewny, proszę wpisać"
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
-msgstr "Usuń"
+msgstr "DELETE"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
@@ -11837,7 +11837,8 @@ msgstr "Wtyczka \"{0}\" zależy od wtyczki \"{1}\""
 
 #: src/metabase/plugins/dependencies.clj
 msgid "{0} dependency {1} satisfied? {2}"
-msgstr "{0} zależności {1} zadowolony? {2}"
+msgstr "{0} zależności {1} zadowolony? {2}\n"
+""
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugins with unsatisfied deps: {0}"
@@ -12530,7 +12531,7 @@ msgstr "Przeglądaj Dane"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:376
 msgid "Write SQL"
-msgstr "Napis SQL"
+msgstr "Napisz SQL"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
 msgid "Simple question"
@@ -12884,7 +12885,8 @@ msgstr "Błąd podczas niszczenia puli wątków dla bazy danych."
 
 #: src/metabase/models/humanization.clj
 msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
-msgstr "Aktualizowanie nazwy wyświetlanej dla {0} ''{1}'': ''{2}'' -> ''{3}''"
+msgstr "Aktualizowanie nazwy wyświetlanej dla {0} ''{1}'': ''{2}'' -> ''{3}''\n"
+""
 
 #: src/metabase/models/humanization.clj
 msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
@@ -13181,7 +13183,7 @@ msgstr "Nie udało się zaplanować zadań dla bazy danych {0}"
 msgid "All elements must be distinct."
 msgstr "Wszystkie elementy muszą być unikalne."
 
-#:
+#: 
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
 msgstr "Wybierz kolumny, które chcesz uwzględnić"
@@ -13223,3 +13225,4 @@ msgstr "Błąd podczas określania oczekiwanych kolumn dla zapytania"
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
 msgstr "Nieobsługiwany wyjątek, oczekiwane oprogramowanie pośredniczące `catch-exceptions`  do obsługi."
+

--- a/locales/tr.po
+++ b/locales/tr.po
@@ -7149,9 +7149,8 @@ msgid "Visible fields"
 msgstr "Görünür alanlar"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-#, fuzzy
 msgid "Write here, and use Markdown if you'd like"
-msgstr "Buraya yaz ve istersen Markdown'u kullan."
+msgstr "Buraya yazın ve isterseniz Markdown'ı kullanın."
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
 msgid "Vertical Alignment"
@@ -12386,7 +12385,7 @@ msgstr "{0} milisaniyenin ardından zaman aşımı."
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
 msgid "Misfire Instruction"
-msgstr ""
+msgstr "Yanlış talimat"
 
 #: frontend/src/metabase/components/ArchiveModal.jsx:31
 msgid "Archive this?"
@@ -12398,7 +12397,7 @@ msgstr "Veri hakkında daha fazla"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
 msgid "Use DNS SRV when connecting"
-msgstr ""
+msgstr "Bağlanırken DNS SRV kullan"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
 msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
@@ -12468,7 +12467,7 @@ msgstr "Bir veri kümesi seçerek filtrele ya da görselleştir"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
 msgid "Custom question"
-msgstr ""
+msgstr "Özel soru"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
@@ -12476,19 +12475,19 @@ msgstr ""
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
 msgid "Basic Metrics"
-msgstr ""
+msgstr "Basit Metrikler"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
 msgid "Custom…"
-msgstr ""
+msgstr "Özel..."
 
 #: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
 msgid "Add grouping"
-msgstr ""
+msgstr "Gruplama ekle"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
 msgid "Pick a limit"
-msgstr ""
+msgstr "Bir limit seçin"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
 msgid "Show maximum"
@@ -12496,15 +12495,15 @@ msgstr ""
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Preview"
-msgstr ""
+msgstr "Önizleme al"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
 msgid "Back to previous results"
-msgstr ""
+msgstr "Önceki sonuçlara dön"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Sample values"
-msgstr ""
+msgstr "Örnek değerler"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
@@ -12512,20 +12511,20 @@ msgstr ""
 
 #: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
 msgid "Visualize"
-msgstr ""
+msgstr "Görselleştir"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
 msgid "Join data"
-msgstr ""
+msgstr "Veri birleştir"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
 msgid "Custom column"
-msgstr ""
+msgstr "Özel kolon"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
 msgid "Summarize"
-msgstr ""
+msgstr "Özetle"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
 msgid "Aggregate"

--- a/locales/zh.po
+++ b/locales/zh.po
@@ -5,29 +5,30 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
 "Project-Id-Version: Metabase\n"
-"Language: ja\n"
+"Language: zh-CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#. 你的数据库已经添加成功！
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:24
 msgid "Your database has been added!"
-msgstr "データベースが追加されました！"
+msgstr "数据库添加成功！"
 
-#. explorationsはどう訳すべきか？
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:28
 msgid "We took a look at your data, and we have some automated explorations that we can show you!"
-msgstr "あなたのデータに基づく自動探索結果を提示することができます！"
+msgstr "我们查看了你的数据，有一些自动化的探索，我们可以告诉你！"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:35
 msgid "I'm good thanks"
-msgstr "結構です"
+msgstr "不用，谢谢"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:42
 msgid "Explore this data"
-msgstr "このデータを詳しく見る"
+msgstr "探索数据"
 
+#. 选择数据库类型
 #: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:42
 msgid "Select a database type"
-msgstr "データベースタイプを選択する"
+msgstr "选择数据库类型"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseEditForms.jsx:76
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
@@ -48,56 +49,62 @@ msgstr "保存"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:122
 msgid "To do some of its magic, Metabase needs to scan your database. We will also rescan it periodically to keep the metadata up-to-date. You can control when the periodic rescans happen below."
-msgstr "効果的に使用するため、Metabaseはデータベースをスキャンします。また、メタデータを最新に保つために定期的に再スキャンします。以下から再スキャンの頻度を設定することができます。"
+msgstr "为了做一些神奇的事情，Metabase需要扫描你的数据库。我们将会定期扫描，来保持源数据是最新的。你也可以在周期的扫描之前，手工来控制扫描。"
 
+#. 数据库正在同步中...
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:127
 msgid "Database syncing"
-msgstr "データベース同期中"
+msgstr "数据库同步中"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:128
 msgid "This is a lightweight process that checks for\n"
 "updates to this database’s schema. In most cases, you should be fine leaving this\n"
 "set to sync hourly."
-msgstr "データベーススキーマの更新チェックは軽量なプロセスです。ほとんどの場合、1時間ごとの同期で問題ありません。"
+msgstr "这是一个检查数据库模式变化的轻量级的过程，大部分情况下，你可以使用每小时同步。"
 
+#. 扫描
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:147
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:183
 msgid "Scan"
-msgstr "スキャン"
+msgstr "扫描"
 
+#. 扫描筛选值
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:152
 msgid "Scanning for Filter Values"
-msgstr "フィルター値をスキャン中"
+msgstr "扫描过滤器值"
 
-#. リソース負荷の高い、という意味だとは思いますが、リソース集約的という表現は一般的な表現でしょうか？私は聞いたことがなかったもので。
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:153
 msgid "Metabase can scan the values present in each\n"
 "field in this database to enable checkbox filters in dashboards and questions. This\n"
 "can be a somewhat resource-intensive process, particularly if you have a very large\n"
 "database."
-msgstr "Metabaseは、このデータベースの各フィールドの値をスキャンして、ダッシュボードや質問のチェックボックスフィルターを有効にすることができます。 データベースが非常に大きい場合は、ややリソースに負荷がかかる処理となります。"
+msgstr "Metabase 可以扫描数据库中每个字段的值, 用以启用查询或仪表板中的选择框过滤器. 当您的数据库较大时, 这可能是一个资源密集型的过程."
 
+#. Metabase应该什么时候自动地扫描并缓存字段的值？
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:158
 msgid "When should Metabase automatically scan and cache field values?"
-msgstr "フィールド値のスキャンとキャッシュをいつ行いますか？"
+msgstr "Metabase应该在什么时候自动扫描缓存的字段值"
 
+#. 通常情况下，需要制定一个计划表
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:163
 msgid "Regularly, on a schedule"
-msgstr "スケジュール通り定期的に行う"
+msgstr "根据排程，周期性地进行"
 
+#. 仅仅当你在添加一个新的过滤器控件的时候
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:194
 msgid "Only when adding a new filter widget"
-msgstr "新しいフィルターウィジェットを追加したときのみ行う"
+msgstr "只有当你在添加一个新的过滤控件时"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:198
 msgid "When a user adds a new filter to a dashboard or a SQL question, Metabase will\n"
 "scan the field(s) mapped to that filter in order to show the list of selectable values."
-msgstr "ユーザーがダッシュボードまたは質問に新しいフィルターを追加すると、Metabaseはそのフィルターにマップされたフィールドをスキャンし、選択可能な値一覧を表示します"
+msgstr "当用户向仪表盘或SQL查询添加一个新的过滤器，Metabase会扫描过滤器对应的字段来显示一个可选值列表。"
 
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:209
 msgid "Never, I'll do this manually if I need to"
-msgstr "自動的に行わず、必要な時に手動設定する"
+msgstr "不用，如果需要我会手动执行"
 
+#. 保存中...
 #: frontend/src/metabase/admin/databases/components/DatabaseSchedulingForm.jsx:221
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:27
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:222
@@ -105,38 +112,41 @@ msgstr "自動的に行わず、必要な時に手動設定する"
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:8
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:477
 msgid "Saving..."
-msgstr "保存中..."
+msgstr "保存中......"
 
+#. 服务器发生错误了
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:38
 #: frontend/src/metabase/components/form/FormMessage.jsx:4
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:146
 msgid "Server error encountered"
-msgstr "サーバーエラーが発生しました"
+msgstr "服务器出错了"
 
+#. 是否要删除这个数据库？
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:56
 msgid "Delete this database?"
-msgstr "データベースを削除しますか？"
+msgstr "是否要删除这个数据库？"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:61
 msgid "All saved questions, metrics, and segments that rely on this database will be lost."
-msgstr "保存された全ての質問、メトリクスおよびセグメントは、このデータベースが削除されると同時に削除されます。"
+msgstr "所有依赖这个数据库保存的问题，指标，数据段将要丢失。"
 
+#. 此操作无法执行
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:62
 msgid "This cannot be undone."
-msgstr "この操作はやり直しできません。"
+msgstr "此操作无法撤销。"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "If you're sure, please type"
-msgstr "間違いなければ入力してください。"
+msgstr "如果确认，请输入。"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:52
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:65
 msgid "DELETE"
-msgstr "削除"
+msgstr "删除"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:66
 msgid "in this box:"
-msgstr "このテキストボックスに:"
+msgstr "在这个框里:"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:77
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:49
@@ -173,14 +183,14 @@ msgstr "このテキストボックスに:"
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:286
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Cancel"
-msgstr "キャンセル"
+msgstr "取消"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:83
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:124
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:135
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:461
 msgid "Delete"
-msgstr "削除"
+msgstr "删除"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:131
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:77
@@ -192,21 +202,22 @@ msgstr "削除"
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:18
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:21
 msgid "Databases"
-msgstr "データベース"
+msgstr "数据库"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:132
 msgid "Add Database"
-msgstr "データベースを追加"
+msgstr "添加数据库"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:114
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:60
 msgid "Connection"
-msgstr "接続"
+msgstr "连接"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:61
 msgid "Scheduling"
-msgstr "スケジューリング"
+msgstr "调度"
 
+#. 保存修改
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:173
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:80
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:82
@@ -216,17 +227,19 @@ msgstr "スケジューリング"
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:356
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:47
 msgid "Save changes"
-msgstr "変更を保存"
+msgstr "保存修改"
 
+#. 动作
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:188
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:34
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:34
 msgid "Actions"
-msgstr "アクション"
+msgstr "动作"
 
+#. 立即同步数据库
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:196
 msgid "Sync database schema now"
-msgstr "今すぐデータベーススキーマと同期する"
+msgstr "开始同步数据库模式"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:197
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:209
@@ -235,49 +248,54 @@ msgstr "今すぐデータベーススキーマと同期する"
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:87
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:95
 msgid "Starting…"
-msgstr "開始しています..."
+msgstr "开始..."
 
+#. 同步失败
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:198
 msgid "Failed to sync"
-msgstr "同期に失敗しました"
+msgstr "同步失败"
 
+#. 触发同步
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:199
 msgid "Sync triggered!"
-msgstr "同期を開始しました！"
+msgstr "同步触发！"
 
+#. 开始重新扫描字段值
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:208
 msgid "Re-scan field values now"
-msgstr "今すぐフィールド値を再スキャンする"
+msgstr "现在重新扫描字段值"
 
+#. 无法开始扫描
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:210
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:16
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:88
 msgid "Failed to start scan"
-msgstr "スキャンのスタートに失敗しました"
+msgstr "无法开始扫描"
 
+#. 已触发扫描
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:211
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:17
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:89
 msgid "Scan triggered!"
-msgstr "スキャンを開始しました！"
+msgstr "扫描已触发！"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:218
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:400
 msgid "Danger Zone"
-msgstr "危険ゾーン"
+msgstr "危险操作"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:224
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:227
 msgid "Discard saved field values"
-msgstr "保存されたフィールド値を破棄する"
+msgstr "放弃保存的字段值"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx:242
 msgid "Remove this database"
-msgstr "このデータベースを削除する"
+msgstr "删除数据库"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:76
 msgid "Add database"
-msgstr "データベースを追加"
+msgstr "添加数据库"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:88
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:32
@@ -293,35 +311,35 @@ msgstr "データベースを追加"
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:472
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:85
 msgid "Name"
-msgstr "名前"
+msgstr "名字"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:89
 msgid "Engine"
-msgstr "エンジン"
+msgstr "引擎"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:118
 msgid "Deleting..."
-msgstr "削除中..."
+msgstr "删除中。。。"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:148
 msgid "Loading ..."
-msgstr "読込中..."
+msgstr "加载中。。。"
 
 #: frontend/src/metabase/admin/databases/containers/DatabaseListApp.jsx:164
 msgid "Bring the sample dataset back"
-msgstr "サンプルデータセットを復元"
+msgstr "恢复样本数据集"
 
 #: frontend/src/metabase/admin/databases/database.js:175
 msgid "Couldn't connect to the database. Please check the connection details."
-msgstr "データベースに接続できません。接続設定を確認してください。"
+msgstr "无法连接到数据库。 请检查连接的详细信息。"
 
 #: frontend/src/metabase/admin/databases/database.js:383
 msgid "Successfully created!"
-msgstr "作成されました！"
+msgstr "创建成功！"
 
 #: frontend/src/metabase/admin/databases/database.js:393
 msgid "Successfully saved!"
-msgstr "保存されました！"
+msgstr "保存成功！"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:44
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:281
@@ -329,39 +347,39 @@ msgstr "保存されました！"
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:200
 #: frontend/src/metabase/reference/components/EditButton.jsx:18
 msgid "Edit"
-msgstr "編集"
+msgstr "编辑"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx:59
 msgid "Revision History"
-msgstr "履歴"
+msgstr "修订记录"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:32
 msgid "Retire this {0}?"
-msgstr "{0}を放棄しますか？"
+msgstr "作废{0}？"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:37
 msgid "Saved questions and other things that depend on this {0} will continue to work, but this {1} will no longer be selectable from the query builder."
-msgstr "保存されている{0}に依存する質問やその他情報は保持されますが、{1}はクエリビルダーから選択できなくなります。"
+msgstr "保存的问题和依赖于此{0}的其他内容将继续有效，但不再可以从查询构建器中选择此{1}。"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:38
 msgid "If you're sure you want to retire this {0}, please write a quick explanation of why it's being retired:"
-msgstr "{0}を放棄して問題なければ、放棄する理由を簡単に説明してください。:"
+msgstr "如果您确定要让此{0}退役，请解释一下原因："
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:42
 msgid "This will show up in the activity feed and in an email that will be sent to anyone on your team who created something that uses this {0}."
-msgstr "{0}を使用して作成をした場合、アクティビティフィードと、あなたのチームに送信されるメールに表示されます。"
+msgstr "这将显示在活动信息和电子邮件中，该电子邮件将发送给您团队中创建使用此{0}内容的任何人。"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:57
 msgid "Retire"
-msgstr "放棄する"
+msgstr "作废"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:58
 msgid "Retiring…"
-msgstr "放棄中..."
+msgstr "正在作废……"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:59
 msgid "Failed"
-msgstr "失敗"
+msgstr "失败"
 
 #: frontend/src/metabase/admin/datamodel/components/ObjectRetireModal.jsx:60
 msgid "Success"
@@ -372,19 +390,19 @@ msgstr "成功"
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:180
 #: frontend/src/metabase/query_builder/components/view/QuestionPreviewToggle.jsx:15
 msgid "Preview"
-msgstr "プレビュー"
+msgstr "预览"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:90
 msgid "No column description yet"
-msgstr "列説明はまだありません"
+msgstr "暂无字段描述"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:123
 msgid "Select a field visibility"
-msgstr "フィールドの可視性を選択する"
+msgstr "选择字段可见性"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:193
 msgid "No special type"
-msgstr "特別タイプなし"
+msgstr "指定的类型不存在"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:148
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:194
@@ -392,15 +410,15 @@ msgstr "特別タイプなし"
 #: frontend/src/metabase/reference/components/Field.jsx:57
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:42
 msgid "Other"
-msgstr "その他"
+msgstr "其他"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:220
 msgid "Select a special type"
-msgstr "特別タイプを選択する"
+msgstr "请选择一个指定类型"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:265
 msgid "Select a target"
-msgstr "ターゲットを選択する"
+msgstr "选择目标"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:17
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:22
@@ -409,93 +427,93 @@ msgstr "ターゲットを選択する"
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:125
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:162
 msgid "Columns"
-msgstr "列"
+msgstr "字段"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:22
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:46
 msgid "Column"
-msgstr "列"
+msgstr "字段"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:24
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:142
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:298
 msgid "Visibility"
-msgstr "可視性"
+msgstr "可见性"
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnsList.jsx:25
 msgid "Type"
-msgstr "タイプ"
+msgstr "类型"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:104
 msgid "Current database:"
-msgstr "現在のデータベース:"
+msgstr "当前数据库"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataHeader.jsx:109
 msgid "Show original schema"
-msgstr "元のスキーマを表示する"
+msgstr "查看原始格式"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:47
 msgid "Data Type"
-msgstr "データタイプ"
+msgstr "数据类型"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchema.jsx:48
 msgid "Additional Info"
-msgstr "付加情報"
+msgstr "附加信息"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:46
 msgid "Find a schema"
-msgstr "スキーマを見つける"
+msgstr "查找数据库模式"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataSchemaList.jsx:53
 msgid "{0} schema"
 msgid_plural "{0} schemas"
-msgstr[0] "{0} スキーマ"
+msgstr[0] "{0} 结构"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:103
 msgid "Why Hide?"
-msgstr "なぜ非表示にしますか？"
+msgstr "隐藏原因"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:104
 msgid "Technical Data"
-msgstr "テクニカルデータ"
+msgstr "日志数据"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:105
 msgid "Irrelevant/Cruft"
-msgstr "無関係/不正データ"
+msgstr "不相关"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:111
 msgid "Queryable"
-msgstr "利用可能"
+msgstr "可查询"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:112
 msgid "Hidden"
-msgstr "非表示"
+msgstr "已隐藏"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:138
 msgid "No table description yet"
-msgstr "テーブルの説明はまだありません"
+msgstr "暂无表格描述"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTable.jsx:124
 msgid "Metadata Strength"
-msgstr "メタデータ強度"
+msgstr "元数据完整度"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:83
 msgid "{0} Queryable Table"
 msgid_plural "{0} Queryable Tables"
-msgstr[0] "{0} 件の利用可能なテーブル"
+msgstr[0] "{0}可查询表格"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:92
 msgid "{0} Hidden Table"
 msgid_plural "{0} Hidden Tables"
-msgstr[0] "{0} 非表示のテーブル"
+msgstr[0] "{0}隐藏表格"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:109
 msgid "Find a table"
-msgstr "テーブルを探す"
+msgstr "查找表格"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetadataTableList.jsx:122
 msgid "Schemas"
-msgstr "スキーマ"
+msgstr "表结构"
 
 #: frontend/src/metabase-lib/lib/queries/StructuredQuery.js:722
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:20
@@ -507,21 +525,21 @@ msgstr "スキーマ"
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:21
 #: frontend/src/metabase/routes.jsx:232
 msgid "Metrics"
-msgstr "メトリクス"
+msgstr "指标"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:26
 msgid "Add a Metric"
-msgstr "メトリクスを追加する"
+msgstr "添加指标"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:33
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:33
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:30
 msgid "Definition"
-msgstr "定義"
+msgstr "定义"
 
 #: frontend/src/metabase/admin/datamodel/components/database/MetricsList.jsx:50
 msgid "Create metrics to add them to the View dropdown in the query builder"
-msgstr "クエリビルダーの表示ドロップダウンにメトリクスを作成し追加する"
+msgstr "创建指标并添加到查询设计器的视图下拉列表"
 
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:20
 #: frontend/src/metabase/home/containers/SearchApp.jsx:73
@@ -531,293 +549,293 @@ msgstr "クエリビルダーの表示ドロップダウンにメトリクスを
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:62
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:21
 msgid "Segments"
-msgstr "セグメント"
+msgstr "过滤器"
 
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:26
 msgid "Add a Segment"
-msgstr "セグメントを追加する"
+msgstr "添加过滤器"
 
 #: frontend/src/metabase/admin/datamodel/components/database/SegmentsList.jsx:50
 msgid "Create segments to add them to the Filter dropdown in the query builder"
-msgstr "クエリビルダーのフィルタードロップダウンにセグメントを作成し追加する"
+msgstr "创建过滤器并添加到查询设计器的筛选下拉列表"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:24
 msgid "created"
-msgstr "作成済み"
+msgstr "已创建"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:27
 msgid "reverted to a previous version"
-msgstr "以前のバージョンに戻す"
+msgstr "恢复到前一个版本"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:33
 msgid "edited the title"
-msgstr "タイトルを編集する"
+msgstr "编辑标题"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:35
 msgid "edited the description"
-msgstr "説明を編集する"
+msgstr "编辑描述"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:37
 msgid "edited the "
-msgstr "␣を編集する"
+msgstr "编辑"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:40
 msgid "made some changes"
-msgstr "変更されました"
+msgstr "做了一些改动"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/Revision.jsx:49
 #: frontend/src/metabase/home/components/Activity.jsx:82
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:333
 msgid "You"
-msgstr "あなた"
+msgstr "您"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:39
 msgid "Datamodel"
-msgstr "データモデル"
+msgstr "数据模型"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:42
 msgid " History"
-msgstr "履歴"
+msgstr "历史"
 
 #: frontend/src/metabase/admin/datamodel/components/revisions/RevisionHistory.jsx:47
 msgid "Revision History for"
-msgstr "履歴"
+msgstr "历史版本"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:233
 msgid "{0} – Field Settings"
-msgstr "{0} - フィールド設定"
+msgstr "{0} - 字段设置"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:299
 msgid "Where this field will appear throughout Metabase"
-msgstr "Metabase上でフィールドが表示される箇所"
+msgstr "这些字段将在哪里显示？"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:321
 msgid "Filtering on this field"
-msgstr "このフィールドでフィルター設定しています"
+msgstr "字段过滤"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:322
 msgid "When this field is used in a filter, what should people use to enter the value they want to filter on?"
-msgstr "このフィールドでフィルター設定がされている場合、他ユーザーがフィルター設定したい値をどのように入力すればよいですか？"
+msgstr "当在过滤器中使用此字段时，人们应该使用什么形式输入他们想要过滤的值?"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:448
 msgid "No description for this field yet"
-msgstr "このフィールドには説明がまだありません"
+msgstr "暂无筛选条件描述"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:388
 msgid "Original value"
-msgstr "元の値"
+msgstr "原始值"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:389
 msgid "Mapped value"
-msgstr "マップされた値"
+msgstr "映射值"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:432
 msgid "Enter value"
-msgstr "値を入力する"
+msgstr "输入值"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:25
 msgid "Use original value"
-msgstr "元の値を使う"
+msgstr "使用原始值"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:26
 msgid "Use foreign key"
-msgstr "外部キーを使う"
+msgstr "使用外键"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:27
 msgid "Custom mapping"
-msgstr "カスタムマッピング"
+msgstr "自定义映射"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:55
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:161
 msgid "Unrecognized mapping type"
-msgstr "マッピングタイプを識別できません"
+msgstr "无法识别对应类型"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:89
 msgid "Current field isn't a foreign key or FK target table metadata is missing"
-msgstr "現在のフィールドは外部キーではないか、FKターゲットテーブルのメタデータがありません"
+msgstr "当前字段不是外键或者缺少外键关联表元数据"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:196
 msgid "The selected field isn't a foreign key"
-msgstr "選択されたフィールドは外部キーではありません"
+msgstr "选中的字段不是外键"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:339
 msgid "Display values"
-msgstr "値を表示する"
+msgstr "显示值"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:340
 msgid "Choose to show the original value from the database, or have this field display associated or custom information."
-msgstr "データベースから元の値を表示するか、このフィールドに関連する情報またはカスタム情報を表示するかを選択します。"
+msgstr "选择显示数据库中的原始值，或者显示此字段的关联或自定义信息。"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:277
 msgid "Choose a field"
-msgstr "フィールドを選択"
+msgstr "选择字段"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:298
 msgid "Please select a column to use for display."
-msgstr "表示に使用する列を選択してください。"
+msgstr "请选择显示字段"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:771
 msgid "Tip:"
-msgstr "ヒント:"
+msgstr "提示："
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:442
 msgid "You might want to update the field name to make sure it still makes sense based on your remapping choices."
-msgstr "再マッピングの選択と内容が合うようにフィールド名を更新すると良いでしょう。"
+msgstr "你可能想要更新这个字段的名称来确保它基于你的重新映射选择时仍然有意义"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:356
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:80
 msgid "Cached field values"
-msgstr "フィールド値をキャッシュする"
+msgstr "缓存字段值"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:357
 msgid "Metabase can scan the values for this field to enable checkbox filters in dashboards and questions."
-msgstr "Metabaseは、ダッシュボードまたは質問のチェックボックスを有効化するため、このフィールドの値をスキャンします"
+msgstr "Metabase 通过扫描该字段，以启用仪表盘和问题的多选框筛选。"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:14
 msgid "Re-scan this field"
-msgstr "このフィールドを再スキャンする"
+msgstr "重新扫描该字段"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:22
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:94
 msgid "Discard cached field values"
-msgstr "キャッシュしたフィールド値を削除する"
+msgstr "丢弃字段缓存"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:24
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:96
 msgid "Failed to discard values"
-msgstr "値の削除に失敗しました"
+msgstr "丢弃字段值失败"
 
 #: frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx:25
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:97
 msgid "Discard triggered!"
-msgstr "削除されました！"
+msgstr "丢弃处理已经触发！"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetadataEditorApp.jsx:116
 msgid "Select any table to see its schema and add or edit metadata."
-msgstr "テーブルを選択し、スキーマを見てメタデータを追加・編集する"
+msgstr "选择任意表单来显示它的所有模式并且添加或删除元数据"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:35
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:32
 #: frontend/src/metabase/entities/collections.js:97
 msgid "Name is required"
-msgstr "名前が必要です"
+msgstr "名称必填"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:38
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:35
 msgid "Description is required"
-msgstr "説明が必要です"
+msgstr "描述必填"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:42
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:39
 msgid "Revision message is required"
-msgstr "履歴メッセージが必要です"
+msgstr "调整信息必填"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:48
 msgid "Aggregation is required"
-msgstr "アグリゲーションが必要です"
+msgstr "聚合信息必填"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Edit Your Metric"
-msgstr "メトリクスを編集する"
+msgstr "编辑指标"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:104
 msgid "Create Your Metric"
-msgstr "メトリクスを作成する"
+msgstr "创建指标"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:108
 msgid "Make changes to your metric and leave an explanatory note."
-msgstr "メトリクスを変更し注釈を加える"
+msgstr "修改指标并留下简要说明。"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:107
 msgid "You can create saved metrics to add a named metric option to this table. Saved metrics include the aggregation type, the aggregated field, and optionally any filter you add. As an example, you might use this to create something like the official way of calculating \"Average Price\" for an Orders table."
-msgstr "保存されたメトリクスを使用して、このテーブルに名前付きメトリクスオプションを追加することができます。 保存されたメトリクスには、集約タイプ、集約フィールド、およびオプションで追加するフィルターが含まれます。 たとえば、これを使用してOrdersテーブルの「平均価格」の公式な計算方法を作成することができます。"
+msgstr "你能够创造已存储的指标来添加一个已经命名的指标选项到这个表单。存储刻度包括你添加的聚合类型，聚合字段和可选的任何筛选项。举个例子，你可能使用这个来为一个订单表单创造一些像是“平均价”的官方计算方法，"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:140
 msgid "Result: "
-msgstr "結果: "
+msgstr "结果："
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:149
 msgid "Name Your Metric"
-msgstr "メトリクスに名前を付ける"
+msgstr "命名指标"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:150
 msgid "Give your metric a name to help others find it."
-msgstr "他ユーザーのためにメトリクスに名前を付ける"
+msgstr "为指标命名，方便其他人查找。"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:154
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:154
 msgid "Something descriptive but not too long"
-msgstr "簡単な説明"
+msgstr "简短的描述"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:158
 msgid "Describe Your Metric"
-msgstr "メトリクスを説明する"
+msgstr "描述指标"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:159
 msgid "Give your metric a description to help others understand what it's about."
-msgstr "他ユーザーのためにメトリクスに説明を加える"
+msgstr "描述指标，方便其他人理解。"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:163
 msgid "This is a good place to be more specific about less obvious metric rules"
-msgstr "メトリクスのルールについてより詳細な情報をこちらに記入してください"
+msgstr "在这里详细描述指标，比如不太明显的规则"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:167
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:167
 msgid "Reason For Changes"
-msgstr "変更理由"
+msgstr "更改原因"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:169
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:169
 msgid "Leave a note to explain what changes you made and why they were required."
-msgstr "変更箇所と変更理由を記入する"
+msgstr "留言以说明您所做的更改以及为何需要这些更改。"
 
 #: frontend/src/metabase/admin/datamodel/containers/MetricForm.jsx:173
 msgid "This will show up in the revision history for this metric to help everyone remember why things changed"
-msgstr "他ユーザーにも変更理由がわかるよう、このメトリクスの履歴に表示されます"
+msgstr "这将显示在此指标的修订历史记录中，以帮助每个人记住事情发生变化的原因"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:47
 msgid "At least one filter is required"
-msgstr "最低1つのフィルターが必要です"
+msgstr "至少需要一个筛选条件"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Edit Your Segment"
-msgstr "セグメントを編集する"
+msgstr "编辑划分"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:106
 msgid "Create Your Segment"
-msgstr "セグメントを作成する"
+msgstr "创建划分"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:112
 msgid "Make changes to your segment and leave an explanatory note."
-msgstr "セグメントを変更し注釈を加える"
+msgstr "更改划分，并描述变动内容。"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:109
 msgid "Select and add filters to create your new segment for the {0} table"
-msgstr "{0}テーブルの新しいセグメントを作成するためのフィルターを選択し追加する"
+msgstr "选择并添加筛选条件以为{0}表创建新段"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:149
 msgid "Name Your Segment"
-msgstr "セグメントに名前を付ける"
+msgstr "命名划分"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:150
 msgid "Give your segment a name to help others find it."
-msgstr "他ユーザーのためにセグメントを名前を付ける"
+msgstr "命名划分方便其他人查找"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:158
 msgid "Describe Your Segment"
-msgstr "セグメントを説明する"
+msgstr "描述划分"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:159
 msgid "Give your segment a description to help others understand what it's about."
-msgstr "他ユーザーのためにセグメントに説明を加える"
+msgstr "描述划分，方便其他人理解。"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:163
 msgid "This is a good place to be more specific about less obvious segment rules"
-msgstr "セグメントのルールについてより詳細な情報をこちらに記入してください"
+msgstr "在这里详细描述划分，比如不太明显的规则"
 
 #: frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx:173
 msgid "This will show up in the revision history for this segment to help everyone remember why things changed"
-msgstr "他ユーザーにも変更理由がわかるよう、このセグメントの履歴に表示されます"
+msgstr "这将显示在过滤器的修订历史记录中，以帮助每个人记住事情发生变化的原因"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:66
 #: frontend/src/metabase/admin/routes.jsx:127
@@ -827,26 +845,26 @@ msgstr "他ユーザーにも変更理由がわかるよう、このセグメン
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:93
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:162
 msgid "Settings"
-msgstr "設定"
+msgstr "设置"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:81
 msgid "Metabase can scan the values in this table to enable checkbox filters in dashboards and questions."
-msgstr "Metabaseは、ダッシュボードまたは質問のチェックボックスを有効化するため、このテーブルの値をスキャンします"
+msgstr "Metabase扫描此表中的值以启用仪表板和问题中的复选框过滤器。"
 
 #: frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx:86
 msgid "Re-scan this table"
-msgstr "このテーブルを再スキャンする"
+msgstr "刷新表格"
 
 #: frontend/src/metabase/admin/people/components/AddRow.jsx:34
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:274
 #: frontend/src/metabase/dashboard/components/DashCard.jsx:281
 msgid "Add"
-msgstr "追加"
+msgstr "添加"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:103
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:67
 msgid "Not a valid formatted email address"
-msgstr "有効なメールアドレスではありません"
+msgstr "非法的email地址"
 
 #: frontend/src/metabase/entities/users.js:34
 #: frontend/src/metabase/setup/components/UserStep.jsx:186
@@ -867,34 +885,34 @@ msgstr "姓"
 #: frontend/src/metabase/setup/components/UserStep.jsx:222
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:138
 msgid "Email address"
-msgstr "メールアドレス"
+msgstr "邮箱地址"
 
 #: frontend/src/metabase/admin/people/components/EditUserForm.jsx:202
 msgid "Permission Groups"
-msgstr "権限グループ"
+msgstr "组权限"
 
 #: frontend/src/metabase/components/form/widgets/FormGroupsWidget.jsx:75
 msgid "Make this user an admin"
-msgstr "このユーザーを管理者にする"
+msgstr "设为管理员"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:34
 msgid "All users belong to the {0} group and can't be removed from it. Setting permissions for this group is a great way to\n"
 "make sure you know what new Metabase users will be able to see."
-msgstr "全てのユーザーは{0}グループに属しており、そのグループから削除することはできません。 このグループの権限を設定することで、新しいMetabaseユーザーの閲覧可能範囲を確認することができます。"
+msgstr "所有属于这个{0}群组的用户，并且不能从这个群组中被移除。为这个群组设置许可权限是一个确保你知道Metabase新用户将会能够看到什么的好办法。"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:43
 msgid "This is a special group whose members can see everything in the Metabase instance, and who can access and make changes to the\n"
 "settings in the Admin Panel, including changing permissions! So, add people to this group with care."
-msgstr "これは、メンバーがMetabaseインスタンス内の全データを参照できるだけでなく、権限の変更などを含む管理者パネルの設定ができる特別なグループです。このグループにメンバーを追加する場合は、十分にご注意ください。"
+msgstr "这是一个特殊的组，其成员可以查看Metabase实例中的所有内容，可以访问和更改管理面板中的设置，包括更改权限！ 因此，小心地将人员添加到该组。"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:47
 msgid "To make sure you don't get locked out of Metabase, there always has to be at least one user in this group."
-msgstr "Metabaseからロックアウトされないため、このグループには最低1ユーザーの登録が必要です"
+msgstr "为了确保你不会被Metabase锁在外面，必须需要至少一个用户在这个群组里。"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Members"
-msgstr "メンバー"
+msgstr "组员"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:187
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:125
@@ -903,66 +921,65 @@ msgstr "メンバー"
 #: frontend/src/metabase/lib/core.js:55
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:300
 msgid "Email"
-msgstr "メール"
+msgstr "邮箱"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:213
 msgid "A group is only as good as its members."
-msgstr "グループもそのメンバーもどちらも大事です。"
+msgstr "组内成员权限一致"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:15
 #: frontend/src/metabase/admin/routes.jsx:48
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:49
 msgid "Admin"
-msgstr "管理者"
+msgstr "管理员"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:16
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:245
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:303
 msgid "and"
-msgstr "そして"
+msgstr "和"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:19
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:31
 msgid "{0} other group"
 msgid_plural "{0} other groups"
-msgstr[0] "{0} 他グループ"
+msgstr[0] "{0}个组"
 
 #: frontend/src/metabase/admin/people/components/GroupSummary.jsx:37
 msgid "Default"
-msgstr "デフォルト"
+msgstr "默认"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:39
 msgid "Something like \"Marketing\""
-msgstr "「マーケティング」等"
+msgstr "如“市场部”"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:58
 msgid "Remove this group?"
-msgstr "このグループを削除しますか？"
+msgstr "移除分组?"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:60
 msgid "Are you sure? All members of this group will lose any permissions settings they have based on this group.\n"
 "This can't be undone."
-msgstr "本気ですか？ このグループのすべてのメンバーは、このグループに基づいて設定されている権限設定を失います。\n"
-"これは元に戻せません。"
+msgstr "确定吗？该组所有成员都将丢失该组下的权限设置。此操作不可逆。"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:71
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 #: frontend/src/metabase/components/ConfirmContent.jsx:17
 msgid "Yes"
-msgstr "はい"
+msgstr "是"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:74
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:43
 msgid "No"
-msgstr "いいえ"
+msgstr "否"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:92
 msgid "Edit Name"
-msgstr "名前を編集する"
+msgstr "编辑名称"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:95
 msgid "Remove Group"
-msgstr "グループを削除する"
+msgstr "移除分组"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:46
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:138
@@ -977,11 +994,11 @@ msgstr "グループを削除する"
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:292
 msgid "Done"
-msgstr "完了"
+msgstr "完成"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:218
 msgid "Group name"
-msgstr "グループ名"
+msgstr "分组名称"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:363
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:25
@@ -989,444 +1006,445 @@ msgstr "グループ名"
 #: frontend/src/metabase/admin/routes.jsx:88
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Groups"
-msgstr "グループ"
+msgstr "分组"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:364
 msgid "Create a group"
-msgstr "グループを作成する"
+msgstr "创建分组"
 
 #: frontend/src/metabase/admin/people/components/GroupsListing.jsx:370
 msgid "You can use groups to control your users' access to your data. Put users in groups and then go to the Permissions section to control each group's access. The Administrators and All Users groups are special default groups that can't be removed."
-msgstr "グループを使用して、ユーザーのデータへのアクセスを管理することができます。 ユーザーをグループに入れた後、権限のセクションに移動して各グループのアクセスを管理してください。 管理者グループとAll Users グループは、削除できない特殊なデフォルトグループです。"
+msgstr "可以通过分组控制成员的数据权限。更改分组权限来控制组内成员权限。管理员和全员是默认分组，无法删除。"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:79
 msgid "Edit Details"
-msgstr "詳細を編集する"
+msgstr "编辑详情"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:85
 msgid "Re-send Invite"
-msgstr "招待を再送する"
+msgstr "重新邀请"
 
 #: frontend/src/metabase/admin/people/components/UserActionsSelect.jsx:90
 msgid "Reset Password"
-msgstr "パスワードをリセットする"
+msgstr "重置密码"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:40
 msgid "Deactivate"
-msgstr "無効化"
+msgstr "停用"
 
 #: frontend/src/metabase/admin/people/containers/AdminPeopleApp.jsx:24
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:94
 #: frontend/src/metabase/admin/routes.jsx:84
 #: frontend/src/metabase/nav/containers/Navbar.jsx:233
 msgid "People"
-msgstr "ユーザー"
+msgstr "人员管理"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:192
 msgid "Who do you want to add?"
-msgstr "誰を追加したいですか？"
+msgstr "想要添加谁？"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:207
 msgid "Edit {0}'s details"
-msgstr "{0}の詳細を編集する"
+msgstr "编辑{0}的详情"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:40
 msgid "{0} has been added"
-msgstr "{0}が追加されました"
+msgstr "{0}已经被添加。"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:224
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:262
 msgid "Add another person"
-msgstr "他のユーザーを追加する"
+msgstr "添加其他人"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:231
 msgid "We couldn’t send them an email invitation,\n"
 "so make sure to tell them to log in using {0}\n"
 "and this password we’ve generated for them:"
-msgstr "招待メールを送信できませんでした。{0}とこのパスワードを利用してログインいただくようご指示ください。:"
+msgstr "我们不能给他们发送邀请电子邮件，请务必告诉他们，使用{0}和密码来登录系统:"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:73
 msgid "If you want to be able to send email invites, just go to the {0} page."
-msgstr "招待メールを送信したい場合は、{0}ページへお進みください"
+msgstr "如果你想要能够发送e-mail 邀请，请转到{0}页面。"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:55
 msgid "We’ve sent an invite to {0} with instructions to set their password."
-msgstr "パスワード設定方法を記載した招待メールを{0}へ送信しました"
+msgstr "我们已经发送了一个带有说明的邀请给{0}来设置他们的密码。"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:283
 msgid "We've re-sent {0}'s invite"
-msgstr "招待メールを{0}に再送しました"
+msgstr "我们已重新发送{0}的邀请邮件"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:22
 msgid "Okay"
-msgstr "確認しました"
+msgstr "好的"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:289
 msgid "Any previous email invites they have will no longer work."
-msgstr "これより前に送信された招待メールは無効です"
+msgstr "任何以前的电子邮件邀请将不再有效。"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:31
 msgid "Deactivate {0}?"
-msgstr "{0}を無効化しますか？"
+msgstr "停用{0}？"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:34
 msgid "{0} won't be able to log in anymore."
-msgstr "{0}はログインすることができません"
+msgstr "{0} 不再能够登录了。"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:320
 msgid "Reactivate {0}'s account?"
-msgstr "{0}のアカウントを再有効化しますか？"
+msgstr "重新激活{0}的账户？"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:58
 msgid "Reactivate"
-msgstr "再有効化する"
+msgstr "重新激活"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:51
 msgid "They'll be able to log in again, and they'll be placed back into the groups they were in before their account was deactivated."
-msgstr "ログインが可能になり、無効化される前のグループに戻りました。"
+msgstr "他们将能够再次登录，并且将被放回到帐户被停用之前所在的群组中。"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:51
 msgid "Reset {0}'s password?"
-msgstr "{0}のパスワードをリセットしますか？"
+msgstr "重置{0}的密码"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:78
 msgid "Reset"
-msgstr "リセットする"
+msgstr "重置"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:54
 #: frontend/src/metabase/components/ConfirmContent.jsx:13
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:18
 msgid "Are you sure you want to do this?"
-msgstr "よろしいですか？"
+msgstr "是否确认执行此操作？"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:41
 msgid "{0}'s password has been reset"
-msgstr "{0}のパスワードがリセットされました"
+msgstr "{0}的密码已被重置"
 
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:45
 msgid "Here’s a temporary password they can use to log in and then change their password."
-msgstr "この仮パスワードでログインし、パスワードを変更してください"
+msgstr "这是系统提供的用于登录的临时密码，登录成功后请修改密码。"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:388
 msgid "We've sent them an email with instructions for creating a new password."
-msgstr "新しいパスワードの作成方法を記載したメールを送信しました"
+msgstr "我们已向他们发送了一封电子邮件，其中包含创建新密码的说明。"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:102
 msgid "Active"
-msgstr "有効化する"
+msgstr "激活"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:103
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:128
 msgid "Deactivated"
-msgstr "無効化した"
+msgstr "已停用"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:116
 msgid "Add someone"
-msgstr "追加する"
+msgstr "邀请其他人"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:133
 msgid "Last Login"
-msgstr "最終ログイン"
+msgstr "上次登录"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:156
 msgid "Signed up via Google"
-msgstr "Googleを利用して登録する"
+msgstr "用谷歌账号登录"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:161
 msgid "Signed up via LDAP"
-msgstr "LDAP経由で登録されました"
+msgstr "用LDAP账号登录"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:173
 msgid "Reactivate this account"
-msgstr "このアカウントを再有効化する"
+msgstr "重启账号"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:197
 msgid "Never"
-msgstr "しない"
+msgstr "永不"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:31
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} table"
 msgid_plural "{0} tables"
-msgstr[0] "{0}テーブル"
+msgstr[0] "表格 {0}\n"
+"Plural: {0} 张表格"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:49
 msgid " will be "
-msgstr "␣は␣になります"
+msgstr "将会"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:52
 msgid "given access to"
-msgstr "にアクセスを付与する"
+msgstr "已经被赋予权限连接至"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:57
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:26
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:36
 msgid " and "
-msgstr "␣と␣"
+msgstr "和"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:60
 msgid "denied access to"
-msgstr "拒否されたアクセス"
+msgstr "拒绝访问"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:74
 msgid " will no longer be able to "
-msgstr "␣はこれ以降␣できません"
+msgstr "将不再能够"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:75
 msgid " will now be able to "
-msgstr "␣は␣できます"
+msgstr "现在将能够"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsConfirm.jsx:83
 msgid " native queries for "
-msgstr "のネイティブクエリ"
+msgstr "本地查询"
 
 #: frontend/src/metabase/admin/permissions/routes.jsx:12
 #: frontend/src/metabase/nav/containers/Navbar.jsx:248
 msgid "Permissions"
-msgstr "権限"
+msgstr "权限"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:32
 msgid "Save permissions?"
-msgstr "権限を保存しますか？"
+msgstr "保存权限吗？"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:38
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:161
 msgid "Save Changes"
-msgstr "変更を保存する"
+msgstr "保存更改"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:44
 msgid "Discard changes?"
-msgstr "変更を破棄する"
+msgstr "放弃更改？"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:46
 msgid "No changes to permissions will be made."
-msgstr "権限は変更されません"
+msgstr "权限无更改。"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsEditor.jsx:65
 msgid "You've made changes to permissions."
-msgstr "権限が変更されました"
+msgstr "权限被更改。"
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:55
 msgid "Permissions for this collection"
-msgstr "このコレクションの権限"
+msgstr "这个集合的权限"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:56
 msgid "You have unsaved changes"
-msgstr "保存されていない変更があります"
+msgstr "有变更未保存"
 
 #: frontend/src/metabase/admin/permissions/containers/PermissionsApp.jsx:57
 msgid "Do you want to leave this page and discard your changes?"
-msgstr "変更を破棄してこのページから離れますか？"
+msgstr "页面上有未保存的变革，你想离开吗？"
 
 #: frontend/src/metabase/admin/permissions/permissions.js:126
 msgid "Sorry, an error occurred."
-msgstr "申し訳ありません、エラーが発生しました"
+msgstr "对不起，发生错误。"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:65
 msgid "Administrators always have the highest level of access to everything in Metabase."
-msgstr "管理者にはMetabaseの全データへのアクセス権限があります"
+msgstr "管理员始终对Metabase中的所有内容具有最高级别的访问权限。"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:67
 msgid "Every Metabase user belongs to the All Users group. If you want to limit or restrict a group's access to something, make sure the All Users group has an equal or lower level of access."
-msgstr "全てのMetabaseユーザーは、All Users グループに属します。 グループへのアクセスを制限またはブロックする場合は、All Users グループのアクセスレベルが同等かそれ以下であることをご確認ください。"
+msgstr "每个Metabase用户都属于“所有用户”组。如果要限制一个用户组对某些内容的访问权限，请确保“所有用户”组具有相同或更低级别的访问权限。"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:69
 msgid "MetaBot is Metabase's Slack bot. You can choose what it has access to here."
-msgstr "MetaBotはMetabaseのSlackボットです。 ここにアクセスできるものを選択できます。"
+msgstr "MetaBot是Metabase的Slack机器人。您可以在此处选择访问权限。"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:122
 msgid "The \"{0}\" group may have access to a different set of {1} than this group, which may give this group additional access to some {2}."
-msgstr "\"{0}\"グループは、このグループとは異なる{1}セットにアクセスする可能性があります。その場合、{0}グループには{2}への追加アクセス権が与えられます。"
+msgstr "“{0}”组可以访问与该组不同的{1}，这可以为该组提供对某些{2}的额外访问权限。"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:127
 msgid "The \"{0}\" group has a higher level of access than this, which will override this setting. You should limit or revoke the \"{1}\" group's access to this item."
-msgstr "\"{0}\"グループのアクセスレベルはこれより高くなり、この設定が上書きされます。 \"{1}\"グループのこのアイテムへのアクセスをブロックまたは取り消す必要があります。"
+msgstr "“{0}”组具有比此更高的访问级别，并将覆盖此设置。您应该限制或撤消“{1}”组对此项目的访问权限。"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Limit"
-msgstr "制限する"
+msgstr "限制"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:157
 msgid "Revoke"
-msgstr "取り消す"
+msgstr "撤销"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:159
 msgid "access even though \"{0}\" has greater access?"
-msgstr "{0}の方がより広いアクセス権限を持っていますが、アクセスを"
+msgstr "即使{0}有更高权限？"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:261
 msgid "Limit access"
-msgstr "アクセスを制限する"
+msgstr "部分权限"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:162
 #: frontend/src/metabase/admin/permissions/selectors.js:226
 #: frontend/src/metabase/admin/permissions/selectors.js:269
 msgid "Revoke access"
-msgstr "アクセスを取り消す"
+msgstr "取消权限"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:171
 msgid "Change access to this database to limited?"
-msgstr "このデータベースへのアクセスを制限しますか？"
+msgstr "更改权限为受限权限"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:172
 msgid "Change"
-msgstr "変更する"
+msgstr "更改"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:185
 msgid "Allow Raw Query Writing?"
-msgstr "ロークエリの作成を許可しますか？"
+msgstr "允许原始查询语句写作？"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:186
 msgid "This will also change this group's data access to Unrestricted for this database."
-msgstr "これにより、このデータベースのこのグループのデータアクセスも無制限に変更されます。"
+msgstr "这也将更改此组对此数据库的“不受限制的”访问权限。"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:187
 msgid "Allow"
-msgstr "許可する"
+msgstr "允许"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:224
 msgid "Revoke access to all tables?"
-msgstr "すべてのテーブルへのアクセスを取り消しますか？"
+msgstr "取消所有表的权限"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:225
 msgid "This will also revoke this group's access to raw queries for this database."
-msgstr "このグループのデータベースのロークエリへのアクセスも取り消されます。"
+msgstr "这也将撤消此组对该数据库的原始查询的访问权限。"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:254
 msgid "Grant unrestricted access"
-msgstr "無制限のアクセスを許可する"
+msgstr "授予不受限制的访问权限"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:255
 msgid "Unrestricted access"
-msgstr "無制限のアクセス"
+msgstr "不受限制的权限"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:262
 msgid "Limited access"
-msgstr "制限されたアクセス"
+msgstr "受限制的权限"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:270
 msgid "No access"
-msgstr "アクセスがありません"
+msgstr "没有权限"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:276
 msgid "Write raw queries"
-msgstr "ロークエリを書く"
+msgstr "写原始查询语句"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:277
 msgid "Can write raw queries"
-msgstr "ロークエリを書くことができる"
+msgstr "能够写原始查询语句"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:284
 msgid "Curate collection"
-msgstr "コレクションを公開する"
+msgstr "修改集合"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:291
 msgid "View collection"
-msgstr "コレクションを見る"
+msgstr "查看集合"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:334
 #: frontend/src/metabase/admin/permissions/selectors.js:430
 #: frontend/src/metabase/admin/permissions/selectors.js:527
 msgid "Data Access"
-msgstr "データアクセス"
+msgstr "允许访问数据"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:495
 #: frontend/src/metabase/admin/permissions/selectors.js:652
 #: frontend/src/metabase/admin/permissions/selectors.js:657
 msgid "View tables"
-msgstr "テーブルを見る"
+msgstr "查看表格"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:593
 msgid "SQL Queries"
-msgstr "SQLクエリ"
+msgstr "SQL查询"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:663
 msgid "View schemas"
-msgstr "スキーマを見る"
+msgstr "查看架构"
 
 #: frontend/src/metabase/admin/routes.jsx:59
 #: frontend/src/metabase/nav/containers/Navbar.jsx:238
 msgid "Data Model"
-msgstr "データモデル"
+msgstr "数据模型"
 
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:11
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:118
 msgid "Sign in with Google"
-msgstr "Googleを利用してサインインする"
+msgstr "Google账号登录"
 
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:120
 msgid "Allows users with existing Metabase accounts to login with a Google account that matches their email address in addition to their Metabase username and password."
-msgstr "Metabaseアカウント保有者に、Metabaseユーザーネームとパスワード以外に、登録されたメールアドレスと一致するGoogleアカウントでログインすることを許可する"
+msgstr "允许拥有Metabase帐户的用户使用与其电子邮件地址匹配的Google帐户以及其Metabase用户名和密码进行登录。"
 
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:16
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:27
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:32
 msgid "Configure"
-msgstr "設定"
+msgstr "配置"
 
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:22
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:13
 #: frontend/src/metabase/admin/settings/selectors.js:204
 msgid "LDAP"
-msgstr "LDAP"
+msgstr "联机分析处理"
 
 #: frontend/src/metabase/admin/settings/components/SettingsAuthenticationOptions.jsx:23
 msgid "Allows users within your LDAP directory to log in to Metabase with their LDAP credentials, and allows automatic mapping of LDAP groups to Metabase groups."
-msgstr "LDAPディレクトリ内のユーザーに対し、LDAP資格情報によるMetabaseへのログインを許可し、LDAPグループをMetabaseグループに自動的にマッピングできるようにする。"
+msgstr "允许用户在没有你的LDAP字典的情况下使用他们的LDAP证书来登录到Metabase，并且允许自动LDAP群组的自动同步到Metabase的群组"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:17
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:69
 #: frontend/src/metabase/admin/settings/selectors.js:157
 msgid "That's not a valid email address"
-msgstr "有効なメールアドレスではありません"
+msgstr "这不是有效的电子邮件地址"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:21
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:73
 msgid "That's not a valid integer"
-msgstr "有効な整数ではありません"
+msgstr "那不是一个有效的整数"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:28
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:161
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:223
 msgid "Changes saved!"
-msgstr "変更が保存されました！"
+msgstr "更改已保存！"
 
 #: frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx:157
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:132
 msgid "Looks like we ran into some problems"
-msgstr "問題が発生したようです"
+msgstr "看起来我们遇到了一些问题"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:12
 msgid "Send test email"
-msgstr "テストメールを送信する"
+msgstr "发送测试邮件"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:13
 msgid "Sending..."
-msgstr "送信中..."
+msgstr "发送中"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:14
 msgid "Sent!"
-msgstr "送信しました！"
+msgstr "已发送"
 
 #: frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx:82
 msgid "Clear"
-msgstr "クリア"
+msgstr "完成"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:12
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:113
 #: frontend/src/metabase/admin/settings/selectors.js:199
 msgid "Authentication"
-msgstr "認証"
+msgstr "认证"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:18
 msgid "Server Settings"
-msgstr "サーバー設定"
+msgstr "服务器设置"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:29
 msgid "User Schema"
-msgstr "ユーザースキーマ"
+msgstr "用户结构"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:33
 msgid "Attributes"
@@ -1434,82 +1452,82 @@ msgstr "属性"
 
 #: frontend/src/metabase/admin/settings/components/SettingsLdapForm.jsx:42
 msgid "Group Schema"
-msgstr "グループスキーマ"
+msgstr "用户组结构"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetting.jsx:28
 msgid "Using "
-msgstr "を利用して"
+msgstr "使用"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:105
 msgid "Getting set up"
-msgstr "開始する"
+msgstr "开始设置向导"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:106
 msgid "A few things you can do to get the most out of Metabase."
-msgstr "Metabaseを有効活用するためにできること"
+msgstr "您可以采取一些措施来充分利用Metabase。"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSetupList.jsx:115
 msgid "Recommended next step"
-msgstr "おすすめの次のステップ"
+msgstr "建议的操作"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:114
 msgid "Google Sign-In"
-msgstr "Googleサインイン"
+msgstr "Google登录"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:123
 msgid "To allow users to sign in with Google you'll need to give Metabase a Google Developers console application client ID. It only takes a few steps and instructions on how to create a key can be found {0}"
-msgstr "ユーザーがGoogleでログインできるようにするには、MetabaseにGoogle DevelopersコンソールアプリケーションクライアントIDを指定する必要があります。 キーの作成方法の確認は非常に簡単です。{0}"
+msgstr "为了允许用户使用Google登录，你需要给Metabase一个Google开发者应用端ID，在如何创建一个可以被找到的密钥上{0}，它只需要几步和一些指导。"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:137
 msgid "Your Google client ID"
-msgstr "GoogleクライアントID"
+msgstr "你的Google客户端ID"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx:142
 msgid "Allow users to sign up on their own if their Google account email address is from:"
-msgstr "Googleアカウントのメールアドレスが以下のものである場合、ユーザーが自分でサインアップできるようにする:"
+msgstr "允许用户用他们自己的邮箱注册，如果他们的Google账户地址来自："
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:242
 msgid "Answers sent right to your Slack #channels"
-msgstr "Slackに回答が送信されました"
+msgstr "答案发送到您的Slack #channels"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:251
 msgid "Create a Slack Bot User for MetaBot"
-msgstr "MetaBotのSlack Botユーザーを作成する"
+msgstr "为MetaBot创建一个Slack Bot用户"
 
 #: frontend/src/metabase/admin/settings/components/SettingsSlackForm.jsx:261
 msgid "Once you're there, give it a name and click {0}. Then copy and paste the Bot API Token into the field below. Once you are done, create a \"metabase_files\" channel in Slack. Metabase needs this to upload graphs."
-msgstr "名前を付けて{0}をクリックします。 ボットAPIトークンをコピーし、下のフィールドに貼り付けます。 完了したら、Slackで \"metabase_files\"チャンネルを作成します。 これはMetabaseでグラフをアップロードするために必要な作業です。"
+msgstr "进入后，请为其命名并单击{0}。然后将Bot API令牌复制并粘贴到下面的字段中。完成后，在Slack中创建“metabase_files”通道。Metabase需要这个来上传图表。"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:91
 msgid "You're running Metabase {0} which is the latest and greatest!"
-msgstr "お使いのMetabase {0}は最新です"
+msgstr "你正在运行的Metabase {0}是最新版本的。"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:100
 msgid "Metabase {0} is available.  You're running {1}"
-msgstr "Metabase {0}が利用可能です。現在{1}を利用中です。"
+msgstr "Metabase {0}可更新。你正在运行是{1}"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:113
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:106
 msgid "Update"
-msgstr "アップデートする"
+msgstr "更新"
 
 #: frontend/src/metabase/admin/settings/components/SettingsUpdatesForm.jsx:117
 msgid "What's Changed:"
-msgstr "変更箇所:"
+msgstr "更新内容"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:131
 msgid "Add a map"
-msgstr "マップを追加する"
+msgstr "添加一个地图"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:184
 #: frontend/src/metabase/lib/core.js:105
 msgid "URL"
-msgstr "URL"
+msgstr "链接"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:201
 msgid "Delete custom map"
-msgstr "カスタムマップを削除する"
+msgstr "删除自定义地图"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:203
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:348
@@ -1518,7 +1536,7 @@ msgstr "カスタムマップを削除する"
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:117
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:157
 msgid "Remove"
-msgstr "削除する"
+msgstr "删除"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:228
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:188
@@ -1526,578 +1544,578 @@ msgstr "削除する"
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:148
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:189
 msgid "Select…"
-msgstr "選択..."
+msgstr "选择"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:243
 msgid "Sample values:"
-msgstr "サンプル値:"
+msgstr "样例值"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Add a new map"
-msgstr "新しいマップを追加する"
+msgstr "添加新地图"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:281
 msgid "Edit map"
-msgstr "マップを編集する"
+msgstr "编辑地图"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:282
 msgid "What do you want to call this map?"
-msgstr "このマップを何と呼びますか？"
+msgstr "这个地图叫什么"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:287
 msgid "e.g. United Kingdom, Brazil, Mars"
-msgstr "例: イギリス、ブラジル、火星"
+msgstr "比如，英国、巴西、火星"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:294
 msgid "URL for the GeoJSON file you want to use"
-msgstr "使用したいGeoJSONファイルのURL"
+msgstr "你想使用的GeoJSON文件URL"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:300
 msgid "Like https://my-mb-server.com/maps/my-map.json"
-msgstr "例: https://my-mb-server.com/maps/my-map.json"
+msgstr "例如 https://my-mb-server.com/maps/my-map.json"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Refresh"
-msgstr "更新"
+msgstr "刷新"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:311
 msgid "Load"
-msgstr "読み込み"
+msgstr "加载"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:317
 msgid "Which property specifies the region’s identifier?"
-msgstr "地域の識別子を指定するプロパティはどれですか？"
+msgstr "哪个属性指定了区域的标识符？"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:326
 msgid "Which property specifies the region’s display name?"
-msgstr "地域の表示名を指定するプロパティはどれですか？"
+msgstr "哪个属性指定了区域的显示名称？"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:347
 msgid "Load a GeoJSON file to see a preview"
-msgstr "GeoJSONファイルを読み込み、プレビューを表示する"
+msgstr "读取一个 GeoJSON 文件来预览"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Save map"
-msgstr "マップを保存する"
+msgstr "保存地图"
 
 #: frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx:365
 msgid "Add map"
-msgstr "マップを追加する"
+msgstr "添加地图"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:7
 msgid "Using embedding"
-msgstr "埋め込みを利用中"
+msgstr "使用嵌入式"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:9
 msgid "By enabling embedding you're agreeing to the embedding license located at"
-msgstr "埋め込みを有効にすると、␣にある埋め込みライセンスに同意します。"
+msgstr "启用嵌入即表示您同意嵌入许可，该许可位于"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:20
 msgid "In plain English, when you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the \"Powered by Metabase\" visible on those embeds. You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature."
-msgstr "Metabaseから独自のアプリケーションにチャートやダッシュボードを埋め込む場合、Metabaseのロゴと「Powered by Metabase」が埋め込みの中でも表示させている限り、そのアプリケーションはMetabaseの残りの部分をカバーするAffero General Public Licenseには拘束されません。ただし、この機能を有効にした場合に同意したことになる実際のライセンスですから、上記リンク先のライセンステキストを必ずお読みください。"
+msgstr "简单来说，当您在自己的应用程序中嵌入Metabase的图表或仪表板时，只要您保留Metabase徽标和“Powered by Metabase”，该应用程序就不受涵盖Metabase其余部分的Affero通用公共许可证的约束。但是，您应该阅读上面链接的许可文本，因为这是您将通过启用此功能同意的实际许可。"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLegalese.jsx:33
 msgid "Enable"
-msgstr "有効化する"
+msgstr "启用"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:24
 msgid "Premium embedding enabled"
-msgstr "プレミアム埋め込みが有効化された"
+msgstr "标准编辑已启用"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:26
 msgid "Enter the token you bought from the Metabase Store"
-msgstr "Metabase Storeから購入したトークンを入力する"
+msgstr "输入你从Metabase商店购买的token"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:53
 msgid "Premium embedding lets you disable \"Powered by Metabase\" on your embedded dashboards and questions."
-msgstr "プレミアム埋め込みを利用すると、埋め込みされたダッシュボードや質問の「Powered by Metabase」という表示を無効化することができます"
+msgstr "高级嵌入允许您在嵌入式仪表板和问题上禁用“Powered by Metabase”。"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:60
 msgid "Buy a token"
-msgstr "トークンを購入する"
+msgstr "购买 token"
 
 #: frontend/src/metabase/admin/settings/components/widgets/EmbeddingLevel.jsx:63
 msgid "Enter a token"
-msgstr "トークンを入力する"
+msgstr "输入 token"
 
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:150
 msgid "Edit Mappings"
-msgstr "マッピングを編集する"
+msgstr "编辑映射"
 
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:156
 msgid "Group Mappings"
-msgstr "グループマッピング"
+msgstr "分组映射"
 
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:163
 msgid "Create a mapping"
-msgstr "マッピングを作成する"
+msgstr "创建映射"
 
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:165
 msgid "Mappings allow Metabase to automatically add and remove users from groups based on the membership information provided by the\n"
 "directory server. Membership to the Admin group can be granted through mappings, but will not be automatically removed as a\n"
 "failsafe measure."
-msgstr "マッピングをすると、ディレクトリサーバーから提供される利用者情報に基づいて、グループからユーザーを自動的に追加または削除することができます。管理者グループへのメンバーシップはマッピングを介して付与できますが、フェイルセーフ対策として自動的に削除されることはありません。"
+msgstr "映射允许Metabase根据目录服务器提供的成员资格信息自动添加和删除组中的用户。Admin组的成员身份可以通过映射授予，但作为故障保护措施并不会被自动删除。"
 
 #: frontend/src/metabase/admin/settings/components/widgets/LdapGroupMappingsWidget.jsx:170
 msgid "Distinguished Name"
-msgstr "識別名"
+msgstr "专有名字"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:92
 msgid "Public Link"
-msgstr "公開リンク"
+msgstr "公开链接"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:93
 msgid "Revoke Link"
-msgstr "リンクを取り消す"
+msgstr "撤销链接"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:123
 msgid "Disable this link?"
-msgstr "このリンクを無効化しますか？"
+msgstr "禁用这个链接吗？"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:124
 msgid "They won't work anymore, and can't be restored, but you can create new links."
-msgstr "作動ならびに復元はできません。ただし新しいリンクを作成することができます。"
+msgstr "它们将不会工作了，并且不能被重新存储，但是你能够创建新的链接。"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:151
 msgid "Public Dashboard Listing"
-msgstr "ダッシュボード一覧を公開する"
+msgstr "公共仪表盘列表"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:154
 msgid "No dashboards have been publicly shared yet."
-msgstr "公開されたダッシュボードがまだありません"
+msgstr "还没有公开分享的仪表盘。"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:162
 msgid "Public Card Listing"
-msgstr "カード一覧を公開する"
+msgstr "公共卡片列表"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:165
 msgid "No questions have been publicly shared yet."
-msgstr "公開された質問はまだありません。"
+msgstr "还没有公开分享任何问题。"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:174
 msgid "Embedded Dashboard Listing"
-msgstr "埋め込みダッシュボード一覧"
+msgstr "嵌入的仪表板列表"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:175
 msgid "No dashboards have been embedded yet."
-msgstr "埋め込みされたダッシュボードはまだありません"
+msgstr "还没有仪表盘被嵌入。"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:185
 msgid "Embedded Card Listing"
-msgstr "埋め込みカード一覧"
+msgstr "嵌入的卡片列表"
 
 #: frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing.jsx:186
 msgid "No questions have been embedded yet."
-msgstr "埋め込みされた質問はまだありません"
+msgstr "还没有提问被嵌入"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:35
 msgid "Regenerate embedding key?"
-msgstr "埋め込みキーを再生成しますか？"
+msgstr "重新更新嵌入密钥"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:36
 msgid "This will cause existing embeds to stop working until they are updated with the new key."
-msgstr "すでに埋め込んでいる質問は、新しいキーで更新されない限り使用できなくなります"
+msgstr "这将会造成已经存在的嵌入页面停止工作，直到它们随着新的密钥被更新"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:39
 msgid "Regenerate key"
-msgstr "キーを再発行する"
+msgstr "重新更新密钥"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget.jsx:47
 msgid "Generate Key"
-msgstr "キーを発行する"
+msgstr "生成秘钥"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
 #: frontend/src/metabase/admin/settings/selectors.js:77
 msgid "Enabled"
-msgstr "有効"
+msgstr "生效"
 
 #: frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx:11
 #: frontend/src/metabase/admin/settings/selectors.js:82
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:104
 msgid "Disabled"
-msgstr "無効"
+msgstr "取消"
 
 #: frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx:120
 msgid "Unknown setting {0}"
-msgstr "不明な設定{0}"
+msgstr "未知设置{0}"
 
 #: frontend/src/metabase/admin/settings/selectors.js:23
 msgid "Setup"
-msgstr "設定"
+msgstr "初始化"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:211
 #: frontend/src/metabase/admin/settings/selectors.js:28
 msgid "General"
-msgstr "一般"
+msgstr "基本设置"
 
 #: frontend/src/metabase/admin/settings/selectors.js:33
 msgid "Site Name"
-msgstr "サイト名"
+msgstr "网站名称"
 
 #: frontend/src/metabase/admin/settings/selectors.js:38
 msgid "Site URL"
-msgstr "サイトのURL"
+msgstr "网站地址"
 
 #: frontend/src/metabase/admin/settings/selectors.js:43
 msgid "Email Address for Help Requests"
-msgstr "ヘルプリクエストのメールアドレス"
+msgstr "客服邮箱"
 
 #: frontend/src/metabase/admin/settings/selectors.js:48
 msgid "Report Timezone"
-msgstr "タイムゾーン"
+msgstr "报表时区"
 
 #: frontend/src/metabase/admin/settings/selectors.js:51
 msgid "Database Default"
-msgstr "データベースのデフォルト"
+msgstr "数据源默认时区"
 
 #: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Select a timezone"
-msgstr "タイムゾーンを選択する"
+msgstr "选择时区"
 
 #: frontend/src/metabase/admin/settings/selectors.js:54
 msgid "Not all databases support timezones, in which case this setting won't take effect."
-msgstr "すべてのデータベースがタイムゾーンをサポートしているわけではありません。この場合、この設定は有効になりません。"
+msgstr "并非所有数据库支持时区，部分设置无法生效。"
 
 #: frontend/src/metabase/admin/settings/selectors.js:59
 msgid "Language"
-msgstr "言語"
+msgstr "语言"
 
 #: frontend/src/metabase/admin/settings/selectors.js:65
 msgid "Select a language"
-msgstr "言語を選択する"
+msgstr "选择语言"
 
 #: frontend/src/metabase/admin/settings/selectors.js:69
 msgid "Anonymous Tracking"
-msgstr "匿名のトラッキング"
+msgstr "匿名跟踪"
 
 #: frontend/src/metabase/admin/settings/selectors.js:74
 msgid "Friendly Table and Field Names"
-msgstr "わかりやすいテーブル名とフィールド名"
+msgstr "友好的表单和字段名称"
 
 #: frontend/src/metabase/admin/settings/selectors.js:80
 msgid "Only replace underscores and dashes with spaces"
-msgstr "アンダースコアとダッシュをスペースに置き換える"
+msgstr "仅用空格替换下划线和短划线"
 
 #: frontend/src/metabase/admin/settings/selectors.js:88
 msgid "Enable Nested Queries"
-msgstr "ネストしたクエリを有効化する"
+msgstr "启用网状查询"
 
 #: frontend/src/metabase/admin/settings/selectors.js:99
 msgid "Updates"
-msgstr "アップデート"
+msgstr "更新"
 
 #: frontend/src/metabase/admin/settings/selectors.js:104
 msgid "Check for updates"
-msgstr "アップデートを確認する"
+msgstr "检查更新"
 
 #: frontend/src/metabase/admin/settings/selectors.js:115
 msgid "SMTP Host"
-msgstr "SMTPホスト"
+msgstr "SMTP地址"
 
 #: frontend/src/metabase/admin/settings/selectors.js:123
 msgid "SMTP Port"
-msgstr "SMTPポート"
+msgstr "SMTP端口"
 
 #: frontend/src/metabase/admin/settings/selectors.js:127
 #: frontend/src/metabase/admin/settings/selectors.js:227
 msgid "That's not a valid port number"
-msgstr "無効なポート番号です"
+msgstr "不是有效的端口"
 
 #: frontend/src/metabase/admin/settings/selectors.js:131
 msgid "SMTP Security"
-msgstr "SMTPセキュリティ"
+msgstr "SMTP安全"
 
 #: frontend/src/metabase/admin/settings/selectors.js:139
 msgid "SMTP Username"
-msgstr "SMTPユーザーネーム"
+msgstr "SMTP用户名"
 
 #: frontend/src/metabase/admin/settings/selectors.js:146
 msgid "SMTP Password"
-msgstr "SMTPパスワード"
+msgstr "SMTP密码"
 
 #: frontend/src/metabase/admin/settings/selectors.js:153
 msgid "From Address"
-msgstr "送信元アドレス"
+msgstr "选择地址"
 
 #: frontend/src/metabase/admin/settings/selectors.js:167
 msgid "Slack API Token"
-msgstr "Slack APIトークン"
+msgstr "Slack API令牌"
 
 #: frontend/src/metabase/admin/settings/selectors.js:169
 msgid "Enter the token you received from Slack"
-msgstr "Slackから受け取ったトークンを入力する"
+msgstr "输入您从Slack收到的令牌"
 
 #: frontend/src/metabase/admin/settings/selectors.js:186
 msgid "Single Sign-On"
-msgstr "シングルサインオン(SSO)"
+msgstr "单点登录"
 
 #: frontend/src/metabase/admin/settings/selectors.js:210
 msgid "LDAP Authentication"
-msgstr "LDAP認証"
+msgstr "LDAP身份验证"
 
 #: frontend/src/metabase/admin/settings/selectors.js:216
 msgid "LDAP Host"
-msgstr "LDAPホスト"
+msgstr "LDAP主机"
 
 #: frontend/src/metabase/admin/settings/selectors.js:224
 msgid "LDAP Port"
-msgstr "LDAPポート"
+msgstr "LDAP端口"
 
 #: frontend/src/metabase/admin/settings/selectors.js:231
 msgid "LDAP Security"
-msgstr "LDAPセキュリティ"
+msgstr "LDAP安全性"
 
 #: frontend/src/metabase/admin/settings/selectors.js:239
 msgid "Username or DN"
-msgstr "ユーザーネームまたはDN"
+msgstr "用户名或DN"
 
 #: frontend/src/metabase/admin/settings/selectors.js:244
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:191
 #: frontend/src/metabase/user/components/UserSettings.jsx:59
 msgid "Password"
-msgstr "パスワード"
+msgstr "密码"
 
 #: frontend/src/metabase/admin/settings/selectors.js:249
 msgid "User search base"
-msgstr "ユーザー検索ベース"
+msgstr "用户搜索库"
 
 #: frontend/src/metabase/admin/settings/selectors.js:255
 msgid "User filter"
-msgstr "ユーザーフィルター"
+msgstr "用户筛选"
 
 #: frontend/src/metabase/admin/settings/selectors.js:261
 msgid "Check your parentheses"
-msgstr "かっこを確認する"
+msgstr "检查括号"
 
 #: frontend/src/metabase/admin/settings/selectors.js:267
 msgid "Email attribute"
-msgstr "メール属性"
+msgstr "电子邮件属性"
 
 #: frontend/src/metabase/admin/settings/selectors.js:272
 msgid "First name attribute"
-msgstr "名の属性"
+msgstr "名字属性"
 
 #: frontend/src/metabase/admin/settings/selectors.js:277
 msgid "Last name attribute"
-msgstr "姓の属性"
+msgstr "姓氏属性"
 
 #: frontend/src/metabase/admin/settings/selectors.js:282
 msgid "Synchronize group memberships"
-msgstr "グループメンバーを同期する"
+msgstr "同步组成员"
 
 #: frontend/src/metabase/admin/settings/selectors.js:288
 msgid "Group search base"
-msgstr "グループ検索ベース"
+msgstr "用户组搜索库"
 
 #: frontend/src/metabase/admin/settings/selectors.js:297
 msgid "Maps"
-msgstr "マップ"
+msgstr "地图"
 
 #: frontend/src/metabase/admin/settings/selectors.js:302
 msgid "Map tile server URL"
-msgstr "マップタイルサーバーのURL"
+msgstr "地图贴片服务器URL"
 
 #: frontend/src/metabase/admin/settings/selectors.js:303
 msgid "Metabase uses OpenStreetMaps by default."
-msgstr "Metabaseはデフォルト設定でOpenStreetMapsを使用します"
+msgstr "Metabase默认使用PoenStreet地图"
 
 #: frontend/src/metabase/admin/settings/selectors.js:308
 msgid "Custom Maps"
-msgstr "カスタムマップ"
+msgstr "自定义地图"
 
 #: frontend/src/metabase/admin/settings/selectors.js:309
 msgid "Add your own GeoJSON files to enable different region map visualizations"
-msgstr "独自のGeoJSONファイルを追加して、異なるリージョンマップのビジュアライゼーションを可能にする"
+msgstr "添加您自己的GeoJSON文件以启用不同的区域地图可视化"
 
 #: frontend/src/metabase/admin/settings/selectors.js:328
 msgid "Public Sharing"
-msgstr "公開"
+msgstr "公开分享"
 
 #: frontend/src/metabase/admin/settings/selectors.js:333
 msgid "Enable Public Sharing"
-msgstr "公開を有効化する"
+msgstr "开启公开共享"
 
 #: frontend/src/metabase/admin/settings/selectors.js:338
 msgid "Shared Dashboards"
-msgstr "公開されたダッシュボード"
+msgstr "已共享仪表盘"
 
 #: frontend/src/metabase/admin/settings/selectors.js:344
 msgid "Shared Questions"
-msgstr "公開された質問"
+msgstr "已共享提问"
 
 #: frontend/src/metabase/admin/settings/selectors.js:351
 msgid "Embedding in other Applications"
-msgstr "他アプリケーションに埋め込む"
+msgstr "嵌入在其他的应用中"
 
 #: frontend/src/metabase/admin/settings/selectors.js:378
 msgid "Enable Embedding Metabase in other Applications"
-msgstr "他アプリケーションへのMetabaseの埋め込みを有効化する"
+msgstr "启用将Metabase嵌入到其他应用中"
 
 #: frontend/src/metabase/admin/settings/selectors.js:388
 msgid "Embedding secret key"
-msgstr "秘密キーを埋め込む"
+msgstr "嵌入秘钥"
 
 #: frontend/src/metabase/admin/settings/selectors.js:394
 msgid "Embedded Dashboards"
-msgstr "埋め込みダッシュボード"
+msgstr "嵌入的仪表板"
 
 #: frontend/src/metabase/admin/settings/selectors.js:400
 msgid "Embedded Questions"
-msgstr "埋め込み質問"
+msgstr "嵌入的问题"
 
 #: frontend/src/metabase/admin/settings/selectors.js:407
 msgid "Caching"
-msgstr "キャッシュ"
+msgstr "缓存中"
 
 #: frontend/src/metabase/admin/settings/selectors.js:412
 msgid "Enable Caching"
-msgstr "キャッシュを有効化する"
+msgstr "启用缓存"
 
 #: frontend/src/metabase/admin/settings/selectors.js:417
 msgid "Minimum Query Duration"
-msgstr "最低クエリ期間"
+msgstr "最小查询周期"
 
 #: frontend/src/metabase/admin/settings/selectors.js:424
 msgid "Cache Time-To-Live (TTL) multiplier"
-msgstr "キャッシュTTL乗数"
+msgstr "缓存生存时间（TTL）乘数"
 
 #: frontend/src/metabase/admin/settings/selectors.js:431
 msgid "Max Cache Entry Size"
-msgstr "最大キャッシュエントリーサイズ"
+msgstr "最大缓存允许大小"
 
 #: frontend/src/metabase/alert/alert.js:60
 msgid "Your alert is all set up."
-msgstr "アラートが設定されました"
+msgstr "你的警报已经全部设置好了"
 
 #: frontend/src/metabase/alert/alert.js:101
 msgid "Your alert was updated."
-msgstr "アラートがアップデートされました"
+msgstr "你的警报已经更新了"
 
 #: frontend/src/metabase/alert/alert.js:149
 msgid "The alert was successfully deleted."
-msgstr "アラートが削除されました"
+msgstr "警报成功删除了"
 
 #: frontend/src/metabase/auth/auth.js:32
 msgid "Please enter a valid formatted email address."
-msgstr "有効なメールアドレスを入力してください"
+msgstr "请输入有效格式的Email地址"
 
 #: frontend/src/metabase/auth/auth.js:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:110
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:69
 msgid "Passwords do not match"
-msgstr "パスワードが一致しません"
+msgstr "密码不匹配"
 
 #: frontend/src/metabase/auth/components/BackToLogin.jsx:6
 msgid "Back to login"
-msgstr "ログイン画面に戻る"
+msgstr "返回登录"
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:15
 msgid "No Metabase account exists for this Google account."
-msgstr "このGoogleアカウントを利用したMetabaseアカウントは存在しません"
+msgstr "这个Google账户不存在Metabase账户"
 
 #: frontend/src/metabase/auth/components/GoogleNoAccount.jsx:17
 msgid "You'll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Googleを利用してログインするには、管理者からMetabaseアカウントを作成してもらう必要があります"
+msgstr "在你能够使用Google账户登录之前，需要一个管理员来创建一个Metabase账户"
 
 #: frontend/src/metabase/auth/components/SSOLoginButton.jsx:18
 msgid "Sign in with {0}"
-msgstr "{0}を利用してサインインする"
+msgstr "用{0}登录"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:56
 msgid "Please contact an administrator to have them reset your password"
-msgstr "パスワードをリセットするには管理者へお問い合わせください"
+msgstr "请联系管理员来重置你的密码"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:69
 msgid "Forgot password"
-msgstr "パスワードをお忘れの場合"
+msgstr "忘记密码"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:84
 msgid "The email you use for your Metabase account"
-msgstr "Metabaseアカウントのメールアドレス"
+msgstr "你作为Metabase账户的Email地址"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:99
 msgid "Send password reset email"
-msgstr "パスワードリセットのメールを送信する"
+msgstr "发送账号重置邮件"
 
 #: frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx:110
 msgid "Check your email for instructions on how to reset your password."
-msgstr "パスワードのリセット方法についてはメールをご確認ください"
+msgstr "检查你的邮件来获取重置密码说明"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:131
 msgid "Sign in to Metabase"
-msgstr "Metabaseにサインインする"
+msgstr "登录Metabase"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:141
 msgid "OR"
-msgstr "または"
+msgstr "或者"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:160
 msgid "Username or email address"
-msgstr "ユーザーネームまたはメールアドレス"
+msgstr "用户名或者邮箱地址"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:220
 msgid "Sign in"
-msgstr "サインイン"
+msgstr "登录"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:233
 msgid "I seem to have forgotten my password"
-msgstr "パスワードを忘れてしまいました"
+msgstr "我似乎忘记了我的密码"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:105
 msgid "request a new reset email"
-msgstr "パスワードリセットのメールをリクエストする"
+msgstr "发送一个新的重置email邮件"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:123
 msgid "Whoops, that's an expired link"
-msgstr "このリンクは有効期限切れです"
+msgstr "噢，那是个过期的链接"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:125
 msgid "For security reasons, password reset links expire after a little while. If you still need\n"
 "to reset your password, you can {0}."
-msgstr "セキュリティの理由により、パスワードリセットのリンクは一定期間を過ぎると無効となります。パスワードリセットが必要な場合は、{0}ができます"
+msgstr "于安全原因，密码重置链接会在一段时间后过期。如果您仍需要重置密码，可以{0}。"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:150
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:126
 msgid "New password"
-msgstr "新しいパスワード"
+msgstr "新密码"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:152
 msgid "To keep your data secure, passwords {0}"
-msgstr "データを安全に保つため、パスワードは{0}"
+msgstr "为了确保您的数据安全，密码{0}"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:166
 msgid "Create a new password"
-msgstr "新しいパスワードを作成する"
+msgstr "创建新密码"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:173
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:137
 msgid "Make sure its secure like the instructions above"
-msgstr "設定方法に従いセキュリティ度の高いパスワードを設定してください"
+msgstr "确保它的安全性像上方说明中一样"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:187
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:145
 msgid "Confirm new password"
-msgstr "新しいパスワードの確認"
+msgstr "确认新密码"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:194
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:155
 msgid "Make sure it matches the one you just entered"
-msgstr "上記で入力したパスワードと同じものを入力してください"
+msgstr "确认它和你刚刚输入的一致"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:219
 msgid "Your password has been reset."
-msgstr "パスワードがリセットされました"
+msgstr "你的密码已经被重置"
 
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:225
 #: frontend/src/metabase/auth/containers/PasswordResetApp.jsx:230
 msgid "Sign in with your new password"
-msgstr "新しいパスワードでサインインする"
+msgstr "用你的新密码登录"
 
 #: frontend/src/metabase/components/ActionButton.jsx:53
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:172
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:186
 msgid "Save failed"
-msgstr "保存が失敗しました"
+msgstr "保存失败"
 
 #: frontend/src/metabase/components/ActionButton.jsx:54
 #: frontend/src/metabase/components/SaveStatus.jsx:60
@@ -2105,19 +2123,19 @@ msgstr "保存が失敗しました"
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:133
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:187
 msgid "Saved"
-msgstr "保存されました"
+msgstr "已保存"
 
 #: frontend/src/metabase/components/Alert.jsx:12
 msgid "Ok"
-msgstr "確認しました"
+msgstr "好"
 
 #: frontend/src/metabase/components/ArchiveCollectionModal.jsx:41
 msgid "Archive this collection?"
-msgstr "このコレクションをアーカイブしますか？"
+msgstr "归档集合"
 
 #: frontend/src/metabase/components/ArchiveCollectionModal.jsx:42
 msgid "The dashboards, collections, and pulses in this collection will also be archived."
-msgstr "このコレクション内のダッシュボード、コレクション、パルスもアーカイブされます"
+msgstr "此集合中的仪表板，集合和定时通知也将被归档。"
 
 #: frontend/src/metabase/components/ArchiveModal.jsx:38
 #: frontend/src/metabase/components/CollectionLanding.jsx:620
@@ -2129,49 +2147,49 @@ msgstr "このコレクション内のダッシュボード、コレクション
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:202
 #: frontend/src/metabase/routes.jsx:199
 msgid "Archive"
-msgstr "アーカイブ"
+msgstr "归档"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:63
 msgid "This {0} has been archived"
-msgstr "この{0}はアーカイブされました"
+msgstr "此{0}已归档。"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:714
 msgid "View the archive"
-msgstr "アーカイブを見る"
+msgstr "查看归档"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:42
 msgid "Unarchive this {0}"
-msgstr "この{0}のアーカイブを取り消す"
+msgstr "取消归档此{0}"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:39
 #: frontend/src/metabase/components/BrowseApp.jsx:102
 #: frontend/src/metabase/components/BrowseApp.jsx:196
 #: frontend/src/metabase/containers/Overworld.jsx:219
 msgid "Our data"
-msgstr "データ"
+msgstr "我们的数据"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:146
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:55
 msgid "X-ray this table"
-msgstr "このテーブルを自動探査(X-ray)する"
+msgstr "透视这个数据表单"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:163
 msgid "Learn about this table"
-msgstr "このテーブルについて詳細を見る"
+msgstr "了解这张数据表"
 
 #: frontend/src/metabase/components/Button.info.js:11
 #: frontend/src/metabase/components/Button.info.js:12
 #: frontend/src/metabase/components/Button.info.js:13
 msgid "Clickity click"
-msgstr "カチカチ"
+msgstr "点击次数"
 
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:9
 msgid "Saved!"
-msgstr "保存されました！"
+msgstr "已保存！"
 
 #: frontend/src/metabase/components/ButtonWithStatus.jsx:10
 msgid "Saving failed."
-msgstr "保存が失敗しました"
+msgstr "保存失败"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Su"
@@ -2179,68 +2197,68 @@ msgstr "日"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Mo"
-msgstr "月"
+msgstr "一"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Tu"
-msgstr "火"
+msgstr "二"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "We"
-msgstr "水"
+msgstr "三"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Th"
-msgstr "木"
+msgstr "四"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Fr"
-msgstr "金"
+msgstr "五"
 
 #: frontend/src/metabase/components/Calendar.jsx:117
 msgid "Sa"
-msgstr "土"
+msgstr "六"
 
 #: frontend/src/metabase/components/ChannelSetupMessage.jsx:41
 msgid "Your admin's email address"
-msgstr "管理者のメールアドレス"
+msgstr "你的管理员的邮箱地址"
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:37
 msgid "To send {0}, you'll need to set up {1} integration."
-msgstr "{0}を送信するには、{1}インテグレーションを設定する必要があります"
+msgstr "要发送{0}，您需要设置{1}集成。"
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:38
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:41
 msgid " or "
-msgstr "␣または␣"
+msgstr "或者"
 
 #: frontend/src/metabase/components/ChannelSetupModal.jsx:40
 msgid "To send {0}, an admin needs to set up {1} integration."
-msgstr "{0}を送信するには、管理者が{1}インテグレーションを設定する必要があります "
+msgstr "要发送{0}，管理员需要设置{1}集成。"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:15
 msgid "This collection is empty, like a blank canvas"
-msgstr "このコレクションは空です"
+msgstr "这个集合空空如也，什么都没有"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:16
 msgid "You can use collections to organize and group dashboards, questions and pulses for your team or yourself"
-msgstr "コレクションを使用して、ダッシュボード、質問とパルスを整理してグループ化することができます。"
+msgstr "您可以使用集合来为您的团队或您自己组织和分组仪表板、问题和定时通知。"
 
 #: frontend/src/metabase/components/CollectionEmptyState.jsx:28
 msgid "Create another collection"
-msgstr "他のコレクションを作成する"
+msgstr "再创建一个集合"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:68
 msgid "Dashboards let you collect and share data in one place."
-msgstr "ダッシュボードを利用することで、データを一箇所に集約し共有することができます"
+msgstr "仪表板允许您在一个位置收集和共享数据。"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:77
 msgid "Pulses let you send out the latest data to your team on a schedule via email or slack."
-msgstr "パルスを利用することで、メールやSlackを通じて定期的にチームメンバーへ最新情報を送ることができます"
+msgstr "定时通知允许您通过电子邮件或Slack向团队发送最新数据。"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:86
 msgid "Questions are a saved look at your data."
-msgstr "データのクエリは質問として保存されました"
+msgstr "问题是对保存的数据查看。"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:286
 msgid "Pins"
@@ -2248,31 +2266,31 @@ msgstr "固定"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:340
 msgid "Drag something here to pin it to the top"
-msgstr "ドラッグしてトップに固定してください"
+msgstr "把东西拖到这里将它固定在顶部"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:740
 #: frontend/src/metabase/components/CollectionLanding.jsx:352
 #: frontend/src/metabase/home/containers/SearchApp.jsx:78
 msgid "Collections"
-msgstr "コレクション"
+msgstr "集合"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:431
 #: frontend/src/metabase/components/CollectionLanding.jsx:454
 msgid "Drag here to un-pin"
-msgstr "固定を外すにはドラッグしてください"
+msgstr "拖到这里取消固定"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:489
 msgid "{0} item selected"
 msgid_plural "{0} items selected"
-msgstr[0] "{0}アイテムが選択されました"
+msgstr[0] "已选择{0}项"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:519
 msgid "Move {0} items?"
-msgstr "{0}アイテムを移動しますか？"
+msgstr "移动{0}项？"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:520
 msgid "Move \"{0}\"?"
-msgstr "{0}を移動しますか？"
+msgstr "移动“{0}”？"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:627
 #: frontend/src/metabase/components/EntityMenu.info.js:29
@@ -2280,81 +2298,84 @@ msgstr "{0}を移動しますか？"
 #: frontend/src/metabase/containers/CollectionMoveModal.jsx:69
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:30
 msgid "Move"
-msgstr "移動する"
+msgstr "移动"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:691
 msgid "Edit this collection"
-msgstr "このコレクションを編集する"
+msgstr "修改集合"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:699
 msgid "Archive this collection"
-msgstr "このコレクションをアーカイブする"
+msgstr "归档集合"
 
 #: frontend/src/metabase/components/CollectionList.jsx:67
 #: frontend/src/metabase/entities/collections.js:158
 msgid "My personal collection"
-msgstr "個人のコレクション"
+msgstr "我的个人集合"
 
 #: frontend/src/metabase/components/CollectionList.jsx:107
 msgid "New collection"
-msgstr "新しいコレクション"
+msgstr "新建集合"
 
 #: frontend/src/metabase/components/CopyButton.jsx:35
 msgid "Copied!"
-msgstr "コピーされました"
+msgstr "已复制！"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:218
 msgid "Use an SSH-tunnel for database connections"
-msgstr "データベース接続にSSHトンネルを利用する"
+msgstr "为Metabse连接使用SSH通道"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:220
 msgid "Some database installations can only be accessed by connecting through an SSH bastion host.\n"
 "This option also provides an extra layer of security when a VPN is not available.\n"
 "Enabling this is usually slower than a direct connection."
-msgstr "一部のデータベースインストールは、SSHホストを介して接続することによってのみアクセスできます。VPNが利用できない場合、このオプションを使用することでセキュリティーレベルを高めることができます。この機能を有効にすると直接接続するよりも動作が遅くなりことがあります。"
+msgstr "一些数据库安装只有通过SSH通道访问的服务器有权访问。\n"
+"当VPN不可用时，这个选项也提供了一个额外的安全层。\n"
+"启用这个选项，通常比直接连接速度更慢。"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:294
 msgid "This is a large database, so let me choose when Metabase syncs and scans"
-msgstr "データベースが大きいため、Metabaseの同期とスキャンのタイミングを選択します"
+msgstr "这是一个大型数据库，让我选择Metabase同步和扫描的时间"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:296
 msgid "By default, Metabase does a lightweight hourly sync and an intensive daily scan of field values.\n"
 "If you have a large database, we recommend turning this on and reviewing when and how often the field value scans happen."
-msgstr "Metabaseはフィールド値に対し1時間毎のクイックスキャンと毎日のフルスキャンを行うようデフォルトで設定されています。データベースが大きい場合、この設定をオンにし、いつどのようにフィールド値のスキャンをするか確認することをお勧めします。"
+msgstr "默认情况下，Metabase每小时执行一次轻量级同步，每天执行一次密集扫描。\n"
+"如果您有一个大型数据库，我们建议启用此功能并查看字段值扫描的发生时间和频率。"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:335
 msgid "{0} to generate a Client ID and Client Secret for your project."
-msgstr "クライアントIDとクライアントシークレットを作成するには{0}してください"
+msgstr "{0}为您的项目生成客户端ID和客户端密钥。"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:337
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:364
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:400
 msgid "Click here"
-msgstr "こちらをクリックしてください"
+msgstr "点击这里"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:340
 msgid "Choose \"Other\" as the application type. Name it whatever you'd like."
-msgstr "アプリケーションタイプは「その他」を選択してください。名前は自由に付けられます。"
+msgstr "选择“其他”作为应用程序类型。把它命名为你想要的任何东西。"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:362
 msgid "{0} to get an auth code"
-msgstr "認証コードを取得するため{0}"
+msgstr "{0}获取身份验证代码"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:374
 msgid "with Google Drive permissions"
-msgstr "Googleドライブ権限で"
+msgstr "使用Google Driver权限"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:395
 msgid "To use Metabase with this data you must enable API access in the Google Developers Console."
-msgstr "このデータでMetabaseを利用するには、Google Developers ConsoleのAPIアクセスを有効化する必要があります"
+msgstr "要将Metabase用于此数据，您必须在Google Developers Console中启用API访问权限。"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:398
 msgid "{0} to go to the console if you haven't already done so."
-msgstr "有効化していない場合は、Consoleで{0}してください"
+msgstr "如果您还没有这样做，请转到控制台{0}。"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:447
 msgid "How would you like to refer to this database?"
-msgstr "どのようにこのデータベースを参照しますか？"
+msgstr "您想如何使用这个数据库？"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:479
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
@@ -2364,148 +2385,148 @@ msgstr "どのようにこのデータベースを参照しますか？"
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:110
 #: frontend/src/metabase/setup/components/UserStep.jsx:308
 msgid "Next"
-msgstr "次へ"
+msgstr "下一步"
 
 #: frontend/src/metabase/components/ArchivedItem.jsx:51
 #: frontend/src/metabase/components/DeleteModalWithConfirm.jsx:80
 msgid "Delete this {0}"
-msgstr "この{0}を削除する"
+msgstr "删除这个{0}"
 
 #: frontend/src/metabase/components/EntityItem.jsx:45
 msgid "Pin this item"
-msgstr "このアイテムを固定する"
+msgstr "标记这个项目"
 
 #: frontend/src/metabase/components/EntityItem.jsx:51
 msgid "Move this item"
-msgstr "このアイテムを移動する"
+msgstr "移动这个项目"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:24
 #: frontend/src/metabase/components/EntityMenu.info.js:80
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:15
 msgid "Edit this question"
-msgstr "この質問を編集する"
+msgstr "编辑这个提问"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:26
 #: frontend/src/metabase/components/EntityMenu.info.js:47
 #: frontend/src/metabase/components/EntityMenu.info.js:82
 #: frontend/src/metabase/components/EntityMenu.info.js:99
 msgid "Action type"
-msgstr "アクションタイプ"
+msgstr "行为的类型"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:28
 #: frontend/src/metabase/components/EntityMenu.info.js:84
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:20
 msgid "View revision history"
-msgstr "履歴を見る"
+msgstr "查看修订历史"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:29
 #: frontend/src/metabase/components/EntityMenu.info.js:85
 msgid "Move action"
-msgstr "アクションを移動する"
+msgstr "移动行为"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:33
 #: frontend/src/metabase/components/EntityMenu.info.js:89
 msgid "Archive action"
-msgstr "アクションをアーカイブする"
+msgstr "档案行为"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:45
 #: frontend/src/metabase/components/EntityMenu.info.js:97
 #: frontend/src/metabase/query_builder/components/view/QuestionEntityMenu.jsx:25
 msgid "Add to dashboard"
-msgstr "ダッシュボードに追加する"
+msgstr "添加到仪表盘"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:49
 #: frontend/src/metabase/components/EntityMenu.info.js:101
 msgid "Download results"
-msgstr "結果をダウンロードする"
+msgstr "下载结果"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:51
 #: frontend/src/metabase/components/EntityMenu.info.js:103
 #: frontend/src/metabase/public/components/widgets/EmbedWidget.jsx:52
 msgid "Sharing and embedding"
-msgstr "共有と埋め込み"
+msgstr "分享并且编辑"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:53
 #: frontend/src/metabase/components/EntityMenu.info.js:105
 msgid "Another action type"
-msgstr "他のアクションタイプ"
+msgstr "另一个行为类型"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:65
 #: frontend/src/metabase/components/EntityMenu.info.js:67
 #: frontend/src/metabase/components/EntityMenu.info.js:113
 #: frontend/src/metabase/components/EntityMenu.info.js:115
 msgid "Get alerts about this"
-msgstr "これに関するアラートを受け取る"
+msgstr "获得关于这个的警报"
 
 #: frontend/src/metabase/components/EntityMenu.info.js:69
 #: frontend/src/metabase/components/EntityMenu.info.js:117
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:21
 msgid "View the SQL"
-msgstr "SQLを見る"
+msgstr "查看SQL语句"
 
 #: frontend/src/metabase/components/EntitySegments.jsx:18
 msgid "Segments for this"
-msgstr "このセグメント"
+msgstr "对于这个的划分"
 
 #: frontend/src/metabase/components/ErrorDetails.jsx:20
 msgid "Show error details"
-msgstr "エラー詳細を表示する"
+msgstr "显示错误详情"
 
 #: frontend/src/metabase/components/ErrorDetails.jsx:26
 msgid "Here's the full error message"
-msgstr "エラーメッセージ全文です"
+msgstr "这里是全部的错误信息"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:19
 msgid "Hi, Metabot here."
-msgstr "やあ、MetaBotです。"
+msgstr "你好，我是Meta机器人"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:94
 msgid "Based on the schema"
-msgstr "スキーマに基づく"
+msgstr "基于这个模式"
 
 #: frontend/src/metabase/components/ExplorePane.jsx:173
 msgid "A look at your"
-msgstr "見てみる"
+msgstr "看看您的"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:240
 msgid "Search the list"
-msgstr "一覧を検索する"
+msgstr "查找列表"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:244
 msgid "Search by {0}"
-msgstr "{0}で検索する"
+msgstr "用{0}搜索"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:246
 msgid " or enter an ID"
-msgstr "␣またはIDを入力する"
+msgstr "或者输入一个ID"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:250
 msgid "Enter an ID"
-msgstr "IDを入力する"
+msgstr "输入一个ID"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:252
 msgid "Enter a number"
-msgstr "番号を入力する"
+msgstr "输入一个数字"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:254
 msgid "Enter some text"
-msgstr "テキストを入力する"
+msgstr "输入一些文本"
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:366
 msgid "No matching {0} found."
-msgstr "一致する{0}が見つかりませんでした"
+msgstr "没有找到匹配的{0} "
 
 #: frontend/src/metabase/components/FieldValuesWidget.jsx:374
 msgid "Including every option in your filter probably won’t do much…"
-msgstr "フィルターに全てのオプションを含めてしまうと、効果的な結果が得られない場合があります"
+msgstr "包括每个选项在你的过滤器中很可能将不会起很大作用……"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:24
 msgid "Something's gone wrong"
-msgstr "問題が発生しました"
+msgstr "有些问题发生了"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:25
 msgid "We've run into an error. You can try refreshing the page, or just go back."
-msgstr "エラーが発生しました。このページを更新するか、前のページにお戻りください"
+msgstr "我们运行中出现了一个错误，你可以尝试刷新这个页面，或者直接返回"
 
 #: frontend/src/metabase/components/Header.jsx:97
 #: frontend/src/metabase/components/HeaderBar.jsx:45
@@ -2518,295 +2539,295 @@ msgstr "エラーが発生しました。このページを更新するか、前
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:212
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:212
 msgid "No description yet"
-msgstr "まだ説明がありません"
+msgstr "暂无描述"
 
 #: frontend/src/metabase/components/Header.jsx:112
 #: frontend/src/metabase/entities/containers/EntityForm.jsx:60
 msgid "New {0}"
-msgstr "新しい{0}"
+msgstr "新的"
 
 #: frontend/src/metabase/components/Header.jsx:123
 msgid "Asked by {0}"
-msgstr "{0}により質問された"
+msgstr "被{0}发起的提问"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:12
 msgid "Today, "
-msgstr "本日は、"
+msgstr "今天"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:14
 msgid "Yesterday, "
-msgstr "昨日は、"
+msgstr "昨天"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:29
 msgid "First revision."
-msgstr "最初の履歴"
+msgstr "第一次修订。"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:31
 msgid "Reverted to an earlier revision and {0}"
-msgstr "以前の履歴と{0}に戻しました"
+msgstr "回滚到一个更早的调整并且{0}"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:42
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:278
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:57
 msgid "Revision history"
-msgstr "履歴"
+msgstr "调整记录"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:46
 msgid "When"
-msgstr "いつ"
+msgstr "什么时候"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:47
 msgid "Who"
-msgstr "誰が"
+msgstr "谁"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:48
 msgid "What"
-msgstr "何を"
+msgstr "什么"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:67
 msgid "Revert"
-msgstr "元に戻す"
+msgstr "恢复"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:68
 msgid "Reverting…"
-msgstr "元に戻しています..."
+msgstr "恢复中……"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:69
 msgid "Revert failed"
-msgstr "元に戻すことができませんでした"
+msgstr "恢复失败"
 
 #: frontend/src/metabase/components/HistoryModal.jsx:70
 msgid "Reverted"
-msgstr "元に戻しました"
+msgstr "已恢复"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:13
 msgid "Everything"
-msgstr "全て"
+msgstr "所有的"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:18
 msgid "Dashboards"
-msgstr "ダッシュボード"
+msgstr "仪表盘"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:23
 msgid "Questions"
-msgstr "質問"
+msgstr "问题"
 
 #: frontend/src/metabase/components/ItemTypeFilterBar.jsx:28
 #: frontend/src/metabase/routes.jsx:323
 msgid "Pulses"
-msgstr "パルス"
+msgstr "定时任务"
 
 #: frontend/src/metabase/components/LeftNavPane.jsx:36
 #: frontend/src/metabase/query_builder/components/SidebarHeader.jsx:16
 msgid "Back"
-msgstr "戻る"
+msgstr "后退"
 
 #: frontend/src/metabase/components/ListSearchField.jsx:17
 msgid "Find..."
-msgstr "探す..."
+msgstr "查找……"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 msgid "An error occured"
-msgstr "エラーが発生しました"
+msgstr "发生了一个错误"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:35
 msgid "Loading..."
-msgstr "読込中..."
+msgstr "加载中……"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:71
 msgid "Metabase Newsletter"
-msgstr "Metabaseニュースレター"
+msgstr "Metabase新闻"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:81
 msgid "Get infrequent emails about new releases and feature updates."
-msgstr "新しいリリースやアップデートに関するメールの回数を減らす"
+msgstr "获取有关新版本和功能更新的电子邮件。"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:99
 msgid "Subscribe"
-msgstr "購読する"
+msgstr "订阅"
 
 #: frontend/src/metabase/components/NewsletterForm.jsx:106
 msgid "You're subscribed. Thanks for using Metabase!"
-msgstr "購読の登録がされました。Metabaseをご利用いただきありがとうございます！"
+msgstr "订阅成功。感谢您使用Metabase！"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:44
 msgid "We're a little lost..."
-msgstr "エラーが発生しました..."
+msgstr "我们有点失落......"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:27
 msgid "Temporary Password"
-msgstr "仮パスワード"
+msgstr "临时密码"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:411
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:426
 msgid "Hide"
-msgstr "非表示にする"
+msgstr "隐藏"
 
 #: frontend/src/metabase/components/PasswordReveal.jsx:68
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:412
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:427
 msgid "Show"
-msgstr "表示する"
+msgstr "显示"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:17
 msgid "Saved! Add this to a dashboard?"
-msgstr "保存しました！ダッシュボードに追加しますか？"
+msgstr "已保存！添加到仪表盘？"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:25
 msgid "Yes please!"
-msgstr "お願いします！"
+msgstr "好的，请吧！"
 
 #: frontend/src/metabase/components/QuestionSavedModal.jsx:29
 msgid "Not now"
-msgstr "今はしない"
+msgstr "先不用"
 
 #: frontend/src/metabase/components/SaveStatus.jsx:53
 msgid "Error:"
-msgstr "エラー:"
+msgstr "错误："
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:23
 msgid "Sunday"
-msgstr "日曜日"
+msgstr "星期日"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:24
 msgid "Monday"
-msgstr "月曜日"
+msgstr "星期一"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:25
 msgid "Tuesday"
-msgstr "火曜日"
+msgstr "星期二"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:26
 msgid "Wednesday"
-msgstr "水曜日"
+msgstr "星期三"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:27
 msgid "Thursday"
-msgstr "木曜日"
+msgstr "星期四"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:28
 msgid "Friday"
-msgstr "金曜日"
+msgstr "星期五"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:29
 msgid "Saturday"
-msgstr "土曜日"
+msgstr "星期六"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:33
 msgid "First"
-msgstr "最初"
+msgstr "第一个"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:34
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:23
 msgid "Last"
-msgstr "最後"
+msgstr "最后一个"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:35
 msgid "15th (Midpoint)"
-msgstr "15日（中日）"
+msgstr "第十五个（中位数）"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:125
 msgid "Calendar Day"
-msgstr "カレンダー日"
+msgstr "日历日"
 
 #: frontend/src/metabase/components/SchedulePicker.jsx:212
 msgid "your Metabase timezone"
-msgstr "Metabaseのタイムゾーン"
+msgstr "你的Metabase时区"
 
 #: frontend/src/metabase/components/SearchHeader.jsx:21
 msgid "Filter this list..."
-msgstr "この一覧にフィルターをかける..."
+msgstr "筛选这个列表……"
 
 #: frontend/src/metabase/components/Select.info.js:8
 msgid "Blue"
-msgstr "青"
+msgstr "蓝色"
 
 #: frontend/src/metabase/components/Select.info.js:9
 msgid "Green"
-msgstr "緑"
+msgstr "绿色"
 
 #: frontend/src/metabase/components/Select.info.js:10
 msgid "Red"
-msgstr "赤"
+msgstr "红色"
 
 #: frontend/src/metabase/components/Select.info.js:11
 msgid "Yellow"
-msgstr "黄"
+msgstr "黄色"
 
 #: frontend/src/metabase/components/Select.info.js:14
 msgid "A component used to make a selection"
-msgstr "選択に使用された要素"
+msgstr "一个用来做出选择的组件"
 
 #: frontend/src/metabase/components/Select.info.js:20
 #: frontend/src/metabase/components/Select.info.js:30
 msgid "Selected"
-msgstr "選択されました"
+msgstr "已选择"
 
 #: frontend/src/metabase/components/Select.jsx:299
 msgid "Nothing to select"
-msgstr "選択するものがありません"
+msgstr "暂无结果"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:54
 msgid "Sorry, you don’t have permission to see that."
-msgstr "申し訳ありません、閲覧権限がありません"
+msgstr "对不起，你没有权限看那些东西"
 
 #: frontend/src/metabase/components/form/FormMessage.jsx:5
 msgid "Unknown error encountered"
-msgstr "不明エラーが発生しました"
+msgstr "未知错误发生了"
 
 #: frontend/src/metabase/components/form/StandardForm.jsx:69
 #: frontend/src/metabase/nav/containers/Navbar.jsx:350
 msgid "Create"
-msgstr "作成する"
+msgstr "创建"
 
 #: frontend/src/metabase/containers/DashboardForm.jsx:9
 msgid "Create dashboard"
-msgstr "ダッシュボードを作成する"
+msgstr "创建仪表盘"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:35
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:57
 msgid "Table"
-msgstr "テーブル"
+msgstr "表格"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:42
 msgid "Database"
-msgstr "ダッシュボード"
+msgstr "数据库"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:49
 msgid "Creator"
-msgstr "作成者"
+msgstr "创造者"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:239
 msgid "No results found"
-msgstr "結果が見つかりませんでした"
+msgstr "未找到结果"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:240
 msgid "Try adjusting your filter to find what you’re looking for."
-msgstr "お探しのデータを見つけるためフィルターの調整をお試しください"
+msgstr "尝试调整过滤器以找到您要查找的内容。"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:259
 msgid "View by"
-msgstr "で見る"
+msgstr "查看方式"
 
 #: frontend/src/metabase/containers/EntitySearch.jsx:495
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:124
 msgid "of"
-msgstr "の"
+msgstr "的"
 
 #: frontend/src/metabase/containers/Overworld.jsx:75
 msgid "Don't tell anyone, but you're my favorite."
-msgstr "皆には内緒ですが、あなたは私のお気に入りです"
+msgstr "不要告诉任何人，但你是我的最爱。"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:85
 msgid "Once you connect your own data, I can show you some automatic explorations called x-rays. Here are some examples with sample data."
-msgstr "データを接続すると、X線と呼ばれる自動探査を表示できます。サンプルデータの例をいくつか表示します。"
+msgstr "一旦连接了自己的数据，我就可以向您展示一些称为透视的自动探索。以下是一些基于示例数据的例子。"
 
 #: frontend/src/metabase/containers/Overworld.jsx:128
 #: frontend/src/metabase/containers/Overworld.jsx:301
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:12
 msgid "Start here"
-msgstr "ここから開始する"
+msgstr "从这里开始"
 
 #: frontend/src/metabase/containers/Overworld.jsx:296
 #: frontend/src/metabase/entities/collections.js:150
@@ -2816,31 +2837,31 @@ msgstr "分析"
 
 #: frontend/src/metabase/containers/Overworld.jsx:203
 msgid "Browse all items"
-msgstr "全データをブラウズする"
+msgstr "浏览所有"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:167
 msgid "Replace or save as new?"
-msgstr "上書きしますか？新しいデータとして保存しますか？"
+msgstr "替换还是保存为新的？"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:175
 msgid "Replace original question, \"{0}\""
-msgstr "元の質問”{0}”を上書きする"
+msgstr "替换原始问题“{0}”"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:180
 msgid "Save as new question"
-msgstr "新しい質問として保存する"
+msgstr "保存为新问题"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:189
 msgid "First, save your question"
-msgstr "まずは、質問を保存してください"
+msgstr "首先，保存您的问题"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:190
 msgid "Save question"
-msgstr "質問を保存する"
+msgstr "保存问题"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:226
 msgid "What is the name of your card?"
-msgstr "カードの名前は？"
+msgstr "这个卡片叫什么名字？"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:31
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:18
@@ -2856,453 +2877,453 @@ msgstr "カードの名前は？"
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:210
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:25
 msgid "Description"
-msgstr "説明"
+msgstr "描述"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:240
 #: frontend/src/metabase/entities/dashboards.js:150
 msgid "It's optional but oh, so helpful"
-msgstr "任意ですが、入力しておくととても便利です"
+msgstr "这是可选的，但非常有帮助"
 
 #: frontend/src/metabase/containers/SaveQuestionModal.jsx:247
 #: frontend/src/metabase/entities/dashboards.js:154
 msgid "Which collection should this go in?"
-msgstr "これはどのコレクションに保存しますか？"
+msgstr "将这个放到哪个集合中？"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:34
 msgid "modified"
-msgstr "修正された"
+msgstr "已修改"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:34
 msgid "item"
-msgstr "アイテム"
+msgstr "项"
 
 #: frontend/src/metabase/containers/UndoListing.jsx:83
 msgid "Undo"
-msgstr "やり直す"
+msgstr "撤销"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:270
 msgid "Applying Question"
-msgstr "質問を適用中"
+msgstr "正在使用的图表"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:274
 msgid "That question isn't compatible"
-msgstr "この質問は互換性がありません"
+msgstr "那个问题不兼容"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:310
 msgid "Search for a question"
-msgstr "質問を検索する"
+msgstr "查找问题"
 
 #: frontend/src/metabase/dashboard/components/AddSeriesModal.jsx:339
 msgid "We're not sure if this question is compatible"
-msgstr "この質問の互換性が不明です"
+msgstr "我们不确定这个提问是否兼容"
 
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:43
 msgid "Archive Dashboard"
-msgstr "ダッシュボードをアーカイブする"
+msgstr "文档仪表盘"
 
 #: frontend/src/metabase/dashboard/components/DashCardParameterMapper.jsx:19
 msgid "Make sure to make a selection for each series, or the filter won't work on this card."
-msgstr "各シリーズを必ず選択してください。選択しない場合、このカードでフィルターは機能しません。"
+msgstr "确保为每个系列都做出了选择，不然筛选将不会在这个卡片上起作用"
 
 #: frontend/src/metabase/dashboard/components/Dashboard.jsx:291
 msgid "This dashboard is looking empty."
-msgstr "このダッシュボードは空です"
+msgstr "这个仪表盘看起来是空的"
 
 #: frontend/src/metabase/dashboard/components/Dashboard.jsx:292
 msgid "Add a question to start making it useful!"
-msgstr "質問を追加して使い易くしましょう！"
+msgstr "添加一个疑问来让它变得有用"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:38
 msgid "Daytime mode"
-msgstr "昼モード"
+msgstr "白天模式"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:38
 msgid "Nighttime mode"
-msgstr "夜モード"
+msgstr "夜晚模式"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:56
 msgid "Exit fullscreen"
-msgstr "フルスクリーンを解除する"
+msgstr "退出全屏"
 
 #: frontend/src/metabase/dashboard/components/DashboardActions.jsx:56
 msgid "Enter fullscreen"
-msgstr "フルスクリーン"
+msgstr "进入全屏"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:171
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:185
 msgid "Saving…"
-msgstr "保存中..."
+msgstr "保存中"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:206
 msgid "Add a question"
-msgstr "質問を追加する"
+msgstr "添加一个问题"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:209
 msgid "Add a question to this dashboard"
-msgstr "このダッシュボードに質問を追加する"
+msgstr "添加报表到仪表盘"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:238
 msgid "Add a filter"
-msgstr "フィルターを追加する"
+msgstr "添加筛选"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:244
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:80
 msgid "Parameters"
-msgstr "パラメーター"
+msgstr "参数"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:264
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:268
 msgid "Add a text box"
-msgstr "テキストボックスを追加する"
+msgstr "添加文本框"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:308
 msgid "Move dashboard"
-msgstr "ダッシュボードを移動する"
+msgstr "移动仪表盘"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:291
 msgid "Edit dashboard"
-msgstr "ダッシュボードを編集する"
+msgstr "编辑仪表盘"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:295
 msgid "Edit Dashboard Layout"
-msgstr "ダッシュボードのレイアウトを編集する"
+msgstr "编辑仪表盘展示"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:358
 msgid "You are editing a dashboard"
-msgstr "ダッシュボード編集中"
+msgstr "正在编辑仪表盘"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:363
 msgid "Select the field that should be filtered for each card"
-msgstr "各カードにフィルタリングするフィールドを選択する"
+msgstr "选择应该在每个卡片中都应该被过滤的字段"
 
 #: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:31
 msgid "Move dashboard to..."
-msgstr "ダッシュボードを移動する..."
+msgstr "移动仪表盘到……"
 
 #: frontend/src/metabase/dashboard/components/DashboardMoveModal.jsx:55
 msgid "Dashboard moved to {0}"
-msgstr "{0}にダッシュボードを移動しました"
+msgstr "仪表盘移动到{0}"
 
 #: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:82
 msgid "What do you want to filter?"
-msgstr "何をフィルターしますか？"
+msgstr "你想要筛选什么"
 
 #: frontend/src/metabase/dashboard/components/ParametersPopover.jsx:115
 msgid "What kind of filter?"
-msgstr "どのようなフィルター？"
+msgstr "什么类型的筛选"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:13
 #: frontend/src/metabase/visualizations/lib/settings/column.js:231
 #: frontend/src/metabase/visualizations/lib/settings/series.js:90
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:247
 msgid "Off"
-msgstr "オフ"
+msgstr "关闭"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:14
 msgid "1 minute"
-msgstr "1分"
+msgstr "1分钟"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:15
 msgid "5 minutes"
-msgstr "5分"
+msgstr "5分钟"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:16
 msgid "10 minutes"
-msgstr "10分"
+msgstr "10分钟"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:17
 msgid "15 minutes"
-msgstr "15分"
+msgstr "15分钟"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:18
 msgid "30 minutes"
-msgstr "30分"
+msgstr "30分钟"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:19
 msgid "60 minutes"
-msgstr "60分"
+msgstr "60分钟"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:31
 msgid "Auto-refresh"
-msgstr "自動更新"
+msgstr "自动刷新"
 
 #: frontend/src/metabase/dashboard/components/RefreshWidget.jsx:37
 msgid "Refreshing in"
-msgstr "更新間隔"
+msgstr "刷新于"
 
 #: frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx:36
 msgid "Remove this question?"
-msgstr "この質問を削除しますか？"
+msgstr "移除这个疑问？"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:74
 msgid "Your dashboard was saved"
-msgstr "ダッシュボードが保存されました"
+msgstr "你的仪表盘已经保存"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:744
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:79
 msgid "See it"
-msgstr "見る"
+msgstr "查看它"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:141
 msgid "Save this"
-msgstr "保存する"
+msgstr "把这个保存"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:173
 msgid "Show more about this"
-msgstr "詳細を表示する"
+msgstr "展示更多"
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:143
 msgid "This card doesn't have any fields or parameters that can be mapped to this parameter type."
-msgstr "このパラメータータイプにマップできるフィールドやパラメーターがこのカードにはありません。"
+msgstr "此卡没有可以映射到此参数类型的任何字段或参数。"
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:145
 msgid "The values in this field don't overlap with the values of any other fields you've chosen."
-msgstr "このフィールドの値は、選択した他のフィールドの値と重複しません。"
+msgstr "此字段中的值不会与您选择的任何其他字段的值重叠。"
 
 #: frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx:185
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:37
 msgid "No valid fields"
-msgstr "有効なフィールドがありません"
+msgstr "无可用字段"
 
 #: frontend/src/metabase/entities/collections.js:98
 msgid "Name must be 100 characters or less"
-msgstr "名前は100文字以下で入力してください"
+msgstr "名称不能超过100个字符"
 
 #: frontend/src/metabase/entities/collections.js:112
 msgid "Color is required"
-msgstr "色が必要です"
+msgstr "颜色是必需的"
 
 #: frontend/src/metabase/entities/dashboards.js:143
 msgid "What is the name of your dashboard?"
-msgstr "このダッシュボードの名前は？"
+msgstr "你的仪表盘叫什么名字？"
 
 #: frontend/src/metabase/home/components/Activity.jsx:94
 msgid "did some super awesome stuff that's hard to describe"
-msgstr "表現できないぐらい最高なことをやろう"
+msgstr "是否有一些超棒的东西很难描述"
 
 #: frontend/src/metabase/home/components/Activity.jsx:103
 #: frontend/src/metabase/home/components/Activity.jsx:118
 msgid "created an alert about - "
-msgstr "␣に関するアラートを作成しました"
+msgstr "创建一个关于……警报"
 
 #: frontend/src/metabase/home/components/Activity.jsx:128
 #: frontend/src/metabase/home/components/Activity.jsx:143
 msgid "deleted an alert about - "
-msgstr "␣に関するアラートを削除しました"
+msgstr "删除一个关于……的警报"
 
 #: frontend/src/metabase/home/components/Activity.jsx:154
 msgid "saved a question about "
-msgstr "␣に関する質問を保存しました"
+msgstr "保存一个关于……的疑问"
 
 #: frontend/src/metabase/home/components/Activity.jsx:167
 msgid "saved a question"
-msgstr "質問を保存しました"
+msgstr "存储一个疑问"
 
 #: frontend/src/metabase/home/components/Activity.jsx:171
 msgid "deleted a question"
-msgstr "質問を削除しました"
+msgstr "删除一个疑问"
 
 #: frontend/src/metabase/home/components/Activity.jsx:174
 msgid "created a dashboard"
-msgstr "ダッシュボードを作成しました"
+msgstr "创建一个仪表盘"
 
 #: frontend/src/metabase/home/components/Activity.jsx:177
 msgid "deleted a dashboard"
-msgstr "ダッシュボードを削除しました"
+msgstr "删除一个仪表盘"
 
 #: frontend/src/metabase/home/components/Activity.jsx:183
 #: frontend/src/metabase/home/components/Activity.jsx:198
 msgid "added a question to the dashboard - "
-msgstr "ダッシュボードに質問を追加しました"
+msgstr "添加一个疑问到仪表盘"
 
 #: frontend/src/metabase/home/components/Activity.jsx:208
 #: frontend/src/metabase/home/components/Activity.jsx:223
 msgid "removed a question from the dashboard - "
-msgstr "ダッシュボードから質問を削除しました"
+msgstr "从仪表盘中移除一个问题"
 
 #: frontend/src/metabase/home/components/Activity.jsx:233
 #: frontend/src/metabase/home/components/Activity.jsx:240
 msgid "received the latest data from"
-msgstr "から最新のデータを受信しました"
+msgstr "接收最新的数据来自"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:814
 #: frontend/src/metabase/home/components/Activity.jsx:246
 #: frontend/src/metabase/lib/query_time.js:180
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:325
 msgid "Unknown"
-msgstr "不明"
+msgstr "未知"
 
 #: frontend/src/metabase/home/components/Activity.jsx:253
 msgid "Hello World!"
-msgstr "こんにちは世界！"
+msgstr "Hello World!"
 
 #: frontend/src/metabase/home/components/Activity.jsx:254
 msgid "Metabase is up and running."
-msgstr "Metabaseを起動しています。"
+msgstr "Metabase正在运行"
 
 #: frontend/src/metabase/home/components/Activity.jsx:260
 #: frontend/src/metabase/home/components/Activity.jsx:290
 msgid "added the metric "
-msgstr "メトリクスを追加しました"
+msgstr "添加指标"
 
 #: frontend/src/metabase/home/components/Activity.jsx:274
 #: frontend/src/metabase/home/components/Activity.jsx:364
 msgid " to the "
-msgstr "に"
+msgstr "到"
 
 #: frontend/src/metabase/home/components/Activity.jsx:284
 #: frontend/src/metabase/home/components/Activity.jsx:324
 #: frontend/src/metabase/home/components/Activity.jsx:374
 #: frontend/src/metabase/home/components/Activity.jsx:415
 msgid " table"
-msgstr "␣テーブル"
+msgstr "表单"
 
 #: frontend/src/metabase/home/components/Activity.jsx:300
 #: frontend/src/metabase/home/components/Activity.jsx:330
 msgid "made changes to the metric "
-msgstr "メトリクスが変更されました"
+msgstr "指标已经被修改"
 
 #: frontend/src/metabase/home/components/Activity.jsx:314
 #: frontend/src/metabase/home/components/Activity.jsx:405
 msgid " in the "
-msgstr "の中"
+msgstr "在……里面"
 
 #: frontend/src/metabase/home/components/Activity.jsx:337
 msgid "removed the metric "
-msgstr "メトリクスを削除しました"
+msgstr "移除指标"
 
 #: frontend/src/metabase/home/components/Activity.jsx:340
 msgid "created a pulse"
-msgstr "パルスを作成しました"
+msgstr "创建定时通知"
 
 #: frontend/src/metabase/home/components/Activity.jsx:343
 msgid "deleted a pulse"
-msgstr "パルスを削除しました"
+msgstr "删除定时通知"
 
 #: frontend/src/metabase/home/components/Activity.jsx:349
 #: frontend/src/metabase/home/components/Activity.jsx:380
 msgid "added the filter"
-msgstr "フィルターを追加しました"
+msgstr "添加筛选"
 
 #: frontend/src/metabase/home/components/Activity.jsx:390
 #: frontend/src/metabase/home/components/Activity.jsx:421
 msgid "made changes to the filter"
-msgstr "フィルターが変更されました"
+msgstr "修改筛选"
 
 #: frontend/src/metabase/home/components/Activity.jsx:428
 msgid "removed the filter {0}"
-msgstr "フィルター{0}を削除しました"
+msgstr "移除筛选"
 
 #: frontend/src/metabase/home/components/Activity.jsx:431
 msgid "joined!"
-msgstr "参加しました！"
+msgstr "已加入！"
 
 #: frontend/src/metabase/home/components/Activity.jsx:531
 msgid "Hmmm, looks like nothing has happened yet."
-msgstr "何も起こりませんでした"
+msgstr "嗯……无事发生"
 
 #: frontend/src/metabase/home/components/Activity.jsx:534
 msgid "Save a question and get this baby going!"
-msgstr "質問を保存して次に進みましょう！"
+msgstr "存储一个问题并让它运行"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:19
 msgid "Ask questions and explore"
-msgstr "質問して調査する"
+msgstr "提问并探索"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:20
 msgid "Click on charts or tables to explore, or ask a new question using the easy interface or the powerful SQL editor."
-msgstr "チャートまたはテーブルをクリックして探索したり、簡単なインターフェースやSQLエディターを使用して新たに質問する"
+msgstr "点击图表进一步探索，或者通过简单界面或者SQL编辑器创建新的图表。"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:30
 msgid "Make your own charts"
-msgstr "自分でチャートを作成する"
+msgstr "创建自己的图表"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:31
 msgid "Create line charts, scatter plots, maps, and more."
-msgstr "棒グラフ、散布図、マップ等を作成する"
+msgstr "创建折线图、散点图、地图热力图等"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:41
 msgid "Share what you find"
-msgstr "結果を共有する"
+msgstr "分享你的发现"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:42
 msgid "Create powerful and flexible dashboards, and send regular updates via email or Slack."
-msgstr "強力かつ柔軟なダッシュボードを作って、更新情報をメールもしくはSlackで受け取りましょう"
+msgstr "创建功能强大且灵活的仪表板，并通过电子邮件或Slack定期发送更新。"
 
 #: frontend/src/metabase/home/components/NewUserOnboardingModal.jsx:97
 msgid "Let's go"
-msgstr "始めましょう"
+msgstr "开始吧"
 
 #: frontend/src/metabase/home/components/NextStep.jsx:34
 msgid "Setup Tip"
-msgstr "設定のヒント"
+msgstr "添加提示"
 
 #: frontend/src/metabase/home/components/NextStep.jsx:40
 msgid "View all"
-msgstr "全て見る"
+msgstr "查看全部"
 
 #: frontend/src/metabase/home/components/RecentViews.jsx:40
 msgid "Recently Viewed"
-msgstr "最近見たデータ"
+msgstr "最近查看"
 
 #: frontend/src/metabase/home/components/RecentViews.jsx:75
 msgid "You haven't looked at any dashboards or questions recently"
-msgstr "最近ダッシュボードや質問を見ていないようです"
+msgstr "最近没有查看的仪表盘或者图表"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:102
 msgid "{0} items selected"
-msgstr "{0}アイテムが選択されました"
+msgstr "{0}项已选择"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:124
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:174
 msgid "Unarchive"
-msgstr "アーカイブを取り消す"
+msgstr "取消归档"
 
 #: frontend/src/metabase/home/containers/HomepageApp.jsx:77
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:58
 msgid "Activity"
-msgstr "アクティビティ"
+msgstr "活动"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:30
 msgid "Results for \"{0}\""
-msgstr "{0}の結果"
+msgstr "{0}的结果"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:138
 msgid "Pulse"
-msgstr "パルス"
+msgstr "定时任务"
 
 #: frontend/src/metabase/lib/core.js:7
 msgid "Entity Key"
-msgstr "エンティティキー"
+msgstr "实体键"
 
 #: frontend/src/metabase/lib/core.js:8 frontend/src/metabase/lib/core.js:14
 #: frontend/src/metabase/lib/core.js:20
 msgid "Overall Row"
-msgstr "行全体"
+msgstr "总行"
 
 #: frontend/src/metabase/lib/core.js:9
 msgid "The primary key for this table."
-msgstr "プライマリーキー"
+msgstr "表格主键"
 
 #: frontend/src/metabase/lib/core.js:13
 msgid "Entity Name"
-msgstr "エンティティ名"
+msgstr "实体名称"
 
 #: frontend/src/metabase/lib/core.js:15
 msgid "The \"name\" of each record. Usually a column called \"name\", \"title\", etc."
-msgstr "各レコードの名前、通常は「名前」「タイトル」等の列"
+msgstr "每条记录的“名字”。通常，列名为：“名称”、“题目”等等"
 
 #: frontend/src/metabase/lib/core.js:19
 msgid "Foreign Key"
-msgstr "外部キー"
+msgstr "外键"
 
 #: frontend/src/metabase/lib/core.js:21
 msgid "Points to another table to make a connection."
-msgstr "接続する別のテーブルを提示する"
+msgstr "选择另外一个表格做连接。"
 
 #: frontend/src/metabase/lib/core.js:25
 msgid "Avatar Image URL"
-msgstr "アバターイメージURL"
+msgstr "头像图片URL链接"
 
 #: frontend/src/metabase/lib/core.js:26 frontend/src/metabase/lib/core.js:31
 #: frontend/src/metabase/lib/core.js:36 frontend/src/metabase/lib/core.js:41
@@ -3326,51 +3347,51 @@ msgstr "アバターイメージURL"
 #: frontend/src/metabase/lib/core.js:216 frontend/src/metabase/lib/core.js:221
 #: frontend/src/metabase/lib/core.js:226 frontend/src/metabase/lib/core.js:231
 msgid "Common"
-msgstr "一般"
+msgstr "共同"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:134
 #: frontend/src/metabase/lib/core.js:30
 #: frontend/src/metabase/meta/Dashboard.js:81
 #: frontend/src/metabase/modes/components/actions/PivotByCategoryAction.jsx:9
 msgid "Category"
-msgstr "カテゴリー"
+msgstr "分类"
 
 #: frontend/src/metabase/lib/core.js:35
 #: frontend/src/metabase/meta/Dashboard.js:61
 msgid "City"
-msgstr "都市"
+msgstr "城市"
 
 #: frontend/src/metabase/lib/core.js:40
 #: frontend/src/metabase/meta/Dashboard.js:73
 msgid "Country"
-msgstr "国"
+msgstr "国家"
 
 #: frontend/src/metabase/lib/core.js:60
 msgid "Enum"
-msgstr "列挙型"
+msgstr "枚举"
 
 #: frontend/src/metabase/lib/core.js:65
 msgid "Image URL"
-msgstr "イメージURL"
+msgstr "图片链接"
 
 #: frontend/src/metabase/lib/core.js:70
 msgid "Field containing JSON"
-msgstr "JSONを含むフィールド"
+msgstr "包含JSON的字段"
 
 #: frontend/src/metabase/lib/core.js:75
 msgid "Latitude"
-msgstr "緯度"
+msgstr "纬度"
 
 #: frontend/src/metabase/lib/core.js:80
 msgid "Longitude"
-msgstr "経度"
+msgstr "经度"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:138
 #: frontend/src/metabase/lib/core.js:85
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:152
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:41
 msgid "Number"
-msgstr "数値"
+msgstr "数字"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:19
 #: frontend/src/metabase/lib/core.js:90
@@ -3380,145 +3401,145 @@ msgstr "州"
 
 #: frontend/src/metabase/lib/core.js:95
 msgid "UNIX Timestamp (Seconds)"
-msgstr "UNIX時刻（秒）"
+msgstr "UNIX时间戳（秒）"
 
 #: frontend/src/metabase/lib/core.js:100
 msgid "UNIX Timestamp (Milliseconds)"
-msgstr "UNIX時刻（ミリ秒）"
+msgstr "UNIX时间戳（毫秒）"
 
 #: frontend/src/metabase/lib/core.js:110
 msgid "Zip Code"
-msgstr "郵便番号"
+msgstr "邮编"
 
 #: frontend/src/metabase/lib/core.js:115
 msgid "Quantity"
-msgstr "量"
+msgstr "数量"
 
 #: frontend/src/metabase/lib/core.js:120
 msgid "Income"
-msgstr "収益"
+msgstr "收入"
 
 #: frontend/src/metabase/lib/core.js:125
 msgid "Discount"
-msgstr "割引"
+msgstr "折扣"
 
 #: frontend/src/metabase/lib/core.js:130
 msgid "Creation timestamp"
-msgstr "タイムスタンプ作成"
+msgstr "创建时间戳"
 
 #: frontend/src/metabase/lib/core.js:135
 msgid "Creation time"
-msgstr "作成時間"
+msgstr "创建时间"
 
 #: frontend/src/metabase/lib/core.js:140
 msgid "Creation date"
-msgstr "作成日"
+msgstr "创建日期"
 
 #: frontend/src/metabase/lib/core.js:145
 msgid "Product"
-msgstr "商品"
+msgstr "产品"
 
 #: frontend/src/metabase/lib/core.js:150
 msgid "User"
-msgstr "ユーザー"
+msgstr "用户"
 
 #: frontend/src/metabase/lib/core.js:155
 msgid "Source"
-msgstr "ソース"
+msgstr "来源"
 
 #: frontend/src/metabase/lib/core.js:160
 msgid "Price"
-msgstr "料金"
+msgstr "价格"
 
 #: frontend/src/metabase/lib/core.js:165
 msgid "Join timestamp"
-msgstr "タイムスタンプ参加"
+msgstr "关联时间戳"
 
 #: frontend/src/metabase/lib/core.js:170
 msgid "Join time"
-msgstr "参加時間"
+msgstr "关联时间"
 
 #: frontend/src/metabase/lib/core.js:175
 msgid "Join date"
-msgstr "登録日"
+msgstr "关联日期"
 
 #: frontend/src/metabase/lib/core.js:180
 msgid "Share"
-msgstr "共有する"
+msgstr "分享"
 
 #: frontend/src/metabase/lib/core.js:185
 msgid "Owner"
-msgstr "オーナー"
+msgstr "拥有者"
 
 #: frontend/src/metabase/lib/core.js:190
 msgid "Company"
-msgstr "会社"
+msgstr "公司"
 
 #: frontend/src/metabase/lib/core.js:195
 msgid "Subscription"
-msgstr "購読"
+msgstr "订阅"
 
 #: frontend/src/metabase/lib/core.js:200
 msgid "Score"
-msgstr "スコア"
+msgstr "分数"
 
 #: frontend/src/metabase/lib/core.js:210
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:49
 #: frontend/src/metabase/visualizations/lib/settings/visualization.js:18
 msgid "Title"
-msgstr "タイトル"
+msgstr "标题"
 
 #: frontend/src/metabase/lib/core.js:215
 msgid "Comment"
-msgstr "コメント"
+msgstr "评论"
 
 #: frontend/src/metabase/lib/core.js:220
 msgid "Cost"
-msgstr "コスト"
+msgstr "花费"
 
 #: frontend/src/metabase/lib/core.js:225
 msgid "Gross margin"
-msgstr "売上総利益"
+msgstr "毛利"
 
 #: frontend/src/metabase/lib/core.js:230
 msgid "Birthday"
-msgstr "生年月日"
+msgstr "生日"
 
 #: frontend/src/metabase/lib/core.js:241
 msgid "Search box"
-msgstr "検索ボックス"
+msgstr "搜索框"
 
 #: frontend/src/metabase/lib/core.js:242
 msgid "A list of all values"
-msgstr "全値の一覧"
+msgstr "一个所有值的列表"
 
 #: frontend/src/metabase/lib/core.js:243
 msgid "Plain input box"
-msgstr "入力ボックス"
+msgstr "文本框"
 
 #: frontend/src/metabase/lib/core.js:249
 msgid "Everywhere"
-msgstr "どこでも"
+msgstr "所有地方"
 
 #: frontend/src/metabase/lib/core.js:250
 msgid "The default setting. This field will be displayed normally in tables and charts."
-msgstr "デフォルト設定。このフィールドは通常テーブルやチャートに表示されます。"
+msgstr "默认设置。这个字段通常将会被展示在表单中和图表中。"
 
 #: frontend/src/metabase/lib/core.js:254
 msgid "Only in Detail Views"
-msgstr "詳細表示のみ"
+msgstr "只在细节视图中"
 
 #: frontend/src/metabase/lib/core.js:255
 msgid "This field will only be displayed when viewing the details of a single record. Use this for information that's lengthy or that isn't useful in a table or chart."
-msgstr "このフィールドは、単一のレコードの詳細を閲覧する場合にのみ表示されます。 処理に時間のかかる情報や、テーブルやチャート内では利用できない情報に使用してください。"
+msgstr "仅在查看单个记录的详细信息时才会显示此字段。将此用于冗长或在表格、图表中无用的信息。"
 
 #: frontend/src/metabase/lib/core.js:259
 msgid "Do Not Include"
-msgstr "含まない"
+msgstr "不要包括"
 
 #: frontend/src/metabase/lib/core.js:260
 msgid "Metabase will never retrieve this field. Use this for sensitive or irrelevant information."
-msgstr "Metabaseはこのフィールドを取得しなくなります。取得するとセキュリティ上問題があったり、無関係なフィールドに使いましょう"
+msgstr "Metabase永远不会获取此字段。将此用于敏感或不相关的信息。"
 
 #: frontend/src/metabase/lib/expressions/config.js:7
 #: frontend/src/metabase/lib/query.js:300
@@ -3530,30 +3551,30 @@ msgstr "Metabaseはこのフィールドを取得しなくなります。取得�
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Count"
-msgstr "カウント"
+msgstr "计数"
 
 #: frontend/src/metabase/lib/expressions/config.js:8
 msgid "CumulativeCount"
-msgstr "累積カウント"
+msgstr "累积计数"
 
 #: frontend/src/metabase/lib/expressions/config.js:9
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:17
 #: frontend/src/metabase/visualizations/lib/utils.js:131
 msgid "Sum"
-msgstr "合計"
+msgstr "求和"
 
 #: frontend/src/metabase/lib/expressions/config.js:10
 msgid "CumulativeSum"
-msgstr "累積和"
+msgstr "累积求和"
 
 #: frontend/src/metabase/lib/expressions/config.js:11
 #: frontend/src/metabase/visualizations/lib/utils.js:132
 msgid "Distinct"
-msgstr "ディスティンクト"
+msgstr "不重复"
 
 #: frontend/src/metabase/lib/expressions/config.js:12
 msgid "StandardDeviation"
-msgstr "標準偏差"
+msgstr "标准差"
 
 #: frontend/src/metabase/lib/expressions/config.js:13
 #: frontend/src/metabase/visualizations/lib/utils.js:129
@@ -3565,18 +3586,18 @@ msgstr "平均"
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:48
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:440
 msgid "Min"
-msgstr "最低"
+msgstr "最小"
 
 #: frontend/src/metabase/lib/expressions/config.js:15
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:29
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:57
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:448
 msgid "Max"
-msgstr "最高"
+msgstr "最大"
 
 #: frontend/src/metabase/lib/expressions/parser.js:386
 msgid "sad sad panda, lexing errors detected"
-msgstr "字句エラーが検出されました"
+msgstr "哎呀，出错了"
 
 #: frontend/src/metabase/lib/formatting.js:787
 msgid "{0} second"
@@ -3586,118 +3607,118 @@ msgstr[0] "{0}秒"
 #: frontend/src/metabase/lib/formatting.js:790
 msgid "{0} minute"
 msgid_plural "{0} minutes"
-msgstr[0] "{0}分"
+msgstr[0] "{0}分钟"
 
 #: frontend/src/metabase/lib/greeting.js:4
 msgid "Hey there"
-msgstr "ようこそ！"
+msgstr "你好"
 
 #: frontend/src/metabase/lib/greeting.js:5
 #: frontend/src/metabase/lib/greeting.js:29
 msgid "How's it going"
-msgstr "調子はどう？"
+msgstr "它工作的怎么样"
 
 #: frontend/src/metabase/lib/greeting.js:6
 msgid "Howdy"
-msgstr "よお"
+msgstr "你好"
 
 #: frontend/src/metabase/lib/greeting.js:7
 msgid "Greetings"
-msgstr "こんにちは"
+msgstr "问候"
 
 #: frontend/src/metabase/lib/greeting.js:8
 msgid "Good to see you"
-msgstr "ようこそ！"
+msgstr "见到你真好"
 
 #: frontend/src/metabase/lib/greeting.js:12
 msgid "What do you want to know?"
-msgstr "何を知りたいですか？"
+msgstr "你想知道什么？"
 
 #: frontend/src/metabase/lib/greeting.js:13
 msgid "What's on your mind?"
-msgstr "何を知りたいですか？"
+msgstr "你在想什么？"
 
 #: frontend/src/metabase/lib/greeting.js:14
 msgid "What do you want to find out?"
-msgstr "何を調べますか？"
+msgstr "你想找出什么？"
 
 #: frontend/src/metabase/lib/query.js:298
 #: frontend/src/metabase/lib/schema_metadata.js:458
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:254
 msgid "Raw data"
-msgstr "ローデータ"
+msgstr "原始数据"
 
 #: frontend/src/metabase/lib/query.js:302
 msgid "Cumulative count"
-msgstr "累積カウント"
+msgstr "累积计数"
 
 #: frontend/src/metabase/lib/query.js:305
 msgid "Average of "
-msgstr "の平均"
+msgstr "平均"
 
 #: frontend/src/metabase/lib/query.js:310
 msgid "Distinct values of "
-msgstr "␣の重複を除いた値"
+msgstr "去重值"
 
 #: frontend/src/metabase/lib/query.js:315
 msgid "Standard deviation of "
-msgstr "の標準偏差"
+msgstr "标准差"
 
 #: frontend/src/metabase/lib/query.js:320
 msgid "Sum of "
-msgstr "の合計"
+msgstr "总计"
 
 #: frontend/src/metabase/lib/query.js:325
 msgid "Cumulative sum of "
-msgstr "の累積和"
+msgstr "累积和"
 
 #: frontend/src/metabase/lib/query.js:330
 msgid "Maximum of "
-msgstr "の最高"
+msgstr "最大"
 
 #: frontend/src/metabase/lib/query.js:335
 msgid "Minimum of "
-msgstr "の最低"
+msgstr "最小"
 
 #: frontend/src/metabase/lib/query.js:349
 msgid "Grouped by "
-msgstr "グループ化された"
+msgstr "以……聚合"
 
 #: frontend/src/metabase/lib/query.js:363
 msgid "Filtered by "
-msgstr "フィルターされた"
+msgstr "以……筛选"
 
 #: frontend/src/metabase/lib/query.js:392
 msgid "Sorted by "
-msgstr "ソートされた"
+msgstr "以……分类"
 
 #: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "True"
-msgstr "正"
+msgstr "真"
 
 #: frontend/src/metabase/lib/schema_metadata.js:227
 msgid "False"
-msgstr "誤"
+msgstr "假"
 
 #: frontend/src/metabase/lib/schema_metadata.js:311
 msgid "Select longitude field"
-msgstr "経度フィールドを選択する"
+msgstr "选择经度字段"
 
 #: frontend/src/metabase/lib/schema_metadata.js:312
 msgid "Enter upper latitude"
-msgstr "もっと上の緯度を入力する"
+msgstr "输入纬度上边届"
 
 #: frontend/src/metabase/lib/schema_metadata.js:313
 msgid "Enter left longitude"
-msgstr "もっと左の経度を入力する"
+msgstr "输入经度左边界"
 
 #: frontend/src/metabase/lib/schema_metadata.js:314
 msgid "Enter lower latitude"
-msgstr "もっと下の緯度を入力する"
+msgstr "输入纬度下边界"
 
 #: frontend/src/metabase/lib/schema_metadata.js:315
 msgid "Enter right longitude"
-msgstr "もっと右の経度を入力する"
+msgstr "输入经度右边界"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:505
 #: frontend/src/metabase-lib/lib/Dimension.js:507
@@ -3709,7 +3730,7 @@ msgstr "もっと右の経度を入力する"
 #: frontend/src/metabase/lib/schema_metadata.js:401
 #: frontend/src/metabase/lib/schema_metadata.js:406
 msgid "Is"
-msgstr "である"
+msgstr "是"
 
 #: frontend/src/metabase/lib/schema_metadata.js:352
 #: frontend/src/metabase/lib/schema_metadata.js:372
@@ -3717,7 +3738,7 @@ msgstr "である"
 #: frontend/src/metabase/lib/schema_metadata.js:396
 #: frontend/src/metabase/lib/schema_metadata.js:402
 msgid "Is not"
-msgstr "ではない"
+msgstr "不是"
 
 #: frontend/src/metabase/lib/schema_metadata.js:353
 #: frontend/src/metabase/lib/schema_metadata.js:367
@@ -3727,7 +3748,7 @@ msgstr "ではない"
 #: frontend/src/metabase/lib/schema_metadata.js:397
 #: frontend/src/metabase/lib/schema_metadata.js:407
 msgid "Is empty"
-msgstr "空"
+msgstr "为空"
 
 #: frontend/src/metabase/lib/schema_metadata.js:354
 #: frontend/src/metabase/lib/schema_metadata.js:368
@@ -3737,184 +3758,184 @@ msgstr "空"
 #: frontend/src/metabase/lib/schema_metadata.js:398
 #: frontend/src/metabase/lib/schema_metadata.js:408
 msgid "Not empty"
-msgstr "空ではない"
+msgstr "不为空"
 
 #: frontend/src/metabase/lib/schema_metadata.js:360
 msgid "Equal to"
-msgstr "同等"
+msgstr "等于"
 
 #: frontend/src/metabase/lib/schema_metadata.js:361
 msgid "Not equal to"
-msgstr "同等ではない"
+msgstr "不等于"
 
 #: frontend/src/metabase/lib/schema_metadata.js:362
 msgid "Greater than"
-msgstr "より大きい"
+msgstr "大于"
 
 #: frontend/src/metabase/lib/schema_metadata.js:363
 msgid "Less than"
-msgstr "より小さい"
+msgstr "小于"
 
 #: frontend/src/metabase/lib/schema_metadata.js:364
 #: frontend/src/metabase/lib/schema_metadata.js:390
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:284
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:96
 msgid "Between"
-msgstr "間"
+msgstr "介于之间"
 
 #: frontend/src/metabase/lib/schema_metadata.js:365
 msgid "Greater than or equal to"
-msgstr "以上"
+msgstr "大于或等于"
 
 #: frontend/src/metabase/lib/schema_metadata.js:366
 msgid "Less than or equal to"
-msgstr "以下"
+msgstr "小于或等于"
 
 #: frontend/src/metabase/lib/schema_metadata.js:373
 msgid "Contains"
-msgstr "含む"
+msgstr "包含"
 
 #: frontend/src/metabase/lib/schema_metadata.js:374
 msgid "Does not contain"
-msgstr "含まない"
+msgstr "不包含"
 
 #: frontend/src/metabase/lib/schema_metadata.js:377
 msgid "Starts with"
-msgstr "で始まる"
+msgstr "以…开始"
 
 #: frontend/src/metabase/lib/schema_metadata.js:378
 msgid "Ends with"
-msgstr "で終わる"
+msgstr "以…结束"
 
 #: frontend/src/metabase/lib/schema_metadata.js:388
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:263
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:74
 msgid "Before"
-msgstr "前"
+msgstr "早于"
 
 #: frontend/src/metabase/lib/schema_metadata.js:389
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:270
 #: frontend/src/metabase/query_builder/components/filters/pickers/TimePicker.jsx:85
 msgid "After"
-msgstr "後"
+msgstr "晚于"
 
 #: frontend/src/metabase/lib/schema_metadata.js:403
 msgid "Inside"
-msgstr "中"
+msgstr "介于中间"
 
 #: frontend/src/metabase/lib/schema_metadata.js:460
 msgid "Just a table with the rows in the answer, no additional operations."
-msgstr "回答内の行を含むテーブルのみ、他操作なし"
+msgstr "只是一个包含数据行的表格，没有其他操作。"
 
 #: frontend/src/metabase/lib/schema_metadata.js:466
 msgid "Count of rows"
-msgstr "行のカウント"
+msgstr "总行数"
 
 #: frontend/src/metabase/lib/schema_metadata.js:468
 msgid "Total number of rows in the answer."
-msgstr "回答の全行数"
+msgstr "总的数据行数。"
 
 #: frontend/src/metabase/lib/schema_metadata.js:474
 msgid "Sum of ..."
-msgstr "の合計"
+msgstr "总和"
 
 #: frontend/src/metabase/lib/schema_metadata.js:476
 msgid "Sum of all the values of a column."
-msgstr "列の全値の合計"
+msgstr "一个字段所有数值的总和。"
 
 #: frontend/src/metabase/lib/schema_metadata.js:482
 msgid "Average of ..."
-msgstr "の平均"
+msgstr "平均值"
 
 #: frontend/src/metabase/lib/schema_metadata.js:484
 msgid "Average of all the values of a column"
-msgstr "列の全値の平均"
+msgstr "一个字段所有数值的平均值。"
 
 #: frontend/src/metabase/lib/schema_metadata.js:490
 msgid "Number of distinct values of ..."
-msgstr "...の異なる値の数"
+msgstr "不重复值的总数"
 
 #: frontend/src/metabase/lib/schema_metadata.js:492
 msgid "Number of unique values of a column among all the rows in the answer."
-msgstr "回答の全行のうちユニーク値の列数"
+msgstr "一个字段所有互不重复的值的总数"
 
 #: frontend/src/metabase/lib/schema_metadata.js:498
 msgid "Cumulative sum of ..."
-msgstr "累積合計"
+msgstr "累积求和"
 
 #: frontend/src/metabase/lib/schema_metadata.js:493
 msgid "Additive sum of all the values of a column.\\\\ne.x. total revenue over time."
-msgstr "列の全値の合計\\\\ne.x. 経年の全収入"
+msgstr "一个字段所有数值的累积加和。\\\\n比如：随着时间推移的总收入。"
 
 #: frontend/src/metabase/lib/schema_metadata.js:506
 msgid "Cumulative count of rows"
-msgstr "行の累積カウント"
+msgstr "累积行数"
 
 #: frontend/src/metabase/lib/schema_metadata.js:501
 msgid "Additive count of the number of rows.\\\\ne.x. total number of sales over time."
-msgstr "行数の合計\\\\ne.x.経年の販売数合計"
+msgstr "累积的数据行数。\\\\ n比如：随着时间的推移销售数量。"
 
 #: frontend/src/metabase/lib/schema_metadata.js:514
 msgid "Standard deviation of ..."
-msgstr "...の標準偏差"
+msgstr "标准差"
 
 #: frontend/src/metabase/lib/schema_metadata.js:516
 msgid "Number which expresses how much the values of a column vary among all rows in the answer."
-msgstr "回答の全行の間で列の値がどれくらい異なるかを表す数値"
+msgstr "一个字段所有数值的标准差。"
 
 #: frontend/src/metabase/lib/schema_metadata.js:522
 msgid "Minimum of ..."
-msgstr "...の最低"
+msgstr "最小值"
 
 #: frontend/src/metabase/lib/schema_metadata.js:524
 msgid "Minimum value of a column"
-msgstr "列の最低値"
+msgstr "一个字段的最小值"
 
 #: frontend/src/metabase/lib/schema_metadata.js:530
 msgid "Maximum of ..."
-msgstr "...の最高"
+msgstr "最大值"
 
 #: frontend/src/metabase/lib/schema_metadata.js:532
 msgid "Maximum value of a column"
-msgstr "列の最高値"
+msgstr "一个字段的最大值"
 
 #: frontend/src/metabase/lib/schema_metadata.js:540
 msgid "Break out by dimension"
-msgstr "ディメンション別に分割する"
+msgstr "按维度划分"
 
 #: frontend/src/metabase/lib/settings.js:108
 msgid "lower case letter"
-msgstr "小文字"
+msgstr "小写字母"
 
 #: frontend/src/metabase/lib/settings.js:110
 msgid "upper case letter"
-msgstr "大文字"
+msgstr "大写字母"
 
 #: frontend/src/metabase/lib/settings.js:112
 #: src/metabase/automagic_dashboards/core.clj
 msgid "number"
-msgstr "番号"
+msgstr "个数"
 
 #: frontend/src/metabase/lib/settings.js:114
 msgid "special character"
-msgstr "特殊文字"
+msgstr "特殊字符"
 
 #: frontend/src/metabase/lib/settings.js:120
 msgid "must be"
-msgstr "でなければならない"
+msgstr "必须"
 
 #: frontend/src/metabase/lib/settings.js:120
 #: frontend/src/metabase/lib/settings.js:121
 msgid "characters long"
-msgstr "文字数"
+msgstr "长字符"
 
 #: frontend/src/metabase/lib/settings.js:121
 msgid "Must be"
-msgstr "でなければならない"
+msgstr "必须"
 
 #: frontend/src/metabase/lib/settings.js:137
 msgid "and include"
-msgstr "含む"
+msgstr "包含"
 
 #: frontend/src/metabase/lib/utils.js:85
 msgid "zero"
@@ -3958,59 +3979,59 @@ msgstr "9"
 
 #: frontend/src/metabase/meta/Dashboard.js:30
 msgid "Month and Year"
-msgstr "月年"
+msgstr "月份和年份"
 
 #: frontend/src/metabase/meta/Dashboard.js:31
 msgid "Like January, 2016"
-msgstr "例: 2016年1月"
+msgstr "比如一月，2016年"
 
 #: frontend/src/metabase/meta/Dashboard.js:35
 msgid "Quarter and Year"
-msgstr "四半期と年"
+msgstr "季度和年"
 
 #: frontend/src/metabase/meta/Dashboard.js:36
 msgid "Like Q1, 2016"
-msgstr "例: 2016年Q1"
+msgstr "比如Q1,2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:40
 msgid "Single Date"
-msgstr "年月日"
+msgstr "单个日期"
 
 #: frontend/src/metabase/meta/Dashboard.js:41
 msgid "Like January 31, 2016"
-msgstr "例: 2016年１月31日"
+msgstr "比如一月31日，2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:45
 msgid "Date Range"
-msgstr "日付範囲"
+msgstr "日期范围"
 
 #: frontend/src/metabase/meta/Dashboard.js:46
 msgid "Like December 25, 2015 - February 14, 2016"
-msgstr "例: 2015年12月25日〜2016年2月14日"
+msgstr "比如十二月25日，2015-二月14日，2016"
 
 #: frontend/src/metabase/meta/Dashboard.js:50
 msgid "Relative Date"
-msgstr "相対日付"
+msgstr "相关日期"
 
 #: frontend/src/metabase/meta/Dashboard.js:51
 msgid "Like \"the last 7 days\" or \"this month\""
-msgstr "例: 「過去7日間」「今月」等"
+msgstr "比如“过去的7天”或者“这个月”"
 
 #: frontend/src/metabase/meta/Dashboard.js:55
 msgid "Date Filter"
-msgstr "日付フィルター"
+msgstr "日期筛选"
 
 #: frontend/src/metabase/meta/Dashboard.js:56
 msgid "All Options"
-msgstr "全オプション"
+msgstr "所有选项"
 
 #: frontend/src/metabase/meta/Dashboard.js:57
 msgid "Contains all of the above"
-msgstr "上記全てを含む"
+msgstr "包含以上全部"
 
 #: frontend/src/metabase/meta/Dashboard.js:69
 msgid "ZIP or Postal Code"
-msgstr "郵便番号"
+msgstr "地区编码或者邮政编码"
 
 #: frontend/src/metabase/meta/Dashboard.js:77
 #: frontend/src/metabase/meta/Dashboard.js:107
@@ -4020,152 +4041,152 @@ msgstr "ID"
 #: frontend/src/metabase/meta/Dashboard.js:95
 #: frontend/src/metabase/modes/components/actions/PivotByTimeAction.jsx:8
 msgid "Time"
-msgstr "時間"
+msgstr "时间"
 
 #: frontend/src/metabase/meta/Dashboard.js:96
 msgid "Date range, relative date, time of day, etc."
-msgstr "時間範囲、相対日付、時間等"
+msgstr "日期范围,相关日期，一天中的时间，等等"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:124
 #: frontend/src/metabase/meta/Dashboard.js:101
 #: frontend/src/metabase/modes/components/actions/PivotByLocationAction.jsx:8
 msgid "Location"
-msgstr "場所"
+msgstr "位置"
 
 #: frontend/src/metabase/meta/Dashboard.js:102
 msgid "City, State, Country, ZIP code."
-msgstr "都市、州、国、郵便番号"
+msgstr "城市，州，国家，地区编码"
 
 #: frontend/src/metabase/meta/Dashboard.js:108
 msgid "User ID, product ID, event ID, etc."
-msgstr "ユーザーID、商品ID、イベントID等"
+msgstr "用户ID，产品ID，活动ID，等等"
 
 #: frontend/src/metabase/meta/Dashboard.js:113
 msgid "Other Categories"
-msgstr "他カテゴリー"
+msgstr "其他类别"
 
 #: frontend/src/metabase/meta/Dashboard.js:114
 msgid "Category, Type, Model, Rating, etc."
-msgstr "カテゴリー、タイプ、モデル、レーティング等"
+msgstr "类别、类型、模型、评分等"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:42
 #: frontend/src/metabase/user/components/UserSettings.jsx:50
 msgid "Account settings"
-msgstr "アカウント設定"
+msgstr "账户设置"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:49
 msgid "Exit admin"
-msgstr "管理画面から離れる"
+msgstr "退出管理员"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:34
 msgid "Logs"
-msgstr "ログ"
+msgstr "日志"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:64
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:99
 msgid "Help"
-msgstr "ヘルプ"
+msgstr "帮助"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:71
 msgid "About Metabase"
-msgstr "Metabaseについて"
+msgstr "关于Metabase"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:77
 msgid "Sign out"
-msgstr "サインアウト"
+msgstr "注销"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:102
 msgid "Thanks for using"
-msgstr "ご利用ありがとうございます"
+msgstr "谢谢使用"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:106
 msgid "You're on version"
-msgstr "ご利用中のバージョンは"
+msgstr "正在使用版本"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:109
 msgid "Built on"
-msgstr "ビルド年月日: "
+msgstr "建立于"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:128
 msgid "is a Trademark of"
-msgstr "は右記の会社が有する商標です"
+msgstr "是一个……的商标"
 
 #: frontend/src/metabase/nav/components/ProfileLink.jsx:130
 msgid "and is built with care in San Francisco, CA"
-msgstr "カリフォルニアのサンフランシスコで制作されています"
+msgstr "并且它在加州，旧金山精心被打造"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:223
 msgid "Metabase Admin"
-msgstr "Metabase管理者"
+msgstr "Metabase管理员"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:331
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:36
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:37
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:37
 msgid "Ask a question"
-msgstr "照会する"
+msgstr "创建问题"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:355
 msgid "New dashboard"
-msgstr "新しいダッシュボード"
+msgstr "新仪表盘"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:361
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "New pulse"
-msgstr "新しいパルス"
+msgstr "新定时任务"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:323
 msgid "Reference"
-msgstr "参照"
+msgstr "参考"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:87
 msgid "Which metric?"
-msgstr "どのメトリクスですか？"
+msgstr "哪个指标？"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:114
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:26
 msgid "Defining common metrics for your team makes it even easier to ask questions"
-msgstr "チームの共通のメトリクスを定義することで、さらに簡単に質問することができます"
+msgstr "为你的团队定义共同指标，让它甚至简单到可以轻松的提问"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:117
 msgid "How to create metrics"
-msgstr "メトリクスの作成方法"
+msgstr "如何创建指标"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:138
 msgid "See data over time, as a map, or pivoted to help you understand trends or changes."
-msgstr "経時的なデータをマップとして表示したり、傾向や変化を理解するのに役立つようにピボットしたりできます。"
+msgstr "按地图、趋势查看时间维度的数据，方便了解趋势变化"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:149
 msgid "Custom"
-msgstr "カスタム"
+msgstr "自定义"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:50
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:142
 msgid "New question"
-msgstr "新しい質問"
+msgstr "新的疑问"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:152
 msgid "Use the simple question builder to see trends, lists of things, or to create your own metrics."
-msgstr "トレンドやリストを表示したり、独自のメトリクスを作成するには、簡単な質問ビルダーを使用してください。"
+msgstr "使用简单的疑问创建器来查看趋势、列表或者事物，或者创建你自己的指标。"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:166
 #: src/metabase/automagic_dashboards/core.clj
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Native query"
-msgstr "ネイティブクエリ"
+msgstr "原生查询"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:167
 msgid "For more complicated questions, you can write your own SQL or native query."
-msgstr "複雑な質問については、独自のSQLまたはネイティブクエリを記述することができます。"
+msgstr "为了回答更多复杂的疑问，你可以写下你自己的SQL语句或者原生查询。"
 
 #: frontend/src/metabase/parameters/components/ParameterValueWidget.jsx:245
 msgid "Select a default value…"
-msgstr "デフォルト値を選択する"
+msgstr "选择一个默认值"
 
 #: frontend/src/metabase/parameters/components/widgets/DateAllOptionsWidget.jsx:150
 #: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 msgid "Update filter"
-msgstr "フィルターをアップデートする"
+msgstr "更新过滤器"
 
 #: frontend/src/metabase/lib/query_time.js:112
 #: frontend/src/metabase/lib/query_time.js:123
@@ -4173,30 +4194,32 @@ msgstr "フィルターをアップデートする"
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:144
 #: src/metabase/pulse/render/datetime.clj
 msgid "Today"
-msgstr "本日"
+msgstr "今天"
 
 #: frontend/src/metabase/lib/query_time.js:118
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:14
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:148
 #: src/metabase/pulse/render/datetime.clj
 msgid "Yesterday"
-msgstr "昨日"
+msgstr "昨天"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:18
 msgid "Past 7 days"
-msgstr "過去7日"
+msgstr "过去7天"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:19
 msgid "Past 30 days"
-msgstr "過去30日"
+msgstr "过去30天"
 
+#. 周
 #: frontend/src/metabase/lib/query_time.js:198
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:24
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:29
 #: src/metabase/api/table.clj
 msgid "Week"
 msgid_plural "Weeks"
-msgstr[0] "週"
+msgstr[0] "周\n"
+"周"
 
 #: frontend/src/metabase/lib/query_time.js:200
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:25
@@ -4204,7 +4227,8 @@ msgstr[0] "週"
 #: src/metabase/api/table.clj
 msgid "Month"
 msgid_plural "Months"
-msgstr[0] "月"
+msgstr[0] "月\n"
+"月"
 
 #: frontend/src/metabase/lib/query_time.js:204
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:26
@@ -4212,35 +4236,36 @@ msgstr[0] "月"
 #: src/metabase/api/table.clj
 msgid "Year"
 msgid_plural "Years"
-msgstr[0] "年"
+msgstr[0] "年\n"
+"年"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:152
 msgid "Past 7 Days"
-msgstr "過去7日"
+msgstr "过去7天"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:156
 msgid "Past 30 Days"
-msgstr "過去30日"
+msgstr "过去30天"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:160
 msgid "Last Week"
-msgstr "先週"
+msgstr "上周"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:164
 msgid "Last Month"
-msgstr "先月"
+msgstr "上个月"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:168
 msgid "Last Year"
-msgstr "昨年"
+msgstr "去年"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:172
 msgid "This Week"
-msgstr "今週"
+msgstr "这周"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:176
 msgid "This Month"
-msgstr "今月"
+msgstr "这个月"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:180
 msgid "This Year"
@@ -4249,314 +4274,314 @@ msgstr "今年"
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:89
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:54
 msgid "Enter a value..."
-msgstr "値を入力する..."
+msgstr "输入一个值……"
 
 #: frontend/src/metabase/parameters/components/widgets/TextWidget.jsx:90
 msgid "Enter a default value..."
-msgstr "デフォルト値を入力する..."
+msgstr "输入一个默认值……"
 
 #: frontend/src/metabase/components/LoadingAndErrorWrapper.jsx:48
 #: frontend/src/metabase/public/components/PublicError.jsx:18
 msgid "An error occurred"
-msgstr "エラーが発生しました"
+msgstr "发生了一个错误"
 
 #: frontend/src/metabase/public/components/PublicNotFound.jsx:11
 msgid "Not found"
-msgstr "見つかりませんでした"
+msgstr "未找到"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:82
 msgid "You’ve made changes that need to be published before they will be reflected in your application embed."
-msgstr "アプリケーションの埋め込みに反映される前に、公開する必要がある変更を加えました。"
+msgstr "你已经做出了更改，在它们嵌入的应用里发生作用前需要被发布。"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:83
 msgid "You will need to publish this {0} before you can embed it in another application."
-msgstr "この{0}を公開してから別のアプリケーションに埋め込む必要があります。"
+msgstr "在能够将它嵌入到另一个应用前，你将需要先发布这个{0}"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:92
 msgid "Discard Changes"
-msgstr "変更を破棄する"
+msgstr "取消更改"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:99
 msgid "Updating..."
-msgstr "アップデート中..."
+msgstr "更新中"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:100
 msgid "Updated"
-msgstr "アップデートしました"
+msgstr "已更新"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:101
 msgid "Failed!"
-msgstr "失敗しました！"
+msgstr "失败！"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:102
 msgid "Publish"
-msgstr "公開"
+msgstr "发布"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedEmbedPane.jsx:111
 msgid "Code"
-msgstr "コード"
+msgstr "代码"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:72
 #: frontend/src/metabase/visualizations/lib/settings/column.js:282
 msgid "Style"
-msgstr "スタイル"
+msgstr "样式"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:82
 msgid "Which parameters can users of this embed use?"
-msgstr "この埋め込みのユーザーはどのパラメーターを使用できますか？"
+msgstr "这个嵌套可以使用什么参数？"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:84
 msgid "This {0} doesn't have any parameters to configure yet."
-msgstr "この{0}には設定するパラメーターがまだありません。"
+msgstr "此{0}尚未配置任何参数。"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:105
 msgid "Editable"
-msgstr "編集可能"
+msgstr "可编辑的"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:106
 msgid "Locked"
-msgstr "ロックされた"
+msgstr "锁定的"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:113
 msgid "Preview Locked Parameters"
-msgstr "ロックされたパラメーターをプレビューする"
+msgstr "预览锁定参数"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:114
 msgid "Try passing some values to your locked parameters here. Your server will have to provide the actual values in the signed token when using this for real."
-msgstr "ロックされたパラメーターにいくつかの値を入力してみてください。 これを実際に使用する場合には、サーバーは署名トークンに実際の値を提供する必要があります。"
+msgstr "尝试在此处将一些值传递给锁定的参数。当您使用此服务器时，您的服务器必须提供签名令牌中的实际值。"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:125
 msgid "Danger zone"
-msgstr "危険ゾーン"
+msgstr "危险区域"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:126
 msgid "This will disable embedding for this {0}."
-msgstr "この{0}への埋め込みを無効化します"
+msgstr "这将会为这个{0}禁用嵌入功能"
 
 #: frontend/src/metabase/public/components/widgets/AdvancedSettingsPane.jsx:127
 msgid "Unpublish"
-msgstr "非公開"
+msgstr "撤销发布"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:17
 msgid "Light"
-msgstr "明るい"
+msgstr "亮"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:18
 msgid "Dark"
-msgstr "暗い"
+msgstr "暗"
 
 #: frontend/src/metabase/public/components/widgets/DisplayOptionsPane.jsx:37
 msgid "Border"
-msgstr "境界"
+msgstr "边界"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:62
 msgid "To embed this {0} in your application:"
-msgstr "アプリケーションへ{0}を埋め込むには:"
+msgstr "来在你的应用中插入这个{0}"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:64
 msgid "Insert this code snippet in your server code to generate the signed embedding URL "
-msgstr "このコードスニペットをサーバーコードに挿入して、署名付き埋め込みURLを生成する"
+msgstr "在你的服务器代码中插入这段代码来生成具有签名的嵌入URL链接"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:87
 msgid "Then insert this code snippet in your HTML template or single page app."
-msgstr "次に、このコードスニペットをHTMLテンプレートまたは単一ページアプリに挿入する"
+msgstr "然后插入这段代码在你的HTML模板或者单个页面APP中"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:94
 msgid "Embed code snippet for your HTML or Frontend Application"
-msgstr "HTMLまたはフロントエンドアプリケーションにコードスニペットを埋め込む"
+msgstr "为你的HTML网页或者前端应用插入一段嵌入代码"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:101
 msgid "More {0}"
-msgstr "さらに{0}"
+msgstr "更多{0}"
 
 #: frontend/src/metabase/public/components/widgets/EmbedCodePane.jsx:103
 msgid "examples on GitHub"
-msgstr "GitHubの例"
+msgstr "在GitHub上的案例"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:71
 msgid "Enable sharing"
-msgstr "共有を有効化する"
+msgstr "开启分享"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:75
 msgid "Disable this public link?"
-msgstr "公開リンクを無効化しますか？"
+msgstr "禁用这个公共链接？"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:76
 msgid "This will cause the existing link to stop working. You can re-enable it, but when you do it will be a different link."
-msgstr "リンクが作動しなくなる可能性があります。再度有効化することはできますが、異なるリンクが作成されます"
+msgstr "会取消已存在的链接。可以重新生效，但是链接会变更。"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:116
 msgid "Public link"
-msgstr "リンクを公開する"
+msgstr "公开链接"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:117
 msgid "Share this {0} with people who don't have a Metabase account using the URL below:"
-msgstr "Metabaseアカウントを保有していない方に下記URLを利用して{0}を共有する:"
+msgstr "将{0}通过下面的链接分享那些没有Metabase账号的人。"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:154
 msgid "Public embed"
-msgstr "公開埋め込み"
+msgstr "公开嵌入"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:155
 msgid "Embed this {0} in blog posts or web pages by copying and pasting this snippet:"
-msgstr "このスニペットをコピーして貼り付けることで、ブログ投稿やウェブページにこの{0}を埋め込むことができます:"
+msgstr "将这个代码块粘贴到页面代码，可以在博客或者网页中启用{0}。"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:172
 msgid "Embed this {0} in an application"
-msgstr "アプリケーションへ{0}を埋め込む"
+msgstr "在一个应用嵌入这个{0}"
 
 #: frontend/src/metabase/public/components/widgets/SharingPane.jsx:173
 msgid "By integrating with your application server code, you can provide a secure stats {0} limited to a specific user, customer, organization, etc."
-msgstr "アプリケーションサーバーコードと統合することで、特定のユーザー、顧客、組織などに限定された安全な統計情報{0}を提供することができます。"
+msgstr "通过与应用程序服务器代码集成，您可以提供仅限于特定用户，客户，组织等的安全统计信息{0}。"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:93
 msgid "Remove attachment"
-msgstr "添付を削除する"
+msgstr "移除附件"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:94
 msgid "Attach file with results"
-msgstr "結果を添付する"
+msgstr "添加结果文件附件"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:126
 msgid "This question will be added as a file attachment"
-msgstr "この質問は添付ファイルとして追加されます"
+msgstr "图表会被添加文件附件"
 
 #: frontend/src/metabase/pulse/components/PulseCardPreview.jsx:127
 msgid "This question won't be included in your Pulse"
-msgstr "この質問はパルスには含まれません"
+msgstr "这个图表不会包含在你的定时任务中"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:91
 msgid "This pulse will no longer be emailed to {0} {1}"
-msgstr "このクエスチョンは{0} {1}にメールされません"
+msgstr "这个定时任务不再发送给{0}{1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:93
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:375
 msgid "{0} address"
 msgid_plural "{0} addresses"
-msgstr[0] "{0}アドレス"
+msgstr[0] "{0}地址"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:102
 msgid "Slack channel {0} will no longer get this pulse {1}"
-msgstr "Slackチャンネル{0}からは、このパルス{1}を取得できません"
+msgstr "Slack通道{0}将不再接收此定时通知{1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:111
 msgid "Channel {0} will no longer receive this pulse {1}"
-msgstr "チャンネル{0}からは、このパルス{1}を受信できません"
+msgstr "{0}不会再收到定时任务{1}"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:129
 msgid "Edit pulse"
-msgstr "パルスを編集する"
+msgstr "编辑定时任务"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:133
 msgid "What's a Pulse?"
-msgstr "パルスとは？"
+msgstr "什么是定时任务"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:143
 msgid "Got it"
-msgstr "了解しました"
+msgstr "得到结果了！"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:159
 msgid "Where should this data go?"
-msgstr "このデータはどちらに保存しますか？"
+msgstr "这个数据应该去哪？"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:175
 msgid "Unarchiving…"
-msgstr "アーカイブ取消中..."
+msgstr "正在取消归档"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:176
 msgid "Unarchive failed"
-msgstr "アーカイブ取消が失敗しました"
+msgstr "取消归档失败"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:177
 msgid "Unarchived"
-msgstr "アーカイブが取り消されました"
+msgstr "已取消归档"
 
 #: frontend/src/metabase/pulse/components/PulseEdit.jsx:184
 msgid "Create pulse"
-msgstr "パルスを作成する"
+msgstr "创建定时任务"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:90
 msgid "Attachment"
-msgstr "添付"
+msgstr "附件"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:104
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:111
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:675
 msgid "Heads up"
-msgstr "警告"
+msgstr "小心"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:105
 msgid "We'll show the first 10 columns and 20 rows of this table in your Pulse. If you email this, we'll add a file attachment with all columns and up to 2,000 rows."
-msgstr "パルス内のテーブルの最初の10列、20行を表示します。これをメールで送信する場合、全列、最大2,000行を添付ファイルとして送信します"
+msgstr "会在你的定时任务展示前20行前10列的表。如果邮件发送，会添加一个2000行所有列的文件附件。"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:112
 msgid "Raw data questions can only be included as email attachments"
-msgstr "ローデータ質問はメール添付としてのみ含まれます"
+msgstr "原始数据疑问仅能以邮件附件的形式包含在内"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:119
 msgid "Looks like this pulse is getting big"
-msgstr "パルスが大きくなっているようです"
+msgstr "似乎这个定时任务正在变大。"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:120
 msgid "We recommend keeping pulses small and focused to help keep them digestible and useful to the whole team."
-msgstr "パルスを小さく保ち、チーム全体にとって使いやすく処理することをお勧めします。"
+msgstr "推荐精简定时任务，方便整个团队理解和使用。"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:160
 #: frontend/src/metabase/query_builder/components/view/View.jsx:123
 msgid "Pick your data"
-msgstr "データを選ぶ"
+msgstr "选择你的数据"
 
 #: frontend/src/metabase/pulse/components/PulseEditCards.jsx:162
 msgid "Choose questions you'd like to send in this pulse"
-msgstr "このパルス内で送信したい質問を選択する"
+msgstr "挑选你想在这个定时任务里发送的图表。"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:27
 msgid "Emails"
-msgstr "メール"
+msgstr "电子邮箱"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:28
 msgid "Slack messages"
-msgstr "Slackメッセージ"
+msgstr "Slack消息"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:220
 msgid "Sent"
-msgstr "送信しました"
+msgstr "发送"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:221
 msgid "{0} will be sent at"
-msgstr "{0}が送信されます"
+msgstr "{0}将会在……被发送"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:223
 msgid "Messages"
-msgstr "メッセージ"
+msgstr "信息"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:239
 msgid "Send email now"
-msgstr "今すぐメールを送信する"
+msgstr "现在发送邮件"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:240
 msgid "Send to {0} now"
-msgstr "今すぐ{0}に送信する"
+msgstr "现在发送邮件给{0}"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:242
 msgid "Sending…"
-msgstr "送信中..."
+msgstr "发送中……"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:243
 msgid "Sending failed"
-msgstr "送信に失敗しました"
+msgstr "发送失败"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:246
 msgid "Didn’t send because the pulse has no results."
-msgstr "パルスの結果が存在しないため送信できませんでした"
+msgstr "未发送，因为定时任务没有结果。"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:247
 msgid "Pulse sent"
-msgstr "パルスが送信されました"
+msgstr "定时任务已发送。"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:286
 msgid "{0} needs to be set up by an administrator."
-msgstr "{0}は管理者が設定する必要があります"
+msgstr "{0}需要被设置成管理员"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:301
 msgid "Slack"
@@ -4564,120 +4589,120 @@ msgstr "Slack"
 
 #: frontend/src/metabase/pulse/components/PulseEditCollection.jsx:12
 msgid "Which collection should this pulse live in?"
-msgstr "このパルスはどのコレクションに保存しますか？"
+msgstr "将这个定时通知放到哪个集合中？"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:35
 msgid "Name your pulse"
-msgstr "パルスに名前を付けましょう"
+msgstr "命名定时任务"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:37
 msgid "Give your pulse a name to help others understand what it's about"
-msgstr "他ユーザーのためにパルスに名前を付けましょう"
+msgstr "命名定时任务方便其他人理解"
 
 #: frontend/src/metabase/pulse/components/PulseEditName.jsx:49
 msgid "Important metrics"
-msgstr "重要なメトリクス"
+msgstr "重要指标"
 
 #: frontend/src/metabase/pulse/components/PulseEditSkip.jsx:22
 msgid "Skip if no results"
-msgstr "結果が存在しない場合スキップする"
+msgstr "如果没有结果就跳过"
 
 #: frontend/src/metabase/pulse/components/PulseEditSkip.jsx:24
 msgid "Skip a scheduled Pulse if none of its questions have any results"
-msgstr "質問の結果が存在しない場合は予定されたパルスをスキップする"
+msgstr "如果都没有结果，跳过该定时任务"
 
 #: frontend/src/metabase/pulse/components/RecipientPicker.jsx:65
 msgid "Enter email addresses you'd like this data to go to"
-msgstr "このデータを送りたいメールアドレスを入力する"
+msgstr "输入你想这个数据被送达的邮箱地址"
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:16
 msgid "Help everyone on your team stay in sync with your data."
-msgstr "チームが常にあなたのデータと同期されるよう心がけましょう"
+msgstr "帮助每个在你们团队的人和你们的数据保持联结"
 
 #: frontend/src/metabase/pulse/components/WhatsAPulse.jsx:30
 msgid "Pulses let you send data from Metabase to email or Slack on the schedule of your choice."
-msgstr "Metabaseのデータをご自身で設定した予定通りにメールまたはSlackで送信することができます"
+msgstr "定时通知允许您根据您选择的时间表从Metabase发送数据到电子邮件或Slack。"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:100
 msgid "After {0}"
-msgstr "{0}後"
+msgstr "之后{0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:102
 msgid "Before {0}"
-msgstr "{0}前"
+msgstr "之前{0}"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:104
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:294
 msgid "Is Empty"
-msgstr "空"
+msgstr "是空的"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:106
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:300
 msgid "Not Empty"
-msgstr "空ではない"
+msgstr "不是空的"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:109
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:212
 msgid "All Time"
-msgstr "全期間"
+msgstr "所有时间"
 
 #: frontend/src/metabase/modes/components/TimeseriesFilterWidget.jsx:155
 msgid "Apply"
-msgstr "適用する"
+msgstr "应用"
 
 #: frontend/src/metabase/modes/components/actions/CommonMetricsAction.jsx:21
 msgid "View {0}"
-msgstr "{0}を見る"
+msgstr "查看"
 
 #: frontend/src/metabase/modes/components/actions/CompareWithTable.jsx:29
 msgid "Compare this with all rows in the table"
-msgstr "テーブル内の全行と比較する"
+msgstr "把这个在表单中和所有原始数据比较"
 
 #: frontend/src/metabase/modes/components/actions/CompoundQueryAction.jsx:14
 msgid "Analyze the results of this Query"
-msgstr "このクエリの結果を分析する"
+msgstr "分析这个查询的结果"
 
 #: frontend/src/metabase/modes/components/actions/CountByTimeAction.jsx:29
 msgid "Count of rows by time"
-msgstr "時間ごとの行数"
+msgstr "按时间对行计数"
 
 #: frontend/src/metabase/modes/components/actions/PivotByAction.jsx:52
 msgid "Break out by {0}"
-msgstr "{0}ごとに分割する"
+msgstr "按{0}分组"
 
 #: frontend/src/metabase/modes/components/actions/SummarizeBySegmentMetricAction.jsx:31
 msgid "Summarize this segment"
-msgstr "このセグメントを要約する"
+msgstr "总结这个划分"
 
 #: frontend/src/metabase/modes/components/actions/UnderlyingDataAction.jsx:14
 msgid "View this as a table"
-msgstr "テーブルとして見る"
+msgstr "以表单的形式查看"
 
 #: frontend/src/metabase/modes/components/actions/UnderlyingRecordsAction.jsx:22
 msgid "View the underlying {0} records"
-msgstr "{0}の基本的なレコードを見る"
+msgstr "查看下层的{0}记录"
 
 #: frontend/src/metabase/modes/components/actions/XRayCard.jsx:20
 msgid "X-Ray this question"
-msgstr "この質問を自動探査(X-ray)する"
+msgstr "透视这个疑问"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 msgid "X-ray {0} {1}"
-msgstr "{0} {1}を自動探査(X-ray)する"
+msgstr "透视{0}{1}"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "these"
-msgstr "これら"
+msgstr "这些"
 
 #: frontend/src/metabase/qb/components/drill/AutomaticDashboardDrill.jsx:32
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "this"
-msgstr "これ"
+msgstr "这个"
 
 #: frontend/src/metabase/qb/components/drill/CompareToRestDrill.js:32
 msgid "Compare {0} {1} to the rest"
-msgstr "{0} {1}を結果と比較する"
+msgstr "将{0}{1}和剩下的比较"
 
 #: frontend/src/metabase/modes/components/drill/DistributionDrill.jsx:35
 msgid "Distribution"
@@ -4685,23 +4710,23 @@ msgstr "分布"
 
 #: frontend/src/metabase/modes/components/drill/ObjectDetailDrill.jsx:38
 msgid "View details"
-msgstr "詳細を見る"
+msgstr "查看细节"
 
 #: frontend/src/metabase/modes/components/drill/QuickFilterDrill.jsx:57
 msgid "View this {0}'s {1}"
-msgstr "{0}の{1}を見る"
+msgstr "查看{0}的{1}"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:42
 msgid "Ascending"
-msgstr "昇順"
+msgstr "升序"
 
 #: frontend/src/metabase/modes/components/drill/SortAction.jsx:50
 msgid "Descending"
-msgstr "降順"
+msgstr "降序"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js:47
 msgid "over time"
-msgstr "時間とともに"
+msgstr "超时"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:21
 msgid "Avg"
@@ -4709,209 +4734,210 @@ msgstr "平均"
 
 #: frontend/src/metabase/modes/components/drill/SummarizeColumnDrill.js:33
 msgid "Distincts"
-msgstr "Distinct"
+msgstr "不重复"
 
 #: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:39
 msgid "View this {0}"
 msgid_plural "View these {0}"
-msgstr[0] "この{0}を見る"
+msgstr[0] "查看这个{0}\n"
+"Plural:查看这些{0}"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:227
 #: frontend/src/metabase/modes/components/drill/ZoomDrill.jsx:26
 msgid "Zoom in"
-msgstr "拡大する"
+msgstr "放大"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:24
 msgid "Custom Expression"
-msgstr "カスタムエクスプレッション"
+msgstr "自定义表达方式"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:22
 msgid "Common Metrics"
-msgstr "共通のメトリクス"
+msgstr "共同指标"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:209
 msgid "Metabasics"
-msgstr "Metabasics"
+msgstr "基本知識"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:387
 msgid "Name (optional)"
-msgstr "名前（任意）"
+msgstr "名称（可选）"
 
 #: frontend/src/metabase/query_builder/components/AggregationWidget.jsx:156
 msgid "Choose an aggregation"
-msgstr "集約を選択する"
+msgstr "选择一个聚合"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:100
 msgid "Set up your own alert"
-msgstr "アラートを設定する"
+msgstr "建立你自己的警报"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:143
 msgid "Unsubscribing..."
-msgstr "購読解除中..."
+msgstr "不可关注……"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:148
 msgid "Failed to unsubscribe"
-msgstr "購読解除に失敗しました"
+msgstr "关注失败"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:206
 msgid "Unsubscribe"
-msgstr "購読解除する"
+msgstr "取消关注"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:236
 msgid "No channel"
-msgstr "チャンネルがありません"
+msgstr "没有频道"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:264
 msgid "Okay, you're unsubscribed"
-msgstr "購読解除しました"
+msgstr "完成，你已经关注了"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:336
 msgid "You're receiving {0}'s alerts"
-msgstr "{0}のアラートを受け取る設定になっています"
+msgstr "你正在接收{0}的警报"
 
 #: frontend/src/metabase/query_builder/components/AlertListPopoverContent.jsx:337
 msgid "{0} set up an alert"
-msgstr "{0}アラートを設定しました。"
+msgstr "{0}设置一个警报"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:160
 msgid "alerts"
-msgstr "アラート"
+msgstr "警报"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:183
 msgid "Let's set up your alert"
-msgstr "アラートを設定しましょう"
+msgstr "让我们来设置你的警报"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:214
 msgid "The wide world of alerts"
-msgstr "アラートの広い世界"
+msgstr "全局警报"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:215
 msgid "There are a few different kinds of alerts you can get"
-msgstr "様々な種類のアラートがあります"
+msgstr "可以设置不同的提醒方式"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:229
 msgid "When a raw data question {0}"
-msgstr "ローデータ質問が{0}のとき"
+msgstr "当一个源数据查询 {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:230
 msgid "returns any results"
-msgstr "どんな結果も返す"
+msgstr "返回任意结果"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:241
 msgid "When a line or bar {0}"
-msgstr "折れ線グラフまたは棒グラフが{0}のとき"
+msgstr "当一个线或者柱{0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:242
 msgid "crosses a goal line"
-msgstr "目標値を超える"
+msgstr "超越目标线"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:253
 msgid "When a progress bar {0}"
-msgstr "プログレスバーが{0}のとき"
+msgstr "当进度条  {0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:254
 msgid "reaches its goal"
-msgstr "目標に到達する"
+msgstr "达到它的目标"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:262
 msgid "Set up an alert"
-msgstr "アラートを設定する"
+msgstr "设置提醒"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:331
 msgid "Edit your alert"
-msgstr "アラートを編有する"
+msgstr "编辑提醒"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:331
 msgid "Edit alert"
-msgstr "アラートを編集する"
+msgstr "编辑提醒"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:373
 msgid "This alert will no longer be emailed to {0}."
-msgstr "このアラートは{0}にメール送信されません"
+msgstr "提醒不再发送{0}"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:381
 msgid "Slack channel {0} will no longer get this alert."
-msgstr "Slackチャンネル{0}では、このアラートを取得できません"
+msgstr "Slack通道{0}将不再接收此警报。"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:385
 msgid "Channel {0} will no longer receive this alert."
-msgstr "チャンネル{0}では、このアラートを受信できません"
+msgstr "{0}不再收到这个提醒"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:402
 msgid "Delete this alert"
-msgstr "このアラートを削除する"
+msgstr "删除提醒"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:404
 msgid "Stop delivery and delete this alert. There's no undo, so be careful."
-msgstr "このアラートを削除する。この操作はやり直しできませんので、ご注意ください"
+msgstr "停止并删除提醒。无法恢复，请注意！"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:412
 msgid "Delete this alert?"
-msgstr "このアラートを削除しますか？"
+msgstr "删除这个警报？"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:499
 msgid "Alert me when the line…"
-msgstr "線が...のときアラートする"
+msgstr "当这个线……时警告我"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:500
 msgid "Alert me when the progress bar…"
-msgstr "プログレスバーが表示されたら..."
+msgstr "警告我，当这个进程条……"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Goes above the goal line"
-msgstr "目標値を超える"
+msgstr "超过目标线"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:503
 msgid "Reaches the goal"
-msgstr "目標に到達する"
+msgstr "达成目标"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal line"
-msgstr "目標値を下回る"
+msgstr "低于目标线"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:506
 msgid "Goes below the goal"
-msgstr "目標を下回る"
+msgstr "低于目标"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:514
 msgid "The first time it crosses, or every time?"
-msgstr "最初に超えたときのみ、または超えたときは毎回"
+msgstr "首次超越，还是每次？"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:515
 msgid "The first time it reaches the goal, or every time?"
-msgstr "最初に目標に到達したときのみ、または目標に到達したときは毎回"
+msgstr "是第一次达成目标，还是每一次都是？"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:517
 msgid "The first time"
-msgstr "最初のみ"
+msgstr "第一次"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:518
 msgid "Every time"
-msgstr "毎回"
+msgstr "每一次"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:621
 msgid "Where do you want to send these alerts?"
-msgstr "アラートをどこに送信しますか？"
+msgstr "你想发送这些警报到哪里？"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:632
 msgid "Email alerts to:"
-msgstr "アラートをメール送信する:"
+msgstr "电子邮件发送警报到："
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:674
 msgid "{0} Goal-based alerts aren't yet supported for charts with more than one line, so this alert will be sent whenever the chart has {1}."
-msgstr "{0} 2行以上のチャートでは目標ベースのアラートがサポートされていないため、チャートに{1}があるたびにアラートが送信されます。"
+msgstr "{0} 多行图表还不支持基于目标的报警，所以当图标有{1}时，这个报警就会发送。"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:677
 msgid "results"
-msgstr "結果"
+msgstr "结果"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:681
 msgid "{0} This kind of alert is most useful when your saved question doesn’t {1} return any results, but you want to know when it does."
-msgstr "{0}このタイプのアラートは、保存された質問が{1}結果を返さない場合でも、いつ実行したかを知りたいときに最も便利です。"
+msgstr "{0}这种类型的警报是最有效果的，当你存储疑问没有"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:682
 msgid "Tip"
-msgstr "ヒント"
+msgstr "提示"
 
 #: frontend/src/metabase/query_builder/components/AlertModals.jsx:684
 msgid "usually"
@@ -4919,91 +4945,91 @@ msgstr "通常"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:60
 msgid "Pick a segment or table"
-msgstr "セグメントまたはテーブルを選ぶ"
+msgstr "选择一个区间或者表单"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:78
 msgid "Select a database"
-msgstr "データベースを選択する"
+msgstr "选择一个数据库"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:93
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:87
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:187
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:35
 msgid "Select..."
-msgstr "選択する..."
+msgstr "选择……"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:133
 msgid "Select a table"
-msgstr "テーブルを選択する"
+msgstr "选择一个表单"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:810
 msgid "No tables found in this database."
-msgstr "このデータベースにはテーブルが見つかりませんでした"
+msgstr "该数据库未发现表"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:847
 msgid "Is a question missing?"
-msgstr "質問がありませんか？"
+msgstr "图表缺失？"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:854
 msgid "Learn more about nested queries"
-msgstr "ネストしたクエリについてもっと調べる"
+msgstr "了解更多关于嵌套查询"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:889
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:30
 msgid "Fields"
-msgstr "フィールド"
+msgstr "字段"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:968
 msgid "No segments were found."
-msgstr "セグメントが見つかりませんでした"
+msgstr "没有划分"
 
 #: frontend/src/metabase/query_builder/components/DataSelector.jsx:991
 msgid "Find a segment"
-msgstr "セグメントを探す"
+msgstr "找到一个划分"
 
 #: frontend/src/metabase/query_builder/components/ExpandableString.jsx:47
 msgid "View less"
-msgstr "少く表示"
+msgstr "查看更少"
 
 #: frontend/src/metabase/query_builder/components/ExpandableString.jsx:57
 msgid "View more"
-msgstr "さらに表示"
+msgstr "查看更多"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:112
 msgid "Pick a field to sort by"
-msgstr "ソートするフィールドを選ぶ"
+msgstr "选择一个字段来排序"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:125
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:75
 msgid "Sort"
-msgstr "ソート"
+msgstr "排序"
 
 #: frontend/src/metabase/query_builder/components/ExtendedOptions.jsx:137
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:82
 msgid "Row limit"
-msgstr "行数制限"
+msgstr "行限制"
 
 #: frontend/src/metabase/query_builder/components/FieldName.jsx:73
 msgid "Unknown Field"
-msgstr "不明なフィールド"
+msgstr "未知字段"
 
 #: frontend/src/metabase/query_builder/components/FieldName.jsx:76
 msgid "field"
-msgstr "フィールド"
+msgstr "字段"
 
 #: frontend/src/metabase/query_builder/components/Filter.jsx:117
 msgid "Matches"
-msgstr "一致"
+msgstr "匹配"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:152
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:160
 #: frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx:18
 msgid "Add filters to narrow your answer"
-msgstr "回答を絞るためにフィルターを追加する"
+msgstr "添加筛选条件来缩小你的答案范围"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:297
 msgid "Add a grouping"
-msgstr "グルーピングを追加する"
+msgstr "添加一个聚合"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:334
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:29
@@ -5021,57 +5047,57 @@ msgstr "グルーピングを追加する"
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:104
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:109
 msgid "Data"
-msgstr "データ"
+msgstr "数据"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:363
 msgid "Filtered by"
-msgstr "フィルターされた"
+msgstr "筛选条件"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:75
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:380
 msgid "View"
-msgstr "閲覧"
+msgstr "查看"
 
 #: frontend/src/metabase/query_builder/components/GuiQueryEditor.jsx:397
 msgid "Grouped By"
-msgstr "グループ化された"
+msgstr "分组条件"
 
 #: frontend/src/metabase/query_builder/components/LimitWidget.jsx:27
 msgid "None"
-msgstr "なし"
+msgstr "没有"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:376
 msgid "This question is written in {0}."
-msgstr "この質問は{0}で書かれました"
+msgstr "这个疑问已经被写入{0}"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:384
 msgid "Hide Editor"
-msgstr "エディターを非表示にする"
+msgstr "隐藏编辑器"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:385
 msgid "Hide Query"
-msgstr "クエリを非表示にする"
+msgstr "隐藏查询"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:390
 msgid "Open Editor"
-msgstr "エディターを表示する"
+msgstr "打开编辑器"
 
 #: frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx:391
 msgid "Show Query"
-msgstr "クエリを表示する"
+msgstr "显示查询"
 
 #: frontend/src/metabase/query_builder/components/QueryDefinitionTooltip.jsx:25
 msgid "This metric has been retired.  It's no longer available for use."
-msgstr "このメトリクスは放棄されており、使用することができません"
+msgstr "这个指标已经被淘汰，它将不再可用了"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:34
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:46
 msgid "Download full results"
-msgstr "全結果をダウンロードする"
+msgstr "下载完整结果"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:35
 msgid "Download this data"
-msgstr "このデータをダウンロードする"
+msgstr "下载数据"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:46
 msgid "Warning"
@@ -5079,49 +5105,49 @@ msgstr "警告"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:50
 msgid "Your answer has a large number of rows so it could take a while to download."
-msgstr "行数が多いため、ダウンロードに時間がかかる場合があります"
+msgstr "数据行太多，需要一段时间才能下载。"
 
 #: frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx:51
 msgid "The maximum download size is 1 million rows."
-msgstr "最大ダウンロードサイズは100万行です"
+msgstr "下载上限是1百万行"
 
 #: frontend/src/metabase/query_builder/components/view/EditQuestionInfoModal.jsx:9
 msgid "Edit question"
-msgstr "質問を編集する"
+msgstr "编辑图表"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:249
 msgid "SAVE CHANGES"
-msgstr "変更を保存する"
+msgstr "保存更改"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:263
 msgid "CANCEL"
-msgstr "キャンセル"
+msgstr "取消"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:276
 msgid "Move question"
-msgstr "質問を移動する"
+msgstr "移动图表"
 
 #: frontend/src/metabase/query_builder/components/QueryModals.jsx:135
 msgid "Which collection should this be in?"
-msgstr "これはどのコレクションに保存しますか？"
+msgstr "将这个放到哪个集合中？"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:134
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx:84
 #: frontend/src/metabase/query_builder/components/view/NativeVariablesButton.jsx:17
 msgid "Variables"
-msgstr "変数"
+msgstr "变量"
 
 #: frontend/src/metabase/query_builder/components/view/DataReferenceButton.jsx:17
 msgid "Learn about your data"
-msgstr "データについて詳しく見る"
+msgstr "了解数据集"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:460
 msgid "Alerts are on"
-msgstr "アラートはオンです"
+msgstr "提醒设置在"
 
 #: frontend/src/metabase/query_builder/components/QueryHeader.jsx:522
 msgid "started from"
-msgstr "から開始"
+msgstr "开始于"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:48
 msgid "SQL"
@@ -5129,39 +5155,39 @@ msgstr "SQL"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:48
 msgid "native query"
-msgstr "ネイティブクエリ"
+msgstr "原生脚本"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:52
 msgid "Not Supported"
-msgstr "サポートされていません"
+msgstr "不支持"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:58
 msgid "View the {0}"
-msgstr "{0}を見る"
+msgstr "查看{0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:59
 msgid "Switch to {0}"
-msgstr "{0}に切り換える"
+msgstr "切换到{0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:62
 msgid "Switch to Builder"
-msgstr "ビルダーに切り換える"
+msgstr "切换到编辑器"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:87
 msgid "{0} for this question"
-msgstr "この質問の{0}"
+msgstr "这个图表的{0}"
 
 #: frontend/src/metabase/query_builder/components/QueryModeButton.jsx:111
 msgid "Convert this question to {0}"
-msgstr "この質問を{0}に転換する"
+msgstr "转换图表为{0}"
 
 #: frontend/src/metabase/query_builder/components/RunButtonWithTooltip.jsx:20
 msgid "This question will take approximately {0} to refresh"
-msgstr "この質問は更新に約{0}かかります"
+msgstr "这个图表大约需要{0}来刷新"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLastUpdated.jsx:13
 msgid "Updated {0}"
-msgstr "{0}をアップデートしました"
+msgstr "已更新"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:141
 msgid "row"
@@ -5170,127 +5196,127 @@ msgstr[0] "行"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:148
 msgid "Showing first {0} {1}"
-msgstr "最初の{0} {1}を表示する"
+msgstr "显示第一个{0}{1}中"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:151
 msgid "Showing {0} {1}"
-msgstr "{0} {1}を表示する"
+msgstr "显示{0}{1}中"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:162
 msgid "Doing science"
-msgstr "実験中"
+msgstr "开始计算"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:149
 msgid "If you give me some data I can show you something cool. Run a Query!"
-msgstr "お見せしたいものがあります。データを入力し、 是非クエリを実行してください！"
+msgstr "如果你给我一些数据我可以展示给你看一些很酷的东西，运行一个查询吧！"
 
 #: frontend/src/metabase/query_builder/components/QueryVisualization.jsx:299
 msgid "How do I use this thing?"
-msgstr "どのように使いますか？"
+msgstr "我该如何使用这个？"
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Answer"
-msgstr "回答を得る"
+msgstr "得到答案"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:12
 msgid "It's okay to play around with saved questions"
-msgstr "保存された質問で自由に操作していただいて構いません"
+msgstr "随便看看已经存储的疑问吧"
 
 #: frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx:14
 msgid "You won't make any permanent changes to a saved question unless you click the edit icon in the top-right."
-msgstr "右上の編集アイコンをクリックしない限り、保存された質問に変更は反映されません"
+msgstr "除非您单击右上角的编辑图标，否则您不会对保存的问题进行任何永久性更改。"
 
 #: frontend/src/metabase/query_builder/components/SearchBar.jsx:28
 msgid "Search for"
-msgstr "を探す"
+msgstr "搜寻"
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:158
 msgid "Advanced..."
-msgstr "高度な..."
+msgstr "高级的……"
 
 #: frontend/src/metabase/query_builder/components/SelectionModule.jsx:167
 msgid "Sorry. Something went wrong."
-msgstr "申し訳ありません、問題が発生しました"
+msgstr "对不起，出现问题了。"
 
 #: frontend/src/metabase/query_builder/components/TimeGroupingPopover.jsx:40
 msgid "Group time by"
-msgstr "で時間をグループ化する"
+msgstr "时间分组"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:50
 msgid "Your question took too long"
-msgstr "質問に時間がかかりすぎました"
+msgstr "你的疑问花了很长时间"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:51
 msgid "We didn't get an answer back from your database in time, so we had to stop. You can try again in a minute, or if the problem persists, you can email an admin to let them know."
-msgstr "データベースから時間内に回答を得られなかったため、動作を終了しました。時間をおいて再度お試しいただくか、問題が続く場合は管理者にメールでお問い合わせください。"
+msgstr "并没有及时从数据库里获取结果，因此停止。可以过段时间再尝试，或者问题依旧存在，可以联系管理员。"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:60
 msgid "We're experiencing server issues"
-msgstr "サーバーの問題が発生しています"
+msgstr "我们碰到了服务器问题"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:61
 msgid "Try refreshing the page after waiting a minute or two. If the problem persists we'd recommend you contact an admin."
-msgstr "数分後にページを再読み込みしてください。問題が続く場合は、管理者へお問い合わせください。"
+msgstr "等待一两分钟后，再刷新页面。如果问题依旧存在，请联系管理员。"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:95
 msgid "There was a problem with your question"
-msgstr "質問で問題が発生しました"
+msgstr "你的疑问有故障"
 
 #: frontend/src/metabase/query_builder/components/VisualizationError.jsx:96
 msgid "Most of the time this is caused by an invalid selection or bad input value. Double check your inputs and retry your query."
-msgstr "これは無効な選択または無効な入力値であるために発生することがあります。 入力を再度確認して、クエリを再試行してください。"
+msgstr "大多数情况，是由于无效查询或错误输入值导致。请确认输入值，重新运行脚本。"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:66
 msgid "This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific."
-msgstr "お探しの回答ですか？そうではない場合は、回答が特定されすぎないように、フィルターを削除または変更してください。"
+msgstr "这可能是您正在寻找的答案。如果不是，请尝试删除或更改过滤器，使其不那么具体。"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:71
 msgid "You can also {0} when there are some results."
-msgstr "結果がある場合は、{0}もできます。"
+msgstr "你也可以{0}，当有一些结果时。"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:73
 msgid "get an alert"
-msgstr "アラートを受け取る"
+msgstr "得到一个警报"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:77
 msgid "Back to last run"
-msgstr "最後の実行に戻る"
+msgstr "返回上一次运行"
 
 #: frontend/src/metabase/query_builder/components/view/ViewFooter.jsx:155
 msgid "Visualization"
-msgstr "ビジュアライゼーション"
+msgstr "可视化"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:95
 msgid "No description set."
-msgstr "まだ説明がありません"
+msgstr "没有设置描述"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Use for current question"
-msgstr "現在の質問で使用する"
+msgstr "为当前疑问使用"
 
 #: frontend/src/metabase/reference/components/UsefulQuestions.jsx:16
 msgid "Potentially useful questions"
-msgstr "役立つかもしれない質問"
+msgstr "有潜在价值的疑问"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:169
 msgid "Group by {0}"
-msgstr "{0}でグループ化する"
+msgstr "按{0}分组"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:165
 msgid "Sum of all values of {0}"
-msgstr "{0}の全値の合計"
+msgstr "{0}的和"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:63
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:51
 msgid "All distinct values of {0}"
-msgstr "{0}の全ての重複を除いた値"
+msgstr "{0}的去重值"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:190
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:39
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:39
 msgid "Number of {0} grouped by {1}"
-msgstr "{1}でグループ化された{0}の数"
+msgstr "按{1}分组的{0}计数"
 
 #: frontend/src/metabase/query_builder/components/dataref/DataReference.jsx:75
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:20
@@ -5302,107 +5328,107 @@ msgstr "{1}でグループ化された{0}の数"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:24
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:23
 msgid "Data Reference"
-msgstr "データ一覧"
+msgstr "数据参考"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:13
 msgid "Learn more about your data structure to ask more useful questions"
-msgstr "さらに役立つ質問をするためにデータ構成を詳しく知る"
+msgstr "了解更多关于你的数据结构并提出更多有用的疑问"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:65
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:91
 msgid "Could not find the table metadata prior to creating a new question"
-msgstr "質問作成前にテーブルメタデータが見つかりませんでした"
+msgstr "在创建一个新的疑问之前不能找到表单元数据"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:87
 msgid "See {0}"
-msgstr "{0}を見る"
+msgstr "查看{0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/MetricPane.jsx:101
 msgid "Metric Definition"
-msgstr "メトリクスの定義"
+msgstr "指标定义"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:125
 msgid "Filter by {0}"
-msgstr "{0}でフィルターをかける"
+msgstr "根据{0}筛选"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:134
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:36
 msgid "Number of {0}"
-msgstr "{0}の数"
+msgstr "{0}的数字"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:141
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:46
 msgid "See all {0}"
-msgstr "全ての{0}を見る"
+msgstr "查看所有的{0}"
 
 #: frontend/src/metabase/query_builder/components/dataref/SegmentPane.jsx:155
 msgid "Segment Definition"
-msgstr "セグメントの定義"
+msgstr "区段定义"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:50
 msgid "An error occurred loading the table"
-msgstr "テーブルの読み込み中にエラーが発生しました"
+msgstr "在加载表时发生了一个错误"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:74
 msgid "See the raw data for {0}"
-msgstr "{0}のローデータを見る"
+msgstr "查看{0}的所有原始数据"
 
 #: frontend/src/metabase/query_builder/components/dataref/TablePane.jsx:179
 msgid "More"
-msgstr "さらに"
+msgstr "更多"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:201
 msgid "Invalid expression"
-msgstr "無効な表現"
+msgstr "不可用的表达式"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:276
 msgid "unknown error"
-msgstr "不明なエラー"
+msgstr "未知错误"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:51
 msgid "Field formula"
-msgstr "フィールド計算式"
+msgstr "字段公式"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:62
 msgid "Think of this as being kind of like writing a formula in a spreadsheet program: you can use numbers, fields in this table, mathematical symbols like +, and some functions. So you could type something like Subtotal - Cost."
-msgstr "これは、スプレッドシートプログラムで数式を書くようなものだとお考えください。数値、この表のフィールド、+などの数学記号、その他一部の機能を使用できます。そのため、Subtotal - Costのようなものを入力することができます。"
+msgstr "这有点像在EXCEL表中编写公式，你可以使用数字，字段，数学符号和一些函数，例如 Subtotal - Cost。"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:71
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:126
 msgid "Learn more"
-msgstr "詳しく見る"
+msgstr "了解更多"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:75
 msgid "Give it a name"
-msgstr "名前を付ける"
+msgstr "给它一个名字吧"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.jsx:81
 msgid "Something nice and descriptive"
-msgstr "分かりやすい説明"
+msgstr "一些超棒的、值得记录的东西"
 
 #: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:60
 msgid "Add a custom field"
-msgstr "カスタムフィールドを追加する"
+msgstr "添加一个自定义字段"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:17
 msgid "Include {0}"
-msgstr "{0}を含む"
+msgstr "包含{0}"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:19
 msgid "Case sensitive"
-msgstr "大文字/小文字を区別する"
+msgstr "大小写敏感"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:23
 msgid "today"
-msgstr "本日"
+msgstr "今天"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:24
 msgid "this week"
-msgstr "今週"
+msgstr "本周"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:25
 msgid "this month"
-msgstr "今月"
+msgstr "本月"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:26
 msgid "this year"
@@ -5410,230 +5436,230 @@ msgstr "今年"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:27
 msgid "this minute"
-msgstr "現在の分"
+msgstr "这一分钟"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterOptions.jsx:28
 msgid "this hour"
-msgstr "現在の時間"
+msgstr "这个小时"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:290
 msgid "not implemented {0}"
-msgstr "未実装の{0}"
+msgstr "未实现{0}"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:291
 msgid "true"
-msgstr "正"
+msgstr "正确"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx:291
 msgid "false"
-msgstr "誤"
+msgstr "错误"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterPopoverFooter.jsx:41
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:32
 msgid "Add filter"
-msgstr "フィルターを追加する"
+msgstr "添加过滤器"
 
 #: frontend/src/metabase/query_builder/components/filters/FilterWidgetList.jsx:64
 msgid "Item"
-msgstr "アイテム"
+msgstr "项"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:220
 msgid "Previous"
-msgstr "前回"
+msgstr "前"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:251
 msgid "Current"
-msgstr "現在"
+msgstr "当前"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/DatePicker.jsx:277
 #: frontend/src/metabase/visualizations/lib/settings/column.js:246
 #: frontend/src/metabase/visualizations/lib/settings/series.js:89
 msgid "On"
-msgstr "オン"
+msgstr "在"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/NumberPicker.jsx:47
 msgid "Enter desired number"
-msgstr "希望の番号を入力する"
+msgstr "输入期望值"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:83
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:150
 msgid "Empty"
-msgstr "空"
+msgstr "空的"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SelectPicker.jsx:116
 msgid "Find a value"
-msgstr "値を探す"
+msgstr "寻找一个值"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:113
 msgid "Hide calendar"
-msgstr "カレンダーを非表示にする"
+msgstr "隐藏日历"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:113
 msgid "Show calendar"
-msgstr "カレンダーを表示する"
+msgstr "显示日历"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx:97
 msgid "You can enter multiple values separated by commas"
-msgstr "コンマ(,)で区切ることで、複数の値を入力できます"
+msgstr "可以输入多个值按逗号分隔"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/TextPicker.jsx:38
 msgid "Enter desired text"
-msgstr "希望のテキストを入力する"
+msgstr "输入想要的文本"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:107
 msgid "Try it"
-msgstr "試してみる"
+msgstr "试试看"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:129
 msgid "What's this for?"
-msgstr "何に使いますか？"
+msgstr "这是针对于？"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:131
 msgid "Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL."
-msgstr "ネイティブクエリの変数を用いることで、フィルターウィジェットまたはURLを使用したクエリの値を置き換えることができます。"
+msgstr "原生查询中的变量允许使用筛选组件或URL参数来动态替换查询中的值。"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:136
 msgid "{0} creates a variable in this SQL template called \"variable_name\". Variables can be given types in the side panel, which changes their behavior. All variable types other than \"Field Filter\" will automatically cause a filter widget to be placed on this question; with Field Filters, this is optional. When this filter widget is filled in, that value replaces the variable in the SQL template."
-msgstr "{0}は、このSQLテンプレートで変数名 \"variable_name\"を作成します。 サイドパネルに変数を指定すると、その動作が変わります。 \"フィールドフィルター\"以外の全ての変数タイプは、この質問に自動的にフィルターウィジェットを配置します。 フィールドフィルターでは、これはオプションです。 このフィルターウィジェットが入力されると、その値がSQLテンプレートの変数に置き換えられます。"
+msgstr "{0}在此SQL模板中创建一个名为“variable_name”的变量。变量可以在侧面板中给出类型，这会改变它们的行为。除“字段过滤器”之外的所有变量类型都将自动导致过滤器小部件放在此问题上;使用字段过滤器，这是可选的。填充此过滤器窗口小部件时，该值将替换SQL模板中的变量。"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:145
 msgid "Field Filters"
-msgstr "フィルターを探す"
+msgstr "字段过滤器"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:147
 msgid "Giving a variable the \"Field Filter\" type allows you to link SQL cards to dashboard filter widgets or use more types of filter widgets on your SQL question. A Field Filter variable inserts SQL similar to that generated by the GUI query builder when adding filters on existing columns."
-msgstr "変数に \"フィールドフィルター\"タイプを指定すると、SQLカードをダッシュボードフィルターウィジェットにリンクしたり、SQL質問にさらに多くのタイプのフィルターウィジェットを使用することができます。 フィールドフィルター変数は、既存の列にフィルターを追加するときにGUIクエリビルダーによって生成されたものと同様のSQLを挿入します。"
+msgstr "为变量提供“字段过滤器”类型将允许您链接SQL卡到仪表盘的过滤组件，或在图表上使用更多类型的过滤组件。 在现有列上添加过滤器时，字段过滤器变量会插入类似于GUI查询构建器生成的SQL。"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:150
 msgid "When adding a Field Filter variable, you'll need to map it to a specific field. You can then choose to display a filter widget on your question, but even if you don't, you can now map your Field Filter variable to a dashboard filter when adding this question to a dashboard. Field Filters should be used inside of a \"WHERE\" clause."
-msgstr "フィールドフィルター変数を追加するときは、特定のフィールドにマップする必要があります。 質問にフィルターウィジェットを表示させるか選択できますが、そうでない場合でも、この質問をダッシュボードに追加するときに、フィールドフィルター変数をダッシュボードフィルターにマッピングすることが可能です。 フィールドフィルターは \"WHERE\"節の中で使用する必要があります。"
+msgstr "添加“字段过滤器”变量时，您需要将其映射到特定字段。 然后，您可以选择在问题上显示过滤组件，但即使不这样做，现在可以在将此问题添加到仪表板时将“字段过滤器”变量映射到仪表盘过滤器。 字段过滤器应在“WHERE”子句中使用。"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:157
 msgid "Optional Clauses"
-msgstr "選択条項"
+msgstr "可选条款"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:132
 msgid "brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr "{0}を囲む括弧は、テンプレート内に任意の句を作成します。 \"変数\"が設定されている場合は、節全体がテンプレートに配置されます。 そうでない場合、節全体が無視されます。"
+msgstr "{0}周围的括号在模板中创建一个可选子句。如果设置了“variable”，则将整个子句放入模板中。否则忽略整个子句。"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:169
 msgid "To use multiple optional clauses you can include at least one non-optional WHERE clause followed by optional clauses starting with \"AND\"."
-msgstr "複数の任意の句を使用するには、最低1つの任意でないWHERE句と、その後に「AND」で始まる任意の句を含めてください。"
+msgstr "要使用多个可选子句，您可以包含至少一个非可选WHERE子句，接着以“AND”开头的可选子句。"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:187
 msgid "Read the full documentation"
-msgstr "全文を読む"
+msgstr "阅读完整文档"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:130
 msgid "Filter label"
-msgstr "フィルターラベル"
+msgstr "过滤标签"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:142
 msgid "Variable type"
-msgstr "値タイプ"
+msgstr "多种类型"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:143
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:151
 msgid "Text"
-msgstr "テキスト"
+msgstr "文本"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:119
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:153
 msgid "Date"
-msgstr "日付"
+msgstr "日期"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:154
 msgid "Field Filter"
-msgstr "フィールドフィルター"
+msgstr "字段筛选条件"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:160
 msgid "Field to map to"
-msgstr "マップするためのフィールド"
+msgstr "字段映射到"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:181
 msgid "Filter widget type"
-msgstr "フィルターウィジェットタイプ"
+msgstr "过滤器样式"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:203
 msgid "Required?"
-msgstr "必要ですか？"
+msgstr "必填项？"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx:213
 msgid "Default filter widget value"
-msgstr "デフォルトのフィルターウィジェット値"
+msgstr "过滤器默认值"
 
 #: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:19
 msgid "Archive this question?"
-msgstr "この質問をアーカイブしますか？"
+msgstr "归档图表？"
 
 #: frontend/src/metabase/query_builder/containers/ArchiveQuestionModal.jsx:20
 msgid "This question will be removed from any dashboards or pulses using it."
-msgstr "この質問は関連したダッシュボードやパルスから削除されます"
+msgstr "这个图表会从已引用的仪表盘或定时任务中移除"
 
 #: frontend/src/metabase/query_builder/containers/QueryBuilder.jsx:151
 msgid "Question"
-msgstr "質問"
+msgstr "疑问"
 
 #: frontend/src/metabase/questions/containers/AddToDashboard.jsx:11
 msgid "Pick a question to add"
-msgstr "追加する質問を選ぶ"
+msgstr "选择一个疑问来添加"
 
 #: frontend/src/metabase/reference/components/EditHeader.jsx:19
 msgid "You are editing this page"
-msgstr "このページを編集中です"
+msgstr "你正在编辑这个页面"
 
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:101
 #: frontend/src/metabase/reference/components/ReferenceHeader.jsx:63
 msgid "See this {0}"
-msgstr "この{0}を見る"
+msgstr "查看这个{0}"
 
 #: frontend/src/metabase/reference/components/EditableReferenceHeader.jsx:117
 msgid "A subset of"
-msgstr "のサブセット"
+msgstr "子集"
 
 #: frontend/src/metabase/reference/components/Field.jsx:47
 #: frontend/src/metabase/reference/components/Field.jsx:86
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:32
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:67
 msgid "Select a field type"
-msgstr "フィールドタイプを選択する"
+msgstr "选择一个字段类型"
 
 #: frontend/src/metabase/reference/components/Field.jsx:56
 #: frontend/src/metabase/reference/components/Field.jsx:71
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:41
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:56
 msgid "No field type"
-msgstr "フィールドタイプがありません"
+msgstr "没有字段类型"
 
 #: frontend/src/metabase/reference/components/FieldToGroupBy.jsx:22
 msgid "by"
-msgstr "で"
+msgstr "通过"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:25
 #: frontend/src/metabase/reference/databases/FieldList.jsx:155
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:156
 msgid "Field type"
-msgstr "フィールドタイプ"
+msgstr "字段类型"
 
 #: frontend/src/metabase/reference/components/FieldTypeDetail.jsx:71
 msgid "Select a Foreign Key"
-msgstr "外部キーを選択する"
+msgstr "选择一个外键"
 
 #: frontend/src/metabase/reference/components/Formula.jsx:56
 msgid "View the {0} formula"
-msgstr "{0}計算式を見る"
+msgstr "查看{0}的公式"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:80
 msgid "Why this {0} is important"
-msgstr "なぜこの{0}は重要ですか？"
+msgstr "为什么{0}重要"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:81
 msgid "Why this {0} is interesting"
-msgstr "なぜこの{0}は興味深いですか？"
+msgstr "为什么{0}有趣"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:87
 msgid "Nothing important yet"
-msgstr "重要なデータはまだありません"
+msgstr "还没有什么重要的事情"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:88
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:171
@@ -5643,11 +5669,11 @@ msgstr "重要なデータはまだありません"
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:222
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:232
 msgid "Nothing interesting yet"
-msgstr "興味深いデータはまだありません"
+msgstr "还没有什么有趣的事情"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:93
 msgid "Things to be aware of about this {0}"
-msgstr "この{0}関して知っておくべきこと"
+msgstr "关于{0}的注意事项"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:97
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:181
@@ -5657,78 +5683,78 @@ msgstr "この{0}関して知っておくべきこと"
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:232
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:242
 msgid "Nothing to be aware of yet"
-msgstr "知っておくべきことはまだありません"
+msgstr "目前暂无注意项"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:103
 msgid "Explore this metric"
-msgstr "このメトリクスを調査する"
+msgstr "探索这个指标"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:105
 msgid "View this metric"
-msgstr "メトリクスを見る"
+msgstr "查看这个指标"
 
 #: frontend/src/metabase/reference/components/GuideDetail.jsx:112
 msgid "By {0}"
-msgstr "{0}で"
+msgstr "按{0}"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:146
 msgid "Remove item"
-msgstr "アイテムを削除する"
+msgstr "移除选项"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:155
 msgid "Why is this dashboard the most important?"
-msgstr "なぜこのダッシュボードが最重要ですか？"
+msgstr "为什么仪表盘最重要？"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:156
 msgid "What is useful or interesting about this {0}?"
-msgstr "{0}の何が役立つまたは興味深いですか？"
+msgstr "{0}中什么有用或者有趣？"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:160
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:174
 msgid "Write something helpful here"
-msgstr "役立つ情報をご記入ください"
+msgstr "在这里写一些有帮助的东西吧"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:169
 msgid "Is there anything users of this dashboard should be aware of?"
-msgstr "このダッシュボードのユーザーが知っておくべきことはありますか？"
+msgstr "有什么事情是这个仪表盘的用户需要知道的吗？"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:170
 msgid "Anything users should be aware of about this {0}?"
-msgstr "{0}に関してユーザーが知っておくべきことはありますか？"
+msgstr "任何事情关于{0}是用户需要知道的吗?"
 
 #: frontend/src/metabase/reference/components/GuideDetailEditor.jsx:182
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:26
 msgid "Which 2-3 fields do you usually group this metric by?"
-msgstr "このメトリクスをグループ化するにあたりよく使うフィールド2〜3個はどれですか？"
+msgstr "你经常用哪2-3个字段把这些指标聚合？"
 
 #: frontend/src/metabase/reference/components/GuideHeader.jsx:23
 msgid "This is the perfect place to start if you’re new to your company’s data, or if you just want to check in on what’s going on."
-msgstr "企業のデータにアクセスするのが初めての場合や、まずはどんな感じか見てみたい場合は、ここから始めると良いでしょう"
+msgstr "如果对于公司数据不了解，或者想检查一下怎么回事，这是一个很好的选择。"
 
 #: frontend/src/metabase/reference/components/MetricImportantFieldsDetail.jsx:65
 msgid "Most useful fields to group this metric by"
-msgstr "このメトリクスをグループ化するのに最も役立つフィールド"
+msgstr "用来聚合这个指标最有效的字段"
 
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:32
 msgid "Reason for changes"
-msgstr "変更理由"
+msgstr "变更的理由"
 
 #: frontend/src/metabase/reference/components/RevisionMessageModal.jsx:36
 msgid "Leave a note to explain what changes you made and why they were required"
-msgstr "変更箇所と変更理由を記入してください"
+msgstr "对为什么必须做这些修改进行文字记录"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:169
 msgid "Why this database is interesting"
-msgstr "なぜこのデータベースは興味深いですか？"
+msgstr "为什么这个数据库十分有趣"
 
 #: frontend/src/metabase/reference/databases/DatabaseDetail.jsx:179
 msgid "Things to be aware of about this database"
-msgstr "このデータベースに関して知っておくべきこと"
+msgstr "关于这个数据库需要了解的事情"
 
 #: frontend/src/metabase/reference/databases/DatabaseList.jsx:49
 #: frontend/src/metabase/reference/guide/BaseSidebar.jsx:39
 msgid "Databases and tables"
-msgstr "データベースとテーブル"
+msgstr "数据库和报表"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:61
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:27
@@ -5742,962 +5768,963 @@ msgstr "データベースとテーブル"
 #: frontend/src/metabase/reference/segments/SegmentFieldSidebar.jsx:31
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:30
 msgid "Details"
-msgstr "詳細"
+msgstr "细节"
 
 #: frontend/src/metabase/reference/databases/DatabaseSidebar.jsx:33
 #: frontend/src/metabase/reference/databases/TableList.jsx:115
 msgid "Tables in {0}"
-msgstr "{0}のテーブル"
+msgstr "{0}中的报表"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:225
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:203
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:221
 msgid "Actual name in database"
-msgstr "データベース上の実際の名前"
+msgstr "实际在数据库中的名称"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:234
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:230
 msgid "Why this field is interesting"
-msgstr "なぜこのフィールドは興味深いですか？"
+msgstr "为什么这个字段有趣"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:244
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:240
 msgid "Things to be aware of about this field"
-msgstr "このフィールドに関して知っておくべきこと"
+msgstr "关于这个字段需要了解的事情"
 
 #: frontend/src/metabase/reference/databases/FieldDetail.jsx:256
 #: frontend/src/metabase/reference/databases/FieldList.jsx:158
 #: frontend/src/metabase/reference/segments/SegmentFieldDetail.jsx:252
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:159
 msgid "Data type"
-msgstr "データタイプ"
+msgstr "数据类型"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:39
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:39
 msgid "Fields in this table will appear here as they're added"
-msgstr "このテーブルのフィールドは追加されるとここに表示されます"
+msgstr "在这个表单中添加字段时，它们将会出现在这里"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:137
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:138
 msgid "Fields in {0}"
-msgstr "{0}のフィールド"
+msgstr "在{0}中的字段"
 
 #: frontend/src/metabase/reference/databases/FieldList.jsx:152
 #: frontend/src/metabase/reference/segments/SegmentFieldList.jsx:153
 msgid "Field name"
-msgstr "フィールド名"
+msgstr "字段名称"
 
 #: frontend/src/metabase/reference/databases/FieldSidebar.jsx:49
 msgid "X-ray this field"
-msgstr "このフィールドを自動探査(X-ray)する"
+msgstr "透视这个字段"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:8
 msgid "Metabase is no fun without any data"
-msgstr "Metabaseを使用するにはデータが必要です"
+msgstr "Metabase没有任何数据的话一点都不好玩"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:9
 msgid "Your databases will appear here once you connect one"
-msgstr "データベースは一度接続するとここに表示されます"
+msgstr "一但你连接了一个数据库，它将会出现在这里"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:10
 msgid "Databases will appear here once your admins have added some"
-msgstr "データベースは一度管理者が追加するとここに表示されます"
+msgstr "一但你的管理员添加了，数据库将会出现在这里"
 
 #: frontend/src/metabase/reference/databases/NoDatabasesEmptyState.jsx:12
 msgid "Connect a database"
-msgstr "データベースを接続する"
+msgstr "连接一个数据库"
 
 #. #-#-#-#-#  metabase-backend.pot (metabase)  #-#-#-#-#
 #. cum-count and cum-sum get names for count and sum, respectively (see explanation in `aggregation-name`)
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:38
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of {0}"
-msgstr "{0}のカウント"
+msgstr "{0}计数"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:47
 msgid "See raw data for {0}"
-msgstr "{0}のローデータを見る"
+msgstr "查看{0}的原始数据"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:212
 msgid "Why this table is interesting"
-msgstr "なぜこのテーブルは興味深いですか？"
+msgstr "为什么这个表单有趣"
 
 #: frontend/src/metabase/reference/databases/TableDetail.jsx:222
 msgid "Things to be aware of about this table"
-msgstr "このテーブルに関して知っておくべきこと"
+msgstr "关于这个表单需要知道的事情"
 
 #: frontend/src/metabase/reference/databases/TableList.jsx:30
 msgid "Tables in this database will appear here as they're added"
-msgstr "このデータベースのテーブルは追加されるとここに表示れます"
+msgstr "当在这个数据库中添加表单时，它们将会出现在这里"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:34
 msgid "Questions about this table will appear here as they're added"
-msgstr "このテーブルに関する質問は追加されるとここに表示されます"
+msgstr "当关于这个表单的疑问被添加时，它们将会出现在这里"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:74
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:78
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:36
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:77
 msgid "Questions about {0}"
-msgstr "{0}に関する質問"
+msgstr "关于{0}的疑问"
 
 #: frontend/src/metabase/reference/databases/TableQuestions.jsx:98
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:102
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:101
 msgid "Created {0} by {1}"
-msgstr "{1}で{0}を作成しました"
+msgstr "根据{1}创建{0}"
 
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:40
 msgid "Fields in this table"
-msgstr "このテーブルのフィールド"
+msgstr "在这个表中的字段"
 
 #: frontend/src/metabase/reference/databases/TableSidebar.jsx:48
 msgid "Questions about this table"
-msgstr "このテーブルに関する質問"
+msgstr "关于这个表的疑问"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:158
 msgid "Help your team get started with your data."
-msgstr "チームとデータを共有する"
+msgstr "帮助团队了解数据"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:160
 msgid "Show your team what’s most important by choosing your top dashboard, metrics, and segments."
-msgstr "トップにくるダッシュボード、メトリクス、セグメントを選択し、チームに重要事項を提示しましょう"
+msgstr "选择TOP仪表盘、指标和划分，向团队展示什么是最重要的。"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:166
 msgid "Get started"
-msgstr "開始する"
+msgstr "开始"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:174
 msgid "Our most important dashboard"
-msgstr "最重要ダッシュボード"
+msgstr "我们最重要的仪表盘"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:189
 msgid "Numbers that we pay attention to"
-msgstr "注視すべき数値"
+msgstr "我们注意的那些数字"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:214
 msgid "Metrics are important numbers your company cares about. They often represent a core indicator of how the business is performing."
-msgstr "メトリクスは企業が重視する数値です。ビジネスが上手くいっているかどうかを示すものです。"
+msgstr "指标是贵公司关心的重要数字,它们通常代表业务运营方式的核心指标。"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:222
 msgid "See all metrics"
-msgstr "全メトリクスを見る"
+msgstr "查看所有的指标"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:236
 msgid "Segments and tables"
-msgstr "セグメントとテーブル"
+msgstr "划分和表格"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:83
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:237
 msgid "Tables"
-msgstr "テーブル"
+msgstr "表格"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:263
 msgid "Segments and tables are the building blocks of your company's data. Tables are collections of the raw information while segments are specific slices with specific meanings, like {0}"
-msgstr "セグメントやテーブルは、会社データの基礎的要素です。 テーブルはローデータをまとめた情報であり、セグメントは{0}など特定の意味を持つ特定の情報です。"
+msgstr "划分和表格是公司数据的构建块。 表格是原始信息的集合，而划分是具有特定含义的切片，如{0}"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:268
 msgid "Tables are the building blocks of your company's data."
-msgstr "テーブルは、会社データの基礎的要素です。"
+msgstr "表示公司数据组织的基本单元"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:278
 msgid "See all segments"
-msgstr "全セグメントを見る"
+msgstr "查看所有的区间"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:294
 msgid "See all tables"
-msgstr "全てのテーブルを見る"
+msgstr "查看所有的表单"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:302
 msgid "Other things to know about our data"
-msgstr "データに関して他に知っておくべきこと"
+msgstr "关于我们的数据需要了解的其他事情"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:303
 msgid "Find out more"
-msgstr "詳細を見る"
+msgstr "发现更多"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:308
 msgid "A good way to get to know your data is by spending a bit of time exploring the different tables and other info available to you. It may take a while, but you'll start to recognize names and meanings over time."
-msgstr "他のテーブルや情報をもっと見ることで、自身のデータをより詳しく知ることができます。時間がかかるかもしれませんが、名前やその意味について理解を深めることができるでしょう。"
+msgstr "了解数据的一个好方法就是花时间去看下不同的表格还有其他可用信息。可能会花一段时间，但是慢慢地会了解很多字段名和含义。"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:314
 msgid "Explore our data"
-msgstr "データを調査する"
+msgstr "探索我们的数据"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:322
 msgid "Have questions?"
-msgstr "質問はありますか？"
+msgstr "有问题吗？"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuide.jsx:327
 msgid "Contact {0}"
-msgstr "{0}に問い合わせる"
+msgstr "联系{0}"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:253
 msgid "Help new Metabase users find their way around."
-msgstr "新しいユーザーをヘルプする"
+msgstr "帮助新的Metabase用户了解如何使用"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:256
 msgid "The Getting Started guide highlights the dashboard, metrics, segments, and tables that matter most, and informs your users of important things they should know before digging into the data."
-msgstr "スタートガイドは、ダッシュボード、メトリクス、セグメントやテーブル等の重要事項に焦点を当て、ユーザーが実際にデータを扱い始める前に知っておくべきことを説明しています。"
+msgstr "“入门指南”重点介绍了仪表盘，指标，划分和表格，并在深入了解数据之前告知用户他们应该了解的重要事项。"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:263
 msgid "Is there an important dashboard for your team?"
-msgstr "チームに重要なダッシュボードはありますか？"
+msgstr "这有一个对你们团队来说重要的仪表盘吗？"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:265
 msgid "Create a dashboard now"
-msgstr "今すぐダッシュボードを作成する"
+msgstr "现在创建一个仪表盘"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:271
 msgid "What is your most important dashboard?"
-msgstr "最重要ダッシュボードはどれですか？"
+msgstr "什么是你最重要的仪表盘?"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:290
 msgid "Do you have any commonly referenced metrics?"
-msgstr "よく参照するメトリクスはありますか？"
+msgstr "你有常引用的指标么？"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:292
 msgid "Learn how to define a metric"
-msgstr "メトリクスの定義づけ方法を確認する"
+msgstr "了解如何定义指标。"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:308
 msgid "What are your 3-5 most commonly referenced metrics?"
-msgstr "よく参照するメトリクス3〜5個は何ですか？"
+msgstr "你最常引用的3~5个指标是什么？"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:352
 msgid "Add another metric"
-msgstr "他のメトリクスを追加する"
+msgstr "添加另外一个指标"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:365
 msgid "Do you have any commonly referenced segments or tables?"
-msgstr "よく参照するセグメントやテーブルはありますか"
+msgstr "你有常引用的划分或表格么？"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:367
 msgid "Learn how to create a segment"
-msgstr "セグメントの作成方法を確認する"
+msgstr "学习如何创建一个区间"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:383
 msgid "What are 3-5 commonly referenced segments or tables that would be useful for this audience?"
-msgstr "オーディエンスに役立つであろう、よく参照するセグメントやテーブル3〜5個は何ですか？"
+msgstr "对其他人有用的3~5个常引用的划分或者表格是什么？"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:429
 msgid "Add another segment or table"
-msgstr "他のセグメントやテーブルを追加する"
+msgstr "添加另外一个区间或表单"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:438
 msgid "Is there anything your users should understand or know before they start accessing the data?"
-msgstr "データへのアクセスを開始する前に、ユーザーが理解し知っておくべきことはありますか？"
+msgstr "有什么是你的用户在开始连接到他们的数据库之前应该理解或者知道的吗？"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:444
 msgid "What should a user of this data know before they start accessing it?"
-msgstr "データへのアクセスを開始する前に、ユーザーが知っておくべきことは何ですか？"
+msgstr "这个数据的用户在开始连接之前应该知道什么？"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:448
 msgid "E.g., expectations around data privacy and use, common pitfalls or misunderstandings, information about data warehouse performance, legal notices, etc."
-msgstr "例: データのプライバシーと使用に関する危険性や誤解、データウェアハウスのパフォーマンスに関する情報、法的通知など"
+msgstr "例如，对数据隐私和使用的期望，常见的陷阱或误解，有关数据仓库性能的信息，法律声明等。"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:459
 msgid "Is there someone your users could contact for help if they're confused about this guide?"
-msgstr "このガイドで不明点があった際にユーザーがコンタクトできる方はいますか？"
+msgstr "有什么人是你的用户如果对向导感到疑惑，可以联系到并且寻求帮助的吗？"
 
 #: frontend/src/metabase/reference/guide/GettingStartedGuideEditForm.jsx:468
 msgid "Who should users contact for help if they're confused about this data?"
-msgstr "このデータで不明点があった際にユーザーは誰にコンタクトすべきですか？"
+msgstr "用户如果对这个数据感到疑惑，他们应该联系谁寻求帮助？"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:75
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:95
 msgid "Please enter a revision message"
-msgstr "履歴メッセージを入力してください"
+msgstr "请输入一个调整信息"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:216
 msgid "Why this Metric is interesting"
-msgstr "なぜこのメトリクスは興味深いですか？"
+msgstr "为什么这个指标有趣"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:226
 msgid "Things to be aware of about this Metric"
-msgstr "このメトリクスに関して知っておくべきこと"
+msgstr "关于这个指标需要注意的事情"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:236
 msgid "How this Metric is calculated"
-msgstr "このメトリクスの計算方法"
+msgstr "这个指标是如何计算的"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:238
 msgid "Nothing on how it's calculated yet"
-msgstr "計算方法はまだありません"
+msgstr "它是如何计算的里面还没有东西"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:295
 msgid "Other fields you can group this metric by"
-msgstr "このメトリクスをグループ化する他のフィールド"
+msgstr "你可以通过聚合这个指标形成的其他领域"
 
 #: frontend/src/metabase/reference/metrics/MetricDetail.jsx:296
 msgid "Fields you can group this metric by"
-msgstr "このメトリクスをグループ化するフィールド"
+msgstr "你可以通过聚合这个指标得到的领域"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:25
 msgid "Metrics are the official numbers that your team cares about"
-msgstr "メトリクスはチームが重視する公式な数値です"
+msgstr "指标是你的团队关心的官方数字"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:27
 msgid "Metrics will appear here once your admins have created some"
-msgstr "メトリクスは管理者が作成次第ここに表示されます"
+msgstr "一但你的管理员创建了一些指标的话，它们将会出现在这里"
 
 #: frontend/src/metabase/reference/metrics/MetricList.jsx:29
 msgid "Learn how to create metrics"
-msgstr "メトリクスの作成方法を詳しく見る"
+msgstr "了解如何创建指标"
 
 #: frontend/src/metabase/reference/metrics/MetricQuestions.jsx:35
 msgid "Questions about this metric will appear here as they're added"
-msgstr "このメトリクスに関する質問は追加されるとここに表示されます"
+msgstr "添加这个指标的图表会在这里显示。"
 
 #: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:29
 msgid "There are no revisions for this metric"
-msgstr "このメトリクスには履歴がありません"
+msgstr "这个指标没有修改历史"
 
 #: frontend/src/metabase/reference/metrics/MetricRevisions.jsx:91
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:51
 #: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:91
 msgid "Revision history for {0}"
-msgstr "{0}の履歴"
+msgstr "{0}的修改历史"
 
 #: frontend/src/metabase/reference/metrics/MetricSidebar.jsx:43
 msgid "X-ray this metric"
-msgstr "このメトリクスを自動探査(X-ray)する"
+msgstr "透视这个指标"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:220
 msgid "Why this Segment is interesting"
-msgstr "なぜこのセグメントは興味深いですか？"
+msgstr "为什么这个区段很有意思"
 
 #: frontend/src/metabase/reference/segments/SegmentDetail.jsx:230
 msgid "Things to be aware of about this Segment"
-msgstr "このセグメントに関して知っておくべきこと"
+msgstr "关于这个区段的注意事项"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:24
 msgid "Segments are interesting subsets of tables"
-msgstr "セグメントはテーブルのサブセットです"
+msgstr "区段是表格的子集"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:25
 msgid "Defining common segments for your team makes it even easier to ask questions"
-msgstr "共通のセグメントについて定義するとチームがより質問しやすくなります"
+msgstr "为你的团队定义公共区段，让它用来提问也十分容易"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:26
 msgid "Segments will appear here once your admins have created some"
-msgstr "セグメントは管理者が作成次第ここに表示されます"
+msgstr "你的管理员添加后，区段将会出现在这里，"
 
 #: frontend/src/metabase/reference/segments/SegmentList.jsx:28
 msgid "Learn how to create segments"
-msgstr "セグメントの作成方法について詳しく見る"
+msgstr "学习如何创建区段"
 
 #: frontend/src/metabase/reference/segments/SegmentQuestions.jsx:35
 msgid "Questions about this segment will appear here as they're added"
-msgstr "このセグメントに関する質問は追加されるとここに表示されます"
+msgstr "当它们被添加时，关于这个区段的疑问将会出现在这里"
 
 #: frontend/src/metabase/reference/segments/SegmentRevisions.jsx:29
 msgid "There are no revisions for this segment"
-msgstr "このセグメントには履歴がありません"
+msgstr "这个区段没有修改过"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:36
 msgid "Fields in this segment"
-msgstr "このセグメントのフィールド"
+msgstr "在这个区段中的字段"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:42
 msgid "Questions about this segment"
-msgstr "このセグメントに関する質問"
+msgstr "有关这个区段的疑问"
 
 #: frontend/src/metabase/reference/segments/SegmentSidebar.jsx:49
 msgid "X-ray this segment"
-msgstr "このセグメントを自動探査(X-ray)する"
+msgstr "透视这个区段"
 
 #: frontend/src/metabase/routes.jsx:182
 msgid "Login"
-msgstr "ログイン"
+msgstr "登录"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:156
 #: frontend/src/metabase/routes.jsx:198
 msgid "Search"
-msgstr "検索"
+msgstr "查询"
 
 #: frontend/src/metabase/routes.jsx:217
 msgid "Dashboard"
-msgstr "ダッシュボード"
+msgstr "仪表盘"
 
 #: frontend/src/metabase/routes.jsx:228
 msgid "New Question"
-msgstr "新しい質問"
+msgstr "新疑问"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:125
 msgid "Select the type of Database you use"
-msgstr "使用するデータベースタイプを選択する"
+msgstr "选择你使用的数据库类型"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:146
 msgid "Add your data"
-msgstr "データを追加する"
+msgstr "添加你的数据"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:150
 msgid "I'll add my own data later"
-msgstr "あとでデータを追加する"
+msgstr "我之后将会添加自己的数据"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:151
 msgid "Connecting to {0}"
-msgstr "{0}に接続中"
+msgstr "连接到{0}"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:170
 msgid "You’ll need some info about your database, like the username and password. If you don’t have that right now, Metabase also comes with a sample dataset you can get started with."
-msgstr "ユーザー名やパスワード等データベースに関する情報が必要です。"
+msgstr "在开始之前需要配置数据库信息（如：用户名、密码）。如果暂时没有这些信息metabase也提供了一个简单数据源供学习使用。"
 
 #: frontend/src/metabase/setup/components/DatabaseConnectionStep.jsx:202
 msgid "I'll add my data later"
-msgstr "あとでデータを追加する"
+msgstr "我之后再添加数据"
 
 #: frontend/src/metabase/setup/components/DatabaseSchedulingStep.jsx:46
 msgid "Control automatic scans"
-msgstr "自動スキャンを設定する"
+msgstr "控制自动化扫描"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:52
 msgid "Usage data preferences"
-msgstr "データ使用の優先度"
+msgstr "使用数据引用"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:55
 msgid "Thanks for helping us improve"
-msgstr "ご協力ありがとうございます"
+msgstr "感谢帮助我们提升"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:56
 msgid "We won't collect any usage events"
-msgstr "Usage eventに関する情報は収集いたしません"
+msgstr "我们不会收集任何使用事件信息"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:75
 msgid "In order to help us improve Metabase, we'd like to collect certain data about usage through Google Analytics."
-msgstr "Metabaseサービスを向上させるため、Google Analyticsを通じてデータ使用に関する情報を収集いたします"
+msgstr "为了提升Metabase的用户体验，可能需要通过Google Analytics收集特定的使用数据。"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:80
 msgid "Here's a full list of everything we track and why."
-msgstr "収集する情報とその理由についてはこちらをご確認ください"
+msgstr "这个我们所有我们要收集的清单，以及为什么要收集"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:93
 msgid "Allow Metabase to anonymously collect usage events"
-msgstr "Metabaseが匿名の情報収集をすることに同意する"
+msgstr "允许Metabase匿名收集使用事件"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:100
 msgid "Metabase {0} collects anything about your data or question results."
-msgstr "Metabase {0}はデータや質問結果に関する情報を収集します"
+msgstr "Metabase{0}收集任何事情关于你的数据或者提问结果"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:101
 msgid "never"
-msgstr "しない"
+msgstr "永不"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:103
 msgid "All collection is completely anonymous."
-msgstr "情報収集は全て匿名です"
+msgstr "所有的收集都是匿名的。"
 
 #: frontend/src/metabase/setup/components/PreferencesStep.jsx:104
 msgid "Collection can be turned off at any point in your admin settings."
-msgstr "情報収集による設定は管理者設定からいつでも変更することができます"
+msgstr "您随时可以在管理设置中关闭信息收集。"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:44
 msgid "If you feel stuck"
-msgstr "お困りの場合"
+msgstr "如果你不知从何下手"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:49
 msgid "our getting started guide"
-msgstr "スタートガイド"
+msgstr "初始化文档"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:50
 msgid "is just a click away."
-msgstr "クリックするだけ"
+msgstr "点击一下"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:92
 msgid "Welcome to Metabase"
-msgstr "Metabaseへようこそ"
+msgstr "欢迎来到Metabase"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:93
 msgid "Looks like everything is working. Now let’s get to know you, connect to your data, and start finding you some answers!"
-msgstr "すべて正常に動作しています。使用を開始し、データを接続して回答を探しましょう。"
+msgstr "看起来一切都在正常工作，现在让我们了解你吧，连接到你的数据，并且开始寻找一些属于你的答案！"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:97
 msgid "Let's get started"
-msgstr "開始しましょう"
+msgstr "让我们开始吧"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:142
 msgid "You're all set up!"
-msgstr "準備ができました！"
+msgstr "你已经设置完毕了！"
 
 #: frontend/src/metabase/setup/components/Setup.jsx:153
 msgid "Take me to Metabase"
-msgstr "Metabaseを使い始める"
+msgstr "带我去Metabase"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:155
 msgid "What should we call you?"
-msgstr "何とお呼びしましょうか？"
+msgstr "我们应该怎么称呼你？"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:156
 msgid "Hi, {0}. nice to meet you!"
-msgstr "やあ {0} さん、はじめまして！"
+msgstr "你好，{0}很高兴见到你！"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:243
 msgid "Create a password"
-msgstr "パスワードを作成する"
+msgstr "创建一个密码"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:259
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:117
 msgid "Shhh..."
-msgstr "シーッ"
+msgstr "嘘……"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:269
 msgid "Confirm password"
-msgstr "パスワード確認"
+msgstr "确认密码"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:278
 msgid "Shhh... but one more time so we get it right"
-msgstr "もう一度お試しください"
+msgstr "嘘……再输入一次让我们确保它是对的"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:287
 msgid "Your company or team name"
-msgstr "企業名またはチーム名"
+msgstr "你的公司或者团队名称"
 
 #: frontend/src/metabase/setup/components/UserStep.jsx:296
 msgid "Department of awesome"
-msgstr "部署名"
+msgstr "超棒的部门"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:26
 msgid "Metabot is admiring your integers…"
-msgstr "MetaBot処理中..."
+msgstr "Metabot正在欣赏你的整数……"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:27
 msgid "Metabot is performing billions of differential equations…"
-msgstr "MetaBot処理中..."
+msgstr "Metabot正在执行数十亿的微分方程......"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:28
 msgid "Metabot is doing science…"
-msgstr "MetaBot処理中..."
+msgstr "Metabot正在计算……"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:29
 msgid "Metabot is checking out your metrics…"
-msgstr "MetaBotはメトリクスを確認中..."
+msgstr "Metabot正在检查你的指标……"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:30
 msgid "Metabot is looking for trends and outliers…"
-msgstr "MetaBot処理中..."
+msgstr "Metabot正在寻找趋势和异常值……"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:31
 msgid "Metabot is consulting the quantum abacus…"
-msgstr "MetaBot処理中..."
+msgstr "Metabot正在咨询量子计算器......"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:32
 msgid "Metabot is feeling pretty good about all this…"
-msgstr "MetaBot処理中..."
+msgstr "Metabot对这一切感觉都非常棒……"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:52
 msgid "We’ll show you some interesting explorations of your data in\n"
 "just a few minutes."
-msgstr "わずか数分であなたのデータに関する興味深い探索結果を提示します。"
+msgstr "我们很快将会展示给你一些关于你的数据的有趣的探索结果。"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:72
 msgid "This seems to be taking a while. In the meantime, you can check out one of these example explorations to see what Metabase can do for you."
-msgstr "しばらく時間がかかります。その間、これらの探索結果のサンプルを見てMetabaseで何ができるか知ることができます。"
+msgstr "这需要花费一段时间。 在此期间，您可以查看其中一个示例，来了解Metabase可以为您做些什么。"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:86
 msgid "I took a look at the data you just connected, and I have some explorations of interesting things I found. Hope you like them!"
-msgstr "今接続されたデータに基づく、興味深い探索結果がいくつかあります。気に入っていただけると嬉しいです。"
+msgstr "我看了一下你刚刚连接的数据，我对一些有趣的数据进行了探索分析。 希望你喜欢他们！"
 
 #: frontend/src/metabase/setup/containers/PostSetupApp.jsx:98
 msgid "I'm done exploring for now"
-msgstr "調査を終了する"
+msgstr "我暂时完成了探索"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:20
 msgid "Welcome to the Query Builder!"
-msgstr "クエリビルダーへようこそ"
+msgstr "欢迎使用报表设计器！"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:22
 msgid "The Query Builder lets you assemble questions (or \"queries\") to ask about your data."
-msgstr "クエリビルダーを使用すると、データに関する質問（またはクエリ）を作成することができます"
+msgstr "查询创建器允许你收集问题（或者“查询”）来向你的数据提问。"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:26
 msgid "Tell me more"
-msgstr "さらに詳しく"
+msgstr "告诉我更多"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:43
 msgid "Start by picking the table with the data that you have a question about."
-msgstr "質問のあるデータを含むテーブルを選ぶことから開始する"
+msgstr "选择你有相关疑问的数据表单来开始吧"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:45
 msgid "Go ahead and select the \"Orders\" table from the dropdown menu."
-msgstr "ドロップダウンメニューから \"Orders\" テーブルを選択する"
+msgstr "继续并且从下拉菜单中选择“指派”表单"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:78
 msgid "Filter your data to get just what you want."
-msgstr "ご希望の情報を得るためにフィルターをかける"
+msgstr "过滤你的数据来获得你想要的结果"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:79
 msgid "Click the plus button and select the \"Created At\" field."
-msgstr "＋ボタンをクリックして、「作成日時」フィールドを選択する"
+msgstr "点击加号按钮并且选择“创建于”字段。"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:93
 msgid "Here we can pick how many days we want to see data for, try 10"
-msgstr "何日間のデータを見たいか選ぶことができます。10日から見てみてはいかがですか？"
+msgstr "这里我们能够选择想要查看多少天的数据，试试10吧"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:116
 msgid "Here's where you can choose to add or average your data, count the number of rows in the table, or just view the raw data."
-msgstr "こちらでデータを追加したり平均したり、テーブル内の行数を数えたり、またはローデータを見たりできます"
+msgstr "您在此处可以选择累加、计算平均值、计算表中的行数或只查看原始数据。"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:118
 msgid "Try it: click on <strong>Raw Data</strong> to change it to <strong>Count of rows</strong> so we can count how many orders there are in this table."
-msgstr "お試しください: <Strong>ローデータ</strong>をクリックして設定を<strong>行数</strong>に変更すると、このテーブル内のオーダー数を確認することができます。"
+msgstr "试一试：点击<strong>Raw Data</strong> 修改为 <strong>Count of rows</strong> ，这样就可以计算出此表中有多少条数据"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:142
 msgid "Add a grouping to break out your results by category, day, month, and more."
-msgstr "グルーピングを追加して、結果をカテゴリー、日、月等で分ける"
+msgstr "添加分组以分类，日期，月份等区隔呈现您的结果。"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:144
 msgid "Let's do it: click on <strong>Add a grouping</strong>, and choose <strong>Created At: by Week</strong>."
-msgstr "やってみましょう: <strong>グルーピングを追加する</strong>をクリックして、<strong>作成日時: 週別</strong>を選択しましょう"
+msgstr "让我们来试试：添加一个聚合，并且选择创建以：周为单位"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:152
 msgid "Click on \"by day\" to change it to \"Week.\""
-msgstr "「1日ごと」をクリックして「週」に変更する"
+msgstr "点击“以天为单位”更改为“以周为单位”"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:173
 msgid "Run Your Query."
-msgstr "クエリを実行する"
+msgstr "运行你的查询"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:175
 msgid "You're doing so well! Click <strong>Run query</strong> to get your results!"
-msgstr "その調子です！<strong>クエリを実行する</strong>をクリックして結果を表示させましょう。"
+msgstr "你做的真棒！点击运行查询来获取你的结果！"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:192
 msgid "You can view your results as a chart instead of a table."
-msgstr "テーブルではなくチャートとして結果を見ることができます"
+msgstr "你可以用图表的形式查看你的结果，而不仅仅是表单"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:194
 msgid "Everbody likes charts! Click the <strong>Visualization</strong> dropdown and select <strong>Line</strong>."
-msgstr "チャートを使うと便利です！<strong>ビジュアライゼーション</strong>のドロップダウンをクリックして、<strong>線</strong>を選択しましょう"
+msgstr "每个人都喜欢图表！点击可视化下拉菜单并且选择线段"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:216
 msgid "Well done!"
-msgstr "よくできました！"
+msgstr "做得漂亮！"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:218
 msgid "That's all! If you still have questions, check out our"
-msgstr "以上です！ご不明な点がありましたら、こちらをご確認ください"
+msgstr "就这些了！如果你还有问题的话，请查看我们的"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "User's Guide"
-msgstr "ユーザーガイド"
+msgstr "用户入门"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:223
 msgid "Have fun exploring your data!"
-msgstr "データ調査をお楽しみください！"
+msgstr "祝你在数据的海洋里探索愉快！"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:226
 msgid "Thanks"
-msgstr "ありがとうございました"
+msgstr "感谢"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:235
 msgid "Save Your Questions"
-msgstr "質問を保存する"
+msgstr "保存你的疑问"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:237
 msgid "By the way, you can save your questions so you can refer to them later. Saved Questions can also be put into dashboards or Pulses."
-msgstr "質問を保存することで、あとからでも参照することができます。保存された質問はダッシュボードやパルスでも確認できます。"
+msgstr "环比，你可以存储你的疑问，你以后可以引用他们。已存储的疑问统一能够被放进仪表盘或者波动中。"
 
 #: frontend/src/metabase/tutorial/QueryBuilderTutorial.jsx:241
 msgid "Sounds good"
-msgstr "確認しました"
+msgstr "听起来不错"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:248
 msgid "Whoops!"
-msgstr "おっと！"
+msgstr "喔！"
 
 #: frontend/src/metabase/tutorial/Tutorial.jsx:249
 msgid "Sorry, it looks like something went wrong. Please try restarting the tutorial in a minute."
-msgstr "申し訳ありません、問題が発生しました。時間をおいてから再度チュートリアルを再生してください。"
+msgstr "对不起，看起来有些错误，请试试立即重启教程"
 
 #: frontend/src/metabase/user/actions.js:34
 msgid "Password updated successfully!"
-msgstr "パスワードがアップデートされました！"
+msgstr "密码成功更新！"
 
 #: frontend/src/metabase/user/actions.js:53
 msgid "Account updated successfully!"
-msgstr "アカウントがアップデートされました！"
+msgstr "账户成功更新！"
 
 #: frontend/src/metabase/user/components/SetUserPassword.jsx:107
 msgid "Current password"
-msgstr "現在のパスワード"
+msgstr "当前密码"
 
 #: frontend/src/metabase/user/components/UpdateUserDetails.jsx:137
 msgid "Sign in with Google Email address"
-msgstr "Googleメールアドレスでサインインする"
+msgstr "用Google邮箱地址登录"
 
 #: frontend/src/metabase/user/components/UserSettings.jsx:65
 msgid "User Details"
-msgstr "ユーザー詳細"
+msgstr "用户详情"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:302
 msgid "Reset to defaults"
-msgstr "デフォルトに戻す"
+msgstr "恢复默认值"
 
 #: frontend/src/metabase/visualizations/components/ChoroplethMap.jsx:137
 msgid "unknown map"
-msgstr "不明なマップ"
+msgstr "未知地图"
 
 #: frontend/src/metabase/visualizations/components/LeafletGridHeatMap.jsx:26
 msgid "Grid map requires binned longitude/latitude."
-msgstr "グリッドマップには経度/緯度がビニングされている必要があります"
+msgstr "网格地图需要绑定经度/纬度。"
 
 #: frontend/src/metabase/visualizations/components/LegendVertical.jsx:112
 msgid "more"
-msgstr "さらに"
+msgstr "更多"
 
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:111
 msgid "Which fields do you want to use for the X and Y axes?"
-msgstr "X軸、Y軸にどのフィールドを使用しますか？"
+msgstr "横坐标和纵坐标想使用那些字段?"
 
 #: frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx:113
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:64
 msgid "Choose fields"
-msgstr "フィールドを選択する"
+msgstr "选择字段"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:215
 msgid "Save as default view"
-msgstr "デフォルトビューとして保存する"
+msgstr "作为默认视图存储"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Draw box to filter"
-msgstr "フィルターにボックスを描く"
+msgstr "添加过滤器"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:237
 msgid "Cancel filter"
-msgstr "フィルターをキャンセルする"
+msgstr "取消过滤器"
 
 #: frontend/src/metabase/visualizations/components/PinMap.jsx:47
 msgid "Pin Map"
-msgstr "マップを固定する"
+msgstr "固定地图"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:369
 msgid "Unset"
-msgstr "解除する"
+msgstr "撤销设置"
 
 #: frontend/src/metabase/visualizations/components/TableSimple.jsx:253
 msgid "Rows {0}-{1} of {2}"
-msgstr "{2}の行{0}〜{1}"
+msgstr "{2}的{0}~{1}行"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:196
 msgid "Data truncated to {0} rows."
-msgstr "{0}行に切り捨てされたデータ"
+msgstr "数据被截断为{0}行。"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:391
 msgid "Could not find visualization"
-msgstr "ビジュアライゼーションが見つかりませんでした"
+msgstr "找不到可视化"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:398
 msgid "Could not display this chart with this data."
-msgstr "このデータではチャートが表示できません"
+msgstr "无法显示这个图表显示这些数据"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:514
 msgid "No results!"
-msgstr "結果が見つかりませんでした"
+msgstr "没有结果！"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:535
 msgid "Still Waiting..."
-msgstr "待機中..."
+msgstr "仍然在等待……"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:538
 msgid "This usually takes an average of {0}."
-msgstr "通常約{0}かかります"
+msgstr "这将通常取一个{0}的平均数。"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:544
 msgid "(This is a bit long for a dashboard)"
-msgstr "（通常のダッシュボード処理より時間がかかっています）"
+msgstr "（这对于仪表盘来说有点太长了）"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:503
 msgid "This is usually pretty fast but seems to be taking awhile right now."
-msgstr "通常より時間がかかっています"
+msgstr "这个一般超级快，但是看起来现在等了有一会儿了"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx:36
 msgid "Select a field"
-msgstr "フィールドを選択する"
+msgstr "选择一个字段"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx:45
 msgid "error"
-msgstr "エラー"
+msgstr "错误"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:122
 msgid "Click and drag to change their order"
-msgstr "順番を変えるにはクリックしてドラッグしてください"
+msgstr "点击并且拖拽来改变他们的指令"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedColumns.jsx:135
 msgid "Add fields from the list below"
-msgstr "以下リストからフィールドを追加する"
+msgstr "从下方列表中添加字段"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:24
 msgid "less than"
-msgstr "より小さい"
+msgstr "少于"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:25
 msgid "greater than"
-msgstr "より大きい"
+msgstr "大于"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "less than or equal to"
-msgstr "以下"
+msgstr "小于或者等于"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "greater than or equal to"
-msgstr "以上"
+msgstr "大于或者等于"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:28
 msgid "equal to"
-msgstr "同等"
+msgstr "等于"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:29
 msgid "not equal to"
-msgstr "同等ではない"
+msgstr "不等于"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:191
 msgid "Conditional formatting"
-msgstr "条件付書式"
+msgstr "条件格式"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:193
 msgid "You can add rules to make the cells in this table change color if\n"
 "they meet certain conditions."
-msgstr "条件にあったテーブルのセルの色を変更するためのルールを追加することができます"
+msgstr "你可以添加规则来使这个表单中的原子数据改变颜色，如果他们满足主要条件。"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:203
 msgid "Add a rule"
-msgstr "ルールを追加する"
+msgstr "添加一个规则"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:208
 msgid "Rules will be applied in this order"
-msgstr "この順番でルールが適用されます"
+msgstr "规则将会被应用在这个指令中"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:209
 msgid "Click and drag to reorder."
-msgstr "順番を変更するにはクリックしてドラッグしてください"
+msgstr "点击并且拖拽来重新分配"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:242
 msgid "No columns selected"
-msgstr "列が選択されていません"
+msgstr "没有选择列"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:290
 msgid "Cells in this column will be tinted based on their values."
-msgstr "この列のセルは値によって色付けされます"
+msgstr "在这个列中的数据将会根据它们的值被染色"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:279
 msgid "When a cell in these columns is {0} it will be tinted this color."
-msgstr "この列のセルが{0}のとき、この色に色付けされます"
+msgstr "当一个数据在这些列中是{0}时，它将会被染成这个颜色。"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:313
 msgid "Which columns should be affected?"
-msgstr "どの列に適用しますか？"
+msgstr "哪些列应受影响？"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:335
 msgid "Formatting style"
-msgstr "フォーマットスタイル"
+msgstr "格式化样式"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:339
 msgid "Single color"
-msgstr "単色"
+msgstr "颜色值"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:340
 msgid "Color range"
-msgstr "色の範囲"
+msgstr "颜色范围"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:312
 msgid "When a cell in this column is…"
-msgstr "この列のセルが...のとき"
+msgstr "当这个栏中的一个单元格是……"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:376
 msgid "…turn its background this color:"
-msgstr "背景がこの色になる:"
+msgstr "……改变它的背景为这个颜色："
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:382
 msgid "Highlight the whole row"
-msgstr "全行をハイライトする"
+msgstr "高亮整行"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:390
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:132
 msgid "Colors"
-msgstr "色"
+msgstr "颜色"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:404
 msgid "Start the range at"
-msgstr "範囲をここから指定する"
+msgstr "范围开始于"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:409
 msgid "Smallest value in this column"
-msgstr "この列の最小値"
+msgstr "在这个列中最小的值"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:411
 msgid "Smallest value in each column"
-msgstr "各列の最小値"
+msgstr "在每个列中最小的值"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:413
 msgid "Smallest value in all of these columns"
-msgstr "これらの列の最小値"
+msgstr "在所有这些列中最小的值"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:417
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:441
 msgid "Custom value"
-msgstr "カスタム値"
+msgstr "自定义值"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:428
 msgid "End the range at"
-msgstr "範囲をここまでに指定する"
+msgstr "结束范围在"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:433
 msgid "Largest value in this column"
-msgstr "この列の最大値"
+msgstr "这个列中最大的值"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:435
 msgid "Largest value in each column"
-msgstr "各列の最大値"
+msgstr "每个列中最大的值"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:437
 msgid "Largest value in all of these columns"
-msgstr "これらの列の最大値"
+msgstr "在所有这些列中的最大的值"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:471
 msgid "Add rule"
-msgstr "ルールを追加する"
+msgstr "添加规则"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:471
 msgid "Update rule"
-msgstr "ルールをアップデートする"
+msgstr "更新规则"
 
 #: frontend/src/metabase/visualizations/index.js:33
 msgid "Visualization is null"
-msgstr "ビジュアライゼーションはnullです。"
+msgstr "可视化是空的"
 
 #: frontend/src/metabase/visualizations/index.js:38
 msgid "Visualization must define an 'identifier' static variable: "
-msgstr "ビジュアライゼーションでは、'識別子'スタティック変数を定義する必要があります: "
+msgstr "可视化图标必须定义一个作为“标识符”的静态变量：␣"
 
 #: frontend/src/metabase/visualizations/index.js:44
 msgid "Visualization with that identifier is already registered: "
-msgstr "この識別子を用いたビジュアライゼーションはすでに存在します: "
+msgstr "具有该标识符的可视化图表已经注册：␣"
 
 #: frontend/src/metabase/visualizations/index.js:72
 msgid "No visualization for {0}"
-msgstr "{0}のビジュアライゼーションがありません"
+msgstr "没有{0}的可视化"
 
+#. 未聚合的字段，如果你没有下一步操作，默认将对这个字段求和。
 #: frontend/src/metabase/visualizations/lib/warnings.js:25
 msgid "\"{0}\" is an unaggregated field: if it has more than one value at a point on the x-axis, the values will be summed."
-msgstr "「{0}」は属性のないフィールドです。X軸上に複数の値がある場合、値は合計値となります。"
+msgstr "“{0}”是未聚合的字段，如果它在X轴的点上有多于一个的值，这些值将会被求和。"
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:87
 msgid "This chart type requires at least 2 columns."
-msgstr "このチャートタイプでは最低2列が必要です"
+msgstr "这种图表需要至少2列"
 
 #: frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js:92
 msgid "This chart type doesn't support more than {0} series of data."
-msgstr "このチャートタイプは、{0}個以上のデータをサポートしていません。"
+msgstr "这种图表不支持超过{0}种数据"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:297
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:62
 msgid "Goal"
-msgstr "目標値"
+msgstr "目标"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "Doh! The data from your query doesn't fit the chosen display choice. This visualization requires at least {0} {1} of data."
-msgstr "クエリのデータが、選択した表示選択に適合しません。 このビジュアライゼーションには少なくとも{0} {1}のデータが必要です。"
+msgstr "正在……噢！从你的查询中获得的数去并不适合所选的展示选项，这个可视化需要最少数据中的{0}{1}。"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:11
 msgid "column"
@@ -6706,7 +6733,7 @@ msgstr[0] "列"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "No dice. We have {0} data {1} to show and that's not enough for this visualization."
-msgstr "{0}データ{1}が表示可能ですが、このビジュアライゼーションには不十分です。"
+msgstr "我们要显示{0}数据{1}，这对于这个可视化图表来说还不够。"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:23
 msgid "point"
@@ -6715,87 +6742,87 @@ msgstr[0] "点"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:35
 msgid "Bummer. We can't actually do a pin map for this data because we require both a latitude and longitude column."
-msgstr "緯度と経度の両方の列が必要なため、このデータのピンマップを作成できません。"
+msgstr "我们无法为此数据执行地图映射，因为我们同时需要纬度和经度列。"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:55
 msgid "Please configure this chart in the chart settings"
-msgstr "チャート設定でこのチャートを設定してください"
+msgstr "请在图表设置中配置这个图表"
 
 #: frontend/src/metabase/visualizations/lib/errors.js:57
 msgid "Edit Settings"
-msgstr "編集設定"
+msgstr "编辑设置"
 
 #: frontend/src/metabase/visualizations/lib/fill_data.js:37
 msgid "xValues missing!"
-msgstr "x値がありません"
+msgstr "x值丢失！"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:90
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:31
 msgid "X-axis"
-msgstr "X軸"
+msgstr "X轴"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:119
 msgid "Add a series breakout..."
-msgstr "ブレークアウトのシリーズを追加する..."
+msgstr "添加一系列断点......"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:132
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:35
 msgid "Y-axis"
-msgstr "Y軸"
+msgstr "Y轴"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:160
 msgid "Add another series..."
-msgstr "別のシリーズを追加する..."
+msgstr "添加另一个系列……"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:177
 msgid "Bubble size"
-msgstr "吹き出しサイズ"
+msgstr "气泡大小"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:71
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:16
 msgid "Line"
-msgstr "線"
+msgstr "线段"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:72
 msgid "Curve"
-msgstr "曲線"
+msgstr "曲线"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:73
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:104
 msgid "Step"
-msgstr "ステップ"
+msgstr "步骤"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:170
 msgid "Show point markers on lines"
-msgstr "線上にポイントマーカーを表示する"
+msgstr "在线上显示点的标记"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:219
 msgid "Stacking"
-msgstr "スタック中"
+msgstr "正在堆叠"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:223
 msgid "Don't stack"
-msgstr "スタックしない"
+msgstr "不要堆叠"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:224
 msgid "Stack"
-msgstr "スタック"
+msgstr "堆叠"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:225
 msgid "Stack - 100%"
-msgstr "スタック - 100%"
+msgstr "堆叠 - 100%"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:281
 msgid "Show goal"
-msgstr "目標値を表示する"
+msgstr "显示目标"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:287
 msgid "Goal value"
-msgstr "目標値"
+msgstr "目标值"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:103
 msgid "Replace missing values with"
-msgstr "欠測値を置き換える"
+msgstr "替换丢失的值以"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:107
 msgid "Zero"
@@ -6803,38 +6830,38 @@ msgstr "0"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:108
 msgid "Nothing"
-msgstr "なし"
+msgstr "什么也没有"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:109
 msgid "Linear Interpolated"
-msgstr "線形補間"
+msgstr "线性插值平滑"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:359
 msgid "X-axis scale"
-msgstr "X軸目盛"
+msgstr "X轴比例"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:378
 msgid "Timeseries"
-msgstr "時系列"
+msgstr "时间系列"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:381
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:399
 msgid "Linear"
-msgstr "線形"
+msgstr "线性"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:383
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:400
 msgid "Power"
-msgstr "累乗"
+msgstr "势"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:384
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:401
 msgid "Log"
-msgstr "ログ"
+msgstr "日志"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:386
 msgid "Histogram"
-msgstr "ヒストグラム"
+msgstr "柱状图"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:388
 msgid "Ordinal"
@@ -6842,157 +6869,157 @@ msgstr "序数"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:394
 msgid "Y-axis scale"
-msgstr "Y軸目盛"
+msgstr "Y轴比例"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:407
 msgid "Show x-axis line and marks"
-msgstr "X軸線とマークを表示する"
+msgstr "显示X轴线和标记"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:413
 msgid "Compact"
-msgstr "コンパクト"
+msgstr "压缩"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:414
 msgid "Rotate 45°"
-msgstr "45°回転"
+msgstr "旋转45°"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:415
 msgid "Rotate 90°"
-msgstr "90°回転"
+msgstr "旋转90°"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:422
 msgid "Show y-axis line and marks"
-msgstr "Y軸線とマークを表示する"
+msgstr "显示Y轴线段和标记"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:434
 msgid "Auto y-axis range"
-msgstr "自動Y軸範囲"
+msgstr "自动Y轴范围"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:478
 msgid "Use a split y-axis when necessary"
-msgstr "必要に応じて分割したY軸を使用する"
+msgstr "当需要时使用一个分离的Y轴"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:485
 msgid "Show label on x-axis"
-msgstr "X軸にラベルを表示する"
+msgstr "展示标签在X轴上"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:491
 msgid "X-axis label"
-msgstr "X軸ラベル"
+msgstr "X轴标签"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:500
 msgid "Show label on y-axis"
-msgstr "Y軸のラベルを表示する"
+msgstr "展示标签在Y轴上"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:506
 msgid "Y-axis label"
-msgstr "Y軸ラベル"
+msgstr "Y轴标签"
 
 #: frontend/src/metabase/visualizations/lib/utils.js:133
 msgid "Standard Deviation"
-msgstr "標準偏差"
+msgstr "标准差"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:256
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:18
 msgid "Area"
-msgstr "範囲"
+msgstr "区域"
 
 #: frontend/src/metabase/visualizations/visualizations/AreaChart.jsx:21
 msgid "area chart"
-msgstr "範囲図"
+msgstr "区域图表"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:257
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:17
 msgid "Bar"
-msgstr "棒"
+msgstr "柱"
 
 #: frontend/src/metabase/visualizations/visualizations/BarChart.jsx:20
 msgid "bar chart"
-msgstr "棒グラフ"
+msgstr "柱形图"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:62
 msgid "Which fields do you want to use?"
-msgstr "どのフィールドを利用しますか？"
+msgstr "你想要使用哪个领域？"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:32
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:122
 msgid "Funnel"
-msgstr "ファネル"
+msgstr "漏斗"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:111
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:110
 msgid "Measure"
-msgstr "測定"
+msgstr "测量"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:117
 msgid "Funnel type"
-msgstr "ファネルタイプ"
+msgstr "漏斗类型"
 
 #: frontend/src/metabase/visualizations/visualizations/Funnel.jsx:123
 msgid "Bar chart"
-msgstr "棒グラフ"
+msgstr "柱形图"
 
 #: frontend/src/metabase/visualizations/visualizations/LineChart.jsx:19
 msgid "line chart"
-msgstr "折れ線グラフ"
+msgstr "线段图表"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:301
 msgid "Please select longitude and latitude columns in the chart settings."
-msgstr "チャート設定で緯度と経度を選択してください"
+msgstr "请在图表设置中选择经度和维度的列"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:307
 msgid "Please select a region map."
-msgstr "地域マップを選択してください"
+msgstr "请选择一个区域地图"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:313
 msgid "Please select region and metric columns in the chart settings."
-msgstr "チャート設定で地域とメトリクス列を選択してください"
+msgstr "请在图表设置中选择一个区域和指标列"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:39
 msgid "Map"
-msgstr "マップ"
+msgstr "地图"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:129
 msgid "Map type"
-msgstr "マップタイプ"
+msgstr "地图类型"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:133
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:226
 msgid "Region map"
-msgstr "地域マップ"
+msgstr "区域地图"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:134
 msgid "Pin map"
-msgstr "ピンマップ"
+msgstr "固定地图"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:180
 msgid "Pin type"
-msgstr "ピンタイプ"
+msgstr "固定类型"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:185
 msgid "Tiles"
-msgstr "タイル"
+msgstr "标题"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:186
 msgid "Markers"
-msgstr "マーカー"
+msgstr "标记"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:204
 msgid "Latitude field"
-msgstr "緯度"
+msgstr "维度字段"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:211
 msgid "Longitude field"
-msgstr "経度"
+msgstr "经度字段"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:218
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:245
 msgid "Metric field"
-msgstr "メトリクスフィールド"
+msgstr "指标字段"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:249
 msgid "Region field"
-msgstr "地域フィールド"
+msgstr "区域字段"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:269
 msgid "Radius"
@@ -7000,7 +7027,7 @@ msgstr "半径"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:275
 msgid "Blur"
-msgstr "ぼかし"
+msgstr "模糊"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:281
 msgid "Min Opacity"
@@ -7008,406 +7035,405 @@ msgstr "最小不透明度"
 
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:287
 msgid "Max Zoom"
-msgstr "最大ズーム"
+msgstr "放到最大"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:227
 msgid "No relationships found."
-msgstr "関係は見つかりませんでした"
+msgstr "没有发现关联。"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:265
 msgid "via {0}"
-msgstr "{0}経由"
+msgstr "通过{0}"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:343
 msgid "This {0} is connected to:"
-msgstr "この{0}は接続していません:"
+msgstr "这个{0}连接到"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:87
 msgid "Object Detail"
-msgstr "オブジェクト詳細"
+msgstr "对象细节"
 
 #: frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx:90
 msgid "object"
-msgstr "オブジェクト"
+msgstr "对象"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:371
 msgid "Total"
-msgstr "合計"
+msgstr "总计"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:73
 msgid "Which columns do you want to use?"
-msgstr "どの列を使用しますか？"
+msgstr "需要用哪些列？"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:49
 msgid "Pie"
-msgstr "円"
+msgstr "饼图"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:105
 msgid "Dimension"
-msgstr "ディメンション"
+msgstr "维度"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:115
 msgid "Show legend"
-msgstr "凡例"
+msgstr "显示说明"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:120
 msgid "Show percentages in legend"
-msgstr "凡例にパーセンテージを表示する"
+msgstr "在说明中显示百分比"
 
 #: frontend/src/metabase/visualizations/visualizations/PieChart.jsx:126
 msgid "Minimum slice percentage"
-msgstr "最小パーセンテージ"
+msgstr "最小切片百分比"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:161
 msgid "Goal met"
-msgstr "目標値に到達しました"
+msgstr "目标达成"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:163
 msgid "Goal exceeded"
-msgstr "目標値を達成しました"
+msgstr "突破目标"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:230
 msgid "Goal {0}"
-msgstr "目標値{0}"
+msgstr "目标{0}"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:43
 msgid "Progress visualization requires a number."
-msgstr "進行状況のビジュアライゼーションには数値が必要です。"
+msgstr "处理可视化需要一个数字。"
 
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:27
 msgid "Progress"
-msgstr "プログレス"
+msgstr "处理"
 
 #: frontend/src/metabase/entities/collections.js:109
 #: frontend/src/metabase/visualizations/visualizations/Map.jsx:253
 #: frontend/src/metabase/visualizations/visualizations/Progress.jsx:68
 msgid "Color"
-msgstr "色"
+msgstr "颜色"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row Chart"
-msgstr "行グラフ"
+msgstr "原始图表"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:16
 msgid "row chart"
-msgstr "行グラフ"
+msgstr "原始图表"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:358
 msgid "Separator style"
-msgstr "桁区切りスタイル"
+msgstr "分隔符"
 
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:88
 msgid "Number of decimal places"
-msgstr "小数点以下の桁数"
+msgstr "小数位数"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:382
 msgid "Add a prefix"
-msgstr "接頭辞をつける"
+msgstr "添加一个前缀"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:386
 msgid "Add a suffix"
-msgstr "接尾辞をつける"
+msgstr "添加一个后缀"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:375
 msgid "Multiply by a number"
-msgstr "掛ける"
+msgstr "乘以数字"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:16
 msgid "Scatter"
-msgstr "散布"
+msgstr "分散"
 
 #: frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx:19
 msgid "scatter plot"
-msgstr "散布図"
+msgstr "散点图"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:83
 msgid "Pivot the table"
-msgstr "テーブルをピボットする"
+msgstr "透视表"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:73
 msgid "Visible fields"
-msgstr "表示されるフィールド"
+msgstr "可见区域"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:167
-#, fuzzy
 msgid "Write here, and use Markdown if you'd like"
-msgstr "書き込みをし、ご自由にMarkdownをご利用ください"
+msgstr "直接输入，可以使用Markdown语法"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:73
 msgid "Vertical Alignment"
-msgstr "垂直配向"
+msgstr "垂直对齐"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:77
 msgid "Top"
-msgstr "上"
+msgstr "顶部"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:78
 msgid "Middle"
-msgstr "中"
+msgstr "中部"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:79
 msgid "Bottom"
-msgstr "下"
+msgstr "底部"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:86
 msgid "Horizontal Alignment"
-msgstr "平行配向"
+msgstr "水平对齐"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:126
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:90
 msgid "Left"
-msgstr "左"
+msgstr "左边"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:91
 msgid "Center"
-msgstr "中央"
+msgstr "中心"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:127
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:92
 msgid "Right"
-msgstr "右"
+msgstr "右边"
 
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:99
 msgid "Show background"
-msgstr "背景を表示する"
+msgstr "显示背景"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:725
 msgid "{0} bin"
 msgid_plural "{0} bins"
-msgstr[0] "{0}ビン"
+msgstr[0] "{0} 刻度间隔"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:731
 msgid "Auto binned"
-msgstr "自動ビニングされた"
+msgstr "自动分组"
 
 #: src/metabase/api/alert.clj
 msgid "DELETE /api/alert/:id is deprecated. Instead, change its `archived` value via PUT /api/alert/:id."
-msgstr "DELETE /api/alert/:idは推奨されていません。 代わりに、'archived'値をPUT /api/alert/:idで変更してください。"
+msgstr "DELETE /api/alert/:id 已弃用，请使用  PUT /api/alert/:id 来更改它的 `archived` 值。"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid show value"
-msgstr "無効な表示値"
+msgstr "不可用显示值"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid value for prefix"
-msgstr "無効な敬称の値"
+msgstr "不可用的前缀值"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "invalid value for rule name"
-msgstr "無効なルール名の値"
+msgstr "不可用的规则名"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "value couldn''t be parsed as base64 encoded JSON"
-msgstr "値をbase64でエンコードされたJSONとして解析できませんでした"
+msgstr "值不能被基于64位编码的JSON解析"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid entity type"
-msgstr "無効なエンティティタイプ"
+msgstr "不可用的实体类型"
 
 #: src/metabase/api/automagic_dashboards.clj
 msgid "Invalid comparison entity type. Can only be one of \"table\", \"segment\", or \"adhoc\""
-msgstr "無効な比較エンティティタイプです。「テーブル」「セグメント」または「アドホック」のうち一つのみが選択可能です。"
+msgstr "无效的比较实体类型。这只能是“表格”，“划分”或“即席查询”之一"
 
 #: src/metabase/query_processor/async.clj
 msgid "Error running query to determine Card result metadata:"
-msgstr "カードの結果メタデータを測定するためのクエリ実行中にエラーが発生しました:"
+msgstr "运行查询以确定卡片结果元数据时出错："
 
 #: src/metabase/api/card.clj
 msgid "DELETE /api/card/:id is deprecated. Instead, change its `archived` value via PUT /api/card/:id."
-msgstr "DELETE /api/card/:id は廃止されました。代わりに、PUT /api/card/:id を使用して`archived`の値を変更してください。"
+msgstr "DELETE /api/card/:id 已弃用，请使用  PUT /api/card/:id 来更改它的 `archived` 值。"
 
 #: src/metabase/api/common.clj src/metabase/api/common/internal.clj
 msgid "Invalid field: {0}"
-msgstr "無効なフィールド: {0}"
+msgstr "无效领域：{0}"
 
 #: src/metabase/api/common.clj
 msgid "Invalid value ''{0}'' for ''{1}'': {2}"
-msgstr "{1}に対する無効な値「{0}」: {2}"
+msgstr "无效的值“{0}”给“{1}”：“{2}”"
 
 #: src/metabase/api/common.clj
 msgid "must be one of: {0}"
-msgstr "{0}の1つでなければならない"
+msgstr "必须是：{0}的其中一个"
 
 #: src/metabase/api/common.clj
 msgid "Invalid Request."
-msgstr "無効なリクエスト"
+msgstr "不可用请求"
 
 #: src/metabase/api/common.clj
 msgid "Not found."
-msgstr "見つかりませんでした"
+msgstr "未找到。"
 
 #: src/metabase/api/common.clj
 msgid "You don''t have permissions to do that."
-msgstr "権限がありません"
+msgstr "你没有权限那么做"
 
 #: src/metabase/api/common.clj
 msgid "Internal server error."
-msgstr "サーバー内部エラー"
+msgstr "内部服务器错误。"
 
 #: src/metabase/api/common.clj
 msgid "Warning: endpoint {0}/{1} does not have a docstring."
-msgstr "警告: エンドポイント{0}/{1}はdocstringがありません"
+msgstr "警告: 末端 {0}/{1} 不包含 docstring."
 
 #: src/metabase/api/common.clj
 msgid "starting streaming request"
-msgstr "ストリーミングリクエスト開始中"
+msgstr "开始流请求"
 
 #: src/metabase/async/api_response.clj
 msgid "connection closed, canceling request"
-msgstr "接続が閉じられ、リクエストをキャンセルしています"
+msgstr "链接已关闭，正在取消请求"
 
 #. a newline padding character as it's harmless and will allow us to check if the client is connected. If
 #. sending this character fails because the connection is closed, the chan will then close.  Newlines are
 #. no-ops when reading JSON which this depends upon.
 #: src/metabase/async/api_response.clj
 msgid "Response not ready, writing one byte & sleeping..."
-msgstr "準備中..."
+msgstr "响应内容没准备好，写一个字节然后暂停了......"
 
 #: src/metabase/api/common.clj
 msgid "Public sharing is not enabled."
-msgstr "公開は有効化されていません"
+msgstr "公开分享未启用"
 
 #: src/metabase/api/common.clj
 msgid "Embedding is not enabled."
-msgstr "埋め込みは有効化されていません"
+msgstr "嵌入功能未启用"
 
 #: src/metabase/api/common.clj
 msgid "The object has been archived."
-msgstr "対象がアーカイブされました"
+msgstr "已经归档"
 
 #: src/metabase/api/common/internal.clj
 msgid "Attempted to return a boolean as an API response. This is not allowed!"
-msgstr "API応答として真偽値を返そうとしました。 これは許可されていない処理です！"
+msgstr "尝试返回一个作为API响应结果的布尔值，这不被允许！"
 
 #: src/metabase/api/dataset.clj
 msgid "Source query for this query is Card {0}"
-msgstr "このクエリのソースクエリは、カード{0}です。"
+msgstr "这个查询的查询源是{0}卡片"
 
 #: src/metabase/api/dataset.clj
 msgid "Invalid export format: {0}"
-msgstr "無効なエクスポートフォーマット: {0}"
+msgstr "无效的导出格式：{0}"
 
 #: src/metabase/api/geojson.clj
 msgid "Invalid JSON URL or resource: {0}"
-msgstr "無効なJSON URLまたはリソース: {0}"
+msgstr "不可用的JSON URL或源:{0}"
 
 #: src/metabase/api/geojson.clj
 msgid "JSON containing information about custom GeoJSON files for use in map visualizations instead of the default US State or World GeoJSON."
-msgstr "JSONには、米国または世界GeoJSONのデフォルトの代わりに、マップビジュアライゼーションで使用するカスタムGeoJSONファイルに関する情報が含まれています。"
+msgstr "JSON包含关于关于在地图可视化中使用，自定义GeoJSON的文件，而不是默认的美国地图或者世界GeoJSON。"
 
 #: src/metabase/api/geojson.clj
 msgid "Invalid custom GeoJSON key: {0}"
-msgstr "無効なカスタムGeoJSONキー: {0}"
+msgstr "不可用的自定义GeoJSON秘钥：{0}"
 
 #. ...but if we *still* couldn't find a match, throw an Exception, because we don't want people
 #. trying to inject new params
 #: src/metabase/api/public.clj
 msgid "Invalid param: {0}"
-msgstr "無効なパラメータ―: {0}"
+msgstr "无效的参数：{0}"
 
 #: src/metabase/api/pulse.clj
 msgid "DELETE /api/pulse/:id is deprecated. Instead, change its `archived` value via PUT /api/pulse/:id."
-msgstr "DELETE /api/pulse/:idは推奨されていません。 代わりに、'archived'値をPUT /api/pulse/:idで変更してください。"
+msgstr "DELETE /api/pulse/:id 已弃用，请使用 PUT /api/pulse/:id 来更改它的`archived`值。"
 
 #: src/metabase/api/routes.clj
 msgid "API endpoint does not exist."
-msgstr "APIエンドポイントが存在しません"
+msgstr "API终点不存在"
 
 #: src/metabase/api/session.clj
 msgid "Password did not match stored password."
-msgstr "保存されたパスワードと一致しませんでした"
+msgstr "密码与存储的密码不匹配。"
 
 #: src/metabase/api/session.clj
 msgid "did not match stored password"
-msgstr "保存されたパスワードと一致しませんでした"
+msgstr "与存储的密码不匹配"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fallback to local authentication {0}"
-msgstr "LDAPサーバーへの接続中に問題が発生しました。ローカル認証{0}にフォールバックします。"
+msgstr "连接到LDAP服务器时出现问题，将会完全返回本地授权验证。"
 
 #: src/metabase/api/session.clj
 msgid "Invalid reset token"
-msgstr "無効なリセットトークン"
+msgstr "无效的重置记号"
 
 #: src/metabase/api/session.clj
 msgid "Client ID for Google Auth SSO. If this is set, Google Auth is considered to be enabled."
-msgstr "Google Auth SSOのクライアントID。こちらが設定されている場合、Google Authは有効化されていると見なされます"
+msgstr "如果Google Auth SSO客户端ID被设置了，Goole Auth将会被启用。"
 
 #: src/metabase/api/session.clj
 msgid "When set, allow users to sign up on their own if their Google account email address is from this domain."
-msgstr "設定されていると、Googleメールアドレスがこのドメインを使用している場合ユーザーは自分でサインアップすることができます"
+msgstr "设置后，如果用户的Google帐户电子邮件地址来自此域，则允许用户自行注册。"
 
 #: src/metabase/api/session.clj
 msgid "Invalid Google Auth token."
-msgstr "無効なGoogle Authトークン"
+msgstr "无效的Google Auth记号"
 
 #: src/metabase/api/session.clj
 msgid "Email is not verified."
-msgstr "メールが確認されていません"
+msgstr "邮箱未认证"
 
 #: src/metabase/api/session.clj
 msgid "You''ll need an administrator to create a Metabase account before you can use Google to log in."
-msgstr "Googleを利用してログインするには、事前に管理者がMetabaseアカウントを作成する必要があります"
+msgstr "在你能够使用Google来登录之前，你需要一个管理员来创建一个Metabase账户。"
 
 #: src/metabase/api/session.clj
 msgid "Successfully authenticated Google Auth token for: {0} {1}"
-msgstr "{0} {1}のGoogle Authトークンの認証に成功しました"
+msgstr "成功为：{0}{1}授权Google Auth记号"
 
 #: src/metabase/api/setup.clj
 msgid "Add a database"
-msgstr "データベースを追加する"
+msgstr "添加一个数据库"
 
 #: src/metabase/api/setup.clj
 msgid "Get connected"
-msgstr "接続する"
+msgstr "连接上"
 
 #: src/metabase/api/setup.clj
 msgid "Connect to your data so your whole team can start to explore."
-msgstr "チームの全員がデータを見れるようにしましょう"
+msgstr "连接到你的数据，让你的整个团队可以开始探索。"
 
 #: src/metabase/api/setup.clj
 msgid "Set up email"
-msgstr "メールの設定"
+msgstr "设置邮箱"
 
 #: src/metabase/api/setup.clj
 msgid "Add email credentials so you can more easily invite team members and get updates via Pulses."
-msgstr "メールの資格情報を追加すると、チームメンバーをより簡単に招待し、パルスを通じて更新情報を入手することができます。"
+msgstr "添加电子邮件凭据，以便您可以更轻松地邀请团队成员并通过Pulses获取更新。"
 
 #: src/metabase/api/setup.clj
 msgid "Set Slack credentials"
-msgstr "Slackの認証情報をセットする"
+msgstr "设置Slack凭证"
 
 #: src/metabase/api/setup.clj
 msgid "Does your team use Slack? If so, you can send automated updates via pulses and ask questions with MetaBot."
-msgstr "チームはSlackを使用していますか？使用している場合、自動アップデートをパルスで送信し、MetaBotで質問することができます。"
+msgstr "你的团队是否使用Slack？如果使用，您可以通过定时通知发送自动更新并通过MetaBot创建问题。"
 
 #: src/metabase/api/setup.clj
 msgid "Invite team members"
-msgstr "チームメンバーを招待する"
+msgstr "邀请团队成员"
 
 #: src/metabase/api/setup.clj
 msgid "Share answers and data with the rest of your team."
-msgstr "チームと回答やデータを共有する"
+msgstr "和团队其余成员分享你的成果和数据。"
 
 #: src/metabase/api/setup.clj
 msgid "Hide irrelevant tables"
-msgstr "無関係なテーブルを非表示にする"
+msgstr "隐藏相关的表单"
 
 #: src/metabase/api/setup.clj
 msgid "Curate your data"
-msgstr "データを公開する"
+msgstr "策划您的数据"
 
 #: src/metabase/api/setup.clj
 msgid "If your data contains technical or irrelevant info you can hide it."
-msgstr "データが技術的または無関係な情報を含む場合、非表示にすることができます"
+msgstr "如果你的数据包含技术性的或者相关的信息，你可以隐藏它们"
 
 #: src/metabase/api/setup.clj
 msgid "Organize questions"
-msgstr "質問を管理する"
+msgstr "组织疑问"
 
 #: src/metabase/api/setup.clj
 msgid "Have a lot of saved questions in {0}? Create collections to help manage them and add context."
-msgstr "{0}に保存された質問が多数ありますか？整理するのにコレクションを使用しましょう。"
+msgstr "在{0}中有很多已保存的问题？创建集合以帮助管理它们并添加上下文。"
 
 #. This is the very first log message that will get printed.
 #. It's here because this is one of the very first namespaces that gets loaded, and the first that has access to the logger
@@ -7418,363 +7444,367 @@ msgstr "Metabase"
 
 #: src/metabase/api/setup.clj
 msgid "Create metrics"
-msgstr "メトリクスを作成する"
+msgstr "创建指标"
 
 #: src/metabase/api/setup.clj
 msgid "Define canonical metrics to make it easier for the rest of your team to get the right answers."
-msgstr "チームが正しい回答を得られるよう標準的なメトリクスを定義する"
+msgstr "定义标准指标来让它更容易被团队其他成员用来得到正确的答案。"
 
 #: src/metabase/api/setup.clj
 msgid "Create segments"
-msgstr "セグメントを作成する"
+msgstr "创建区间"
 
 #: src/metabase/api/setup.clj
 msgid "Keep everyone on the same page by creating canonical sets of filters anyone can use while asking questions."
-msgstr "質問をする際に誰でも使用できる標準的なフィルターを作成し、利用者全員に共通認識を持たせましょう。"
+msgstr "保持每个人在相同的页面来创造任何人都能够在提问时使用的标准筛选项。"
 
 #: src/metabase/api/table.clj
 msgid "Table ''{0}'' is now visible. Resyncing."
-msgstr "テーブル \"{0}\" は表示設定されています。再同期中。"
+msgstr "表单“{0}”现在可以被看见了，重新连接中。"
 
 #: src/metabase/api/table.clj
 msgid "Auto bin"
-msgstr "自動ビン"
+msgstr "自动间隔"
 
 #: src/metabase/api/table.clj
 msgid "Don''t bin"
-msgstr "ビニングしない"
+msgstr "无间隔"
 
 #: frontend/src/metabase/lib/query_time.js:196 src/metabase/api/table.clj
 msgid "Day"
 msgid_plural "Days"
-msgstr[0] "日"
+msgstr[0] "天\n"
+"天"
 
 #. note the order of these options corresponds to the order they will be shown to the user in the UI
 #: frontend/src/metabase/lib/query_time.js:192 src/metabase/api/table.clj
 msgid "Minute"
 msgid_plural "Minutes"
-msgstr[0] "分"
+msgstr[0] "分钟\n"
+"分钟"
 
 #: frontend/src/metabase/lib/query_time.js:194 src/metabase/api/table.clj
 msgid "Hour"
 msgid_plural "Hours"
-msgstr[0] "時間"
+msgstr[0] "小时\n"
+"小时"
 
 #: frontend/src/metabase/lib/query_time.js:202 src/metabase/api/table.clj
 msgid "Quarter"
 msgid_plural "Quarters"
-msgstr[0] "四半期"
+msgstr[0] "季度\n"
+"季度"
 
 #: src/metabase/api/table.clj
 msgid "Minute of Hour"
-msgstr "1時間のうち1分"
+msgstr "一小时中的分钟"
 
 #: src/metabase/api/table.clj
 msgid "Hour of Day"
-msgstr "1日のうち1時間"
+msgstr "一天中的小时"
 
 #: src/metabase/api/table.clj
 msgid "Day of Week"
-msgstr "1週間のうち1日"
+msgstr "一周中的天"
 
 #: src/metabase/api/table.clj
 msgid "Day of Month"
-msgstr "1か月のうち1日"
+msgstr "一个月中的天"
 
 #: src/metabase/api/table.clj
 msgid "Day of Year"
-msgstr "1年のうち1日"
+msgstr "一年中的天"
 
 #: src/metabase/api/table.clj
 msgid "Week of Year"
-msgstr "1年のうち1週間"
+msgstr "一年中的周"
 
 #: src/metabase/api/table.clj
 msgid "Month of Year"
-msgstr "1年のうち1か月"
+msgstr "一年中的月"
 
 #: src/metabase/api/table.clj
 msgid "Quarter of Year"
-msgstr "1年の4分の1"
+msgstr "一年中的季度"
 
 #: src/metabase/api/table.clj
 msgid "10 bins"
-msgstr "10ビン"
+msgstr "10个刻度间隔"
 
 #: src/metabase/api/table.clj
 msgid "50 bins"
-msgstr "50ビン"
+msgstr "间隔50"
 
 #: src/metabase/api/table.clj
 msgid "100 bins"
-msgstr "100ビン"
+msgstr "间隔100"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 0.1 degrees"
-msgstr "0.1度ごとにビニングする"
+msgstr "按0.1度间隔"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 1 degree"
-msgstr "1度ごとにビニングする"
+msgstr "按1度间隔"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 10 degrees"
-msgstr "10度ごとにビニングする"
+msgstr "Bin每度10度"
 
 #: src/metabase/api/table.clj
 msgid "Bin every 20 degrees"
-msgstr "20度ごとにビニングする"
+msgstr "按20度间隔"
 
 #. returns `true` if successful -- see JavaDoc
 #: src/metabase/api/tiles.clj src/metabase/pulse/render/sparkline.clj
 msgid "No appropriate image writer found!"
-msgstr "最適なイメージライターが見つかりませんでした"
+msgstr "找不到合适的图像写入器！"
 
 #: src/metabase/api/user.clj
 msgid "Email address already in use."
-msgstr "メールアドレスはすでに使用されています"
+msgstr "邮箱地址已经被使用。"
 
 #: src/metabase/api/user.clj
 msgid "Email address already associated to another user."
-msgstr "メールアドレスは他ユーザーがすでに使用しています"
+msgstr "邮箱地址已经被另一个用户关联。"
 
 #: src/metabase/api/user.clj
 msgid "Not able to reactivate an active user"
-msgstr "アクティブユーザーを再有効化することはできません"
+msgstr "不能恢复活动一个已经处于活动状态的用户"
 
 #: src/metabase/api/user.clj
 msgid "Invalid password"
-msgstr "無効なパスワード"
+msgstr "不可用密码"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "All {0}"
-msgstr "全{0}"
+msgstr "全部 {0}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "{0}, all {1}"
-msgstr "{0}、全{1}"
+msgstr "{0}，所有的{1}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "Comparison of {0} and {1}"
-msgstr "{0}と{1}の比較"
+msgstr "比较 {0} 和 {1}"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 msgid "Automatically generated comparison dashboard comparing {0} and {1}"
-msgstr "{0}と{1}を比較する比較ダッシュボードが自動作成されました"
+msgstr "自动生成的 {0} 和 {1} 的对比仪表盘"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "sum"
-msgstr "合計"
+msgstr "总和"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "average"
-msgstr "平均"
+msgstr "平均值"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "minumum"
-msgstr "最低"
+msgstr "最小值"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "maximum"
-msgstr "最大"
+msgstr "最大值"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "distinct count"
-msgstr "重複を除いたカウント"
+msgstr "不重复计数"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "standard deviation"
-msgstr "標準偏差"
+msgstr "标准差"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative count"
-msgstr "累積カウント"
+msgstr "累积计数"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "cumulative sum"
-msgstr "累積和"
+msgstr "累积总和"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} and {1}"
-msgstr "{0}と{1}"
+msgstr "{0} 和 {1}"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Aggregation.js:68
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} of {1}"
-msgstr "{1}の{0}"
+msgstr "{0} 的 {1}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:39
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} by {1}"
-msgstr "{1}で{0}"
+msgstr "{0} by {1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} in the {1} segment"
-msgstr "{1}セグメントの{0}"
+msgstr "划分 {1} 中的 {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} segment"
-msgstr "{0}セグメント"
+msgstr "划分 {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:19
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} metric"
 msgid_plural "{0} metrics"
-msgstr[0] "{0}メトリクス"
+msgstr[0] "指标 {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} field"
-msgstr "{0}フィールド"
+msgstr "字段 {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "\"{0}\" question"
-msgstr "\"{0}\"質問"
+msgstr "问题 “{0}”"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Compare with {0}"
-msgstr "{0}と比較する"
+msgstr "与{0}比较"
 
 #: src/metabase/automagic_dashboards/comparison.clj
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Compare with entire dataset"
-msgstr "全データセットと比較する"
+msgstr "与整个数据集进行比较"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Applying heuristic %s to %s."
-msgstr "ヒューリスティック%sを%sに適用しています"
+msgstr "将启发式算法 %s 应用于 %s 。"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Dimensions bindings:n%s"
-msgstr "ディメンションのバインディング: n%s"
+msgstr "维度绑定中:n%s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Using definitions:nMetrics:n%snFilters:n%s"
-msgstr "定義を使用中:nMetrics:n%snFilters:n%s"
+msgstr "定义启用中:n进度:n%sn过滤:n%s"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Can''t create dashboard for {0}"
-msgstr "{0}のダッシュボードが作成できません"
+msgstr "不能为{0}创建仪表盘"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}st"
-msgstr "{0}番目"
+msgstr "{0}st"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}nd"
-msgstr "{0}番目"
+msgstr "{0}nd"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}rd"
-msgstr "{0}番目"
+msgstr "{0}rd"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0}th"
-msgstr "{0}番目"
+msgstr "{0}th"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "at {0}"
-msgstr "{0}で"
+msgstr "at {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "on {0}"
-msgstr "{0}で"
+msgstr "on {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in {0} week - {1}"
-msgstr "{0}週 - {1}"
+msgstr "在{0}-{1}周之间"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in {0}"
-msgstr "{0}で"
+msgstr "在{0}之内"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "in Q{0} - {1}"
-msgstr "Q{0} - {1}で"
+msgstr "在Q{0}-{1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Q{0}"
-msgstr "Ｑ{0}"
+msgstr "Q{0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is {1}"
-msgstr "{0}は{1}"
+msgstr "{0}是{1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is between {1} and {2}"
-msgstr "{0}は{1}と{2}の間"
+msgstr "{0}是在{1}和{2}中间的"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "{0} is between {1} and {2}; and {3} is between {4} and {5}"
-msgstr "{0}は{1}と{2}の間、{3}は{4}と{5}の間"
+msgstr "{0}在{1} 和 {2}之间; and {3} 在{4} 和 {5}之间；"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "where {0}"
-msgstr "{0}で"
+msgstr "where {0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "A closer look at {0}"
-msgstr "{0}を詳しく見る"
+msgstr "更详细地查看{0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "A closer look at the {0}"
-msgstr "{0}を詳しく見る"
+msgstr "仔细观察这个集合{ 0 }"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding %s cards to dashboard %s:n%s"
-msgstr "%sカードをダッシュボード%s:n%sに追加中"
+msgstr "将%s卡添加到仪表板%s:n%s"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "0 <= score <= {0}"
-msgstr "0 <= スコア <= {0}"
+msgstr "0≤分数≤{0}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "1 <= width <= {0}"
-msgstr "1 <= 幅 <= {0}"
+msgstr "1≤宽度≤{0}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid metrics references"
-msgstr "有効なメトリクス参照"
+msgstr "有效的指标引用"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid filters references"
-msgstr "有効なフィルター参照"
+msgstr "有效的筛选引用"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid group references"
-msgstr "有効なグループ参照"
+msgstr "有效的聚合引用"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid order_by references"
-msgstr "有効なorder_by参照"
+msgstr "有效的分类引用"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid dashboard filters references"
-msgstr "有効なダッシュボードフィルター参照"
+msgstr "有效的仪表盘筛选引用"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid dimension references"
-msgstr "有効なディメンション参照"
+msgstr "有效的维度引用"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Valid card dimension references"
-msgstr "有効なカードディメンション参照"
+msgstr "有效的卡片维度引用"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Error parsing %s:n%s"
-msgstr "%s:n%sを解析中にエラーが発生しました。"
+msgstr "错误解析%s:n%s"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "No user found with email address ''{0}''. "
-msgstr "メールアドレス\"{0}\"のユーザーが見つかりませんでした"
+msgstr "用邮箱地址没有找到用户“{0}”"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Please check the spelling and try again."
-msgstr "スペルを確認し再度お試しください"
+msgstr "请检查拼写并再试一遍"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "Resetting password for {0}..."
-msgstr "{0}のパスワードをリセットしています..."
+msgstr "为{0}重置密码"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "OK [[[{0}]]]"
@@ -7782,1296 +7812,1296 @@ msgstr "成功 [[[{0}]]]"
 
 #: src/metabase/cmd/reset_password.clj
 msgid "FAIL [[[{0}]]]"
-msgstr "失敗 [[[{0}]]]"
+msgstr "失败 [[[{0}]]]"
 
 #: src/metabase/core.clj
 msgid "Please use the following URL to setup your Metabase installation:"
-msgstr "Metabaseインストールを設定するには次のURLを使用してください:"
+msgstr "请使用下列URL来设置你的Metabase安装程序:"
 
 #: src/metabase/core.clj
 msgid "Metabase Shutting Down ..."
-msgstr "Metabaseをシャットダウン中..."
+msgstr "Metabase正在关闭……"
 
 #: src/metabase/core.clj
 msgid "Metabase Shutdown COMPLETE"
-msgstr "Metabaseのシャットダウンが完了しました"
+msgstr "Metabase关闭完成"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase version {0} ..."
-msgstr "Metabaseバージョン{0}を起動中..."
+msgstr "开始Metabase 版本{0}……"
 
 #: src/metabase/core.clj
 msgid "System timezone is ''{0}'' ..."
-msgstr "システムタイムゾーンは\"{0}\"です..."
+msgstr "系统时区是“{0}”"
 
 #. startup database.  validates connection & runs any necessary migrations
 #: src/metabase/core.clj
 msgid "Setting up and migrating Metabase DB. Please sit tight, this may take a minute..."
-msgstr "Metabase DBのセットアップとマイグレーション中。これには時間がかかることがあります。"
+msgstr "Metabse数据库设置、迁移中。坐稳了，这个可能要花一分钟……"
 
 #: src/metabase/core.clj
 msgid "Looks like this is a new installation ... preparing setup wizard"
-msgstr "新規インストールのようです。セットアップウィザードを準備中。"
+msgstr "看起来这是一个新的安装过程……正在准备安装向导"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization COMPLETE"
-msgstr "Metabaseの初期化が完了しました"
+msgstr "Metabase初始化完成"
 
 #: src/metabase/server.clj
 msgid "Launching Embedded Jetty Webserver with config:"
-msgstr "埋め込みJetty Webserverを起動中 設定:"
+msgstr "用配置启动嵌入式Jetty Webserver"
 
 #: src/metabase/server.clj
 msgid "Shutting Down Embedded Jetty Webserver"
-msgstr "埋め込みJetty Webserverをシャットダウン中"
+msgstr "关闭嵌入式Jetty We服务器"
 
 #: src/metabase/core.clj
 msgid "Starting Metabase in STANDALONE mode"
-msgstr "MetabaseをSTANDALONEモードで起動中"
+msgstr "在脱机模式下启动Metabase"
 
 #: src/metabase/core.clj
 msgid "Metabase Initialization FAILED"
-msgstr "Metabaseの初期化に失敗しました"
+msgstr "Metabase初始化失败"
 
 #: src/metabase/db.clj
 msgid "Database has migration lock; cannot run migrations."
-msgstr "データベースはマイグレーションロックされています。マイグレーションを実行できません。"
+msgstr "数据库有迁移锁；无法运行迁移"
 
 #: src/metabase/db.clj
 msgid "You can force-release these locks by running `java -jar metabase.jar migrate release-locks`."
-msgstr "`java -jar metabase.jar migrate release-locks`を実行することでこのロックを強制解除することができます"
+msgstr "您可以通过运行'java -jar metabase.jar migrate release-locks'来强制释放这些锁。"
 
 #: src/metabase/db.clj
 msgid "Checking if Database has unrun migrations..."
-msgstr "データベースがマイグレーションを取り消したか確認中..."
+msgstr "检查数据库是否有未运行的迁移..."
 
 #: src/metabase/db.clj
 msgid "Database has unrun migrations. Waiting for migration lock to be cleared..."
-msgstr "データベースはマイグレーションを取り消しました。 マイグレーションロックが解除されるのを待っています..."
+msgstr "数据库有未运行的迁移。等待迁移锁定被清除…"
 
 #: src/metabase/db.clj
 msgid "Migration lock is cleared. Running migrations..."
-msgstr "マイグレーションロックが解除されました。マイグレーションを実行中..."
+msgstr "清除迁移锁。运行迁移…"
 
 #: src/metabase/db.clj
 msgid "Migration lock cleared, but nothing to do here! Migrations were finished by another instance."
-msgstr "マイグレーションロックは解除されましたが、ここでは処理されません！ マイグレーションは別のインスタンスで終了しました。"
+msgstr "迁移锁清除了，但这里没什么可做的！迁移是由另一个实例完成的。"
 
 #. Set up liquibase and let it do its thing
 #: src/metabase/db.clj
 msgid "Setting up Liquibase..."
-msgstr "Liquibaseの設定中..."
+msgstr "Liquibase设置"
 
 #: src/metabase/db.clj
 msgid "Liquibase is ready."
-msgstr "Liquibaseの準備ができました"
+msgstr "Liquibase已经准备好了"
 
 #: src/metabase/db.clj
 msgid "Verifying {0} Database Connection ..."
-msgstr "{0}データベース接続を確認中..."
+msgstr "{0}数据库连接认证中"
 
 #: src/metabase/db.clj
 msgid "Verify Database Connection ... "
-msgstr "データベース接続を確認... "
+msgstr "认证数据库连接……"
 
 #: src/metabase/db.clj
 msgid "Running Database Migrations..."
-msgstr "データベースマイグレーションを実行中..."
+msgstr "正在运行数据库迁移…"
 
 #: src/metabase/db.clj
 msgid "Database Migrations Current ... "
-msgstr "データベースマイグレーションは現在... "
+msgstr "数据库迁移当前…"
 
 #: src/metabase/driver/common.clj
 msgid "Hmm, we couldn''t connect to the database."
-msgstr "データベースに接続できませんでした"
+msgstr "嗯……我们不能连接到数据库。"
 
 #: src/metabase/driver/common.clj
 msgid "Make sure your host and port settings are correct"
-msgstr "ホストとポート設定が正しいことをお確かめください"
+msgstr "确保你的服务器和端口设置正确"
 
 #: src/metabase/driver/common.clj
 msgid "We couldn''t connect to the ssh tunnel host."
-msgstr "SSHトンネルホストに接続できませんでした"
+msgstr "我们不能连接到SSH通道服务器。"
 
 #: src/metabase/driver/common.clj
 msgid "Check the username, password."
-msgstr "ユーザーネームとパスワードをお確かめください"
+msgstr "检查用户名、密码。"
 
 #: src/metabase/driver/common.clj
 msgid "Check the hostname and port."
-msgstr "ホスト名とポートをお確かめください"
+msgstr "检查服务器名和端口。"
 
 #: src/metabase/driver/common.clj
 msgid "Looks like the database name is incorrect."
-msgstr "データベース名が間違っているようです"
+msgstr "看起来数据库名称不正确。"
 
 #: src/metabase/driver/common.clj
 msgid "It looks like your host is invalid."
-msgstr "ホストが無効のようです"
+msgstr "看起来你的服务器不可用。"
 
 #: src/metabase/driver/common.clj
 msgid "Please double-check it and try again."
-msgstr "再度ご確認の上お試しください"
+msgstr "请再次确认并且重试一遍。"
 
 #: src/metabase/driver/common.clj
 msgid "Looks like your password is incorrect."
-msgstr "パスワードが間違っているようです"
+msgstr "看起来你的密码不正确。"
 
 #: src/metabase/driver/common.clj
 msgid "Looks like you forgot to enter your password."
-msgstr "パスワードが入力されていないようです"
+msgstr "看起来你忘了输入密码。"
 
 #: src/metabase/driver/common.clj
 msgid "Looks like your username is incorrect."
-msgstr "ユーザー名が間違っているようです"
+msgstr "看起来你的用户名不正确。"
 
 #: src/metabase/driver/common.clj
 msgid "Looks like the username or password is incorrect."
-msgstr "ユーザーネームまたはパスワードが間違っているようです"
+msgstr "看起来用户名或者密码不正确。"
 
 #. ## CONFIG
 #: src/metabase/driver.clj
 msgid "Connection timezone to use when executing queries. Defaults to system timezone."
-msgstr "クエリを実行するときに使用する接続タイムゾーン。 デフォルトはシステムタイムゾーンです。"
+msgstr "执行查询时使用的连接时区。默认为系统时区"
 
 #: src/metabase/driver.clj
 msgid "Registered driver {0} {1}"
-msgstr "登録されたドライバー{0} {1}"
+msgstr "已注册的驱动器 {0} {1}"
 
 #: src/metabase/driver.clj
 msgid "No -init-driver function found for ''{0}''"
-msgstr "\"{0}\"の初期ドライバー機能が見つかりません。"
+msgstr "对于''{0}''没找到“init-driver”函数"
 
 #: src/metabase/driver/common.clj
 msgid "Unable to parse date string ''{0}'' for database engine ''{1}''"
-msgstr "データベースエンジン\"{1}\"の日付文字列\"{0}\"を解析できません。"
+msgstr "数据库引擎“{ 1 }”无法解析日期字符串“{ 0 }”"
 
 #. all-NULL columns in DBs like Mongo w/o explicit types
 #: src/metabase/driver/common.clj
 msgid "Don''t know how to map class ''{0}'' to a Field base_type, falling back to :type/*."
-msgstr "クラス\"{0}\"をフィールドbase_typeにマップする方法が不明です。:type/*.にお戻りください。"
+msgstr "不知道如何将类“{ 0 }”映射到字段BaseType类型，落回到：type/*"
 
 #: src/metabase/driver/util.clj
 msgid "Failed to connect to database: {0}"
-msgstr "データベースへの接続が失敗しました: {0}"
+msgstr "连接到数据库失败:{0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Invalid BigQuery identifier: ''{0}''"
-msgstr "無効なBigQuery識別子: \"{0}\""
+msgstr "无效的 BigQuery 标识符：''{0}''"
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can't be parameterized!"
-msgstr "BigQueryステートメントをパラメーター化することはできません。"
+msgstr "BigQuery 语句不能参数化！"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Failed to set timezone:"
-msgstr "タイムゾーンの設定に失敗しました:"
+msgstr "设置时区失败:"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "You must enable the Google Analytics API. Use this link to go to the Google Developers Console: {0}"
-msgstr "Google Analytics APIを有効化する必要があります。こちらのリンクを利用しGoogle Developers Consoleにアクセスしてください: {0}"
+msgstr "您必须启用 Google AnalyticsAPI。 使用此链接转到 Google Developers Console：{0}"
 
 #: src/metabase/driver/h2.clj
 msgid "Running SQL queries against H2 databases using the default (admin) database user is forbidden."
-msgstr "デフォルトの（管理者）データベースユーザーを使用してH2データベースに対してSQLクエリを実行することは禁じられています。"
+msgstr "禁止使用默认用户（admin）对 H2 数据库运行 SQL 查询。"
 
 #: src/metabase/driver/sparksql.clj
 msgid "Error: metabase.driver.FixedHiveDriver is registered, but JDBC does not seem to be using it."
-msgstr "エラー: metabase.driver.FixedHiveDriverは登録されていますが、JDBCがそれを使用していないようです。"
+msgstr "错误： metabase.driver.FixedHiveDriver 已经注册，但是 JDBC 好像无法使用"
 
 #: src/metabase/driver/sparksql.clj
 msgid "Found metabase.driver.FixedHiveDriver."
-msgstr "metabase.driver.FixedHiveDriverが見つかりました。"
+msgstr "发现 metabase.driver.FixedHiveDriver."
 
 #: src/metabase/driver/sparksql.clj
 msgid "Successfully registered metabase.driver.FixedHiveDriver with JDBC."
-msgstr "metabase.driver.FixedHiveDriverが正常にJDBCに登録されました。"
+msgstr "成功用JDBC注册Metabse.驱动.修复的Hive驱动"
 
 #. CONFIG
 #. TODO - smtp-port should be switched to type :integer
 #: src/metabase/email.clj
 msgid "Email address you want to use as the sender of Metabase."
-msgstr "Metabaseの送信者として使用したいメールアドレス"
+msgstr "你想要使用的作为Metabse发送者的邮箱地址"
 
 #: src/metabase/email.clj
 msgid "The address of the SMTP server that handles your emails."
-msgstr "メール管理をするSMTPサーバーのアドレス"
+msgstr "SMTP服务器地址处理你的邮箱。"
 
 #: src/metabase/email.clj
 msgid "SMTP username."
-msgstr "SMTPユーザー名"
+msgstr "SMTP用户名"
 
 #: src/metabase/email.clj
 msgid "SMTP password."
-msgstr "SMTPパスワード"
+msgstr "SMTP密码"
 
 #: src/metabase/email.clj
 msgid "The port your SMTP server uses for outgoing emails."
-msgstr "メール送信に使用するSMTPサーバーのポート"
+msgstr "你的SMTP服务发送邮件使用的端口"
 
 #: src/metabase/email.clj
 msgid "SMTP secure connection protocol. (tls, ssl, starttls, or none)"
-msgstr "SMTP接続プロトコル（TLS、SSL、STARTTLS、または該当なし）"
+msgstr "SMTP安全连接协议（tls，sll，starttls，或者没有）"
 
 #: src/metabase/email.clj
 msgid "none"
-msgstr "なし"
+msgstr "没有"
 
 #: src/metabase/email.clj
 msgid "SMTP host is not set."
-msgstr "SMTPホストが設定されていません"
+msgstr "SMTP服务器未设置。"
 
 #: src/metabase/email.clj
 msgid "Failed to send email"
-msgstr "メールの送信に失敗しました"
+msgstr "发送邮件失败"
 
 #: src/metabase/email.clj
 msgid "Error testing SMTP connection"
-msgstr "SMTP接続テストエラー"
+msgstr "测试SMTP连接错误"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Enable LDAP authentication."
-msgstr "LDAP認証を有効化する"
+msgstr "启用LDAP身份验证。"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Server hostname."
-msgstr "サーバーホスト名"
+msgstr "服务器主机名"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Server port, usually 389 or 636 if SSL is used."
-msgstr "サーバーポート、SSLを使用している場合は通常389または636です"
+msgstr "服务器端口，通常使用389或者636如果SSL被使用的话。"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Use SSL, TLS or plain text."
-msgstr "SSL、TLSまたはプレーンテキストを使用する"
+msgstr "使用SSL、TLS或纯文本"
 
 #: src/metabase/integrations/ldap.clj
 msgid "The Distinguished Name to bind as (if any), this user will be used to lookup information about other users."
-msgstr "バインドの識別名（ある場合）。このユーザーは、他のユーザーに関する情報を参照するために使用されます。"
+msgstr "要绑定的可分辨名称（如果有的话），该用户将被用来查找有关其他用户的信息。"
 
 #: src/metabase/integrations/ldap.clj
 msgid "The password to bind with for the lookup user."
-msgstr "検索ユーザー用にバインドするパスワード"
+msgstr "查找用户绑定的密码"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Search base for users. (Will be searched recursively)"
-msgstr "ユーザーのための検索ベース。 （繰り返し検索されます）"
+msgstr "用户搜索基础.（将采用递归检索）"
 
 #: src/metabase/integrations/ldap.clj
 msgid "User lookup filter, the placeholder '{login}' will be replaced by the user supplied login."
-msgstr "ユーザー検索フィルター。プレースホルダー '{login}'はユーザーが入力したログインに置き換えられます。"
+msgstr "用户查找过滤器，占位符'{Login}'将被用户提供的登录替换"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user's email. (usually ''mail'', ''email'' or ''userPrincipalName'')"
-msgstr "ユーザーのメールに使用する属性。（通常は、\"メール\"、\"Eメール\"、\"userPrincipalName\"など）"
+msgstr "使用用户的'mail'属性。（通常是'mail', 'email' or 'userPrincipalName'）"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user''s first name. (usually ''givenName'')"
-msgstr "ユーザーの名に使用する属性。（通常は、\"givenName\"）"
+msgstr "使用用户的'last name'属性（通常是‘givenName’）"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Attribute to use for the user''s last name. (usually ''sn'')"
-msgstr "ユーザーの姓に使用する属性。（通常は、\"sn\"）"
+msgstr "使用用户的'first name'属性（通常是‘SN’）"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Enable group membership synchronization with LDAP."
-msgstr "LDAPとのグループ同期を有効化する"
+msgstr "启用团队成员通过LDAP同步。"
 
 #: src/metabase/integrations/ldap.clj
 msgid "Search base for groups, not required if your LDAP directory provides a ''memberOf'' overlay. (Will be searched recursively)"
-msgstr "グループの検索ベース。LDAPディレクトリが\"memberOf”オーバーレイを提供する場合は不要です。（繰り返し検索されます）"
+msgstr "如果您的LDAP目录提供了“成员”的覆盖，则不需要搜索组。（将递归检索）"
 
 #. Should be in the form: {"cn=Some Group,dc=...": [1, 2, 3]} where keys are LDAP groups and values are lists of MB groups IDs
 #: src/metabase/integrations/ldap.clj
 msgid "JSON containing LDAP to Metabase group mappings."
-msgstr "LDAPとMetabaseのグループマッピングを含むJSON"
+msgstr "JSON包含LDAP到Metabase 组映射"
 
 #. Define a setting which captures our Slack api token
 #: src/metabase/integrations/slack.clj
 msgid "Slack API bearer token obtained from https://api.slack.com/web#authentication"
-msgstr "https://api.slack.com/web#authenticationから入手したSlack APIベアラートークン"
+msgstr "从 https://api.slack.com/web#authentication 获取的Slack API的不记名令牌"
 
 #: src/metabase/metabot.clj
 msgid "Enable MetaBot, which lets you search for and view your saved questions directly via Slack."
-msgstr "MetaBotを有効化すると、Slackで保存された質問を直接検索したり見たりすることができます"
+msgstr "启用MetaBot，可让您直接通过Slack搜索和查看已保存的问题。"
 
 #: src/metabase/metabot/instance.clj
 msgid "Last MetaBot checkin was {0} ago."
-msgstr "MetaBotへの最後のチェックインは{0}前でした。"
+msgstr "上次MetaBot确认已经是{0}之前了。"
 
 #: src/metabase/metabot/instance.clj
 msgid "This instance will now handle MetaBot duties."
-msgstr "このインスタンスはMetaBotのタスクを処理しています。"
+msgstr "这个实例现在将处理Myabor任务"
 
 #: src/metabase/metabot.clj
 msgid "Here''s what I can {0}:"
-msgstr "ここに {0} できるものがあります:"
+msgstr "这里是我能做的{0}:"
 
 #: src/metabase/metabot.clj
 msgid "I don''t know how to {0} `{1}`.n{2}"
-msgstr "'{1}と{2}の{0}方法が不明です。"
+msgstr "我不知道如何{0}`{1}`.n{2}"
 
 #: src/metabase/metabot/slack.clj
 msgid "Uh oh! :cry:n> {0}"
-msgstr ":cry:n> {0}"
+msgstr "啊喔！:( n> {0}"
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s your {0} most recent cards:n{1}"
-msgstr "最新{0}のカードがあります: n{1}"
+msgstr "这是你的{0}张最新的卡片:n{1}"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific? I found these cards with names that matched:n{0}"
-msgstr "より詳細に誤入力ください。名前が一致するカードが見つかりました: n{0}"
+msgstr "你能再具体一点吗？我找到了这些名称匹配{0}的卡片"
 
 #: src/metabase/metabot/command.clj
 msgid "I don''t know what Card `{0}` is. Give me a Card ID or name."
-msgstr "カード'{0}'が不明です。カードIDかカード名をご入力ください。"
+msgstr "我不知道卡片 `{0} `是什么。给我一个卡片ID或者名称。"
 
 #: src/metabase/metabot/command.clj
 msgid "Show which card? Give me a part of a card name or its ID and I can show it to you. If you don''t know which card you want, try `metabot list`."
-msgstr "どのカードを表示しますか？ カード名やカードIDの一部を入力していただくと、ご希望のカードを表示することができます。 どのカードが必要なのかわからない場合は、「MetaBotリスト」をお試しください。"
+msgstr "展示哪个卡片？给我卡片名字或者它的ID的一部分，我可以展示它。如果你不知道你需要的是哪个卡片，试试 `metabot列表 `"
 
 #: src/metabase/metabot/command.clj
 msgid "Ok, just a second..."
-msgstr "少々お待ちください..."
+msgstr "Ok，马上就好……"
 
 #: src/metabase/metabot/command.clj
 msgid "Not Found"
-msgstr "見つかりませんでした"
+msgstr "未找到"
 
 #: src/metabase/metabot/command.clj
 msgid "Loading Kanye quotes..."
-msgstr "処理中..."
+msgstr "加载Kanye名言"
 
 #: src/metabase/metabot/events.clj
 msgid "Evaluating Metabot command:"
-msgstr "MetaBotコマンドを診断中:"
+msgstr "评估Metabot 命令"
 
 #: src/metabase/metabot.clj
 msgid "Go home websocket, you're drunk."
-msgstr "WebSocketで問題が発生しました"
+msgstr "回家吧 websocket，你喝醉了"
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error launching metabot:"
-msgstr "MetaBot起動中にエラーが発生しました:"
+msgstr "运行Metabot时发生错误："
 
 #: src/metabase/metabot/websocket.clj
 msgid "MetaBot WebSocket is closed. Reconnecting now."
-msgstr "MetaBot WebSocketが終了しました。再接続中。"
+msgstr "MetaBot WebSocket已关闭。现在重新连接。"
 
 #: src/metabase/metabot/websocket.clj
 msgid "Error connecting websocket:"
-msgstr "WebSocketへの接続中にエラーが発生しました。:"
+msgstr "连接websocket时发生错误："
 
 #: src/metabase/metabot/instance.clj
 msgid "This instance is performing MetaBot duties."
-msgstr "このインスタンスはMetaBotのタスクを処理しています。"
+msgstr "此实例正在执行MetaBot职责。"
 
 #: src/metabase/metabot/instance.clj
 msgid "Another instance is already handling MetaBot duties."
-msgstr "別のインスタンスが既にMetaBotのタスクを処理しています。"
+msgstr "另一个实例已经在处理MetaBot职责。"
 
 #: src/metabase/metabot.clj
 msgid "Starting MetaBot threads..."
-msgstr "MetaBotスレッドを開始中..."
+msgstr "MetaBot 启动中..."
 
 #: src/metabase/metabot.clj
 msgid "Stopping MetaBot...  🤖"
-msgstr "MetaBotを停止しています...  🤖"
+msgstr "Metabot停止中……"
 
 #: src/metabase/metabot.clj
 msgid "MetaBot already running. Killing the previous WebSocket listener first."
-msgstr "MetaBotは既に実行中です。 前のWebSocketリスナーを強制終了します。"
+msgstr "MetaBot已经在运行。请先杀死之前的WebSocket侦听器。"
 
 #: src/metabase/middleware/security.clj
 msgid "Base-64 encoded public key for this site's SSL certificate."
-msgstr "このサイトのSSL証明書のBase-64でエンコードされた公開キー"
+msgstr "此站点的SSL证书公钥（public key）需要通过Base-64加密"
 
 #: src/metabase/middleware/security.clj
 msgid "Specify this to enable HTTP Public Key Pinning."
-msgstr "これを指定すると、HTTP公開キーのピン設定が有効になります。"
+msgstr "指定这个选项来打开HTTP Public Key Pinning"
 
 #: src/metabase/middleware/security.clj
 msgid "See {0} for more information."
-msgstr "詳細は{0}を参照してください。"
+msgstr "查看{0}获取更多信息。"
 
 #: src/metabase/models/card.clj
 msgid "Cannot save Question: source query has circular references."
-msgstr "質問が保存できません: ソースクエリに循環参照があります"
+msgstr "不能保存疑问：源查询拥有循环引用。"
 
 #: src/metabase/models/card.clj src/metabase/models/query/permissions.clj
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "Card {0} does not exist."
-msgstr "カード{0}は存在しません。"
+msgstr "卡片{0}不存在"
 
 #: src/metabase/models/card.clj
 msgid "You do not have permissions to run ad-hoc native queries against Database {0}."
-msgstr "データベース{0}に対してアドホックネイティブクエリを実行する権限がありません。"
+msgstr "你没有权限来对数据库{0}运行点对点原始查询。"
 
 #: src/metabase/models/collection.clj
 msgid "Invalid color"
-msgstr "無効な色"
+msgstr "无效的颜色"
 
 #: src/metabase/models/collection.clj
 msgid "must be a valid 6-character hex color code"
-msgstr "有効な6文字の16進数カラーコードでなければなりません"
+msgstr "必须是有效的6个字符的十六进制颜色代码"
 
 #: src/metabase/models/collection.clj
 msgid "Collection name cannot be blank!"
-msgstr "コレクション名は空欄にできません！"
+msgstr "集合名字不能为空！"
 
 #: src/metabase/models/collection.clj
 msgid "cannot be blank"
-msgstr "空欄にできません"
+msgstr "不能是空白的"
 
 #: src/metabase/models/collection.clj
 msgid "Invalid Collection location: path is invalid."
-msgstr "無効なコレクションの場所: パスが無効です。"
+msgstr "集合位置无效：路径无效。"
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Personal Collection."
-msgstr "パーソナルコレクションは移動できません。"
+msgstr "您无法移动个人集合。"
 
 #: src/metabase/models/collection.clj
 msgid "Invalid Collection location: some or all ancestors do not exist."
-msgstr "無効なコレクションの場所: 一部またはすべての先祖が存在しません。"
+msgstr "集合位置无效：部分或全部祖先不存在。"
 
 #: src/metabase/models/collection.clj
 msgid "You cannot archive the Root Collection."
-msgstr "ルートコレクションはアーカイブできません。"
+msgstr "您无法归档根集合。"
 
 #: src/metabase/models/collection.clj
 msgid "You cannot archive a Personal Collection."
-msgstr "パーソナルコレクションはアーカイブできません。"
+msgstr "您无法归档个人集合。"
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move the Root Collection."
-msgstr "ルートコレクションは移動できません。"
+msgstr "您无法移动根集合。"
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection into itself or into one of its descendants."
-msgstr "コレクションをそれ自身または子孫の1つに移動することはできません。"
+msgstr "您无法将一个集合移动到其自身或其后代中。"
 
 #. first move this Collection
 #: src/metabase/models/collection.clj
 msgid "Moving Collection {0} and its descendants from {1} to {2}"
-msgstr "コレクション{0}およびその子孫を{1}から{2}に移動中"
+msgstr "将集合{0}及其后代从{1}移动到{2}"
 
 #: src/metabase/models/collection.clj
 msgid "You're not allowed to change the owner of a Personal Collection."
-msgstr "パーソナルコレクションの所有者は変更できません。"
+msgstr "您无权更改个人集合的所有者。"
 
 #: src/metabase/models/collection.clj
 msgid "You're not allowed to move a Personal Collection."
-msgstr "パーソナルコレクションは移動できません。"
+msgstr "您无权移动个人集合。"
 
 #: src/metabase/models/collection.clj
 msgid "You cannot move a Collection and archive it at the same time."
-msgstr "コレクションを移動し同時にアーカイブすることはできません。"
+msgstr "您无法同时移动集合并将其存档。"
 
 #: src/metabase/models/collection.clj
 msgid "You cannot delete a Personal Collection!"
-msgstr "パーソナルコレクションを削除することはできません。"
+msgstr "您无法删除个人集合！"
 
 #: src/metabase/models/collection.clj
 msgid "{0} {1}''s Personal Collection"
-msgstr "{0} {1}さんのパーソナルコレクション"
+msgstr "{0} {1}的个人集合"
 
 #: src/metabase/models/collection_revision.clj
 msgid "You cannot update a CollectionRevision!"
-msgstr "コレクション履歴をアップデートすることはできません。"
+msgstr "您无法更新集合修订版！"
 
 #: src/metabase/models/field_values.clj
 msgid "Field {0} was previously automatically set to show a list widget, but now has {1} values."
-msgstr "フィールド{0}は以前は自動的にリストウィジェットを表示するよう設定されていましたが、現在は{1}の値を持っています。"
+msgstr "字段{0}之前自动设定显示为一个列表组件，但是现在有{1}个值。"
 
 #: src/metabase/models/field_values.clj
 msgid "Switching Field to use a search widget instead."
-msgstr "検索ウィジェットを代わりに使用するようフィールド切り替え中。"
+msgstr "转换领域来使用一个搜索组件。"
 
 #: src/metabase/models/field_values.clj
 msgid "Storing updated FieldValues for Field {0}..."
-msgstr "フィールド{0}の更新されたフィールド値を保存中..."
+msgstr "保存Field{0}更新过的FieldValues"
 
 #: src/metabase/models/field_values.clj
 msgid "Storing FieldValues for Field {0}..."
-msgstr "フィールド{0}のフィールド値を保存中..."
+msgstr "保存Field{0}的FieldValues"
 
 #: src/metabase/models/humanization.clj
 msgid "Metabase can attempt to transform your table and field names into more sensible, human-readable versions, e.g. \"somehorriblename\" becomes \"Some Horrible Name\"."
-msgstr "Metabaseはテーブルとフィールド名をより理に適った、読みやすい名前に変更することができます。例: 「somehorriblename」を「Some Horrible Name」へ変更する"
+msgstr "Metabase 会尝试将数据表名称和表中字段名称转换为适合阅读的版本，例如：将somehorriblename转换为 Some Horrible Name。"
 
 #: src/metabase/models/humanization.clj
 msgid "This doesn’t work all that well if the names are in a language other than English, however."
-msgstr "しかし、英語以外の言語の名前の場合はうまく動作しません。"
+msgstr "然而，如果名字是用英语以外的语言命名的，这将不会工作的很好"
 
 #: src/metabase/models/humanization.clj
 msgid "Do you want us to take a guess?"
-msgstr "予想したいですか？"
+msgstr "你想让我们猜一下吗？"
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot create or revoke permissions for the 'Admin' group."
-msgstr "「管理者」グループの権限を作成または取り消すことはできません。"
+msgstr "您无法为“管理员”组创建或撤消权限。"
 
 #: src/metabase/models/permissions.clj
 msgid "Invalid permissions object path: ''{0}''."
-msgstr "無効な権限のオブジェクトパス: \"{0}\""
+msgstr "不可用的许可对象路径：“{0}”。"
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot update a permissions entry!"
-msgstr "権限エントリーを更新することはできません！"
+msgstr "你不能更新一个许可权限入口！"
 
 #: src/metabase/models/permissions.clj
 msgid "Delete it and create a new one."
-msgstr "削除して新しく作成する"
+msgstr "删除它并且创建一个新的"
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot edit permissions for a Personal Collection or its descendants."
-msgstr "パーソナルコレクションまたはその子孫の権限を編集することはできません。"
+msgstr "您无法编辑个人集合或其后代的权限。"
 
 #: src/metabase/models/permissions.clj
 msgid "Looks like someone else edited the permissions and your data is out of date."
-msgstr "他ユーザーが権限を編集したようです。そのため、あなたのデータは最新ではありません。"
+msgstr "看起来别的什么人编辑了许可，并且你的数据过期了。"
 
 #: src/metabase/models/permissions.clj
 msgid "Please fetch new data and try again."
-msgstr "新しいデータを取得し、再度お試しください。"
+msgstr "请获取新的数据并且再次尝试。"
 
 #: src/metabase/models/permissions_group.clj
 msgid "Created magic permissions group ''{0}'' (ID = {1})"
-msgstr "特別な権限のグループ\"{0}\"（ID = {1}）が作成されました。"
+msgstr "创建万能权限群组“{0}”（ID={1}）"
 
 #: src/metabase/models/permissions_group.clj
 msgid "A group with that name already exists."
-msgstr "同じ名前のグループが既に存在します。"
+msgstr "组名称已存在"
 
 #: src/metabase/models/permissions_group.clj
 msgid "You cannot edit or delete the ''{0}'' permissions group!"
-msgstr "\"{0}\"権限グループを編集または削除することはできません！"
+msgstr "你不能编辑或删除“{0}”权限群组"
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'MetaBot' group."
-msgstr "「MetaBot」グループへユーザーを追加したりユーザーを削除することはできません"
+msgstr "你不能在MetaBot群组中添加或者移除成员。"
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the 'All Users' group."
-msgstr "'All Users'グループへユーザーを追加したりユーザーを削除することはできません"
+msgstr "你不能在所有用户群组中添加或者移除成员。"
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the 'Admin' group!"
-msgstr "「管理者」グループの最後のメンバーを削除することはできません！"
+msgstr "你不能移除最后一个管理员群组的成员。"
 
 #: src/metabase/models/permissions_revision.clj
 msgid "You cannot update a PermissionsRevision!"
-msgstr "権限履歴をアップデートすることはできません！"
+msgstr "你不能更新一个许可权限的修订版本！"
 
 #. if there's still not a Card, throw an Exception!
 #: src/metabase/models/pulse.clj
 msgid "Invalid Alert: Alert does not have a Card assoicated with it"
-msgstr "無効なアラート: アラートにはカードが関連付けられていません"
+msgstr "不可用警告:警报没有一个与它相关联的卡片。"
 
 #: src/metabase/models/pulse.clj
 msgid "value must be a map with the keys `{0}`, `{1}`, and `{2}`."
-msgstr "値は、キー'{0}'、'{1}'、'{2}'を含むマップでなければなりません。"
+msgstr "值必须是包含键`{0}`,`{1}`和`{2}`的map"
 
 #: src/metabase/models/pulse.clj
 msgid "value must be a map with the following keys `({0})`"
-msgstr "値は次のキーを含むマップでなければなりません: `({0})`"
+msgstr "值必须是带有以下键的映射 `({0})`"
 
 #: src/metabase/models/query/permissions.clj
 msgid "Error calculating permissions for query: {0}"
-msgstr "クエリの権限を処理中にエラーが発生しました: {0}"
+msgstr "错误的查询计算许可:{0}"
 
 #: src/metabase/models/query/permissions.clj
 msgid "Invalid query type: {0}"
-msgstr "無効なクエリタイプ: {0}"
+msgstr "不可用的请求类型：{0}"
 
 #: src/metabase/models/query_execution.clj
 msgid "You cannot update a QueryExecution!"
-msgstr "クエリ実行をアップデートすることはできません！"
+msgstr "你不能更新一个查询执行方案！"
 
 #: src/metabase/models/revision.clj
 msgid "You cannot update a Revision!"
-msgstr "履歴をアップデートできません！"
+msgstr "你不能更新一个修订版本！"
 
 #: src/metabase/models/setting.clj
 msgid "Setting {0} does not exist.nFound: {1}"
-msgstr "設定{0}は存在しません: {1}"
+msgstr "设置 {0} 不存在，未找到: {1}"
 
 #: src/metabase/models/setting/cache.clj
 msgid "Updating value of settings-last-updated in DB..."
-msgstr "データベース内で最後に更新された値をアップデート中..."
+msgstr "将最新设置内容更新到数据库中..."
 
 #: src/metabase/models/setting/cache.clj
 msgid "Checking whether settings cache is out of date (requires DB call)..."
-msgstr "キャッシュ設定が最新か確認中（データベースコースが必要）..."
+msgstr "查询设置缓存是否过期中（需要数据库连接）"
 
 #: src/metabase/models/setting/cache.clj
 msgid "Settings have been changed on another instance, and will be reloaded here."
-msgstr "別のインスタンスで変更された設定は、ここで再読み込みされます。"
+msgstr "设置已在另一个实例上更改，并将在此处重新加载。"
 
 #: src/metabase/models/setting/cache.clj
 msgid "Refreshing Settings cache..."
-msgstr "設定キャッシュを更新中..."
+msgstr "刷新设置缓存中……"
 
 #: src/metabase/models/setting.clj
 msgid "Invalid value for string: must be either \"true\" or \"false\" (case-insensitive)."
-msgstr "文字列の値が無効です: \"true\"または \"false\"（大文字小文字を区別しない）である必要があります。"
+msgstr "无效的值：内容必须为“true”或“false”（不区分大小写）。"
 
 #: src/metabase/models/setting.clj
 msgid "You cannot update `settings-last-updated` yourself! This is done automatically."
-msgstr "'最後に更新された設定'を手動でアップデートすることはできません。これは自動でアップデートされます。"
+msgstr "你不能自己更新`settings-last-updated`！这是自动完成的。"
 
 #. go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
 #: src/metabase/models/setting.clj
 msgid "Error inserting a new Setting:"
-msgstr "新設定の適用中にエラーが発生しました:"
+msgstr "插入一项新设置时错误:"
 
 #: src/metabase/models/setting.clj
 msgid "Assuming Setting already exists in DB and updating existing value."
-msgstr "設定が既にデータベースに存在すると仮定し、既存の値を更新中"
+msgstr "如果在数据库中已经存在设置则更新存在的值"
 
 #: src/metabase/models/user.clj
 msgid "value must be a map with each value either a string or number."
-msgstr "値は、各値が文字列または数値のいずれかを含むマップでなければなりません。"
+msgstr "值必须是每一个数字或字符串的映射值"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in directory {0}..."
-msgstr "ディレクトリ{0}のプラグインを読込中..."
+msgstr "在字典{0}中读取插件……"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugin {0}... "
-msgstr "プラグイン{0}を読込中... "
+msgstr "加载插件{0}……"
 
 #: src/metabase/plugins.clj
 msgid "It looks like you have some external dependencies in your Metabase plugins directory."
-msgstr "Metabaseプラグインディレクトリに、外部依存関係があるようです。"
+msgstr "你的Metabase插件目录中应该有一些外部依赖项。"
 
 #: src/metabase/plugins.clj
 msgid "With Java 9 or higher, Metabase cannot automatically add them to your classpath."
-msgstr "Java 9以降では、Metabaseはクラスパスに自動的に追加できません。"
+msgstr "对于Java 9或更高版本，Metabase无法自动将它们添加到类路径中。"
 
 #: src/metabase/plugins.clj
 msgid "Instead, you should include them at launch with the -cp option. For example:"
-msgstr "代わりに、起動時に-cpオプションを使用して含める必要があります。 例:"
+msgstr "相反，您应该在启动时使用-cp选项。 例如："
 
 #: src/metabase/plugins.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#java-versions for more details."
-msgstr "詳しくは、 https://metabase.com/docs/latest/operations-guide/start.html#java-versions を見てください"
+msgstr "查看更多细节： https://metabase.com/docs/latest/operations-guide/start.html#java-versions"
 
 #: src/metabase/plugins.clj
 msgid "(If you're already running Metabase this way, you can ignore this message.)"
-msgstr "（すでにこの方法でMetabaseを実行している場合は、このメッセージを無視してください。）"
+msgstr "（如果你已经用这个方法运行了Metabse，你可以忽略这条信息）"
 
 #: src/metabase/public_settings.clj
 msgid "Identify when new versions of Metabase are available."
-msgstr "Metabaseの新しいバージョンがいつ入手可能かを確認する"
+msgstr "确定新版本的Metabase何时可用。"
 
 #: src/metabase/public_settings.clj
 msgid "Information about available versions of Metabase."
-msgstr "Metabaseの利用可能なバージョンに関する情報"
+msgstr "关于Metabase可用版本的信息"
 
 #: src/metabase/public_settings.clj
 msgid "The name used for this instance of Metabase."
-msgstr "このMetabaseのインスタンスの名前"
+msgstr "用于此Metabase实例的名称。"
 
 #: src/metabase/public_settings.clj
 msgid "The base URL of this Metabase instance, e.g. \"http://metabase.my-company.com\"."
-msgstr "このMetabaseインスタンスのベースURL、例: \"http://metabase.my-company.com\""
+msgstr "此Metabase实例的基本URL，例如“http://metabase.my-company.com”。"
 
 #: src/metabase/public_settings.clj
 msgid "The default language for this Metabase instance."
-msgstr "このMetabaseインスタンスのデフォルトの言語です。"
+msgstr "这个Metabse实例的默认语言"
 
 #: src/metabase/public_settings.clj
 msgid "This only applies to emails, Pulses, etc. Users'' browsers will specify the language used in the user interface."
-msgstr "これはメール、パルス等だけに適用されます。ブラウザーの言語は、ユーザーが使用しているインターフェイスの言語が適用されます"
+msgstr "这个只应用于邮箱、趋势及其他。用户的浏览器将指定在用户界面中使用的语言"
 
 #: src/metabase/public_settings.clj
 msgid "The email address users should be referred to if they encounter a problem."
-msgstr "問題が発生した場合に、ユーザーが参照すべきメールアドレス"
+msgstr "如果碰到问题，可以使用用户的邮件地址"
 
 #: src/metabase/public_settings.clj
 msgid "Enable the collection of anonymous usage data in order to help Metabase improve."
-msgstr "Metabaseのサービス向上のため、匿名の使用状況データの収集を許可する。"
+msgstr "启用匿名使用数据的收集，以帮助改进Metabase。"
 
 #: src/metabase/public_settings.clj
 msgid "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox."
-msgstr "マップのビジュアライゼーションで使用されるマップタイルサーバーのURLテンプレート（例: OpenStreetMaps、MapBoxなど）。"
+msgstr "采用可视化地图的过程中，要使用地图服务器的url模板，例如使用OpenStreetMaps or MapBox"
 
 #: src/metabase/public_settings.clj
 msgid "Enable admins to create publicly viewable links (and embeddable iframes) for Questions and Dashboards?"
-msgstr "管理者が質問とダッシュボード用に公開閲覧リンク（および埋め込み可能なiframe）を作成できるようにしますか？"
+msgstr "启用管理员来为疑问和仪表盘创建公开的可浏览链接（并且可嵌入的iframes框架）吗？"
 
 #: src/metabase/public_settings.clj
 msgid "Allow admins to securely embed questions and dashboards within other applications?"
-msgstr "管理者が質問やダッシュボードを他のアプリケーションに安全に埋め込めるよう許可しますか？"
+msgstr "允许管理员在其他应用程序中安全地嵌入报表和仪表板?"
 
 #: src/metabase/public_settings.clj
 msgid "Allow using a saved question as the source for other queries?"
-msgstr "保存された質問を他のクエリのソースとして使用することを許可しますか？"
+msgstr "允许使用一个已经存储的疑问作为"
 
 #: src/metabase/public_settings.clj
 msgid "Enabling caching will save the results of queries that take a long time to run."
-msgstr "キャッシングを有効にすると、実行に時間がかかるクエリの結果が保存されます。"
+msgstr "能够使用缓存保存需要长时间运行的查询结果集"
 
 #: src/metabase/public_settings.clj
 msgid "The maximum size of the cache, per saved question, in kilobytes:"
-msgstr "保存された質問ごとのキャッシュの最大サイズ（キロバイト）:"
+msgstr "缓存最大值，"
 
 #: src/metabase/public_settings.clj
 msgid "The absolute maximum time to keep any cached query results, in seconds."
-msgstr "キャッシュされたクエリの結果を保持する最長時間（秒単位）"
+msgstr "保留任何缓存查询结果的绝对最长时间（以秒为单位）。"
 
 #: src/metabase/public_settings.clj
 msgid "Metabase will cache all saved questions with an average query execution time longer than this many seconds:"
-msgstr "Metabaseは、保存された全ての質問を、平均クエリ実行時間内にキャッシュします。:"
+msgstr "Metabase会捕捉所有平均查询时间大于这么多秒的已保存问题"
 
 #: src/metabase/public_settings.clj
 msgid "To determine how long each saved question''s cached result should stick around, we take the query''s average execution time and multiply that by whatever you input here."
-msgstr "クエリの平均実行時間を取得し、ここに入力した値で乗算することで、保存された各質問のキャッシュ結果の保存期間を判断します。"
+msgstr "为了确定每一个saved Question的缓存结果应该持续多长时间，我们用查询的平均执行时间乘以您输入的数值。"
 
 #: src/metabase/public_settings.clj
 msgid "So if a query takes on average 2 minutes to run, and you input 10 for your multiplier, its cache entry will persist for 20 minutes."
-msgstr "したがって、クエリの実行に平均2分かかる場合、乗数に10を入力すると、そのキャッシュエントリは20分間保持されます。"
+msgstr "如果一个查询平均要花了2分钟，同时你输入了10作为放大因子，那么这个缓存入口将持续20分钟"
 
 #: src/metabase/public_settings.clj
 msgid "When using the default binning strategy and a number of bins is not provided, this number will be used as the default."
-msgstr "デフォルトのビニング設定を使用しており、かつビンが入力されていない場合には、この数値がデフォルトとして使用されます。"
+msgstr "当使用缺省的封装（打包）策略是，如果没有提供封装（打包）的数量，该数字将用作默认值"
 
 #: src/metabase/public_settings.clj
 msgid "When using the default binning strategy for a field of type Coordinate (such as Latitude and Longitude), this number will be used as the default bin width (in degrees)."
-msgstr "座標タイプ（緯度と経度など）のフィールドにデフォルトのビニング設定を使用する場合、この数値はデフォルトビン幅（度）として使用されます。"
+msgstr "当使用坐标类型（例如经度和经度）字段的缺省封装（打包）策略时，该编号将用作缺省的封装（打包）步长（以度为单位）"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token."
-msgstr "トークンを検証できません"
+msgstr "无法验证令牌。"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error fetching token status:"
-msgstr "トークンステータスの取得中にエラーが発生しました:"
+msgstr "获取令牌状态时出错:"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid."
-msgstr "このトークンの有効性を確認中にエラーが発生しました。"
+msgstr "检查token是否有效时报错"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token validation timed out."
-msgstr "トークンの検証がタイムアウトしました。"
+msgstr "令牌验证超时"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Invalid token: token isn't in the right format."
-msgstr "トークンが不正です。トークンが正しいフォーマットではありません。"
+msgstr "令牌无效：令牌格式不正确。"
 
 #. attempt to query the metastore API about the status of this token. If the request doesn't complete in a
 #. reasonable amount of time throw a timeout exception
 #: src/metabase/public_settings/metastore.clj
 msgid "Checking with the MetaStore to see whether {0} is valid..."
-msgstr "{0}の有効性を確認するためにMetaStoreをチェック中..."
+msgstr "检查MetaStore确认 {0} 是否有效..."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium embedding. Go to the MetaStore to get yours!"
-msgstr "プレミアム埋め込みのためのトークン。 是非あなたもMetaStoreから入手してください！"
+msgstr "请前往MetaStore获取你的高级嵌入令牌。"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token is valid."
-msgstr "トークンは有効です"
+msgstr "有效令牌."
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error setting premium embedding token"
-msgstr "プレミアム埋め込みトークンの設定中にエラーが発生しました。"
+msgstr "设置高级嵌入令牌时出错"
 
 #: src/metabase/pulse.clj
 msgid "Unable to compare results to goal for alert."
-msgstr "結果と目標を比較できませんでした"
+msgstr "无法将结果与警报目标进行比较"
 
 #: src/metabase/pulse.clj
 msgid "Question ID is ''{0}'' with visualization settings ''{1}''"
-msgstr "ビジュアライゼーション設定が \"{1}\"の質問IDは\"{0}\"です。"
+msgstr "疑问ID是“{0}”，可视化设置是“{1}”"
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized alert with condition ''{0}''"
-msgstr "状態\"{0}\"の認識できないアラート"
+msgstr "无法识别带有条件{0}的警报"
 
 #: src/metabase/pulse.clj
 msgid "Unrecognized channel type {0}"
-msgstr "認識できないチャンネルタイプ{0}"
+msgstr "无法识别的频道类型(0)"
 
 #: src/metabase/pulse.clj
 msgid "Error sending notification!"
-msgstr "通知送信中にエラーが発生しました！"
+msgstr "发送提醒错误！"
 
 #: src/metabase/pulse/render/color.clj
 msgid "Can't find JS color selector at ''{0}''"
-msgstr "\"{0}\"にJSカラーセレクタが見つかりません。"
+msgstr "在“{0}”中找不到JS颜色选择项"
 
 #: src/metabase/pulse/render.clj
 msgid "Card has errors: {0}"
-msgstr "カードにエラーがあります: {0}"
+msgstr "卡片存在错误:{0}"
 
 #: src/metabase/pulse/render.clj
 msgid "Pulse card render error"
-msgstr "パルスカードレンダリングエラー"
+msgstr "推送卡片显示错误"
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Trimming trailing comment from card with id {0}"
-msgstr "ID{0}のカードの後続コメントをトリミング中"
+msgstr "从id{0}的卡片末尾去除注释"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Can't find field with ID: {0}"
-msgstr "ID {0}のフィールドが見つかりません"
+msgstr "无法找到ID: {0}字段"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "''{0}'' is a required param."
-msgstr "\"{0}\"は必須パラメータ―です"
+msgstr "''{0}'' 是必要的参数"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Found ''{0}'' with no terminating ''{1}'' in query ''{2}''"
-msgstr "クエリ\"{2}\"に\"{1}\"が終了していない\"{0}\"が見つかりました。"
+msgstr "在查询''{2}''中找到没有结束''{1}''的''{0}''"
 
 #: src/metabase/query_processor/middleware/parameters/sql.clj
 msgid "Unable to substitute ''{0}'': param not specified.nFound: {1}"
-msgstr "\"{0}\"を置換できません: パラメーターは指定されていないため見つかりませんでした: {1}"
+msgstr "无法替换“{0}”：参数未指定。n未找到：{1}"
 
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "You do not have permissions to view Card {0}."
-msgstr "カード{0}の閲覧権限がありません"
+msgstr "没有查看报表{0}的权限"
 
 #: src/metabase/query_processor/middleware/permissions.clj
 msgid "You do not have permissions to run this query."
-msgstr "このクエリを実行する権限がありません"
+msgstr "没有运行查询的权限"
 
 #: src/metabase/sync/analyze.clj
 msgid "Fingerprint updates attempted {0}, updated {1}, no data found {2}, failed {3}"
-msgstr "{0}のフィンガープリントを更新しようとし、{1}件更新、{2}件はデータが見つからず、{3}件は失敗しました"
+msgstr "水印更新尝试 {0}, 更新 {1}, 无数据{2}, 失败 {3}"
 
 #: src/metabase/sync/analyze.clj
 msgid "Total number of fields classified {0}, {1} failed"
-msgstr "合計{0}フィールドが分類され、{1}件が失敗しました"
+msgstr "共分类了{0}个字段，{1}个失败"
 
 #: src/metabase/sync/analyze.clj
 msgid "Total number of tables classified {0}, {1} updated"
-msgstr "合計{0}テーブルが分類され、{1}件が失敗しました "
+msgstr "表数目分类 {0}, {1} 更新"
 
 #: src/metabase/sync/analyze/fingerprint/fingerprinters.clj
 msgid "Error generating fingerprint for {0}"
-msgstr "{0}のフィンガープリント生成中にエラーが発生しました。"
+msgstr "{0}生成水印错误"
 
 #: src/metabase/sync/field_values.clj
 msgid "Updated {0} field value sets, created {1}, deleted {2} with {3} errors"
-msgstr "{0}件のフィールド値セットを更新、{1}件作成、{2}件削除、{3}件エラー"
+msgstr "更新{0}领域值集合，创建了{1}，删除了{2}和{3}错误"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of fields sync''d {0}, number of fields updated {1}"
-msgstr "合計{0}フィールドが同期され、{1}フィールドが更新されました"
+msgstr "共同步字段{0}个，更新字段{1}个"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of tables sync''d {0}, number of tables updated {1}"
-msgstr "合計{0}テーブルが同期され、{1}テーブルが更新されました"
+msgstr "共同步表{0}个，更新表{1}个"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Found timezone id {0}"
-msgstr "タイムゾーンID{0}が見つかりました。"
+msgstr "发现时区id{0}"
 
 #: src/metabase/sync/sync_metadata.clj
 msgid "Total number of foreign keys sync''d {0}, {1} updated and {2} tables failed to update"
-msgstr "合計{0}の外部キーが同期され、{1}件更新、{2}テーブルが更新に失敗しました"
+msgstr "共同步外键{0}个，{1}个更新，{2}个表更新失败"
 
 #: src/metabase/sync/util.clj
 msgid "{0} Database {1} ''{2}''"
-msgstr "{0}データベース{1} ''{2}''"
+msgstr "{0}数据库{1}“{2}”"
 
 #: src/metabase/sync/util.clj
 msgid "Table {0} ''{1}''"
-msgstr "テーブル {0} \"{1}\""
+msgstr "表单{0}“{1}”"
 
 #: src/metabase/sync/util.clj
 msgid "Field {0} ''{1}''"
-msgstr "フィールド{0} ''{1}''"
+msgstr "字段 {0} ''{1}''"
 
 #: src/metabase/sync/util.clj
 msgid "Field ''{0}''"
-msgstr "フィールド\"{0}\""
+msgstr "字段 ''{0}''"
 
 #: src/metabase/sync/util.clj
 msgid "step ''{0}'' for {1}"
-msgstr "{1}のステップ\"{0}\""
+msgstr "为{1}执行步骤“{0}”"
 
 #: src/metabase/sync/util.clj
 msgid "Completed {0} on {1}"
-msgstr "{1}で{0}を完了しました"
+msgstr "完成 {0} on {1}"
 
 #: src/metabase/sync/util.clj
 msgid "Start: {0}"
-msgstr "開始: {0}"
+msgstr "开始:{0}"
 
 #: src/metabase/sync/util.clj
 msgid "End: {0}"
-msgstr "終了: {0}"
+msgstr "结束:{0}"
 
 #: src/metabase/sync/util.clj
 msgid "Duration: {0}"
-msgstr "期間: {0}"
+msgstr "进行中: {0}"
 
 #: src/metabase/sync/util.clj
 msgid "Completed step ''{0}''"
-msgstr "ステップ\"{0}\"が完了しました"
+msgstr "完成步骤“{0}”"
 
 #: src/metabase/task.clj
 msgid "Loading tasks namespace:"
-msgstr "タスクのネームスペースを読込中:"
+msgstr "加载任务命名空间"
 
 #: src/metabase/task.clj
 msgid "Starting Quartz Scheduler"
-msgstr "Quartz Schedulerを開始中"
+msgstr "启动Quartz调度"
 
 #: src/metabase/task.clj
 msgid "Stopping Quartz Scheduler"
-msgstr "Quartz Schedulerを停止中"
+msgstr "停止Quartz调度"
 
 #: src/metabase/task.clj
 msgid "Job already exists:"
-msgstr "ジョブが既に存在します:"
+msgstr "job已存在"
 
 #. This is the very first log message that will get printed.  It's here because this is one of the very first
 #. namespaces that gets loaded, and the first that has access to the logger It shows up a solid 10-15 seconds before
 #. the "Starting Metabase in STANDALONE mode" message because so many other namespaces need to get loaded
 #: src/metabase/util.clj
 msgid "Loading Metabase..."
-msgstr "Metabaseを読込中..."
+msgstr "正在加载Metabase……"
 
 #: src/metabase/util/date.clj
 msgid "Possible timezone conflict found on database {0}."
-msgstr "データベース{0}でタイムゾーンのコンフリクトが検出されました"
+msgstr "数据库时区冲突"
 
 #: src/metabase/util/date.clj
 msgid "JVM timezone is {0} and detected database timezone is {1}."
-msgstr "JVMのタイムゾーンは{0}で、検出されたデータベースのタイムゾーンは{1}です。"
+msgstr "jvm域数据库时区不一致"
 
 #: src/metabase/util/date.clj
 msgid "Configure a report timezone to ensure proper date and time conversions."
-msgstr "レポートのタイムゾーンを構成して、適切な日時変換が行われるようにします。"
+msgstr "正确配置报表的日期格式"
 
 #: src/metabase/util/embed.clj
 msgid "Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints."
-msgstr "`/ api / embed`エンドポイントへのリクエストに対してJSON Webトークンに署名するために使用される秘密キー。"
+msgstr "用于签署发起`/api/embed`请求的JSON Web令牌的密钥"
 
 #: src/metabase/util/encryption.clj
 msgid "MB_ENCRYPTION_SECRET_KEY must be at least 16 characters."
-msgstr "MB_ENCRYPTION_SECRET_KEYは16文字以上にしてください。"
+msgstr "MB_ENCRYPTION_SECRET_KEY至少要16个字符"
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is ENABLED for this Metabase instance."
-msgstr "このMetabaseインスタンスに対して、保存された資格情報の暗号化が有効になっています。"
+msgstr "已存储的证书加密方式已经为这个Metabase事例启用"
 
 #: src/metabase/util/encryption.clj
 msgid "Saved credentials encryption is DISABLED for this Metabase instance."
-msgstr "保存された資格情報は、このMetabase Instanceでは無効化されています"
+msgstr "已存储的证书加密方式已经为这个Metabase事例禁用"
 
 #: src/metabase/util/encryption.clj
 msgid "nFor more information, see"
-msgstr "詳細はこちらを参照してください。"
+msgstr "浏览更多信息，参阅"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer."
-msgstr "値は整数値でなくてはなりません"
+msgstr "值必须是一个整数"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a string."
-msgstr "値は文字列でなくてはなりません"
+msgstr "值必须是字符串"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a boolean."
-msgstr "値は真偽値でなくてはなりません"
+msgstr "值必须是布尔值"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a string that matches the regex `{0}`."
-msgstr "値は正規表現'{0}'に一致する文字列にしてください。"
+msgstr "值必须是与正则表达式“{0}”匹配的字符串。"
 
 #: src/metabase/util/schema.clj
 msgid "value must satisfy one of the following requirements: "
-msgstr "値は、次のいずれかの要件を満たす必要があります: "
+msgstr "值必须满足下列一个要求:"
 
 #: src/metabase/util/schema.clj
 msgid "value may be nil, or if non-nil, {0}"
-msgstr "値はnilでも良いし、non-nilの場合には{0}"
+msgstr "值可以为空，如果不为空，则{0}"
 
 #: src/metabase/util/schema.clj
 msgid "value must be one of: {0}."
-msgstr "値は次のいずれかにしてください: {0}"
+msgstr "值必须是{0}其中之一。"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an array."
-msgstr "値は配列でなくてはなりません"
+msgstr "值必须是一个数组。"
 
 #: src/metabase/util/schema.clj
 msgid "Each {0}"
-msgstr "各{0}"
+msgstr "遍历 {0}"
 
 #: src/metabase/util/schema.clj
 msgid "The array cannot be empty."
-msgstr "配列は空欄にできません。"
+msgstr "数组不能为空。"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a non-blank string."
-msgstr "値は空欄のない文字列でなければなりません"
+msgstr "值必须是非空字符串。"
 
 #: src/metabase/util/schema.clj
 msgid "Integer greater than zero"
-msgstr "ゼロより大きい整数"
+msgstr "大于0的整数"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer greater than zero."
-msgstr "値はゼロより大きい整数でなければなりません"
+msgstr "值必须是一个大于0的整数。"
 
 #: src/metabase/util/schema.clj
 msgid "Number greater than zero"
-msgstr "ゼロより大きい数値"
+msgstr "大于0的数字"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a number greater than zero."
-msgstr "値はゼロより大きい数値でなければなりません"
+msgstr "值必须是一个大于0的数字"
 
 #: src/metabase/util/schema.clj
 msgid "Keyword or string"
-msgstr "キーワードや文字列"
+msgstr "关键词或字符串"
 
 #: src/metabase/util/schema.clj
 msgid "Valid field type"
-msgstr "有効なフィールドタイプ"
+msgstr "有效的字段类型"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid field type."
-msgstr "値は有効なフィールドタイプでなければなりません"
+msgstr "必须是有效的字段类型"
 
 #: src/metabase/util/schema.clj
 msgid "Valid field type (keyword or string)"
-msgstr "有効なフィールドタイプ（キーワードや文字列）"
+msgstr "有效的字段类型(关键词或字符串)"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid field type (keyword or string)."
-msgstr "値は有効なフィールドタイプ（キーワードや文字列）でなければなりません"
+msgstr "值必须有效的字段类型(关键词或字符串)"
 
 #: src/metabase/util/schema.clj
 msgid "Valid entity type (keyword or string)"
-msgstr "有効なエンティティタイプ（キーワードや文字列）"
+msgstr "有效的实体类型（关键词或者字符串）"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid entity type (keyword or string)."
-msgstr "値は有効なエンティティタイプ（キーワードや文字列）でなければなりません"
+msgstr "值必须是有效的实体类型（关键词或者字符串）"
 
 #: src/metabase/util/schema.clj
 msgid "Valid map"
-msgstr "有効なマップ"
+msgstr "有效的地图"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a map."
-msgstr "値はマップでなければなりません"
+msgstr "必须是MAP"
 
 #: src/metabase/util/schema.clj
 msgid "Valid email address"
-msgstr "有効なメールアドレス"
+msgstr "有效的邮箱地址"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid email address."
-msgstr "値は有効なメールアドレスでなければなりません"
+msgstr "值必须是有效的邮箱地址"
 
 #: src/metabase/util/schema.clj
 msgid "Insufficient password strength"
-msgstr "パスワードの強度が足りません"
+msgstr "密码长度不足"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer."
-msgstr "値は有効な整数でなければなりません"
+msgstr "值必须是个有效的整数。"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer greater than zero."
-msgstr "値はゼロより大きい有効な整数でなければなりません"
+msgstr "值必须是个有效的大于0的整数。"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid boolean string (''true'' or ''false'')."
-msgstr "valueは有効な真偽値の文字列（ '' true ''または '' false ''）でなければなりません。"
+msgstr "必须是布尔值（“true”或者“false”）"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid JSON string."
-msgstr "値は有効なJSON文字列でなければなりません。"
+msgstr "值必须是个有效的JSON字符串。"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid embedding params map."
-msgstr "値は有効な埋め込みパラメーターマップでなければなりません。"
+msgstr "值必须是个有效的嵌入地图的参数。"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx:12
 msgid "Data permissions"
-msgstr "データ権限"
+msgstr "数据权限"
 
 #: frontend/src/metabase/admin/permissions/components/PermissionsTabs.jsx:13
 msgid "Collection permissions"
-msgstr "コレクション権限"
+msgstr "文件夹权限"
 
 #: frontend/src/metabase/admin/permissions/containers/CollectionPermissionsModal.jsx:59
 msgid "See all collection permissions"
-msgstr "全てのコレクション権限を見る"
+msgstr "查看所有文件夹权限"
 
 #: frontend/src/metabase/admin/permissions/containers/TogglePropagateAction.jsx:27
 msgid "Also change sub-collections"
-msgstr "サブコレクションを変更することもできます"
+msgstr "同时更改子集合"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:285
 msgid "Can edit this collection and its contents"
-msgstr "このコレクションとコンテンツを編集することができます"
+msgstr "允许修改集合及其内容"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:292
 msgid "Can view items in this collection"
-msgstr "このコレクション内のアイテムを見ることができます"
+msgstr "允许查看该集合的内容"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:752
 msgid "Collection Access"
-msgstr "コレクションアクセス"
+msgstr "集合的权限"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:828
 msgid "This group has permission to view at least one subcollection of this collection."
-msgstr "このグループには、コレクション内の最低一つのサブコレクションの閲覧権限があります"
+msgstr "该组有权查看此集合的至少一个子集合。"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:833
 msgid "This group has permission to edit at least one subcollection of this collection."
-msgstr "このグループは、このコレクションの最低1つのサブコレクションを編集する権限があります"
+msgstr "该组有权编辑此集合的至少一个子集合。"
 
 #: frontend/src/metabase/admin/permissions/selectors.js:846
 msgid "View sub-collections"
-msgstr "サブコレクションを見る"
+msgstr "查看子集合"
 
 #: frontend/src/metabase/auth/containers/LoginApp.jsx:214
 msgid "Remember Me"
-msgstr "記憶する"
+msgstr "记住我"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:63
 msgid "X-ray this schema"
-msgstr "このスキーマを自動探査(X-ray)する"
+msgstr "透视这个图表"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:258
 msgid "Edit the permissions for this collection"
-msgstr "このコレクションの権限を編集する"
+msgstr "修改集合权限"
 
 #: frontend/src/metabase/containers/AddToDashSelectDashModal.jsx:55
 msgid "Add this question to a dashboard"
-msgstr "ダッシュボードにこの質問を追加する"
+msgstr "把报表添加到dashboard"
 
 #: frontend/src/metabase/containers/AddToDashSelectDashModal.jsx:65
 msgid "Create a new dashboard"
-msgstr "新ダッシュボードを作成する"
+msgstr "创建一个新的仪表板"
 
 #: frontend/src/metabase/containers/ErrorPages.jsx:45
 msgid "The page you asked for couldn't be found."
-msgstr "リクエストしたページが見つかりませんでした"
+msgstr "找不到您要访问的页面"
 
 #: frontend/src/metabase/containers/ItemSelect.jsx:30
 msgid "Select a {0}"
-msgstr "{0}を選択する"
+msgstr "选择{0}"
 
 #: frontend/src/metabase/containers/Overworld.jsx:185
 msgid "Save dashboards, questions, and collections in \"{0}\""
-msgstr "\"{0}\"にダッシュボード、質問、コレクションを保存する"
+msgstr "在“{0}”中保存仪表板，问题和集合"
 
 #: frontend/src/metabase/containers/Overworld.jsx:188
 msgid "Access dashboards, questions, and collections in \"{0}\""
-msgstr "\"{0}\"のダッシュボード、質問、コレクションにアクセスする"
+msgstr "访问“{0}”中的仪表板，问题和集合"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:223
 msgid "Compare"
-msgstr "比較"
+msgstr "比较"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:231
 msgid "Zoom out"
-msgstr "ズームアウト"
+msgstr "缩小"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:235
 msgid "Related"
-msgstr "関連"
+msgstr "相关"
 
 #: frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx:295
 msgid "More X-rays"
-msgstr "さらに自動探査(X-ray)"
+msgstr "更多透视方法"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:40
 #: src/metabase/pulse/render/body.clj
 msgid "No results"
-msgstr "結果がありません"
+msgstr "没有结果"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:41
 msgid "Metabase couldn't find any results for your search."
-msgstr "検索結果が見つかりませんでした"
+msgstr "Metabase无法找到您的搜索结果。"
 
 #: frontend/src/metabase/new_query/containers/MetricSearch.jsx:115
 msgid "No metrics"
-msgstr "メトリクスがありません"
+msgstr "没有指标"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:31
 msgid "Aggregations"
-msgstr "集約"
+msgstr "聚合"
 
 #: frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield.jsx:32
 msgid "Operators"
-msgstr "オペレーター"
+msgstr "运算符"
 
 #: frontend/src/metabase/query_builder/components/expressions/Expressions.jsx:30
 msgid "Custom fields"
-msgstr "カスタムフィールド"
+msgstr "自定义字段"
 
 #. 2. Create the new collections.
 #: src/metabase/db/migrations.clj
 msgid "Migrated Dashboards"
-msgstr "マイグレーションされたダッシュボード"
+msgstr "迁移仪表盘"
 
 #: src/metabase/db/migrations.clj
 msgid "Migrated Pulses"
-msgstr "マイグレーションされたパルス"
+msgstr "迁移的Pulses"
 
 #: src/metabase/db/migrations.clj
 msgid "Migrated Questions"
-msgstr "マイグレーションされた質問"
+msgstr "迁移的报表"
 
 #. 4. move everything not in this Collection to a new Collection
 #: src/metabase/db/migrations.clj
 msgid "Moving instances of {0} that aren't in a Collection to {1} Collection {2}"
-msgstr "コレクションにない{0}のインスタンスを{1}コレクション{2}にマイグレーションする"
+msgstr "移动{0}中不在集合{1}到集合{2}中的实例"
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions: {0}"
-msgstr "権限を付与できませんでした: {0}"
+msgstr "无法获取权限：{0}"
 
 #: src/metabase/util/encryption.clj
 msgid "Cannot decrypt encrypted string. Have you changed or forgot to set MB_ENCRYPTION_SECRET_KEY?"
-msgstr "暗号化された文字列を復号化できません。 MB_ENCRYPTION_SECRET_KEYを変更または設定しましたか？"
+msgstr "无法解密已加密的字符。你是否忘记设置 MB_ENCRYPTION_SECRET_KEY？"
 
 #: frontend/src/metabase/entities/collections.js:167
 msgid "All personal collections"
-msgstr "全てのパーソナルコレクション"
+msgstr "所有个人集合"
 
 #: src/metabase/driver/common.clj
 msgid "Host"
-msgstr "ホスト"
+msgstr "主机"
 
 #: src/metabase/driver/common.clj
 msgid "Port"
-msgstr "ポート"
+msgstr "端口"
 
 #: src/metabase/driver/common.clj
 msgid "Database username"
-msgstr "データベースユーザー名"
+msgstr "数据库用户名"
 
 #: src/metabase/driver/common.clj
 msgid "What username do you use to login to the database?"
-msgstr "データベースへのログインにどのユーザー名を使用しますか？"
+msgstr "您登陆数据库的用户名是什么？"
 
 #: src/metabase/driver/common.clj
 msgid "Database password"
-msgstr "データベースパスワード"
+msgstr "数据库密码"
 
 #: src/metabase/driver/common.clj
 msgid "Database name"
-msgstr "データベース名"
+msgstr "数据库名称"
 
 #: src/metabase/driver/common.clj
 msgid "birds_of_the_world"
@@ -9079,23 +9109,23 @@ msgstr "birds_of_the_world"
 
 #: src/metabase/driver/common.clj
 msgid "Use a secure connection (SSL)?"
-msgstr "セキュア接続（SSL）を使用しますか？"
+msgstr "使用安全连接(SSL)?"
 
 #: src/metabase/driver/common.clj
 msgid "Additional JDBC connection string options"
-msgstr "追加のJDBC接続文字列オプション"
+msgstr "额外的JDBC连接字符串选项"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Project ID"
-msgstr "プロジェクトID"
+msgstr "项目 ID"
 
 #: src/metabase/driver/bigquery.clj
 msgid "praxis-beacon-120871"
-msgstr "プラクシスビーコン-120871"
+msgstr "praxis-beacon-120871"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Dataset ID"
-msgstr "データセットID"
+msgstr "数据集 ID"
 
 #: src/metabase/driver/bigquery.clj
 msgid "toucanSightings"
@@ -9103,31 +9133,31 @@ msgstr "toucanSightings"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Client ID"
-msgstr "クライアントID"
+msgstr "客户端 ID"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Client Secret"
-msgstr "クライアントシークレット"
+msgstr "客户端密钥"
 
 #: src/metabase/driver/bigquery.clj src/metabase/driver/googleanalytics.clj
 msgid "Auth Code"
-msgstr "認証コード"
+msgstr "授权码"
 
 #: src/metabase/driver/crate.clj
 msgid "Hosts"
-msgstr "ホスト"
+msgstr "域名"
 
 #: src/metabase/driver/druid.clj
 msgid "Broker node port"
-msgstr "ブローカーノードポート"
+msgstr "代理节点端口"
 
 #: src/metabase/driver/googleanalytics.clj
 msgid "Google Analytics Account ID"
-msgstr "Google AnalyticsアカウントID"
+msgstr "Google Analytics 帐户ID"
 
 #: src/metabase/driver/h2.clj
 msgid "Connection String"
-msgstr "接続文字列"
+msgstr "连接字符串"
 
 #: src/metabase/driver/h2.clj
 msgid "Users/camsaul/bird_sightings/toucans"
@@ -9139,39 +9169,39 @@ msgstr "carrierPigeonDeliveries"
 
 #: src/metabase/driver/mongo.clj
 msgid "Authentication Database"
-msgstr "認証データベース"
+msgstr "认证数据库"
 
 #: src/metabase/driver/mongo.clj
 msgid "Optional database to use when authenticating"
-msgstr "認証時に使用する任意のデータベース"
+msgstr "认证时使用的可选数据库"
 
 #: src/metabase/driver/mongo.clj
 msgid "Additional Mongo connection string options"
-msgstr "追加のMongo接続文字列オプション"
+msgstr "附加的Mongo连接字符串选项"
 
 #: src/metabase/driver/oracle.clj
 msgid "Oracle system ID (SID)"
-msgstr "OracleシステムID（SID）"
+msgstr "Oracle系统ID(SID)"
 
 #: src/metabase/driver/oracle.clj
 msgid "Usually something like ORCL or XE."
-msgstr "通常ORCLやXE等。"
+msgstr "通常是ORCL或XE之类的"
 
 #: src/metabase/driver/oracle.clj
 msgid "Optional if using service name"
-msgstr "サービス名を使用している場合は任意です"
+msgstr "如果使用服务名称，可选"
 
 #: src/metabase/driver/oracle.clj
 msgid "Oracle service name"
-msgstr "Oracleサービス名"
+msgstr "Oracle服务名称"
 
 #: src/metabase/driver/oracle.clj
 msgid "Optional TNS alias"
-msgstr "任意のTNSエイリアス"
+msgstr "可选的TNS别名"
 
 #: src/metabase/driver/presto.clj
 msgid "hive"
-msgstr "ハイブ"
+msgstr "hive数据仓库"
 
 #: src/metabase/driver/redshift.clj
 msgid "my-cluster-name.abcd1234.us-east-1.redshift.amazonaws.com"
@@ -9183,15 +9213,15 @@ msgstr "toucan_sightings"
 
 #: src/metabase/driver/sparksql.clj
 msgid "default"
-msgstr "デフォルト"
+msgstr "默认"
 
 #: src/metabase/driver/sqlite.clj
 msgid "Filename"
-msgstr "ファイル名"
+msgstr "文件名"
 
 #: src/metabase/driver/sqlite.clj
 msgid "/home/camsaul/toucan_sightings.sqlite 😋"
-msgstr "/home/camsaul/toucan_sightings.sqlite 😋"
+msgstr "/home/camsaul/toucan_sightings.sqlite"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "BirdsOfTheWorld"
@@ -9199,46 +9229,46 @@ msgstr "BirdsOfTheWorld"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "Database instance name"
-msgstr "データベースインスタンス名"
+msgstr "数据库实例名"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "N/A"
-msgstr "該当なし"
+msgstr "不适用"
 
 #: src/metabase/driver/sqlserver.clj
 msgid "Windows domain"
-msgstr "ウィンドウズドメイン"
+msgstr "Windows域名"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:484
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:490
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:499
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:505
 msgid "Labels"
-msgstr "ラベル"
+msgstr "标签"
 
 #: frontend/src/metabase/admin/people/components/GroupDetail.jsx:339
 msgid "Add members"
-msgstr "メンバーを追加する"
+msgstr "添加成员"
 
 #: frontend/src/metabase/entities/collections.js:116
 msgid "Collection it's saved in"
-msgstr "保存先のコレクション"
+msgstr "集合保存在"
 
 #: frontend/src/metabase/lib/groups.js:4
 msgid "All Users"
-msgstr "All Users"
+msgstr "所有用户"
 
 #: frontend/src/metabase/lib/groups.js:5
 msgid "Administrators"
-msgstr "管理者"
+msgstr "管理员"
 
 #: frontend/src/metabase/lib/groups.js:6
 msgid "MetaBot"
-msgstr "MetaBot"
+msgstr "Meta机器人"
 
 #: frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx:290
 msgid "Sharing"
-msgstr "共有"
+msgstr "分享"
 
 #: frontend/src/metabase/visualizations/components/ChartSettings.jsx:23
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:218
@@ -9259,7 +9289,7 @@ msgstr "共有"
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:85
 #: frontend/src/metabase/visualizations/visualizations/Text.jsx:98
 msgid "Display"
-msgstr "表示"
+msgstr "显示"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:358
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:393
@@ -9270,228 +9300,228 @@ msgstr "表示"
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:447
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:477
 msgid "Axes"
-msgstr "軸"
+msgstr "坐标轴"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:216
 #: frontend/src/metabase/admin/settings/selectors.js:316
 #: frontend/src/metabase/modes/components/drill/FormatAction.jsx:27
 #: frontend/src/metabase/visualizations/lib/settings/column.js:63
 msgid "Formatting"
-msgstr "書式"
+msgstr "格式化"
 
 #: frontend/src/metabase/containers/Overworld.jsx:102
 msgid "Try these x-rays based on your data."
-msgstr "データに基づく自動探査(X-ray)を試す"
+msgstr "根据你的数据试试这些透视。"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:36
 msgid "There was a problem displaying this chart."
-msgstr "チャートの表示で問題が発生しました"
+msgstr "显示这个图表有一个问题。"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:37
 msgid "Sorry, you don't have permission to see this card."
-msgstr "申し訳ありません、このカードの閲覧権限がありません。"
+msgstr "对不起，您没有权限看这张卡。"
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:55
 msgid "Just a heads up:"
-msgstr "注意喚起:"
+msgstr "只是提个醒："
 
 #: frontend/src/metabase/admin/databases/components/DeleteDatabaseModal.jsx:63
 msgid "{0} without the Sample Dataset, the Query Builder tutorial won't work. You can always restore the Sample Dataset, but any questions you've saved using this data will be lost."
-msgstr "サンプルデータセットのない{0}では、クエリビルダーのチュートリアルは機能しません。 サンプルデータセットはいつでも復元できますが、このデータを使用して保存した質問は失われます。"
+msgstr "{0}没有样本数据集，查询创建器教程将不会工作。你可以总是重新存储样本数据集，但是任何你已经保存的问题将会丢失。"
 
 #: frontend/src/metabase/modes/components/drill/AutomaticDashboardDrill.jsx:33
 msgid "X-ray"
-msgstr "自動探査(X-ray)"
+msgstr "透视"
 
 #: frontend/src/metabase/modes/components/drill/CompareToRestDrill.js:34
 msgid "Compare to the rest"
-msgstr "残りと比較する"
+msgstr "和其余的比较"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:246
 msgid "Use the Java Virtual Machine (JVM) timezone"
-msgstr "JVMのタイムゾーンを使う"
+msgstr "使用Java虚拟机时区"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:248
 msgid "We suggest you leave this off unless you're doing manual timezone casting in\n"
 "many or most of your queries with this data."
-msgstr "もしほとんどのクエリで手動でタイムゾーンのキャストをしていない限り、この設定はそのままにしておくことをおすすめします"
+msgstr "我们建议你让它关闭，除非你用这些数据在大部分查询中手动调整时区"
 
 #: frontend/src/metabase/containers/Overworld.jsx:312
 msgid "Your team's most important dashboards go here"
-msgstr "あなたのチームの最も重要なダッシュボードがここに表示されます"
+msgstr "你的团队的最重要的仪表盘在这里"
 
 #: frontend/src/metabase/containers/Overworld.jsx:313
 msgid "Pin dashboards in {0} to have them appear in this space for everyone"
-msgstr "他の人も閲覧できるようこの場所に表示させるため、ダッシュボードを{0}でピン留めする"
+msgstr "把面板固定在{0}里，使之对所有人可见"
 
 #: src/metabase/db.clj
 msgid "Unable to release the Liquibase lock after a migration failure"
-msgstr "マイグレーション失敗後、Liquibaseのロックを解放できません"
+msgstr "迁移失败后无法释放Liquibase锁"
 
 #: src/metabase/driver/bigquery.clj
 msgid "Use JVM Time Zone"
-msgstr "JVMのタイムゾーンを使う"
+msgstr "使用Java虚拟机时区"
 
 #: frontend/src/metabase/admin/databases/components/CreatedDatabaseModal.jsx:29
 msgid "We're currently analyzing the tables and fields to help you explore your data."
-msgstr "あなたがデータ分析を簡単にできるようテーブルとフィールドを解析中です・・"
+msgstr "我们现在正在分析数据表和字段来帮助你探索数据"
 
 #: frontend/src/metabase/admin/datamodel/components/FieldRemapping.jsx:441
 msgid "Tip: "
-msgstr "ヒント: "
+msgstr "提示："
 
 #: frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx:246
 msgid "Select a currency type"
-msgstr "通貨単位を選択"
+msgstr "选择一个统用的类型"
 
 #: frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx:310
 msgid "Field Type"
-msgstr "フィールドタイプ"
+msgstr "字段类型"
 
 #: frontend/src/metabase/admin/routes.jsx:109
 #: frontend/src/metabase/nav/containers/Navbar.jsx:253
 msgid "Troubleshooting"
-msgstr "トラブルシューティング"
+msgstr "错误排查"
 
 #: frontend/src/metabase/admin/settings/selectors.js:93
 msgid "Enable X-ray features"
-msgstr "自動探査(X-ray)機能を有効化"
+msgstr "开启透视(X-ray) 功能"
 
 #: frontend/src/metabase/admin/settings/selectors.js:320
 msgid "Formatting Options"
-msgstr "書式オプション"
+msgstr "格式化"
 
 #: frontend/src/metabase/admin/tasks/containers/TaskModal.jsx:22
 msgid "Task details"
-msgstr "タスク詳細"
+msgstr "任务详情"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:29
 msgid "Troubleshooting logs"
-msgstr "トラブルシューティングログ"
+msgstr "分析日志"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:31
 msgid "Trying to get to the bottom of something? This section shows logs of Metabase's background tasks, which can help shed light on what's going on."
-msgstr "何かの原因究明をしようとしていますか？このセクションではMetabaseのバックグラウンドタスクのログを表示しています。これを見れば何が起こっているかを知る助けになるでしょう。"
+msgstr "Trying to get to the bottom of something? This section shows logs of Metabase's background tasks, which can help shed light on what's going on."
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:56
 msgid "Task"
-msgstr "タスク"
+msgstr "任务"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:57
 msgid "DB ID"
-msgstr "データベースID"
+msgstr "数据库 ID"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:58
 msgid "Started at"
-msgstr "に開始"
+msgstr "开始于"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:59
 msgid "Ended at"
-msgstr "に終了"
+msgstr "结束于"
 
 #: frontend/src/metabase/admin/tasks/containers/TasksApp.jsx:60
 msgid "Duration (ms)"
-msgstr "実行時間(ms)"
+msgstr "用时"
 
 #: frontend/src/metabase/lib/core.js:45
 msgid "Currency"
-msgstr "通貨"
+msgstr "货币"
 
 #: frontend/src/metabase/pulse/components/PulseEditChannels.jsx:161
 msgid "Pick a user or channel..."
-msgstr "ユーザーかチャンネルを選ぶ..."
+msgstr "选择一个用户或频道"
 
 #: frontend/src/metabase/visualizations/components/ColumnSettings.jsx:89
 msgid "No formatting settings"
-msgstr "フォーマット設定はありません"
+msgstr "无格式化设置"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:81
 msgid "Label for this range (optional)"
-msgstr "範囲のラベル（任意）"
+msgstr "该范围的标签（可选）"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingGaugeSegments.jsx:93
 msgid "Add a range"
-msgstr "範囲を追加"
+msgstr "添加一个范围"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:26
 msgid "is less than"
-msgstr "未満"
+msgstr "小于"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:27
 msgid "is greater than"
-msgstr "大きい"
+msgstr "大于"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:28
 msgid "is less than or equal to"
-msgstr "以下"
+msgstr "小于等于"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:29
 msgid "is greater than or equal to"
-msgstr "以上"
+msgstr "大于等于"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:30
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:37
 msgid "is equal to"
-msgstr "等しい"
+msgstr "等于"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:31
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:38
 msgid "is not equal to"
-msgstr "等しくない"
+msgstr "不等于"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:32
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:39
 msgid "is null"
-msgstr "null値"
+msgstr "为空"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:33
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:40
 msgid "is not null"
-msgstr "null値でない"
+msgstr "不为空"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:41
 msgid "contains"
-msgstr "含む"
+msgstr "包含"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:42
 msgid "does not contain"
-msgstr "含まない"
+msgstr "不包含"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:43
 msgid "starts with"
-msgstr "接頭辞"
+msgstr "开始于"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:44
 msgid "ends with"
-msgstr "接尾辞"
+msgstr "结束于"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:292
 msgid "When a cell in these columns {0} it will be tinted this color."
-msgstr "この列のセルが{0}のとき、この色に色付けされます"
+msgstr "当一个单元在这些列{0}中时，将被涂上这个颜色"
 
 #: frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx:351
 msgid "When a cell in this column…"
-msgstr "この列のセルが…したとき"
+msgstr "当这栏内的一个单元格..."
 
 #: frontend/src/metabase/visualizations/lib/errors.js:42
 msgid "This visualization requires you to group by a field."
-msgstr "表示にはグループ化するためのフィールドが必要です。"
+msgstr "这个可视化需要你按字段分组"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:178
 msgid "Date style"
-msgstr "日付の形式"
+msgstr "日期格式"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:196
 msgid "Date separators"
-msgstr "日付の区切り文字"
+msgstr "日期分隔符"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:215
 msgid "Abbreviate names of days and months"
-msgstr "日と月の略称"
+msgstr "日和月的缩写"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:225
 msgid "Show the time"
-msgstr "時間を表示"
+msgstr "显示时间"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:232
 msgid "HH:MM"
@@ -9507,175 +9537,172 @@ msgstr "HH:MM:SS.MS"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:254
 msgid "Time style"
-msgstr "時刻の形式"
+msgstr "时间格式"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:300
 msgid "Unit of currency"
-msgstr "通貨単位"
+msgstr "货币单位"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:320
 msgid "Currency label style"
-msgstr "通貨単位の表示形式"
+msgstr "货币标签风格"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:338
 msgid "Where to display the unit of currency"
-msgstr "通貨単位の表示場所"
+msgstr "在哪里显示货币单位"
 
 #: frontend/src/metabase/visualizations/lib/settings/column.js:371
 msgid "Minimum number of decimal places"
-msgstr "小数点の最小桁数"
+msgstr "最少小数位数"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:252
 msgid "Stacked chart type"
-msgstr "積み上げグラフ形式"
+msgstr "堆叠图表类型"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:295
 msgid "Goal label"
-msgstr "ゴールラベル"
+msgstr "目标标签"
 
 #: frontend/src/metabase/visualizations/lib/settings/graph.js:303
 msgid "Show trend line"
-msgstr "傾向線を表示"
+msgstr "显示趋势线"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:67
 msgid "Line style"
-msgstr "線の形式"
+msgstr "线条样式"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:84
 msgid "Show dots on lines"
-msgstr "点線で表示"
+msgstr "在线上显示圆圈"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:88
 #: frontend/src/metabase/visualizations/lib/settings/series.js:125
 msgid "Auto"
-msgstr "自動"
+msgstr "自动"
 
 #: frontend/src/metabase/visualizations/lib/settings/series.js:120
 msgid "Which axis?"
-msgstr "どちらの軸？"
+msgstr "哪个轴？"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
 msgid "Line + Bar"
-msgstr "折れ線＋棒"
+msgstr "线状图+条行图"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:19
 msgid "line and bar chart"
-msgstr "折れ線＋棒グラフ"
+msgstr "线状图和条型图"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:76
 msgid "Gauge visualization requires a number."
-msgstr "ゲージビジュアライゼーションには数値が必要です"
+msgstr "标尺可视化需要一个数字"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:60
-#, fuzzy
 msgid "Gauge"
-msgstr "ゲージ"
+msgstr "标尺"
 
 #: frontend/src/metabase/visualizations/visualizations/Gauge.jsx:115
-#, fuzzy
 msgid "Gauge ranges"
-msgstr "ゲージの範囲"
+msgstr "标尺范围"
 
 #: frontend/src/metabase/visualizations/visualizations/Scalar.jsx:98
 msgid "Field to show"
-msgstr "表示するフィールド"
+msgstr "显示的字段"
 
-#. 「前{0}」はどうでしょう。前日、前月、…
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:140
 msgid "last {0}"
-msgstr "前{0}"
+msgstr "上一{0}"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:204
 msgid "{0} was {1} {2}"
-msgstr "{0} は {1} {2}でした"
+msgstr "{0}{2} {1}"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:66
 msgid "Group by a time field to see how this has changed over time"
-msgstr "時間経過と共にどのように変化したか見るため時間のフィールドでグルーピング"
+msgstr "聚一个时间字段来看指标随着时间的变化情况"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:46
 msgid "Switch positive / negative colors?"
-msgstr "＋/ーの色を入れ替える？"
+msgstr "切换正、负颜色"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:95
 msgid "Pivot column"
-msgstr "ピボット項目"
+msgstr "透视列"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:126
 msgid "Cell column"
-msgstr "セル項目"
+msgstr "列单元"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:163
 msgid "Visible columns"
-msgstr "表示列"
+msgstr "可见列"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:191
 msgid "Conditional Formatting"
-msgstr "条件付き書式"
+msgstr "条件格式化"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:233
 msgid "Column title"
-msgstr "項目名"
+msgstr "列抬头"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:240
 msgid "Show a mini bar chart"
-msgstr "ミニバーを表示"
+msgstr "显示迷你条形图"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:251
 msgid "Link"
-msgstr "リンク"
+msgstr "连接"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:255
 msgid "Email link"
-msgstr "メールアドレス"
+msgstr "Email地址"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:259
 msgid "Image"
-msgstr "イメージ"
+msgstr "图片"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:263
 msgid "Automatic"
-msgstr "自動"
+msgstr "自动"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:268
 msgid "View as link or image"
-msgstr "リンクまたは画像として表示"
+msgstr "以链接或图片查看"
 
 #: frontend/src/metabase/visualizations/visualizations/Table.jsx:278
 msgid "Link text"
-msgstr "リンクテキスト"
+msgstr "链接文字"
 
 #: src/metabase/api/common/internal.clj
 msgid "Not a valid integer: ''{0}''"
-msgstr "有効な数値ではありません: \"{0}\""
+msgstr "无效的整数：“{0}”"
 
 #: src/metabase/api/embed.clj
 msgid "Embedding is not enabled for this object."
-msgstr "このオブジェクトは埋め込み可能になっていません。"
+msgstr "这个对象的嵌入功能没有启用。"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fallback to local authentication: {0}"
-msgstr "LDAPサーバー接続に失敗し、ローカルで認証します: {0}"
+msgstr "连接LDAP服务发生错误，将使用本地认证：{0}"
 
 #: src/metabase/api/task.clj
 msgid "When including an offset, a limit must also be included."
-msgstr "オフセットを含む場合、上限も含まないといけません"
+msgstr "When including an offset, a limit must also be included."
 
 #: src/metabase/api/task.clj
 msgid "When including a limit, an offset must also be included."
-msgstr "上限を含む場合、オフセットも含まないといけません"
+msgstr "When including a limit, an offset must also be included."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Applying heuristic {0} to {1}."
-msgstr ""
+msgstr "Applying heuristic {0} to {1}."
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Dimensions bindings:n{0}"
-msgstr ""
+msgstr "Dimensions bindings:n{0}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "Using definitions:nMetrics:n{0}nFilters:n{1}"
-msgstr ""
+msgstr "使用定义：nMetrics:n{0}nFilters:n{1}"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "minute"
@@ -9683,23 +9710,23 @@ msgstr "分"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "hour"
-msgstr "時"
+msgstr "小时"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of week"
-msgstr "曜日"
+msgstr "一周中的天"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of month"
-msgstr "日"
+msgstr "一个月中的天"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "day of year"
-msgstr "年間通算日"
+msgstr "一年中的天"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "week"
-msgstr "週"
+msgstr "周"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "month"
@@ -9707,175 +9734,176 @@ msgstr "月"
 
 #: src/metabase/automagic_dashboards/core.clj
 msgid "quarter"
-msgstr "四半期"
+msgstr "季度"
 
 #: src/metabase/automagic_dashboards/populate.clj
 msgid "Adding {0} cards to dashboard {1}:n{2}"
-msgstr "{0}カードをダッシュボード{1}:n{2}に追加中"
+msgstr "添加 {0} 卡片到仪表盘 {1}:n{2}"
 
 #: src/metabase/automagic_dashboards/rules.clj
 msgid "Error parsing {0}:n{1}"
-msgstr ""
+msgstr "解析错误 {0}:n{1}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Filtering only works on dimensions! ''{0}'' is a metric. Ignoring filter."
-msgstr "警告: フィルタリングはディメンションでのみ機能します！ ''{0}''はメトリックです。フィルターを無視します。"
+msgstr "警告：过滤只在列上有效! \"{0}\"是一个指标。忽略过滤"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: A date can't belong to multiple discrete intervals, so ANDing them together doesn't make sense."
-msgstr "警告: 日付は複数の連続しない区間に属することはないので、それらの条件をAND条件でつなぐことは意味を成しません。"
+msgstr "警告：日期不能属于多个离散间隔，因此将它们组合（AND）在一起没有意义。"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Ignoring these intervals: {0}"
-msgstr "これらの間隔を無視: {0}"
+msgstr "忽略这些间隔：{0}"
 
 #. We should never get to this point since the all non-string negations should get automatically rewritten
 #. by the query expander.
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Don't know how to negate: {0}"
-msgstr "警告: 無効にする方法がわからない: {0}"
+msgstr "WARNING: Don't know how to negate: {0}"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "Sorting with Druid is only allowed in queries that have one or more breakout columns. Ignoring :order-by clause."
-msgstr "Druid によるソートは、1つ以上のブレークアウト列があるクエリでのみ許可されます。 :order-by 句を無視します。"
+msgstr "只有具有一个或多个分组列的查询才允许使用Druid进行排序。忽略 :order-by 子句。"
 
 #. TODO - this is not really true, is it
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: It only makes sense to specify :fields for a query with no aggregation. Ignoring the clause."
-msgstr "警告: 集計のないクエリには :fields を指定することだけが意味があります。句を無視します。"
+msgstr "警告：仅指定没有聚合的查询的 :fields 才有意义。 忽略该子句。"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid doenst allow limitSpec in timeseries queries. Ignoring the LIMIT clause."
-msgstr "警告: Druid は時系列クエリで limitSpec を許可しません。 LIMIT 句を無視します。"
+msgstr "警告：Druid在时间序列查询中不允许使用limitSpec。 忽略LIMIT子句。"
 
 #: src/metabase/driver/sql/query_processor.clj
 msgid "HoneySQL Form:"
-msgstr "HoneySQLフォーム:"
+msgstr "HoneySQL 表单:"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Unable to parse date ''{0}''"
-msgstr "日付として解析できません: \"{0}\""
+msgstr "不能解析日期\"{0}\""
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, cancelling query"
-msgstr "クライアントは切断しました。クエリをキャンセルしています。"
+msgstr "客户端关闭了连接，正在取消查询"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Setting timezone with statement: {0}"
-msgstr "ステートメントでタイムゾーンを設定: {0}"
+msgstr "使用语句设置时区： {0}"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid "Multiple date filters are not supported"
-msgstr "複数の日付フィルターはサポートされていません"
+msgstr "不支持多个过滤器"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid ":not is not yet implemented"
-msgstr ":not はまだ実装されていません"
+msgstr ":not还未实现"
 
 #: src/metabase/driver/googleanalytics/query_processor.clj
 msgid "Only one Google Analytics segment allowed at a time."
-msgstr "同時に複数のGoogle Analyticsセグメントは利用できません。"
+msgstr "一次只允许一个Google Analytics segment"
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "MONGO AGGREGATION PIPELINE:"
-msgstr "MongoDB集約パイプライン："
+msgstr "MONGO AGGREGATION PIPELINE:"
 
 #: src/metabase/driver/mongo/query_processor.clj
 msgid "Error: mismatched columns in results! Expected: {0} Got: {1}"
-msgstr "エラー: 結果に整合しない項目があります！ 想定は {0} 、結果は {1} でした"
+msgstr "Error: mismatched columns in results! Expected: {0} Got: {1}"
 
 #: src/metabase/email/messages.clj
 msgid "Unable to create temp file in `{0}` for email attachments "
-msgstr "`{0}` にメール添付のための一時ファイルを作成できません"
+msgstr "Unable to create temp file in `{0}` for email attachments"
 
 #: src/metabase/events/activity_feed.clj
 msgid "Error preprocessing query:"
-msgstr "クエリ処理に失敗:"
+msgstr "预处理查询时出错："
 
 #: src/metabase/mbql/normalize.clj
 msgid "Illegal filter clause: {0}"
-msgstr "不正なフィルター条件: {0}"
+msgstr "非法的过滤条件：{0}"
 
 #: src/metabase/mbql/normalize.clj
 msgid "Invalid clause:"
-msgstr "不正な条件:"
+msgstr "无效的语句:"
 
 #: src/metabase/mbql/util.clj
 msgid "Error: query's source query has not been resolved. You probably need to `preprocess` the query first."
-msgstr "エラー: クエリに使われているソースクエリを特定できません。恐らく初めに事前処理する必要があります。"
+msgstr "Error: query's source query has not been resolved. You probably need to `preprocess` the query first."
 
 #: src/metabase/mbql/util.clj
 msgid "No expression named ''{0}''"
-msgstr "\"{0}\" という名前はありません"
+msgstr "No expression named ''{0}''"
 
 #: src/metabase/mbql/util.clj
 msgid "No aggregation at index: {0}"
-msgstr "{0} のインデックスに集合はありません"
+msgstr "No aggregation at index: {0}"
 
 #: src/metabase/models/field_values.clj
 msgid "Field values total length is {0} (max {1})."
-msgstr "フィールド値の長さが {0} です。(最大 )"
+msgstr "字段总长度为 {0} (最大值为 {1})."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues are allowed for this Field."
-msgstr "FieldValues はこのフィールドに設定できます"
+msgstr "FieldValues are allowed for this Field."
 
 #: src/metabase/models/field_values.clj
 msgid "FieldValues are NOT allowed for this Field."
-msgstr "FieldValues はこのフィールドに設定できません"
+msgstr "FieldValues are NOT allowed for this Field."
 
 #: src/metabase/models/field_values.clj
 msgid "Field {0} ''{1}'' should have FieldValues and belongs to a Database with On-Demand FieldValues updating."
-msgstr ""
+msgstr "字段{0}''{1}''应具有字段值，并且属于具有按需字段值更新的数据库。"
 
 #: src/metabase/models/permissions.clj
 msgid "You cannot create or revoke permissions for the ''Admin'' group."
-msgstr "Adminグループの権限の作成または取り消しはできません"
+msgstr "你不能为“管理员（Admin）”群组创建或撤销权限"
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the ''MetaBot'' group."
-msgstr "MetaBotグループのユーザーは変更できません"
+msgstr "你不能添加或移除’MetaBot‘组的成员"
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot add or remove users to/from the ''All Users'' group."
-msgstr "All Usersグループのユーザーは変更できません"
+msgstr "你不能添加或移除‘All Users'组的成员"
 
 #: src/metabase/models/permissions_group_membership.clj
 msgid "You cannot remove the last member of the ''Admin'' group!"
-msgstr "Adminグループには最低１人のメンバーを残さないといけません！"
+msgstr "你不能移除‘Admin’组的最后一个成员"
 
 #. go ahead and log the Exception anyway on the off chance that it *wasn't* just a race condition issue
 #: src/metabase/models/setting/cache.clj
 msgid "Error inserting a new Setting: {0}"
-msgstr "新しい設定の追加に失敗: {0}"
+msgstr "插入新设置时出错： {0}"
 
 #: src/metabase/models/setting.clj
+#, fuzzy
 msgid "defsetting descriptions strings must be `:internal?` or internationalized, found: `{0}`"
-msgstr ""
+msgstr "defsetting描述字符串必须是`：internal？`或internationalized，found：`{0}`"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugin {0}... {1}"
-msgstr "プラグインを読み込み中 {0}... {1}"
+msgstr "加载插件 {0}...{1}"
 
 #: src/metabase/public_settings.clj
 msgid "Object keyed by type, containing formatting settings"
-msgstr ""
+msgstr "按类型键入的对象包含格式设置"
 
 #: src/metabase/public_settings.clj
 msgid "Allow users to explore data using X-rays"
-msgstr "自動探査(X-ray)を使ってデータの探索を許可する"
+msgstr "允许用户使用X-rays探索数据"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Using this URL to check token: {0}"
-msgstr "トークンのチェックにこのURLを使います: {0}"
+msgstr "使用这个URL来检查token: {0}"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Unable to validate token: 404 not found."
-msgstr "トークンを検証できません: 404"
+msgstr "不能验证token：404 not found"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "There was an error checking whether this token was valid:"
-msgstr "トークンの有効性チェックでエラー:"
+msgstr "检查此令牌是否有效时出错："
 
 #. +----------------------------------------------------------------------------------------------------------------+
 #. |                                             SETTING & RELATED FNS                                              |
@@ -9883,270 +9911,271 @@ msgstr "トークンの有効性チェックでエラー:"
 #. TODO - rename this to premium-features-token?
 #: src/metabase/public_settings/metastore.clj
 msgid "Token for premium features. Go to the MetaStore to get yours!"
-msgstr "プレミアム機能のトークン取得のためMetaStoreに行きましょう！"
+msgstr "令牌（Token）为高级功能。 转到MetaStore来获取你的令牌！"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Token format is invalid. Token should be 64 hexadecimal characters."
-msgstr "トークンの形式が不正です。トークンは64文字の16進数です。"
+msgstr "令牌格式无效。 令牌应为64个十六进制字符。"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error setting premium features token"
-msgstr "プレミアム機能トークンの設定に失敗"
+msgstr "设置高级功能-令牌时出错"
 
 #: src/metabase/public_settings/metastore.clj
 msgid "Error validating token:"
-msgstr "トークンの検証エラー:"
+msgstr "验证令牌时出错："
 
 #: src/metabase/query_processor.clj
 msgid "Error preprocessing query"
-msgstr "クエリの処理エラー"
+msgstr "预处理查询时出错"
 
 #: src/metabase/query_processor.clj
 msgid "No native form returned."
-msgstr "ネイティブフォームは返されません。"
+msgstr "没有返回原生表格。"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Invalid response from database driver. No :status provided."
-msgstr "データベースドライバーから不正な応答: ステータスを確認できません"
+msgstr "数据库驱动程序的响应无效。 无 :status 提供。"
 
 #: src/metabase/query_processor.clj
 msgid "General error"
-msgstr "一般的なエラー"
+msgstr "一般错误"
 
 #: src/metabase/query_processor.clj
 msgid "Missing query hash!"
-msgstr "クエリハッシュが不足しています"
+msgstr "缺少查询哈希！"
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Table ''{0}'' has no Fields associated with it."
-msgstr "テーブル \"{0}\" には指定されたフィールドに関連するフィールドはありません。"
+msgstr "表 “{0}” 和它没有任何关联字段."
 
 #: src/metabase/query_processor/middleware/add_query_throttle.clj
 msgid "Max concurrent query limit reached"
-msgstr "最大同時クエリ数に達しました"
+msgstr "达到最大并发查询限制"
 
 #. we should never reach this if our patterns are written right so this is more to catch code mistakes than
 #. something the user should expect to see
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Don't know how to get information about Field:"
-msgstr "フィールドの情報を取得する方法を知りません:"
+msgstr "不知道如何获取有关这个字段的信息："
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "metabase.query-processor.interface/*driver* is unbound."
-msgstr ""
+msgstr "metabase.query-processor.interface/*driver* 未绑定."
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: mismatched number of columns in query and results."
-msgstr "クエリプロセッサエラー：クエリと結果におけるコラム数が一致していません"
+msgstr "查询处理器错误：查询和结果中的列数不匹配。"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected {0} fields, got {1}"
-msgstr "{0} のフィールドのうち {1} を取得しました"
+msgstr "预期 {0} 个字段，取得 {1} 个"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Expected: {0}"
-msgstr "予定: {0}"
+msgstr "预期： {0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Actual: {0}"
-msgstr "結果: {0}"
+msgstr "实际： {0}"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Unable to bin Field without a min/max value"
-msgstr "最小値、最大値なしにフィールドを格納できません"
+msgstr "因缺少最大/最小值, 无法对该字段进行切分."
 
 #: src/metabase/query_processor/middleware/check_features.clj
 msgid "{0} is not supported by this driver."
-msgstr "{0} はこのドライバーでサポートされていません"
+msgstr "不支持{0}驱动程序"
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Segment {0} does not exist, or is invalid."
-msgstr "セグメント {0} は存在しないか無効です。"
+msgstr "划分 {0} 无效或不存在."
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Metric {0} does not exist, or is invalid."
-msgstr "メトリック {0} は存在しないか無効です。"
+msgstr "指标 {0} 不存在或无效."
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Missing source query in Card {0}"
-msgstr "カード {0} にはソースクエリが不足しています"
+msgstr "卡片中缺少源查询 {0}"
 
 #: src/metabase/query_processor/middleware/fetch_source_query.clj
 msgid "Fetched source query from Card {0}:"
-msgstr "カード {0} から取得されたソースクエリ"
+msgstr "从卡片 {0} 中获取源查询:"
 
 #: src/metabase/query_processor/middleware/mbql_to_native.clj
 msgid "Error transforming MBQL query to native:"
-msgstr "MBQLクエリからネイティブクエリに変換中にエラーが起こりました:"
+msgstr "将MBQL查询转为本地时出错："
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
 msgid "Cannot run query: could not find source table {0}."
-msgstr "クエリを実行できません: ソーステーブル {0} が見つかりません"
+msgstr "无法执行查询：找不到源表 {0} 。"
 
 #: src/metabase/query_processor/middleware/results_metadata.clj
 msgid "Error recording results metadata for query:"
-msgstr ""
+msgstr "记录查询结果元数据时出错："
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Query Processor store is not initialized."
-msgstr "エラー: クエリ処理ストアが初期化されていません。"
+msgstr "错误：未初始化查询处理器存储。"
 
+#. 错误：查询处理器存储中不存在表{0}。
 #: src/metabase/query_processor/store.clj
 msgid "Error: Table {0} is not present in the Query Processor Store."
-msgstr "エラー: テーブル{0}がクエリ処理ストアに存在しません。"
+msgstr "错误：查询处理器存储中不存在表{0}。"
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Field {0} is not present in the Query Processor Store."
-msgstr "エラー: フィールド{0}がクエリ処理ストアに存在しません。"
+msgstr "错误：查询处理器存储中不存在字段{0}。"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were {0}deleted"
-msgstr "タスク履歴の削除は成功しました。{0}行が削除されました。"
+msgstr "任务历史清理完毕, 记录删除 {0}"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "not"
-msgstr "でない"
+msgstr "不"
 
 #: src/metabase/util/encryption.clj
 msgid "For more information, see"
-msgstr "詳細はこちら"
+msgstr "查看更多信息，看"
 
 #: src/metabase/util/schema.clj
 msgid "Integer greater than or equal to zero"
-msgstr "0以上の整数"
+msgstr "大于等于0的整数"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer greater than or equal to zero."
-msgstr "値は0以上の整数でないといけません"
+msgstr "值必须是一个大于等于0的整数"
 
 #: src/metabase/util/schema.clj
 msgid "value must be an integer zero or greater."
-msgstr "値は0かそれより大きな整数でないといけません"
+msgstr "值必须是一个大于等于0的整数"
 
 #: src/metabase/util/schema.clj
 msgid "value must be a valid integer greater than or equal to zero."
-msgstr "値は0以上の有効な整数でないといけません"
+msgstr "值必须是一个大于等于0的有效整数"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "New users per state in the last 30 days"
-msgstr "過去30日の状態ごとの新規ユーザー"
+msgstr "最近30天每州新增用户"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by day of the week"
-msgstr "曜日別の作成日時"
+msgstr "创建于周"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by quarter of the year"
-msgstr "四半期別の作成日時"
+msgstr "创建于第{0}季度"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] per country"
-msgstr "国ごとの [[this.short-name]]"
+msgstr "[[this.short-name]] 每国家"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Users per source"
-msgstr "ソースごとのユーザー"
+msgstr "每来源用户"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "The top external pages that brought users to your site"
-msgstr "ユーザーを最も呼び込んでいる外部ページ"
+msgstr "将用户带到您网站的外部热门网页"
 
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "How [[this]] is distributed and more."
-msgstr ""
+msgstr "[[这个]]如何分发等等。"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "The [[this]] over time"
-msgstr "[[this]] の時間推移"
+msgstr "超时了"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "User growth"
-msgstr "ユーザー増加"
+msgstr "用户增长"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Whether or not there are any patterns to when they happen."
-msgstr "いつ発生したかに何らかのパターンがあるかどうか"
+msgstr "当它们发生时，是否有任何模式。"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Users per state"
-msgstr "状態ごとのユーザー"
+msgstr "各州的用户"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions"
-msgstr "セッション"
+msgstr "会话"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How some of the numbers in [[this]] relate to each other"
-msgstr ""
+msgstr "How some of the numbers in [[this]] relate to each other"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per country"
-msgstr "国ごとの売上"
+msgstr "每个国家的销售额"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by month of the year"
-msgstr "月別の登録日"
+msgstr "Join date by month of the year"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by hour of the day"
-msgstr "時間別の [[Timestamp]]"
+msgstr "[[Timestamp]] by hour of the day"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "A look at the [[this]]"
-msgstr "[[this]] の概要"
+msgstr "看一看 [[this]]"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Bottom 5 per category"
-msgstr "カテゴリーごとの下位5位"
+msgstr "每类的后5个"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Number of orders"
-msgstr "注文数"
+msgstr "订单数"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Event growth"
-msgstr "イベント増加"
+msgstr "Event growth"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "Total [[GenericTable]]"
-msgstr "[[GenericTable]] 合計"
+msgstr "Total [[GenericTable]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Income growth"
-msgstr "収益の増加"
+msgstr "收入增长"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales in the last 30 days"
-msgstr "過去30日の売上上位10位の国"
+msgstr "Top 10 countries by sales in the last 30 days"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by month of the year"
-msgstr "月別の [[this]]"
+msgstr "[[this]] by month of the year"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per day of the week"
-msgstr "曜日毎のトランザクション"
+msgstr "该周每一天的交易量"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by device type"
-msgstr "デバイスタイプ別のセッション"
+msgstr "Sessions by device type"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Transactions per country"
-msgstr "国ごとのトランザクション"
+msgstr "每个国家的交易量"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by quarter of the year"
-msgstr "四半期別の登録日"
+msgstr "Join date by quarter of the year"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per hour of the day"
-msgstr "時間帯ごとのイベント"
+msgstr "当日每小时事件"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Singleton]]"
@@ -10155,20 +10184,20 @@ msgstr "[[Singleton]]"
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Top 5 [[this]]"
-msgstr "[[this]] の上位5つ"
+msgstr "前5 [[this]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Bottom 5 [[this]]"
-msgstr "[[this]] の下位5つ"
+msgstr "后5 [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "[[Timestamp]] by day of the month"
-msgstr "日別の [[Timestamp]]"
+msgstr "[[Timestamp]] by day of the month"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[GenericCategoryLarge]]"
-msgstr "[[GenericCategoryLarge]] ごと"
+msgstr "Per [[GenericCategoryLarge]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10176,335 +10205,352 @@ msgstr "[[GenericCategoryLarge]] ごと"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Null values"
-msgstr "Null値"
+msgstr "空值"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Total events"
-msgstr "総イベント数"
+msgstr "总事件"
 
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "A look at [[GenericTable]] across your [[this]], and how it changes over time."
-msgstr ""
+msgstr "A look at [[GenericTable]] across your [[this]], and how it changes over time."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per [[GenericCategoryMedium]]"
-msgstr "[[GenericCategoryMedium]] ごとの [[this]]"
+msgstr "[[this]] per [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] changes with time"
-msgstr "[[this]]が時間とともにどのように変化するか"
+msgstr "How the [[this]] changes with time"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "How they compare by seasonality"
-msgstr "季節ごとの比較"
+msgstr "How they compare by seasonality"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average income per transaction"
-msgstr "トランザクションごとの平均収益"
+msgstr "每次交易的平均收入"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per country"
-msgstr "国ごとの [[this]]"
+msgstr "每个国家"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Income per state"
-msgstr "州ごとの収益"
+msgstr "每州收入"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
+#, fuzzy
 msgid "Per [[GenericCategoryMedium]]"
-msgstr "[[GenericCategoryMedium]] ごとの"
+msgstr "按[[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "A closer look at your [[this]]"
-msgstr "あなたの [[this]] を詳しく見る"
+msgstr "细看你的 [[this]]"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
+#, fuzzy
 msgid "How [[GenericNumber]] is distributed"
-msgstr "[[GenericNumber]] の分散"
+msgstr "如何分发[[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by quarter of year"
-msgstr "四半期別の [[Timestamp]]"
+msgstr "[[时间戳]]按季度计算"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per country"
-msgstr "国ごとのイベント"
+msgstr "每个国家的事件"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "Weekdays when [[this.short-name]] were added"
-msgstr "[[this.short-name]] が追加された曜日"
+msgstr "添加[[this.short-name]]的工作日"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "Months when [[this.short-name]] were added"
-msgstr "[[this.short-name]] が追加された月"
+msgstr "添加[[this.short-name]]的月份"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across different categories"
-msgstr "異なるカテゴリーを比較する方法"
+msgstr "他们如何比较不同的类别"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30"
-msgstr "直近30件のうちソースごとの新規ユーザー"
+msgstr "在过去30年，每个来源的新用户"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per quarter of the year"
-msgstr "四半期毎のイベント"
+msgstr "该年每季度事件"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Heres a quick look at your [[this]]"
-msgstr "これが [[this]] の概要です"
+msgstr "这里是 [[this]] 的速览"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#, fuzzy
 msgid "[[this]] per [[GenericCategoryLarge]], top 5"
-msgstr "[[GenericCategoryLarge]] ごとの [[this]] 上位5つ"
+msgstr "[[this]]按[[GenericCategoryLarge]]，前5名"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "Days when [[this.short-name]] were added"
-msgstr "[[this.short-name]] が追加されて経過した日数"
+msgstr "添加[[this.short-name]]的天数"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Total orders per source"
-msgstr "ソースごとの総オーダー数"
+msgstr "分来源订单总数"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by quarter of the year"
-msgstr "四半期別の [[this]]"
+msgstr "[[这个]]按季度计算"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
+#, fuzzy
 msgid "Events per [[GenericCategoryMedium]]"
-msgstr "[[GenericCategoryMedium]] ごとのイベント"
+msgstr "每个[[GenericCategoryMedium]]的事件"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per state"
-msgstr "状態ごとのイベント"
+msgstr "每个州的事件"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top landing pages"
-msgstr "人気のページ"
+msgstr "热门访问页面"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Heres a closer look at your [[this]] over time"
-msgstr "経時的に [[this]] を詳しく見てみましょう"
+msgstr "随着时间的推移，你会仔细看看[[这个]]"
 
 #: resources/automagic_dashboards/field/Number.yaml
+#, fuzzy
 msgid "Sum of [[this]] by [[Country]]"
-msgstr "[[Country]] 別の [[this]] 合計"
+msgstr "[[国家]]的[[this]]之和"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "States that are performing best"
-msgstr "最もパフォーマンスが良い州"
+msgstr "States that are performing best"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by month of the year"
-msgstr "月別の作成日時"
+msgstr "Created At by month of the year"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Sum of [[this]] by [[State]]"
-msgstr "[[State]] 別の [[this]] の合計"
+msgstr "Sum of [[this]] by [[State]]"
 
 #: resources/automagic_dashboards/field/State.yaml
 msgid "Sum of [[GenericNumber]] per [[this]]"
-msgstr "[[this]] ごとの [[GenericNumber]] の合計"
+msgstr "Sum of [[GenericNumber]] per [[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by coordinates"
-msgstr "座標別のイベント"
+msgstr "Events by coordinates"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top referral pages"
-msgstr "最も参照されたページ"
+msgstr "Top referral pages"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "An exploration of your users to get you started."
-msgstr ""
+msgstr "An exploration of your users to get you started."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "An overview of your [[this]] and how its distributed across time, place, and categories."
-msgstr ""
+msgstr "An overview of your [[this]] and how its distributed across time, place, and categories."
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average income per state"
-msgstr "州ごとの平均収益"
+msgstr "Average income per state"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "[[this]] by [[GenericCategoryMedium]]"
-msgstr "[[GenericCategoryMedium]] 別の [[this]]"
+msgstr "[[this]] by [[GenericCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total transactions"
-msgstr "総トランザクション数"
+msgstr "总交易量"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] that have joined over time"
-msgstr "[[this.short-name]] の参加数推移"
+msgstr "[[this.short-name]] that have joined over time"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "The [[this]] by location"
-msgstr "場所別の [[this]]"
+msgstr "The [[this]] by location"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per month of the year"
-msgstr "月毎のイベント"
+msgstr "Events per month of the year"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] by [[GenericNumber]]"
-msgstr "[[GenericNumber]] 別の [[this]]"
+msgstr "[[this]] by [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Quarters when [[this.short-name]] were added"
-msgstr "[[this.short-name]] が追加された四半期"
+msgstr "Quarters when [[this.short-name]] were added"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "How these [[this.short-name]] are distributed"
-msgstr "[[this.short-name]] がどのように拡散したか"
+msgstr "查看 [[this.short-name]] 是如何分布的"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[this.short-name]] by [[GenericNumber]]"
-msgstr "[[GenericNumber]] 別の [[this.short-name]]"
+msgstr "[[this.short-name]] by [[GenericNumber]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where users are coming from"
-msgstr "ユーザーがどこから来たか"
+msgstr "用户来源"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "[[this]] comparisons and correlations"
-msgstr "[[this]] の比較と相関"
+msgstr "[[this]] comparisons and correlations"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income"
-msgstr "総収益"
+msgstr "总收入"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Total income per month"
-msgstr "月毎の全収益"
+msgstr "每月总收入"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Number of users per source"
-msgstr "ソースごとのユーザー数"
+msgstr "每个来源的用户数量"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Transactions per state"
-msgstr "状態ごとのトランザクション"
+msgstr "每个州的交易量"
 
 #: resources/automagic_dashboards/field/Number.yaml
+#, fuzzy
 msgid "[[this]] by [[Timestamp]]"
-msgstr "[[Timestamp]] 別の [[this]]"
+msgstr "resources/automagic_dashboards/field/Number.yaml"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "New users per source in the last 30 days"
-msgstr "過去30日のソースごとのユーザー"
+msgstr "过去30天内每个来源的新用户"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the month"
-msgstr "日別の登録日"
+msgstr "加入日期(几月几日)"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount %"
-msgstr "平均値引率"
+msgstr "平均折扣%"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Autogenerated metrics about [[GenericTable]]."
-msgstr "[[GenericTable]]に関して自動生成されたメトリクス"
+msgstr "关于 [[GenericTable]] 的自动生成指标."
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "[[this]] per day of the month"
-msgstr "日毎の [[this]]"
+msgstr "每月的每一天"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions in each country"
-msgstr "国別の総セッション数"
+msgstr "每个国家的会话总数"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per month of the year"
-msgstr "月毎のトランザクション数"
+msgstr "该年每个月的交易量"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per product"
-msgstr "製品ごとの売上"
+msgstr "每类产品销售额"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Users in each country"
-msgstr "国ごとのユーザー"
+msgstr "每个国家的用户"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "[[this]] by hour of the day"
-msgstr "時間別の [[this]]"
+msgstr "按小时计算"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events in the last 30 days"
-msgstr "過去30日のイベント"
+msgstr "最近30日的事件"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Transactions per source"
-msgstr "ソースごとのトランザクション"
+msgstr "每个来源的交易"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where youve acquired your users"
-msgstr "あなたがどこで顧客を獲得したのか"
+msgstr "您获得用户的地方"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare acrosss location"
-msgstr "場所を超えて比較する方法"
+msgstr "他们如何比较不同的位置"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "[[this]] per product"
-msgstr "製品ごとの [[this]]"
+msgstr "每个产品"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#, fuzzy
 msgid "[[this]] per month of the year"
-msgstr "月毎の [[this]]"
+msgstr "[[this]]每年的每月"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per country"
-msgstr "国ごと"
+msgstr "每个国家"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "A deeper look at how different countries are performing for you."
-msgstr ""
+msgstr "深入了解不同国家/地区的表现"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per state"
-msgstr "州ごとの売上"
+msgstr "每个州的销售量"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
+#, fuzzy
 msgid "Events by [[GenericNumber]]"
-msgstr "[[GenericNumber]] 別のイベント"
+msgstr "[[GenericNumber]]的活动"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
+#, fuzzy
 msgid "Sales per product [[ProductCategoryMedium]]"
-msgstr "[[ProductCategoryMedium]] 製品ごとの売上"
+msgstr "每个产品的销售[[ProductCategoryMedium]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "User acquisition by country"
-msgstr "国ごとのユーザー獲得"
+msgstr "按国家/地区获取的用户"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
+#, fuzzy
 msgid "[[this]] per source"
-msgstr "ソースごとの [[this]]"
+msgstr "每个来源[[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
+#, fuzzy
 msgid "[[this]] by day of the week"
-msgstr "曜日別の [[this]]"
+msgstr "[[this]]到星期几"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "Days of the month when [[this.short-name]] joined"
-msgstr "その月の[[this.short-name]]が参加した日"
+msgstr "加入[[this.short-name]]的那几天"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
+#, fuzzy
 msgid "Heres an overview of the people in your [[this]]"
-msgstr "あなたの [[this]] の人々の概要はここにあります"
+msgstr "以下是[[this]]中人物的概述"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
+#, fuzzy
 msgid "How [[GenericTable]] are distributed across this time field, and if it has any seasonal patterns."
-msgstr ""
+msgstr "[[GenericTable]]如何在此时间字段中分布，以及是否有任何季节性模式。"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10515,137 +10561,147 @@ msgstr ""
 #: resources/automagic_dashboards/table/EventTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Overview"
-msgstr "概要"
+msgstr "总览"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How this metric is distributed across different categories"
-msgstr "このメトリックがさまざまなカテゴリーにどのように分布しているか"
+msgstr "该指标如何在不同类别中分布"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[this.short-name]] per state"
-msgstr "州ごとの [[this.short-name]]"
+msgstr "每个州[[this.short-name]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "Weekdays when [[this.short-name]] joined"
-msgstr "[[this.short-name]] が加わった曜日"
+msgstr "[[this.short-name]]加入时的工作日"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "Hours when [[this.short-name]] joined"
-msgstr ""
+msgstr "[[this.short-name]]加入时的小时数"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Total income by month"
-msgstr "月別の総収益"
+msgstr "按月收入总额"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "A breakdown of your [[this]] over time, and its min, max, average and more."
-msgstr "[[this]] の時系列分析および最小、最大、平均など"
+msgstr "你[[这个]]随时间的细分，以及它的最小值，最大值，平均值等等。"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Average quantity per state"
-msgstr "ソースごとの平均数量"
+msgstr "各州的平均数量"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare by across different numbers"
-msgstr ""
+msgstr "他们如何通过不同的数字进行比较"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "New users per country in the last 30 days"
-msgstr "過去30日の国ごとの新規ユーザー"
+msgstr "过去30天内每个国家/地区的新用户"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions over time"
-msgstr ""
+msgstr "随着时间的推移"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#, fuzzy
 msgid "[[this]] per [[GenericCategorySmall]]"
-msgstr "[[GenericCategorySmall]]ごとの[[this]]"
+msgstr "每[[GenericCategorySmall]] [[this]]"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Some breakdown"
-msgstr "いくつかの分析"
+msgstr "一些故障"
 
 #: resources/automagic_dashboards/field/Number.yaml
+#, fuzzy
 msgid "Average of [[this]] by [[State]]"
-msgstr "[[State]] 別の [[this]] の平均"
+msgstr "平均[[this]]乘[[State]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per quarter of the year"
-msgstr "四半期毎のトランザクション数"
+msgstr "每季度的交易量"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "By coordinates"
-msgstr "座標別"
+msgstr "根据经纬度坐标"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
+#, fuzzy
 msgid "Heres a closer look at your [[this]] by products"
-msgstr "商品別に [[this]] を詳しく見てみましょう"
+msgstr "下面仔细看看你的[[this]]产品"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#, fuzzy
 msgid "[[this]] per quarter of the year"
-msgstr "四半期毎の [[this]]"
+msgstr "[[this]]每年的每个季度"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#, fuzzy
 msgid "Heres an overview of your [[this]] data from Google Analytics"
-msgstr "Google Analyticsから得られた[[this]]のデータの概要です"
+msgstr "下面是对Google Analytics中[[this]]数据的概述"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "Quarters when [[this.short-name]] joined"
-msgstr "[[this.short-name]] が加わった四半期"
+msgstr "[[this.short-name]]加入时的宿舍"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
+#, fuzzy
 msgid "New [[this.short-name]] in the last 30 days"
-msgstr "過去30日の新しい[[this.short-name]] "
+msgstr "过去30天内新[[this.short-name]]"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Total sessions by desktop, mobile, or tablet"
-msgstr "デスクトップ、モバイル、またはタブレットごとの合計セッション"
+msgstr "桌面，移动设备或平板电脑的总会话数"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "Indepth example"
-msgstr "詳細な例"
+msgstr "深入示例"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average income per source"
-msgstr "ソースごとの平均収益"
+msgstr "每个来源的平均收入"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[Timestamp]] by day of week"
-msgstr "曜日別の [[Timestamp]]"
+msgstr "[[时间戳]]按星期几"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "Heres a closer look at your [[this]]"
-msgstr "[[this]] を詳しく見てみましょう"
+msgstr "继续仔细看看[[这个]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
 msgid "Heres a closer look at your [[this]] field"
-msgstr "[[this]] フィールドを詳しく見てみましょう"
+msgstr "继续仔细看看[[这个]]字段"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Summary"
-msgstr "要約"
+msgstr "概览"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "How the [[this]] is distributed geographically"
-msgstr "[[this]]は地理的にどのように分布しているのか"
+msgstr "[[这个]]如何按地理分布"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "The pages with the most pageviews"
-msgstr "最大のビュー数があるページ"
+msgstr "浏览量最多的页"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "How [[Number1]] is correlated with [[Number2]]"
-msgstr "[[Number1]]は[[Number2]]とどのように相関しているのか"
+msgstr "这里是 [[NUmber1]] 和 [[Number2]] 是如何相关的"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales in the last 30 days"
-msgstr "過去30日の売上トップ10の州"
+msgstr "过去30天内销售额排名前十的州"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Top 10 states by sales"
-msgstr "売上トップ10の州"
+msgstr "销售量前10的州"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "[[Timestamp]]"
@@ -10653,62 +10709,65 @@ msgstr "[[Timestamp]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Where these transactions happened"
-msgstr "これらのトランザクションが発生した場所"
+msgstr "这些交易发生在何处"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top 10 countries by sales"
-msgstr "売上トップ10の国"
+msgstr "销售额前10国家"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by state"
-msgstr "州別の売上"
+msgstr "按州销售"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Where most of your sessions originate from"
-msgstr "最も多くセッションが発生したのはどこか"
+msgstr "会话数最多的地方"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Top acquisition channels"
-msgstr "トップの顧客獲得チャンネル"
+msgstr "顶级收购渠道"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "These [[this.short-name]] across time"
-msgstr ""
+msgstr "这些[[this.short-name]]跨时间"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity"
-msgstr "国ごとの平均数量"
+msgstr "平均数量"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per source"
-msgstr "ソースごとの売上"
+msgstr "每个来源的销售量"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average income per country"
-msgstr "国別の平均収益"
+msgstr "每个国家平均收入"
 
 #: resources/automagic_dashboards/comparison/State.yaml
 #: resources/automagic_dashboards/comparison/FK.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
+#, fuzzy
 msgid "How [[this]] is distributed"
-msgstr "どのように[[this]]が分布しているか"
+msgstr "如何[[this]]分发"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Distinct [[FK]]"
-msgstr ""
+msgstr "唯一的 [[FK]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "How these transactions are distributed"
-msgstr "これらのトランザクションの分散方法"
+msgstr "这些交易是如何分布的"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per state"
-msgstr "州ごと"
+msgstr "每个州"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
+#, fuzzy
 msgid "Count of [[GenericCategoryMedium]] by [[this]]"
-msgstr ""
+msgstr "由[[this]]计算[[GenericCategoryMedium]]的数量"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -10723,292 +10782,317 @@ msgstr ""
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
 msgid "A look at your [[this]]"
-msgstr ""
+msgstr "查看你的 [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#, fuzzy
 msgid "[[GenericNumber]] by [[this]]"
-msgstr ""
+msgstr "[[GenericNumber]] [[this]]"
 
 #: resources/automagic_dashboards/field/Country.yaml
+#, fuzzy
 msgid "Sum of [[GenericNumber]] by [[this]]"
-msgstr "[[this]] ごとの [[GenericNumber]] の合計"
+msgstr "[[GenericNumber]]的总和[[this]]"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
+#, fuzzy
 msgid "A look at your [[this]] table"
-msgstr ""
+msgstr "由[[this]]计算[[GenericCategoryMedium]]的数量"
 
 #: resources/automagic_dashboards/field/State.yaml
+#, fuzzy
 msgid "How many [[GenericTable]] there are per state, and how each state is represented across other categories."
-msgstr ""
+msgstr "[[GenericNumber]] [[this]]"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Most-viewed pages"
-msgstr "最もビュー数の多いページ"
+msgstr "查看最多的页"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Example exploration"
-msgstr "探索の例"
+msgstr "探索示例"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
+#, fuzzy
 msgid "Sales vs. rating"
-msgstr "売上高対評価"
+msgstr "销售额与评级"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#, fuzzy
 msgid "[[this]] per hour of the day"
-msgstr ""
+msgstr "[[GenericNumber]]的总和[[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "Where your [[this.short-name]] are"
-msgstr ""
+msgstr "看看你的[[this]]表"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "These are the same for all your [[this.short-name]]"
-msgstr ""
+msgstr "每个州有多少[[GenericTable]]，以及每个州如何在其他类别中表示。"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events by different categories"
-msgstr "さまざまなカテゴリーのイベント"
+msgstr "不同类别的活动"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
+#, fuzzy
 msgid "Where these [[this.short-name]] are"
-msgstr ""
+msgstr "销售额与评级"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Over time"
-msgstr ""
+msgstr "所有时间"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A summary of the events in your [[this]] table"
-msgstr ""
+msgstr "[[this]]表中事件的摘要"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Transactions per source over time"
-msgstr "ソースごとのトランザクション推移"
+msgstr "每个来源的交易"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
+#, fuzzy
 msgid "How the [[this]] is distributed"
-msgstr ""
+msgstr "[[this]]每天的每小时"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Total income per source"
-msgstr "ソースごとの総収益"
+msgstr "每个来源的总收入"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/UserTable.yaml
+#, fuzzy
 msgid "Total [[this.short-name]]"
-msgstr "合計[[this.short-name]]"
+msgstr "您[[this.short-name]]的位置"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#, fuzzy
 msgid "Some metrics we found about your transactions."
-msgstr "あなたのトランザクションに関して、あるメトリクスを見つけました。"
+msgstr "我们找到的有关您的交易的一些指标"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
 msgid "How your different products are performing."
-msgstr ""
+msgstr "您的不同产品的表现如何。"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Where these events are happening"
-msgstr "これらのイベントがどこで起きているか"
+msgstr "这些事件发生的地方"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Which US states are bringing you the most business."
-msgstr "どの米国州が最も大きな業績をもたらしているか"
+msgstr "美国哪些州为您带来最大的业务？"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across time"
-msgstr ""
+msgstr "他们如何比较时间？"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
-#, fuzzy
 msgid "Average transaction income per month"
-msgstr "月毎の平均トランザクション収益"
+msgstr "月均交易收入"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average quantity per month"
-msgstr "月毎の平均数量"
+msgstr "每月平均数量"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 msgid "Seasonal patterns in the [[this]]"
-msgstr "[[this]] の季節変動パターン"
+msgstr "[[这个]]中的季节性模式"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events over time"
-msgstr ""
+msgstr "一段时间的事件"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Orders and income per source"
-msgstr "ソースごとの注文と収益"
+msgstr "每个订单和收入"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "Transactions per hour of the day"
-msgstr "その日の時間ごとのトランザクション数"
+msgstr "该日每小时的交易量"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Where most of your traffic is coming from."
-msgstr "最大のトラフィックがどこから来ているか"
+msgstr "您的大部分流量来自哪里。"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Heres a quick look at the [[this]]"
-msgstr ""
+msgstr "这里是 [[this]] 的速览"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
+#, fuzzy
 msgid "It looks like your [[this]] has transactions, so heres a look at them"
-msgstr ""
+msgstr "你的所有[[this.short-name]]都是一样的"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average discount per month"
-msgstr "月毎の平均割引"
+msgstr "每月的平均折扣"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
+#, fuzzy
 msgid "[[Timestamp]] by month of the year"
-msgstr "月別の [[Timestamp]]"
+msgstr "这些[[this.short-name]]的位置"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#, fuzzy
 msgid "[[this]] per [[GenericCategorySmall]] over time"
-msgstr ""
+msgstr "如何分发[[this]]"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Distribution by coordinates"
-msgstr "座標別の分布"
+msgstr "按坐标的分布"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by source"
-msgstr "ソース別の売上"
+msgstr "按来源销售"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales for each product category"
-msgstr "各製品カテゴリーの売上"
+msgstr "每产品分类销售"
 
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
 msgid "A closer look at the metrics and dimensions used in this saved question."
-msgstr "この保存された質問で使用されるメトリックとディメンションの詳細。"
+msgstr "仔细查看此已保存问题中使用的指标和维度。"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[this.short-name]] per [[GenericCategoryMedium]]"
-msgstr ""
+msgstr "每[[GenericCategoryMedium]] [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
+#, fuzzy
 msgid "Sales per product [[ProductCategoryLarge]]"
-msgstr "[[ProductCategoryLarge]] 製品ごとの売上"
+msgstr "每件产品的销售[[ProductCategoryLarge]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Average quantity per country"
-msgstr "国別平均数量"
+msgstr "每个国家的平均数量"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[this.short-name]] per [[GenericCategoryLarge]]"
-msgstr ""
+msgstr "每[[GenericCategoryLarge]] [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
+#, fuzzy
 msgid "Heres a closer look at your [[this]] per source"
-msgstr "ソース毎の [[this]] を詳しく見てみましょう"
+msgstr "下面仔细看看你的[[this]]每个来源"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the month"
-msgstr "日毎のイベント"
+msgstr "这个月的每日事件"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If youre into correlations, this is the x-ray for you."
-msgstr "もしもあなたが相関に興味があるのならば、これはおすすめのX-Rayです。"
+msgstr "如果您正在关注相关性，那么这就是X-ray为您提供的信息。"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#, fuzzy
 msgid "Sessions by Country"
-msgstr "国別セッション"
+msgstr "总计[[this.short-name]]"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Some interesting metrics about your GA stats to get you started."
-msgstr ""
+msgstr "有关GA统计数据的一些有趣指标可帮助您入门。"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#, fuzzy
 msgid "[[this]] per state"
-msgstr "州ごとの [[this]]"
+msgstr "[[this]]每个区域"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
+#, fuzzy
 msgid "[[Timestamp]] by quarter of the year"
-msgstr "四半期別の [[Timestamp]]"
+msgstr "看起来你[[this]]有交易，所以看看他们"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How its distributed across time and other categories."
-msgstr "時間や他のカテゴリーにどのように分布しているか。"
+msgstr "它的分布如何跨时间和其他类别。"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "A look at your events over time and by several categories."
-msgstr ""
+msgstr "随着时间和几个类别来看你的事件。"
 
 #: resources/automagic_dashboards/field/State.yaml
+#, fuzzy
 msgid "[[GenericTable]] per [[this]]"
-msgstr ""
+msgstr "[[时间戳]]按年份计算"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average quantity per source"
-msgstr "ソース別平均数量"
+msgstr "每个来源的平均数量"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Top 5 per category"
-msgstr "カテゴリーごとの上位5位"
+msgstr "各类的前5"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
 msgid "Events per day of the week"
-msgstr "曜日毎のイベント"
+msgstr "一周中每天的活动"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
+#, fuzzy
 msgid "New [[this.short-name]] per month"
-msgstr "月毎の新しい[[this.short-name]]"
+msgstr "每月新[[this.short-name]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Top performers"
-msgstr "業績優秀者"
+msgstr "表现最佳者"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Transactions in the last 30 days"
-msgstr "過去30日のトランザクション数"
+msgstr "过去30天的交易量"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
+#, fuzzy
 msgid "[[GenericTable]] by [[this]]"
-msgstr ""
+msgstr "[[this]]每[[GenericCategorySmall]]随着时间的推移"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#, fuzzy
 msgid "Overview of your [[this]] data from Google Analytics"
-msgstr "Google Analyticsの[[this]]データの概要"
+msgstr "每[[GenericCategoryMedium]] [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by hour of the day"
-msgstr "時間別の作成日時"
+msgstr "按小时创建"
 
 #: resources/automagic_dashboards/table/example.yaml
 msgid "Sales by month"
-msgstr "月別の売上"
+msgstr "按月销售"
 
 #: resources/automagic_dashboards/field/Number.yaml
+#, fuzzy
 msgid "How the [[this]] is distributed across categories"
-msgstr ""
+msgstr "每件产品的销售[[ProductCategoryLarge]]"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
+#, fuzzy
 msgid "[[Timestamp]] by month of year"
-msgstr "月別の [[Timestamp]]"
+msgstr "每[[GenericCategoryLarge]] [[this.short-name]]"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "How many total sessions vs. how many individual users you had each day."
-msgstr "合計セッション数と毎日の個別ユーザー数。"
+msgstr "总会话数与每天的个人用户数相比。"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How this metric is distributed across different numbers"
-msgstr "このメトリックが異なる数値にどのように分布しているか"
+msgstr "该指标如何分布在不同的数字上"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions by page where the session began"
-msgstr "ページ別の開始されたセッション"
+msgstr "会话开始时的页面会话"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -11016,20 +11100,23 @@ msgstr "ページ別の開始されたセッション"
 #: resources/automagic_dashboards/field/Country.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
 msgid "Distinct values"
-msgstr "重複のない値"
+msgstr "不重复的值"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "Hours when [[this.short-name]] were added"
-msgstr "[[this.short-name]] が追加された時間"
+msgstr "下面仔细看看你的[[this]]每个来源"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/table/EventTable.yaml
+#, fuzzy
 msgid "[[Timestamp]] by day of the week"
-msgstr "曜日別の [[Timestamp]]"
+msgstr "国家会议"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[GenericNumber]] over time"
-msgstr "[[GenericNumber]] の推移"
+msgstr "[[this]]每州"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
@@ -11037,44 +11124,50 @@ msgstr "[[GenericNumber]] の推移"
 #: resources/automagic_dashboards/comparison/FK.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
+#, fuzzy
 msgid "Heres an overview of your [[this]]"
-msgstr "あなたの[[this]]の概要はこちらです"
+msgstr "以下是[[this]]的概述"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[this.short-name]] by coordinates"
-msgstr "座標別の[[this.short-name]]"
+msgstr "[[时间戳]]按季度计算"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
+#, fuzzy
 msgid "Heres a closer look at your [[this]] per state"
-msgstr "州毎の [[this]] を詳しく見てみましょう"
+msgstr "继续仔细看看你的[[this]]每个州"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Created At by day of the month"
-msgstr "日別の作成日時"
+msgstr "按照每月的某天创建"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales by coordinates"
-msgstr "座標別の売上"
+msgstr "销售的坐标"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "New [[this.short-name]] over time"
-msgstr "時系列の新しい[[this.short-name]]"
+msgstr "[[GenericTable]]每[[this]]"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by hour of the day"
-msgstr "時間別の登録日"
+msgstr "按照一天中的小时进行日期连接"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
+#, fuzzy
 msgid "[[Timestamp]] by hour of day"
-msgstr "時間別の [[Timestamp]]"
+msgstr "每月新[[this.short-name]]"
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
 msgid "Sessions and unique users per day"
-msgstr "1日あたりのセッションとユニークユーザー"
+msgstr "每天的会话和唯一身份用户"
 
 #: resources/automagic_dashboards/table/EventTable.yaml
+#, fuzzy
 msgid "Events per [[GenericCategoryLarge]]"
-msgstr ""
+msgstr "[[GenericTable]] [[this]]"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/field/State.yaml
@@ -11083,163 +11176,174 @@ msgstr ""
 #: resources/automagic_dashboards/field/GenericField.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "How they compare by distribution"
-msgstr ""
+msgstr "他们如何通过分布进行比较"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
 msgid "Income per country"
-msgstr "国別の収益"
+msgstr "每个国家的收入"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
+#, fuzzy
 msgid "Heres a closer look at your [[this]] per country"
-msgstr "国毎の [[this]] を詳しく見てみましょう"
+msgstr "来自Google Analytics的[[this]]数据概述"
 
 #: resources/automagic_dashboards/table/example.yaml
+#, fuzzy
 msgid "Sales by product [[ProductCategory]]"
-msgstr "[[ProductCategory]] の製品別の売上"
+msgstr "[[this]]如何跨类别分布"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#, fuzzy
 msgid "[[this]] per [[GenericCategoryLarge]], bottom 5"
-msgstr ""
+msgstr "[[时间戳]]按年份计算"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[this.short-name]] added in the last 30 days"
-msgstr "過去30日に追加された [[this.short-name]]"
+msgstr "添加[[this.short-name]]的小时数"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
 msgid "Per [[Source]]"
-msgstr "[[Source]] ごと"
+msgstr "每个 [[Source]]"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Average item quantity per month"
-msgstr "月毎の平均項目数"
+msgstr "每月平均物品数量"
 
 #: resources/automagic_dashboards/field/Country.yaml
+#, fuzzy
 msgid "The number of [[GenericTable]] per country, and how each country is represented in different categories."
-msgstr ""
+msgstr "[[时间戳]]按星期几"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
+#, fuzzy
 msgid "[[this]] per day of the week"
-msgstr "曜日毎の [[this]]"
+msgstr "[[this]]每周的每一天"
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
 msgid "Average qunatity per source"
-msgstr "ソースごとの平均数量"
+msgstr "每个来源的平均数量"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[this.short-name]] by [[Timestamp]]"
-msgstr ""
+msgstr "[[GenericNumber]]随着时间的推移"
 
 #: resources/automagic_dashboards/field/Number.yaml
 msgid "Summary statistics"
-msgstr "要約統計"
+msgstr "摘要统计"
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
 msgid "Sales per month"
-msgstr "月毎の売上"
+msgstr "每月销售"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[GenericNumber]] by join date"
-msgstr "登録日別の [[GenericNumber]]"
+msgstr "以下是[[this]]的概述"
 
 #: resources/automagic_dashboards/field/Number.yaml
+#, fuzzy
 msgid "Average of [[this]] by [[Country]]"
-msgstr "[[Country]] 別の [[this]] の平均"
+msgstr "[[国家]]的[[this]]平均值"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
 msgid "[[this]] over time"
-msgstr "[[this]] の推移"
+msgstr "[[this]] 所有时间"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Join date by day of the week"
-msgstr "曜日別の登録日"
+msgstr "加入日期(按周计算，周几)"
 
 #: resources/automagic_dashboards/field/Number.yaml
+#, fuzzy
 msgid "We crunched the numbers for your [[this]]"
-msgstr "[[this]]の数値を計算しました"
+msgstr "我们为你[[this]]打了个数字"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "Months when [[this.short-name]] joined"
-msgstr "[[this.short-name]]が加わった月"
+msgstr "加入[[this.short-name]]的几个月"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to parse resource `{0}` as JSON"
-msgstr "`{0}` のリソースをJSONとして解析できません"
+msgstr "无法将资源`{0}`解析为JSON格式"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to find JSON via relative path `{0}`"
-msgstr "`{0}` の相対パスにJSONを見つけられません"
+msgstr "找不到JSON `{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection to host timed out for URL `{0}`"
-msgstr "`{0}` のURLへの接続はタイムアウトしました"
+msgstr "建立连接至主机超时：`{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to connect to unknown host at URL `{0}`"
-msgstr "`{0}` のURLで未知のホストへの接続ができません"
+msgstr "无法连接到未知主机：`{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to connect to host at URL `{0}`"
-msgstr "`{0}` のURLでホストへの接続ができません"
+msgstr "无法连接至主机：`{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection refused by host at for URL `{0}`"
-msgstr "`{0}` のURLでホストへの接続が拒否されました"
+msgstr "连接被主机拒绝：`{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to retrieve resource at URL `{0}`"
-msgstr "`{0}` のURLでリソースの取得ができません"
+msgstr "无法获取资源：`{0}`"
 
 #: src/metabase/api/geojson.clj
 msgid "Unable to parse resource at URL `{0}` as JSON"
-msgstr "`{0}` のURLのリソースをJSONとして解析できません"
+msgstr "无法将对应资源转换为JSON格式：`{0}`"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fall back to local authentication: {0}"
-msgstr "LDAPサーバーへの接続に問題が起こりました。ローカルでの認証へフォールバックします: {0}"
+msgstr "无法连接到配置的LDAP服务器，改为使用本地鉴权：{0}"
 
 #: src/metabase/driver/bigquery.clj
 msgid "BigQuery statements can''t be parameterized!"
-msgstr "BigQueryステートメントはパラメーター化できません！"
+msgstr "BigQuery语句无法被参数化！"
 
 #: src/metabase/driver/druid/query_processor.clj
 msgid "WARNING: Druid does not allow limitSpec in time series queries. Ignoring the LIMIT clause."
-msgstr "警告: Druid は時系列クエリで limitSpec を許可しません。 LIMIT 句を無視します。"
+msgstr "警告：Druid不支持在时间序列的查询中使用Limit语句。忽略Limit关键字。"
 
 #: src/metabase/driver/snowflake.clj
 msgid "Invalid Snowflake connection details: missing DB name."
-msgstr "無効なSnowflakeへの接続の詳細：データベース名が指定されていません"
+msgstr "无效的Snowflake连接详情：缺少DB名"
 
 #: src/metabase/email/messages.clj
 msgid "We’d love your feedback."
-msgstr "フィードバックは大歓迎です"
+msgstr "我们需要您的反馈。"
 
 #: src/metabase/email/messages.clj
 msgid "It looks like Metabase wasn’t quite a match for you."
-msgstr "Metabaseはあなたに合わなかったようです。"
+msgstr "看起来似乎Metabase不是很适合您使用。"
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 5 question survey to help the Metabase team understand why and make things better in the future?"
-msgstr "Metabaseチームがその理由を理解し、将来的に物事を改善するのを助けるために、5問の高速アンケートに回答していただけますか"
+msgstr "为了帮助Metabase团队改进产品，请参与完成包含5个简单问题的调查，谢谢。"
 
 #: src/metabase/email/messages.clj
 msgid "We hope you''ve been enjoying Metabase."
-msgstr "Metabaseを楽しんでくださいね"
+msgstr "我们希望您能对Metabase满意。"
 
 #: src/metabase/email/messages.clj
 msgid "Would you mind taking a fast 6 question survey to tell us how it’s going?"
-msgstr "どのような感じだったか私たちが知るため簡単な6つの質問に答えてくれませんか？"
+msgstr "您是否愿意帮助我们来快速填写一个有着6个问题的调查问卷？"
 
 #: src/metabase/email/messages.clj
 msgid "{0} created a Metabase account"
-msgstr "{0} はMetabaseアカウントを作成しました"
+msgstr "{0}创建了一个Metabase账号"
 
 #: src/metabase/email/messages.clj
 msgid "{0} accepted their Metabase invite"
-msgstr "{0} はMetabaseへの招待を受付けました"
+msgstr "{0}接受了Metabase的邀请"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Password Reset Request"
-msgstr "[Metabase] パスワードリセット申告"
+msgstr "[Metabase] 重置密码请求"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Notification"
@@ -11247,460 +11351,482 @@ msgstr "[Metabase] 通知"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Help make Metabase better."
-msgstr "[Metabase] Metabaseの改善にご協力ください"
+msgstr "[Metabase] 帮助Metabase变得更好"
 
 #: src/metabase/email/messages.clj
 msgid "[Metabase] Tell us how things are going."
-msgstr "[Metabase] 感想をお聞かせください"
+msgstr "[Metabase] 使用反馈"
 
 #: src/metabase/mbql/util.clj
 msgid "Error: query''s source query has not been resolved. You probably need to `preprocess` the query first."
-msgstr ""
+msgstr "错误：查询语句无法解析，请先验证查询语句的正确性。"
 
 #: src/metabase/models/params.clj
 msgid "Don't know what to do with:"
-msgstr "何をすべきかわからない:"
+msgstr "不知道要做什么:"
 
 #: src/metabase/models/params.clj
 msgid "Don't know how to wrap:"
-msgstr "ラップする方法がわからない:"
+msgstr "不知道怎么包装："
 
 #: src/metabase/public_settings.clj
 msgid "Failed setting `query-caching-max-kb` to {0}."
-msgstr "`query-caching-max-kb`を{0}に設定するのに失敗しました。"
+msgstr "设置参数query-caching-max-kb为{0}失败。"
 
 #: src/metabase/public_settings.clj
 msgid "Values greater than {1} are not allowed."
-msgstr "{1} より大きな値は指定できません。"
+msgstr "不允许设置大于{1}的值。"
 
 #: src/metabase/query_processor/store.clj
 msgid "Database {0} does not exist."
-msgstr "データベース {0} は存在しません。"
+msgstr "数据库 {0} 不存在。"
 
 #: src/metabase/query_processor/store.clj
 msgid "Error: Database is not present in the Query Processor Store."
-msgstr "エラー: データベース{0}がクエリ処理ストアに存在しません。"
+msgstr "错误：数据库在查询处理仓库中不存在。"
 
 #: src/metabase/util/embed.clj
 msgid "Invalid embedding-secret-key! Secret key must be a hexadecimal-encoded 256-bit key (i.e., a 64-character string)."
-msgstr ""
+msgstr "错误的内置密钥！密钥必须为长度为256个比特的16进制编码的字符串（比如，64个字符的字符串）。"
 
 #: src/metabase/util/embed.clj
 msgid "JWT is missing `alg`."
-msgstr "JWTには`alg`がありません。"
+msgstr "JWT 确少 `alg`"
 
 #: src/metabase/util/embed.clj
 msgid "JWT `alg` cannot be `none`."
-msgstr "JWT `alg`は`none`にはできません。"
+msgstr "JWT的`alg`不能为`none`"
 
 #: src/metabase/util/embed.clj
 msgid "The embedding secret key has not been set."
-msgstr "埋め込み秘密鍵が設定されていません。"
+msgstr "内置密钥没有被设置。"
 
 #: src/metabase/util/embed.clj
 msgid "Token is missing value for keypath"
-msgstr "トークンにキーパスの値がありません"
+msgstr "令牌（Token）的keypath的值缺失。"
 
 #: resources/automagic_dashboards/table/example/indepth.yaml
 msgid "In-depth example"
-msgstr ""
+msgstr "有内涵的例子"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:29
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:17
 msgid "Key"
-msgstr "キー"
+msgstr "关键"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:30
 msgid "Class"
-msgstr "クラス"
+msgstr "类"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:32
 msgid "Triggers"
-msgstr "トリガー"
+msgstr "触发器"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:48
 msgid "View triggers"
-msgstr ""
+msgstr "查看触发器"
 
 #: frontend/src/metabase/admin/tasks/containers/JobInfoApp.jsx:85
 msgid "Scheduler Info"
-msgstr "スケジューラ情報"
+msgstr "调度器信息"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:20
 msgid "Priority"
-msgstr "優先度"
+msgstr "优先级"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:21
 msgid "Last Fired"
-msgstr ""
+msgstr "上次调起"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:22
 msgid "Next Fire Time"
-msgstr "次回実行時間"
+msgstr "下次调起时间"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:23
 msgid "Start Time"
-msgstr "開始時間"
+msgstr "起始时间"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:24
 msgid "End Time"
-msgstr "終了時間"
+msgstr "结束时间"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:25
 msgid "Final Fire Time"
-msgstr "最終実行時間"
+msgstr "最后一次调起时间"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:26
 msgid "May Fire Again?"
-msgstr ""
+msgstr "是否反复调起?"
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:83
 msgid "Triggers for {0}"
-msgstr "{0}へのトリガー"
+msgstr "{0}的触发器"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:25
 msgid "Tasks"
-msgstr "タスク"
+msgstr "任务"
 
 #: frontend/src/metabase/admin/tasks/containers/TroubleshootingApp.jsx:30
 msgid "Jobs"
-msgstr "ジョブ"
+msgstr "任务"
 
 #: frontend/src/metabase/components/CollectionLanding.jsx:739
 msgid "Duplicated {0}"
-msgstr ""
+msgstr "复制 {0}"
 
 #: frontend/src/metabase/components/EntityItem.jsx:57
 msgid "Duplicate this item"
-msgstr "このアイテムを複製する"
+msgstr "复制该项目"
 
 #: frontend/src/metabase/components/EntityItem.jsx:63
 msgid "Archive this item"
-msgstr "このアイテムをアーカイブする"
+msgstr "归档该项目"
 
 #: frontend/src/metabase/dashboard/components/DashboardHeader.jsx:319
 msgid "Duplicate dashboard"
-msgstr "ダッシュボードを複製する"
+msgstr "复制仪表板"
 
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:16
 msgid "Duplicate \"{0}\""
-msgstr "“{0}”を複製"
+msgstr "复制 \"{0}\""
 
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:21
 #: frontend/src/metabase/entities/containers/EntityCopyModal.jsx:26
 msgid "Duplicate"
-msgstr "複製"
+msgstr "复制"
 
 #: frontend/src/metabase/lib/query_time.js:115
 msgid "Tomorrow"
-msgstr "明日"
+msgstr "明天"
 
 #: frontend/src/metabase/lib/query_time.js:129
 #: frontend/src/metabase/lib/query_time.js:143
 msgid "This {0}"
-msgstr "現在の{0}"
+msgstr "这个{0}"
 
 #: frontend/src/metabase/lib/query_time.js:132
 msgid "Next {0}"
-msgstr "次の{0}"
+msgstr "下一个{0}"
 
 #: frontend/src/metabase/lib/query_time.js:135
 msgid "Previous {0}"
-msgstr "前の{0}"
+msgstr "上一页{0}"
 
 #: frontend/src/metabase/lib/query_time.js:139
+#, fuzzy
 msgid "Previous {0} {1}"
-msgstr "前の {0} {1}"
+msgstr "上一页{0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:141
 msgid "Next {0} {1}"
-msgstr "次の {0} {1}"
+msgstr "下一个 {0} {1}"
 
 #: frontend/src/metabase/lib/query_time.js:171
 msgid "Now"
-msgstr "今"
+msgstr "现在"
 
 #: frontend/src/metabase/lib/query_time.js:174
+#, fuzzy
 msgid "{0} {1} ago"
-msgstr "{0}{1}前"
+msgstr "{0} {1}前"
 
 #: frontend/src/metabase/lib/query_time.js:175
+#, fuzzy
 msgid "{0} {1} from now"
-msgstr "今から{0}{1}"
+msgstr "[[this.short-name]]按坐标"
 
 #: frontend/src/metabase/lib/query_time.js:190
 msgid "Default period"
 msgid_plural "Default periods"
-msgstr[0] ""
+msgstr[0] "默认周期"
 
 #: frontend/src/metabase/lib/query_time.js:206
 msgid "Minute of hour"
 msgid_plural "Minutes of hour"
-msgstr[0] ""
+msgstr[0] "一小时内的分钟数"
 
 #: frontend/src/metabase/lib/query_time.js:208
 msgid "Hour of day"
 msgid_plural "Hours of day"
-msgstr[0] ""
+msgstr[0] "一天内的小时数"
 
 #: frontend/src/metabase/lib/query_time.js:210
 msgid "Day of week"
 msgid_plural "Days of week"
-msgstr[0] ""
+msgstr[0] "一周内的天数"
 
 #: frontend/src/metabase/lib/query_time.js:212
 msgid "Day of month"
 msgid_plural "Days of month"
-msgstr[0] ""
+msgstr[0] "一月内的天数"
 
 #: frontend/src/metabase/lib/query_time.js:214
 msgid "Day of year"
 msgid_plural "Days of year"
-msgstr[0] ""
+msgstr[0] "一年内的天数"
 
 #: frontend/src/metabase/lib/query_time.js:216
 msgid "Week of year"
 msgid_plural "Weeks of year"
-msgstr[0] ""
+msgstr[0] "一年的星期数"
 
 #: frontend/src/metabase/lib/query_time.js:218
 msgid "Month of year"
 msgid_plural "Months of year"
-msgstr[0] ""
+msgstr[0] "月"
 
 #: frontend/src/metabase/lib/query_time.js:220
 msgid "Quarter of year"
 msgid_plural "Quarters of year"
-msgstr[0] ""
+msgstr[0] "季度"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:257
 #: frontend/src/metabase/parameters/components/widgets/CategoryWidget.jsx:62
 #: frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget.jsx:58
 #: frontend/src/metabase/query_builder/components/Filter.jsx:82
+#, fuzzy
 msgid "{0} selection"
 msgid_plural "{0} selections"
-msgstr[0] ""
+msgstr[0] "继续仔细看看你的[[this]]每个州"
 
 #: frontend/src/metabase/parameters/components/widgets/DateQuarterYearWidget.jsx:11
+#, fuzzy
 msgid "[Q]Q"
-msgstr "[Q]Q"
+msgstr "新的[[this.short-name]]随着时间的推移"
 
 #: frontend/src/metabase/parameters/components/widgets/DateRelativeWidget.jsx:28
 msgid "This"
-msgstr ""
+msgstr "这个"
 
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:99
 #: frontend/src/metabase/query_builder/components/AggregationName.jsx:139
 msgid "Invalid"
-msgstr "無効"
+msgstr "无效"
 
 #: frontend/src/metabase/query_builder/components/filters/pickers/SpecificDatePicker.jsx:137
 msgid "Add a time"
-msgstr "時間を追加する"
+msgstr "添加时间"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:189
 msgid "Nothing to compare for the previous {0}."
-msgstr ""
+msgstr "无法与前{0}比较"
 
 #: frontend/src/metabase-lib/lib/Dimension.js:678
+#, fuzzy
 msgid "by {0}"
-msgstr ""
+msgstr "[[时间戳]]按小时计算"
 
 #: src/metabase/api/database.clj
 msgid "value must be a valid database engine."
-msgstr "値は有効なデータベースエンジンである必要があります。"
+msgstr "数值必须是有效的数据库引擎"
 
 #: src/metabase/api/geojson.clj
 msgid "Connection refused by host for URL `{0}`"
-msgstr "`{0}`のURLでホストへの接続が拒否されました"
+msgstr "连接被主机拒绝: `{0}`"
 
 #: src/metabase/db.clj
 msgid "Warning: Postgres connection string with `ssl=true` detected."
-msgstr "警告: `ssl=true`のPostgres接続文字列が検出されました。"
+msgstr "警告: Postgres "
 
 #: src/metabase/db.clj
 msgid "You may need to add `?sslmode=require` to your application DB connection string."
-msgstr "アプリケーションのDB接続文字列に `?sslmode=require`を追加する必要がある場合があります。"
+msgstr "您可能需要将参数“？sslmode = require”添加到应用程序数据库连接字符串中。"
 
 #: src/metabase/db.clj
 msgid "If Metabase fails to launch, please add it and try again."
-msgstr "Metabaseが起動に失敗したときは、これを加えて再試行をお願いします。"
+msgstr "如果Metabase无法启动，请添加并重试。"
 
 #: src/metabase/db.clj
 msgid "See https://github.com/metabase/metabase/issues/8908 for more details."
-msgstr "詳細については、 https://github.com/metabase/metabase/issues/8908 を参照してください。"
+msgstr "有关详细信息，请参阅https://github.com/metabase/metabase/issues/8908。"
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recomended for production deployments."
-msgstr "警告: 本番環境で、MetabaseをH2アプリケーションデータベースと共に使用することはお勧めできません。"
+msgstr "警告：建议不要将Metabase与H2应用程序数据库一起用于生产部署。"
 
 #: src/metabase/db.clj
 msgid "For production deployments, we highly recommend using Postgres, MySQL, or MariaDB instead."
-msgstr "本番環境の場合は、代わりにPostgres、MySQL、またはMariaDBを使用することを強くお勧めします。"
+msgstr "对于生产部署，我们强烈建议使用Postgres，MySQL或MariaDB。"
 
 #: src/metabase/db.clj
 msgid "If you decide to continue to use H2, please be sure to back up the database file regularly."
-msgstr "H2の使用を継続する場合は、データベースファイルを定期的にバックアップしてください。"
+msgstr "如果您决定继续使用H2，请务必定期备份数据库文件。"
 
 #: src/metabase/db.clj
 msgid "See https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres for more information."
-msgstr "詳細については、 https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres を参照してください。"
+msgstr "有关详细信息，请参阅https://metabase.com/docs/latest/operations-guide/start.html#migrating-from-using-the-h2-database-to-mysql-or-postgres。"
 
 #: src/metabase/db.clj
 msgid "Unable to connect to Metabase {0} DB."
-msgstr "Metabase {0} DBに接続できません。"
+msgstr " 不能连接到 Metabase {0} 数据库。"
 
 #: src/metabase/db/migrations.clj
 msgid "Error adding legacy SQL directive to BigQuery saved Question"
-msgstr ""
+msgstr "将遗留SQL指令添加到BigQuery保存问题时出错"
 
 #: src/metabase/driver.clj
+#, fuzzy
 msgid "Failed to notify {0} Database {1} updated"
-msgstr ""
+msgstr "每个[[GenericCategoryLarge]]的事件"
 
 #: src/metabase/driver.clj
 msgid "Loading driver {0} {1}"
-msgstr "{0} {1} ドライバーを読込中"
+msgstr "正在加载驱动 {0} {1}"
 
 #: src/metabase/driver.clj
 msgid "Load driver {0}"
-msgstr "{0} ドライバーを読込"
+msgstr "加载驱动{0}"
 
 #: src/metabase/driver.clj
+#, fuzzy
 msgid "Driver not registered after loading: {0}"
-msgstr "ロード後にドライバーが登録されていません: {0}"
+msgstr "继续仔细看看每个国家的[[this]]"
 
 #: src/metabase/driver.clj
+#, fuzzy
 msgid "Error: attempting to change {0} property `:abstract?` from {1} to {2}."
-msgstr ""
+msgstr "按产品销售[[ProductCategory]]"
 
 #: src/metabase/driver.clj
+#, fuzzy
 msgid "Registered abstract driver {0}"
-msgstr "抽象ドライバー {0} を登録しました"
+msgstr "[[this]]每[[GenericCategoryLarge]]，底部5"
 
 #: src/metabase/driver.clj
 msgid "Registered driver {0}"
-msgstr "ドライバー {0} を登録しました"
+msgstr "已注册的驱动程序 {0}"
 
 #: src/metabase/driver.clj
 msgid "(parents: {0})"
-msgstr ""
+msgstr "(父节点: {0})"
 
 #: src/metabase/driver.clj
 msgid "Initializing driver {0}..."
-msgstr "ドライバー{0}の初期化中です..."
+msgstr "初始化驱动 {0}…"
 
 #: src/metabase/driver.clj
 msgid "Reason:"
-msgstr "理由:"
+msgstr "原因: "
 
 #: src/metabase/driver.clj
+#, fuzzy
 msgid "Invalid driver feature: {0}"
-msgstr "無効なドライバー機能: {0}"
+msgstr "[[this.short-name]]在过去30天内添加"
 
 #: src/metabase/driver/sql/query_processor.clj
 msgid "Invalid HoneySQL form:"
-msgstr "不正なHoney SQLの形式:"
+msgstr "无效的HoneySQL形式:"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
+#, fuzzy
 msgid "Closing connection pool for database {0} ..."
-msgstr "データベース {0} へのコネクションプールを切断中です..."
+msgstr "每个国家/地区的[[GenericTable]]数量，以及每个国家/地区在不同类别中的表示方式。"
 
 #: src/metabase/driver/util.clj
 msgid "Error loading namespace"
-msgstr "名前空間の読み込みエラー"
+msgstr "加载命名空间失败"
 
 #: src/metabase/events.clj
 msgid "Starting events listener:"
-msgstr "イベントリスナーを開始しています:"
+msgstr "开始监听事件"
 
 #: src/metabase/events.clj
 msgid "Unexpected error listening on events"
-msgstr "イベントをリッスンする際の予期しないエラー"
+msgstr "监听事件时出现意外错误"
 
 #: src/metabase/events/sync_database.clj
+#, fuzzy
 msgid "Error syncing Database {0}"
-msgstr "データベース {0} の同期に失敗しました"
+msgstr "[[this]]每周的每一天"
 
 #: src/metabase/events/sync_database.clj
+#, fuzzy
 msgid "Failed to process sync-database event."
-msgstr "データベース同期イベントの実行に失敗しました"
+msgstr "[[this.short-name]]按[[Timestamp]]"
 
 #: src/metabase/mbql/util.clj
+#, fuzzy
 msgid "Bad nested-query-level: query does not have a source query"
-msgstr ""
+msgstr "[[GenericNumber]]按加入日期"
 
 #: src/metabase/metabot/command.clj
+#, fuzzy
 msgid "I don''t know how to `{0}`."
-msgstr ""
+msgstr "[[国家]]的[[this]]平均值"
 
 #: src/metabase/metabot/command.clj
 msgid "Here''s what I can do: "
-msgstr ""
+msgstr "这是我能做的:"
 
 #: src/metabase/metabot/slack.clj
 msgid "Error in Metabot command"
-msgstr "MetaBotコマンドのエラー"
+msgstr "Metabot命令错误"
 
 #: src/metabase/metabot/websocket.clj
+#, fuzzy
 msgid "Websocket associated with this Slack event is different from the websocket we're currently using."
-msgstr "このSlackイベントに関連付けられているWebSocketは、現在使用しているWebSocketとは異なります。"
+msgstr "我们为你[[this]]打了个数字"
 
 #: src/metabase/models/field_values.clj
+#, fuzzy
 msgid "FieldValues for Field {0} remain unchanged. Skipping..."
-msgstr ""
+msgstr "加入[[this.short-name]]的几个月"
 
 #: src/metabase/models/interface.clj
+#, fuzzy
 msgid "Unable to normalize:"
-msgstr "正規化できません:"
+msgstr "上一页{0} {1}"
 
 #: src/metabase/models/params.clj
+#, fuzzy
 msgid "Could not find matching Field ID for target:"
-msgstr "ターゲットに一致するフィールドIDが見つかりませんでした:"
+msgstr "{0} {1}前"
 
 #: src/metabase/plugins.clj
+#, fuzzy
 msgid "Metabase does not have permissions to write to plugins directory {0}"
-msgstr "Metabaseはプラグインディレクトリへの書き込み権限を持っていません"
+msgstr "{0} {1}从现在开始"
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot use the plugins directory {0}"
-msgstr "Metabaseはプラグインディレクトリ {0} を使用できません"
+msgstr "Metabase不能使用plugins路径下的{0}文件"
 
 #: src/metabase/plugins.clj
 msgid "Please make sure the directory exists and that Metabase has permission to write to it."
-msgstr "ディレクトリが存在するか、Metabaseに書き込み権限があるか確認してください。"
+msgstr "请确保该目录存在，并且Metabase有权写入该目录。"
 
 #: src/metabase/plugins.clj
 msgid "You can change the directory Metabase uses for modules by setting the environment variable MB_PLUGINS_DIR."
-msgstr "環境変数 MB_PLUGINS_DIR を設定することにより、Metabaseがモジュールに使用するディレクトリを変更できます。"
+msgstr "您可以通过设置环境变量MB_PLUGINS_DIR来更改Metabase用于模块的目录。"
 
 #: src/metabase/plugins.clj
 msgid "Falling back to a temporary directory for now."
-msgstr "今のところ一時ディレクトリにフォールバックしています。"
+msgstr "暂时回到临时目录。"
 
 #: src/metabase/plugins.clj
 msgid "Metabase cannot write to temporary directory. Please set MB_PLUGINS_DIR to a writable directory and restart Metabase."
-msgstr "Metabaseは一時ディレクトリに書き込めません。 MB_PLUGINS_DIR を書き込み可能なディレクトリに設定し、Metabaseを再起動してください。"
+msgstr "Metabase无法写入临时目录。请将MB_PLUGINS_DIR设置为可写目录并重新启动Metabase。"
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 1.0+. You can delete it from the plugins directory."
-msgstr "spark-deeps.jarはMetabase 1.0以降では必要ありません。プラグインディレクトリから削除して構いません。"
+msgstr "Metabase 1.0+以上版本不再需要spark-deps.jar。您可以从plugins目录中删除它。"
 
 #: src/metabase/plugins.clj
 msgid "Failied to initialize plugin {0}"
-msgstr "プラグイン {0} の初期化に失敗しました"
+msgstr "初始化插件 {0} 错误"
 
 #: src/metabase/plugins.clj
 msgid "Loading plugins in {0}..."
-msgstr "{0}のプラグインを読込中…"
+msgstr "正在加载 {0} 中的插件"
 
 #: src/metabase/plugins/classloader.clj
 msgid "Using Clojure base loader as shared context classloader: {0}"
-msgstr "Clojureベースローダーを共有コンテキストクラスローダーとして使用: {0}"
+msgstr "使用Clojure基础加载程序作为共享上下文类加载器：{0}"
 
 #: src/metabase/plugins/classloader.clj
+#, fuzzy
 msgid "Setting current thread context classloader to shared classloader {0}..."
-msgstr ""
+msgstr "{0}选择"
 
 #. it's important that we deref the promise again here instead of using the one we just created because it is
 #. possible thru a race condition that somebody else delivered the promise before we did; in that case,
@@ -11708,121 +11834,134 @@ msgstr ""
 #. value of it rather than one that ends up getting discarded
 #: src/metabase/plugins/classloader.clj
 msgid "Setting current thread context classloader to NEWLY CREATED classloader {0}..."
-msgstr ""
+msgstr "将当前线程上下文类加载器设置为NEWLY CREATED类加载器{0} ..."
 
 #: src/metabase/plugins/classloader.clj
 msgid "Added URL {0} to classpath"
-msgstr "URL {0} をクラスパスに追加しました"
+msgstr "将{0}添加到 classpath"
 
 #: src/metabase/plugins/dependencies.clj
+#, fuzzy
 msgid "Plugin {0} declares a dependency that Metabase does not understand: {1}"
-msgstr "プラグイン{0}はMetabaseが理解できない依存を宣言しています: {1}"
+msgstr "插件{0}声明了Metabase不理解的依赖项：{1}"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Refer to the plugin manifest reference for a complete list of valid plugin dependencies:"
-msgstr "有効なプラグインの依存関係の完全なリストについては、プラグインマニフェストリファレンスを参照してください:"
+msgstr "有关有效插件依赖项的完整列表，请参阅插件清单引用："
 
 #: src/metabase/plugins/dependencies.clj
+#, fuzzy
 msgid "Metabase cannot initialize plugin {0} due to required dependencies."
-msgstr "必要な依存性を満たしていないため、Metabaseはプラグイン{0}を初期化できません。"
+msgstr "由于所需的依赖性，Metabase无法初始化插件{0}。"
 
 #: src/metabase/plugins/dependencies.clj
+#, fuzzy
 msgid "Class not found: {0}"
-msgstr "クラスが見つかりません: {0}"
+msgstr "[Q]问"
 
 #: src/metabase/plugins/dependencies.clj
 msgid "Plugin ''{0}'' depends on plugin ''{1}''"
-msgstr "プラグイン ''{0}'' はプラグイン ''{1}'' に依存しています。"
+msgstr "插件\"{0}\" 依赖\"{1}\""
 
 #: src/metabase/plugins/dependencies.clj
+#, fuzzy
 msgid "{0} dependency {1} satisfied? {2}"
-msgstr ""
+msgstr "由{0}"
 
 #: src/metabase/plugins/dependencies.clj
+#, fuzzy
 msgid "Plugins with unsatisfied deps: {0}"
-msgstr "満たされていない依存関係を持つプラグイン: {0}"
+msgstr "无法通知{0}数据库{1}已更新"
 
 #: src/metabase/plugins/files.clj
+#, fuzzy
 msgid "Extract file {0} -> {1}"
-msgstr ""
+msgstr "加载后未注册的驱动程序：{0}"
 
 #: src/metabase/plugins/files.clj
 msgid "Resource does not exist."
-msgstr "リソースが存在しません。"
+msgstr "资源不存在"
 
 #: src/metabase/plugins/init_steps.clj
 msgid "Loading plugin namespace {0}..."
-msgstr "ネームスペース{0}のプラグインを読込中..."
+msgstr "加载插件命名空间 {0}…"
 
 #: src/metabase/plugins/initialize.clj
+#, fuzzy
 msgid "Dependencies satisfied; these plugins will now be loaded: {0}"
-msgstr "依存関係が満たされました。 これらのプラグインがロードされます: {0}"
+msgstr "错误：尝试将{0}属性`：abstract？`从{1}更改为{2}。"
 
 #: src/metabase/plugins/jdbc_proxy.clj
 msgid "Registering JDBC proxy driver for {0}..."
-msgstr "{0}のJDBCプロキシドライバーを登録しています..."
+msgstr "正在为 {0} 注册JDBC代理服务器..."
 
 #: src/metabase/plugins/jdbc_proxy.clj
+#, fuzzy
 msgid "Deregistering original JDBC driver {0}..."
-msgstr "これまで利用されていたJDBCドライバー{0}を登録解除しています..."
+msgstr "注册抽象驱动程序{0}"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
+#, fuzzy
 msgid "Default connection property {0} does not exist."
-msgstr ""
+msgstr "无效的驱动程序功能：{0}"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
+#, fuzzy
 msgid "Invalid connection property {0}: not a string or map."
-msgstr "有効でない接続設定値{0}: 文字列またはマップではありません。"
+msgstr "关闭数据库{0}的连接池..."
 
 #. ok, do the init steps listed in the plugin mainfest
 #: src/metabase/plugins/lazy_loaded_driver.clj
+#, fuzzy
 msgid "Load lazy loading driver {0}"
-msgstr ""
+msgstr "同步数据库{0}时出错"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
 msgid "Cannot initialize plugin: missing required property `driver-name`"
-msgstr "プラグインを初期化できません: driver-nameプロパティが設定されていません"
+msgstr "无法初始化插件：缺少必需的‘driver-name’属性"
 
 #: src/metabase/plugins/lazy_loaded_driver.clj
+#, fuzzy
 msgid "Warning: plugin manifest for {0} does not include connection properties"
-msgstr "警告: {0}へのプラグインマニフェストに接続プロパティがありません"
+msgstr "无法处理同步数据库事件。"
 
 #. finally, register the Metabase driver
 #: src/metabase/plugins/lazy_loaded_driver.clj
+#, fuzzy
 msgid "Registering lazy loading driver {0}..."
-msgstr "遅延ロードドライバー {0} の登録中です..."
+msgstr "错误的嵌套查询级别：查询没有源查询"
 
 #: src/metabase/pulse.clj
 msgid "Error running query for Card {0}"
-msgstr "カード {0} のクエリ実行中にエラー"
+msgstr "执行查询发生错误"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last week"
-msgstr "先週"
+msgstr "上周"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This week"
-msgstr "今週"
+msgstr "这周"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last month"
-msgstr "先月"
+msgstr "上个月"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This month"
-msgstr "今月"
+msgstr "这个月"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last quarter"
-msgstr ""
+msgstr "上季度"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This quarter"
-msgstr "今四半期"
+msgstr "本季度"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "Last year"
-msgstr "昨年"
+msgstr "去年"
 
 #: src/metabase/pulse/render/datetime.clj
 msgid "This year"
@@ -11830,196 +11969,216 @@ msgstr "今年"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "*driver* is unbound."
-msgstr ""
+msgstr "*driver* 未绑定."
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Error syncing Fields for Table ''{0}''"
-msgstr ""
+msgstr "同步表\"{0}\"字段失败"
 
 #: src/metabase/sync/sync_metadata/fields.clj
 msgid "Hash of {0} matches stored hash, skipping Fields sync"
-msgstr ""
+msgstr "{0}的校验值与当前存储的相同, 跳过字段同步"
 
 #: src/metabase/sync/sync_metadata/fields/common.clj
 msgid "Field"
-msgstr "フィールド"
+msgstr "字段"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
+#, fuzzy
 msgid "Error checking if Fields {0} need to be created or reactivated"
-msgstr ""
+msgstr "我不知道如何`{0}`。"
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Marking Field ''{0}'' as inactive."
-msgstr "''{0}'' フィールドを非アクティブとしてマークする"
+msgstr "将字段 \"{0}\" 标记为不活跃的."
 
 #: src/metabase/sync/sync_metadata/fields/sync_instances.clj
 msgid "Error retiring {0}"
-msgstr ""
+msgstr "获取 {0} 失败"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+#, fuzzy
 msgid "Database type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "{0}のデータベースタイプが”{1}”から”{2}”に変更されました"
+msgstr "与此Slack事件关联的Websocket与我们当前使用的websocket不同。"
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+#, fuzzy
 msgid "Base type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr ""
+msgstr "字段{0}的FieldValues保持不变。跳绳..."
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
+#, fuzzy
 msgid "Special type of {0} has changed from ''{1}'' to ''{2}''."
-msgstr "{0}の特別タイプは”{1}”から”{2}”に変更されました"
+msgstr "无法规范化："
 
 #: src/metabase/sync/sync_metadata/fields/sync_metadata.clj
 msgid "Comment has been added for {0}."
-msgstr "{0}へのコメントが追加されました。"
+msgstr "为 {0} 添加注释."
 
 #: src/metabase/task.clj
+#, fuzzy
 msgid "Stopping Quartz Scheduler {0}"
-msgstr "Quartzスケジューラ {0} を停止中です"
+msgstr "找不到匹配的目标字段ID："
 
 #: src/metabase/task.clj
+#, fuzzy
 msgid "Starting Quartz Scheduler {0}"
-msgstr "Quartzスケジューラ {0} を開始中です"
+msgstr "Metabase无权写入插件目录{0}"
 
 #: src/metabase/task.clj
+#, fuzzy
 msgid "Error loading tasks namespace {0}"
-msgstr ""
+msgstr "将当前线程上下文类加载器设置为共享类加载器{0} ..."
 
 #. don't bother logging namespace for now, maybe in the future if there's tasks of the same name in multiple
 #. namespaces we can log it
 #: src/metabase/task.clj
 msgid "Initializing task {0}"
-msgstr "タスク {0} を初期化しています"
+msgstr "初始化任务 {0}"
 
 #: src/metabase/task.clj
 msgid "Error initializing task {0}"
-msgstr "タスク {0} の初期化中にエラーが発生しました"
+msgstr "初始化任务 {0} 异常"
 
 #: src/metabase/task/follow_up_emails.clj
 msgid "Problem sending abandonment email"
-msgstr "放棄メールの送信に関する問題"
+msgstr "发送放弃邮件的问题"
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Sending anonymous usage stats."
-msgstr "匿名の使用状況統計を送信します。"
+msgstr "发送匿名使用统计信息"
 
 #: src/metabase/task/send_anonymous_stats.clj
 msgid "Error sending anonymous usage stats"
-msgstr "匿名の利用統計の送信に失敗しました"
+msgstr "发送匿名使用统计信息失败"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Error sending Pulse {0}"
-msgstr "パルス {0} の送信に失敗しました"
+msgstr "发送定时任务报告失败"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Sending scheduled pulses..."
-msgstr "スケジュールされたパルスを送信しています…"
+msgstr "正在发送定时任务报告..."
 
 #: src/metabase/task/send_pulses.clj
 msgid "SendPulses task failed"
-msgstr "SendPlusesタスクが失敗しました"
+msgstr "发送定时任务失败"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to scheduler tasks for Database {0}"
-msgstr "データベース {0} のスケジューラタスクが失敗しました"
+msgstr "设置数据 {0} 的调度任务失败"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Cleaning up task history"
-msgstr "タスク履歴の削除"
+msgstr "正在清理任务历史"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, rows were deleted"
-msgstr "タスク履歴の削除は成功しました。行が削除されました。"
+msgstr "任务历史清理完毕, 记录已被删除"
 
 #: src/metabase/task/task_history_cleanup.clj
 msgid "Task history cleanup successful, no rows were deleted"
-msgstr "タスク履歴の削除は成功しました。削除された行はありませんでした。"
+msgstr "任务历史清理完毕, 无记录被删除"
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Checking for new Metabase version info."
-msgstr "新しいバージョンのMetabaseの確認"
+msgstr "检查Metabase新版本."
 
 #: src/metabase/task/upgrade_checks.clj
 msgid "Error fetching version info"
-msgstr "バージョン情報の取得に失敗しました"
+msgstr "获取版本信息失败."
 
 #: src/metabase/util.clj
 msgid "Maximum memory available to JVM: {0}"
-msgstr "JVMに割り当てられる最大メモリ量: {0}"
+msgstr "JVM可用的最大内存量: {0}"
 
 #: src/metabase/util.clj
+#, fuzzy
 msgid "Not something with an ID: {0}"
-msgstr "IDのあるものではありません: {0}"
+msgstr "将当前线程上下文类加载器设置为NEWLY CREATED类加载器{0} ..."
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[CreateDate]] by month of the year"
-msgstr "月別の [[CreateDate]]"
+msgstr "[[CreateDate]]按年份计算"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
 msgid "Here's a quick look at your [[this]]"
-msgstr ""
+msgstr "这里是 [[this]] 的速览"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[CreateTimestamp]] by hour of the day"
-msgstr "時間別の [[CreateTimestamp]]"
+msgstr "[[CreateTimestamp]]按小时计算"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
 msgid "Where you've acquired your users"
-msgstr "どこでユーザーを獲得したか"
+msgstr "您已经获取用户的地方"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How it's distributed across time and other categories."
-msgstr ""
+msgstr "在时间和其他分类维度上的分布."
 
 #: resources/automagic_dashboards/table/TransactionTable/BySource.yaml
+#, fuzzy
 msgid "Here's a closer look at your [[this]] per source"
-msgstr "ソース毎の [[this]] を詳しく見てみましょう"
+msgstr "以下是您对[[this]]每个来源的详细介绍"
 
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "Here's a quick look at the [[this]]"
-msgstr ""
+msgstr "这里是 [[this]] 的速览"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[CreateTimestamp]] by day of the month"
-msgstr "日別の [[CreateTimestamp]]"
+msgstr "插件{0}声明了Metabase不理解的依赖项：{1}"
 
 #: resources/automagic_dashboards/table/UserTable.yaml
+#, fuzzy
 msgid "Here's an overview of the people in your [[this]]"
-msgstr ""
+msgstr "由于所需的依赖性，Metabase无法初始化插件{0}。"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[CreateTimestamp]] by quarter of the year"
-msgstr "四半期別の [[CreateTimestamp]]"
+msgstr "找不到类：{0}"
 
 #: resources/automagic_dashboards/field/Number.yaml
 #: resources/automagic_dashboards/table/GenericTable.yaml
 #: resources/automagic_dashboards/metric/GenericMetric.yaml
 msgid "How they compare across location"
-msgstr "場所を超えて比較する方法"
+msgstr "他们如何比较不同的位置"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByProduct.yaml
+#, fuzzy
 msgid "Here's a closer look at your [[this]] by products"
-msgstr "商品別に [[this]] を詳しく見てみましょう"
+msgstr "{0}依赖{1}满意吗？{2}"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[CreateTimestamp]] by month of the year"
-msgstr "月別の [[CreateTimestamp]]"
+msgstr "带有不满意deps的插件：{0}"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "An overview of your [[this]] and how it's distributed across time, place, and categories."
-msgstr "[[this]]と、それが時間の経過、異なる場所やカテゴリでどのように分布しているかの概要です。"
+msgstr "提取文件{0} - > {1}"
 
 #: resources/automagic_dashboards/field/DateTime.yaml
 #: resources/automagic_dashboards/question/GenericQuestion.yaml
+#, fuzzy
 msgid "Here's a closer look at your [[this]]"
-msgstr "[[this]] を詳しく見てみましょう"
+msgstr "依赖性满足; 现在将加载这些插件：{0}"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[CreateTimestamp]] by day of the week"
-msgstr "曜日別の [[CreateTimestamp]]"
+msgstr "取消注册原始JDBC驱动程序{0} ..."
 
 #: resources/automagic_dashboards/table/GoogleAnalyticsTable.yaml
+#, fuzzy
 msgid "Here's an overview of your [[this]] data from Google Analytics"
-msgstr "Google Analyticsから得られた[[this]]のデータの概要です"
+msgstr "默认连接属性{0}不存在。"
 
 #: resources/automagic_dashboards/field/State.yaml
 #: resources/automagic_dashboards/field/GenericField.yaml
@@ -12027,632 +12186,661 @@ msgstr "Google Analyticsから得られた[[this]]のデータの概要です"
 #: resources/automagic_dashboards/comparison/FK.yaml
 #: resources/automagic_dashboards/comparison/Country.yaml
 #: resources/automagic_dashboards/comparison/GenericField.yaml
+#, fuzzy
 msgid "Here's an overview of your [[this]]"
-msgstr "[[this]]の概要です"
+msgstr "无效的连接属性{0}：不是字符串或映射。"
 
 #: resources/automagic_dashboards/field/Country.yaml
+#, fuzzy
 msgid "Here's a closer look at your [[this]] field"
-msgstr "[[this]] フィールドを詳しく見てみましょう"
+msgstr "加载延迟加载驱动程序{0}"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByCountry.yaml
+#, fuzzy
 msgid "Here's a closer look at your [[this]] per country"
-msgstr "国毎の [[this]] を詳しく見てみましょう"
+msgstr "警告：{0}的插件清单不包含连接属性"
 
 #: resources/automagic_dashboards/table/GenericTable/Correlations.yaml
 msgid "If you're into correlations, this is the x-ray for you."
-msgstr "もしもあなたが相関に興味があるのならば、これはおすすめのX-rayです。"
+msgstr "如果您正在进行相关，那么这就是您的X射线。"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[CreateDate]] by day of the week"
-msgstr "曜日別の [[CreateDate]]"
+msgstr "注册延迟加载驱动程序{0} ..."
 
 #: resources/automagic_dashboards/table/TransactionTable.yaml
+#, fuzzy
 msgid "It looks like your [[this]] has transactions, so here's a look at them"
-msgstr ""
+msgstr "检查是否需要创建或重新激活字段{0}时出错"
 
 #: resources/automagic_dashboards/table/TransactionTable/ByState.yaml
+#, fuzzy
 msgid "Here's a closer look at your [[this]] per state"
-msgstr "州毎の [[this]] を詳しく見てみましょう"
+msgstr "数据库类型{0}已从“{1}”更改为“{2}”。"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[CreateDate]] by day of the month"
-msgstr "日別の [[CreateDate]]"
+msgstr "基本类型{0}已从“{1}”更改为“{2}”。"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[CreateTime]] by hour of the day"
-msgstr "時間別の [[CreateTime]]"
+msgstr "特殊类型的{0}已从“{1}”更改为“{2}”。"
 
 #: resources/automagic_dashboards/table/TransactionTable/Seasonality.yaml
+#, fuzzy
 msgid "Here's a closer look at your [[this]] over time"
-msgstr "経時的に [[this]] を詳しく見てみましょう"
+msgstr "停止Quartz Scheduler {0}"
 
 #: resources/automagic_dashboards/table/GenericTable.yaml
+#, fuzzy
 msgid "[[CreateDate]] by quarter of the year"
-msgstr "四半期別の [[CreateDate]]"
+msgstr "启动Quartz Scheduler {0}"
 
 #: frontend/src/metabase/admin/people/containers/EditUserModal.jsx:12
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:204
 msgid "Edit user"
-msgstr "ユーザーを編集"
+msgstr "编辑用户"
 
 #: frontend/src/metabase/admin/people/containers/NewUserModal.jsx:13
 msgid "New user"
-msgstr "新規ユーザー"
+msgstr "新增用户"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:208
 #: frontend/src/metabase/admin/people/containers/UserPasswordResetModal.jsx:69
 msgid "Reset password"
-msgstr "パスワードをリセットする"
+msgstr "重置密码"
 
 #: frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx:212
 msgid "Deactivate user"
-msgstr "ユーザーを無効化"
+msgstr "停用用户"
 
 #: frontend/src/metabase/admin/people/containers/UserActivationModal.jsx:47
 msgid "Reactivate {0}?"
-msgstr "{0}を再有効化しますか？"
+msgstr "启用用户 {0} ?"
 
 #: frontend/src/metabase/admin/people/containers/UserSuccessModal.jsx:63
 msgid "We couldn’t send them an email invitation, so make sure to tell them to log in using {0} and this password we’ve generated for them:"
-msgstr "メールによる招待を送ることに失敗したので、{0}と自動で生成したこのパスワードを利用してログインするように招待者に伝えてください。"
+msgstr "我们无法向他们发送电子邮件邀请，因此请务必告诉他们使用{0}和我们为他们生成的密码登录："
 
 #: frontend/src/metabase/entities/collections.js:24
 msgid "collection"
-msgstr "コレクション"
+msgstr "收藏"
 
 #: frontend/src/metabase/entities/collections.js:25
 msgid "collections"
-msgstr "コレクション"
+msgstr "收藏"
 
 #: frontend/src/metabase/entities/dashboards.js:32
 msgid "dashboard"
-msgstr "ダッシュボード"
+msgstr "仪表板"
 
 #: frontend/src/metabase/entities/dashboards.js:33
 msgid "dashboards"
-msgstr "ダッシュボード"
+msgstr "仪表板"
 
 #: frontend/src/metabase/entities/users.js:37
 msgid "First name is required"
-msgstr "名が必要です"
+msgstr "名字是必须的"
 
 #: frontend/src/metabase/entities/users.js:38
 #: frontend/src/metabase/entities/users.js:46
 msgid "Must be 100 characters or less"
-msgstr "100文字以下でなければなりません"
+msgstr "不能超过100个字符长度"
 
 #: frontend/src/metabase/entities/users.js:45
 msgid "Last name is required"
-msgstr "姓は必須です"
+msgstr "姓是必须的"
 
 #: frontend/src/metabase/entities/users.js:52
 msgid "Email is required"
-msgstr "Emailアドレスは必須です"
+msgstr "电子邮件是必须的"
 
 #: frontend/src/metabase/home/containers/ArchiveApp.jsx:93
 msgid "Items you archive will appear here."
-msgstr "アーカイブしたアイテムはここに現れます"
+msgstr "您存档的项目将显示在此处。"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:16
 msgid "No description"
-msgstr "説明がありません"
+msgstr "没有描述"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:178
 msgid "Sum of all values"
-msgstr "すべての値の合計"
+msgstr "所有值的总和"
 
 #: frontend/src/metabase/query_builder/components/dataref/FieldPane.jsx:186
 msgid "See all distinct values"
-msgstr "個別の値をすべて表示"
+msgstr "查看所有无重复数值"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:12
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started"
-msgstr "データベース、テーブル、および列の内容を参照します。 開始するデータベースを選択してください"
+msgstr "浏览数据库，表和列的内容。选择一个数据库即可开始使用"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is VALID. Thanks!"
-msgstr ""
+msgstr "传递给API的卡片结果元数据是有效的。谢谢！"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is INVALID. Running query to fetch correct metadata."
-msgstr ""
+msgstr "传递给API的卡片结果元数据是INVALID。运行查询以获取正确的元数据。"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is  ISSING. Running query to fetch correct metadata."
-msgstr ""
+msgstr "传递给API的卡片结果元数据是ISSING。运行查询以获取正确的元数据。"
 
 #: src/metabase/api/email.clj
+#, fuzzy
 msgid "{0} was autocorrected to {1}"
-msgstr "{0}は{1}へオートコレクトされました"
+msgstr "加载任务名称空间{0}时出错"
 
+#. DELETE /api/metric/:id 样式使用的是Restful风格的数据访问接口，按照Metabase文档所述，‘:id’应当是URL路径可变参数。
 #: src/metabase/api/metric.clj
 msgid "DELETE /api/metric/:id is deprecated. Instead, change its `archived` value via PUT /api/metric/:id."
-msgstr "DELETE /api/metric/:idは推奨されていません。 代わりに、'archived'値をPUT /api/metric/:idで変更してください。"
+msgstr "DELETE /api/metric/:id 已弃用。请替代通过PUT /api/metric/:id修改其‘archived’的取值。"
 
 #: src/metabase/api/segment.clj
 msgid "DELETE /api/segment/:id is deprecated. Instead, change its `archived` value via PUT /api/segment/:id."
-msgstr "DELETE /api/segment/:idは推奨されていません。 代わりに、'archived'値をPUT /api/segment/:idで変更してください。"
+msgstr "DELETE /api/segment/:id 已弃用。请替代通过PUT /api/segment/:id修改其‘archived’的取值。"
 
 #: src/metabase/api/user.clj
 msgid "Value of is_superuser must correspond to presence of Admin group ID in group_ids."
-msgstr "is_superuser の値は、 group_ids の管理グループIDの存在に対応する必要があります。"
+msgstr "is_superuser的值必须与group_ids中Admin组的ID相对应"
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected error writing keepalive characters"
-msgstr "キープアライブ文字の書き込みで予期しないエラーが発生しました"
+msgstr "写入长链接字符时出现意外错误"
 
 #: src/metabase/async/api_response.clj
 msgid "Unexpected output in async API response"
-msgstr "非同期APIのレスポンスが予想外の出力です"
+msgstr "异步API响应中的意外输出"
 
 #: src/metabase/async/api_response.clj
 msgid "starting streaming response"
-msgstr "ストリーミング応答の開始"
+msgstr "开始流式响应"
 
 #: src/metabase/async/api_response.clj
 msgid "Output chan closed, canceling keepalive request."
-msgstr "出力チャンネルが閉じられ、キープアライブ要求がキャンセルされました。"
+msgstr "输出通道关闭，取消长链接请求"
 
 #: src/metabase/async/api_response.clj
 msgid "Async response finished, closing channels."
-msgstr "非同期通信が終了しました。チャンネルをクローズします。"
+msgstr "异步响应完成，关闭通道。"
 
 #: src/metabase/async/api_response.clj
+#, fuzzy
 msgid "No response after waiting {0}. Canceling request."
-msgstr "{0} 待ちましたが応答がありません。問い合わせをキャンセルします"
+msgstr "不是具有ID的东西：{0}"
 
 #: src/metabase/async/api_response.clj
 msgid "Input channel unexpectedly closed."
-msgstr "入力チャンネルが予期せず閉じられました。"
+msgstr "输入通道意外关闭。"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "f finished, permit will be returned"
-msgstr ""
+msgstr "F完成后，将返回许可。"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "request canceled, permit will be returned"
-msgstr "リクエストはキャンセルされ、許可が返されます"
+msgstr "请求取消后，将返回许可。"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Unexpected error attempting to run function after obtaining permit"
-msgstr "許可を取得した後に関数を実行しようとすると予期しないエラーが発生しました"
+msgstr "获得许可后尝试运行函数时出现意外错误"
 
 #: src/metabase/async/semaphore_channel.clj
 msgid "Not running pending function call: output channel already closed."
-msgstr ""
+msgstr "不能运行待处理函数调用：输出通道已关闭。"
 
 #: src/metabase/async/semaphore_channel.clj
+#, fuzzy
 msgid "Current thread already has a permit for {0}, will not wait to acquire another"
-msgstr ""
+msgstr "[[CreateDate]]按年份计算"
 
 #: src/metabase/async/util.clj
 msgid "Output channel closed, will skip running {0}."
-msgstr ""
+msgstr "输出通道关闭, 将跳过运行 {0}."
 
 #: src/metabase/async/util.clj
 msgid "Running {0} on separate thread..."
-msgstr "{0}を複数のスレッドで実行中..."
+msgstr "在单独线程中运行 {0} …"
 
 #: src/metabase/async/util.clj
+#, fuzzy
 msgid "Caught error running {0}"
-msgstr "{0}の実行中にエラーが発生しました"
+msgstr "抓到错误运行 {0}"
 
 #: src/metabase/async/util.clj
+#, fuzzy
 msgid "Request canceled, canceling future"
-msgstr "リクエストがキャンセルされたため、フューチャーをキャンセルしています"
+msgstr "请求已取消，取消了未来"
 
 #: src/metabase/driver/sql_jdbc/connection.clj
+#, fuzzy
 msgid "Closing old connection pool for database {0} ..."
-msgstr "データベース{0}への古いコネクションプールを閉じています..."
+msgstr "关闭数据库的旧连接池{0}..."
 
 #: src/metabase/metabot/command.clj
+#, fuzzy
 msgid "Here''s your {0} most recent cards:"
-msgstr ""
+msgstr "[[CreateTimestamp]]按小时计算"
 
 #: src/metabase/metabot/command.clj
 msgid "Could you be a little more specific, or use the ID? I found these cards with names that matched:"
-msgstr ""
+msgstr "您可以更详细一点，或者使用ID？ 我找到了这些名字匹配的卡片："
 
 #: src/metabase/metabot/command.clj
 msgid "Card {0} not found."
-msgstr "カード {0} が見つかりません"
+msgstr "卡片 {0} 未找到."
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Exception in API call"
-msgstr "API呼び出しの例外"
+msgstr "API调用异常"
 
 #: src/metabase/middleware/exceptions.clj
 msgid "Request canceled before finishing."
-msgstr "問い合わせは終了前にキャンセルされました"
+msgstr "请求在完成之前发生异常."
 
 #: src/metabase/middleware/json.clj
 msgid "Metabase only supports JSON requests."
-msgstr "MetabaseはJSONリクエストのみをサポートしています"
+msgstr "Metabase仅支持JSON请求"
 
 #: src/metabase/middleware/json.clj
 msgid "Make sure you set a 'Content-Type: application/json' header."
-msgstr "Content-Type: application/jsonのヘッダを設定したか確認してください"
+msgstr "确定你设置了一个'Content-Type：application / json'报头。"
 
 #: src/metabase/middleware/misc.clj
 msgid "Setting Metabase site URL to {0}"
-msgstr "MetabaseのサイトURLを{0}に設定しています"
+msgstr "将Metabase的站点URL设置为{0}"
 
 #: src/metabase/models/database.clj
 msgid "Error scheduling tasks for DB"
-msgstr "DBのタスクのスケジューリングエラー"
+msgstr "DB调度任务失败"
 
 #: src/metabase/models/database.clj
 msgid "Error unscheduling tasks for DB."
-msgstr "DBのタスクのスケジュール解除エラー。"
+msgstr "数据库未安排任务出错。"
 
 #: src/metabase/models/database.clj
+#, fuzzy
 msgid "{0} Database ''{1}'' sync/analyze schedules have changed!"
-msgstr ""
+msgstr "以下是您对[[this]]每个来源的详细介绍"
 
 #: src/metabase/models/database.clj
+#, fuzzy
 msgid "Sync metadata was: ''{0}'' is now: ''{1}''"
-msgstr ""
+msgstr "[[CreateTimestamp]]按月的日期"
 
 #: src/metabase/models/database.clj
+#, fuzzy
 msgid "Cache FieldValues was: ''{0}'', is now: ''{1}''"
-msgstr ""
+msgstr "以下是[[this]]中人物的概述"
 
 #: src/metabase/models/metric.clj
 msgid "You cannot update the creator_id of a Metric."
-msgstr "メトリックの creator_id を更新することはできません。"
+msgstr "您不能更新指标的创建者标识(creator_id)"
 
 #: src/metabase/models/permissions.clj
 msgid "MetaBot can only have Collection permissions."
-msgstr "MetaBotは、コレクションの権限のみを持つことができます。"
+msgstr "MetaBot只能拥有Collection权限。"
 
 #: src/metabase/models/permissions.clj
 msgid "Failed to grant permissions"
-msgstr "権限を付与できませんでした"
+msgstr "授权失败"
 
 #: src/metabase/models/permissions.clj
 msgid "Changing permissions"
-msgstr "権限の変更"
+msgstr "更改权限"
 
 #: src/metabase/models/permissions.clj
 msgid "FROM:"
-msgstr ""
+msgstr "FROM:"
 
 #: src/metabase/models/permissions.clj
 msgid "TO:"
-msgstr ""
+msgstr "TO:"
 
 #: src/metabase/models/segment.clj
 msgid "You cannot update the creator_id of a Segment."
-msgstr "セグメントの creator_id を更新することはできません。"
+msgstr "您不能更新划分的创建者标识(creator_id)"
 
 #: src/metabase/models/setting.clj
+#, fuzzy
 msgid "Attempted to set Setting {0} to obfuscated value. Ignoring change."
-msgstr ""
+msgstr "[[CreateTimestamp]]按季度计算"
 
 #: src/metabase/models/setting.clj
+#, fuzzy
 msgid "Using value of env var {0}"
-msgstr ""
+msgstr "以下是您的[[this]]产品的详细介绍"
 
 #: src/metabase/models/user.clj
+#, fuzzy
 msgid "Adding User {0} to All Users permissions group..."
-msgstr "ユーザー {0} をAll Users権限グループに追加しています..."
+msgstr "[[CreateTimestamp]]按年份的月份"
 
 #: src/metabase/models/user.clj
+#, fuzzy
 msgid "Adding User {0} to Admin permissions group..."
-msgstr "ユーザー {0} を管理者権限グループに追加しています..."
+msgstr "您[[this]]的概述及其在时间，地点和类别中的分布情况。"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query failure"
-msgstr "クエリの失敗"
+msgstr "查询失败"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Maximum number of simultaneous queries to allow per connected Database."
-msgstr "接続されたデータベースごとに許可する同時クエリの最大数。"
+msgstr "每个已连接的数据库允许的最大并发查询数量。"
 
 #: src/metabase/util.clj
 msgid "Timed out after {0} milliseconds."
-msgstr "{0} ミリ秒後にタイムアウトしました。"
+msgstr "{0} ms 后超时."
 
 #: frontend/src/metabase/admin/tasks/containers/JobTriggersModal.jsx:27
+#, fuzzy
 msgid "Misfire Instruction"
-msgstr ""
+msgstr "失火指令"
 
 #: frontend/src/metabase/components/ArchiveModal.jsx:31
 msgid "Archive this?"
-msgstr "これをアーカイブしますか？"
+msgstr "将这个归档?"
 
 #: frontend/src/metabase/components/BrowseApp.jsx:244
 msgid "Learn about our data"
-msgstr "データについて学ぶ"
+msgstr "了解我们的数据"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:267
 msgid "Use DNS SRV when connecting"
-msgstr "接続時にDNS SRVを使用する"
+msgstr "连接时使用DNS SRV（域名服务器）"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:269
 msgid "Using this option requires that provided host is a FQDN.  If connecting to \n"
 "an Atlas cluster, you might need to enable this option.  If you don't know what this means,\n"
 "leave this disabled."
-msgstr "このオプションを使用するには、提供されたホストがFQDNである必要があります。 Atlasクラスターに接続する場合は、このオプションを有効にする必要があります。 これが何を意味するのかわからない場合は、これを無効のままにします。"
+msgstr "使用此选项要求提供的主机是一个FQDN。 如果连接到一个Atlas集群，您可能需要启用此选项。 如果你不知道这意味着什么，请保持禁用该选项。"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:318
 msgid "Automatically run queries when doing simple filtering and summarizing"
-msgstr "簡単なフィルタリングと要約を行うときに自動的にクエリを実行する"
+msgstr "在进行简单的过滤和汇总时自动运行查询"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
 msgid "When this is on Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "これを有効にすることにより、ユーザ―がテーブルやチャートを見るときに要約やフィルターボタンを利用して簡単な探索を行った場合に、Metabaseが自動的にクエリを実行するようになります。このデータベースへのクエリが遅い場合は、この設定を無効にすることができます。この設定によってドリルスルーやSQLクエリが影響を受けることはありません。"
+msgstr "这个选项开启时，当用户在查看表格或图表时使用“汇总”和“过滤”按钮进行简单数据探索时，Metabase将自动运行查询。 如果查询此数据库的速度很慢，可以将该选项关闭。 此设置不会影响数据钻探或SQL查询。"
 
 #: frontend/src/metabase/containers/Overworld.jsx:247
 msgid "Learn about this database"
-msgstr "このデータベースについて詳細を見る"
+msgstr "了解这个数据库"
 
 #: frontend/src/metabase/dashboard/components/ArchiveDashboardModal.jsx:17
 msgid "Archive this dashboard?"
-msgstr "このダッシュボードをアーカイブしますか？"
+msgstr "是否归档该仪表板?"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:113
 msgid "All results"
-msgstr "全ての結果"
+msgstr "所有结果"
 
 #: frontend/src/metabase/home/containers/SearchApp.jsx:180
 msgid "Our Analytics"
-msgstr "我々の分析"
+msgstr "我们的分析"
 
 #: frontend/src/metabase/lib/schema_metadata.js:500
+#, fuzzy
 msgid "Additive sum of all the values of a column.\\ne.x. total revenue over time."
-msgstr ""
+msgstr "这里仔细看看[[this]]"
 
 #: frontend/src/metabase/lib/schema_metadata.js:508
 msgid "Additive count of the number of rows.\\ne.x. total number of sales over time."
-msgstr ""
+msgstr "行数的附加计数。\\ ne.x。总销售额随着时间的推移。"
 
 #: frontend/src/metabase/modes/components/drill/ColumnFilterDrill.jsx:42
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:47
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:91
 msgid "Filter"
-msgstr "フィルター"
+msgstr "过滤器"
 
 #: frontend/src/metabase/modes/components/drill/UnderlyingRecordsDrill.jsx:34
 msgid "record"
 msgid_plural "records"
-msgstr[0] "レコード"
+msgstr[0] "记录"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:346
 msgid "Browse Data"
-msgstr "データを見る"
+msgstr "流量数据"
 
 #: frontend/src/metabase/nav/containers/Navbar.jsx:376
 msgid "Write SQL"
-msgstr "SQLを書く"
+msgstr "写SQL"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:147
 msgid "Simple question"
-msgstr "簡単な質問"
+msgstr "简单查询"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:148
 msgid "Pick some data, view it, and easily filter, summarize, and visualize it."
-msgstr "データを選択し、見て、そして簡単にフィルタリングや集約をし、可視化します。"
+msgstr "挑选并浏览数据, 添加简单的过滤或聚合, 然后将数据可视化."
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:156
 msgid "Custom question"
-msgstr "カスタム質問"
+msgstr "自定义查询"
 
 #: frontend/src/metabase/new_query/containers/NewQueryOptions.jsx:157
 msgid "Use the advanced notebook editor to join data, create custom columns, do math, and more."
-msgstr "高度なノートブックエディターを使用して、データの結合、カスタム列の作成、計算などを行います。"
+msgstr "使用高级查询编辑器完成关联, 创建自定义列, 实现数学计算等更多高级功能."
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:23
 msgid "Basic Metrics"
-msgstr "基本的なメトリクス"
+msgstr "基础指标"
 
 #: frontend/src/metabase/query_builder/components/AggregationPopover.jsx:319
 msgid "Custom…"
-msgstr "カスタム…"
+msgstr "自定义"
 
 #: frontend/src/metabase/query_builder/components/DimensionList.jsx:147
 msgid "Add grouping"
-msgstr "グルーピングを追加する"
+msgstr "添加分组"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:14
 msgid "Pick a limit"
-msgstr ""
+msgstr "请选择一个记录行返回数量的限定值"
 
 #: frontend/src/metabase/query_builder/components/LimitPopover.jsx:38
 msgid "Show maximum"
-msgstr "最大を表示"
+msgstr "显示最大值"
 
 #: frontend/src/metabase/query_builder/components/RunButton.jsx:47
 msgid "Get Preview"
-msgstr ""
+msgstr "预览"
 
 #: frontend/src/metabase/query_builder/components/VisualizationResult.jsx:82
 msgid "Back to previous results"
-msgstr "前の結果に戻る"
+msgstr "返回上一结果集"
 
 #: frontend/src/metabase/query_builder/components/dataref/DetailPane.jsx:21
 msgid "Sample values"
-msgstr "サンプル値"
+msgstr "样例数据"
 
 #: frontend/src/metabase/query_builder/components/dataref/MainPane.jsx:10
 msgid "Browse the contents of your databases, tables, and columns. Pick a database to get started."
-msgstr "データベース、テーブル、および列の内容を参照します。 データベースを選択して開始します。"
+msgstr "浏览您的数据库，表和列的内容。 选择一个数据库即可开始使用。"
 
 #: frontend/src/metabase/query_builder/components/notebook/Notebook.jsx:40
 msgid "Visualize"
-msgstr "ビジュアライズ"
+msgstr "可视化"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:34
 msgid "Join data"
-msgstr "結合"
+msgstr "关联"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:41
 msgid "Custom column"
-msgstr "カスタム列"
+msgstr "自定义列"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:54
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:61
 msgid "Summarize"
-msgstr "要約"
+msgstr "聚合"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:61
 msgid "Aggregate"
-msgstr ""
+msgstr "聚合"
 
 #: frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx:68
 msgid "Breakout"
-msgstr "ブレークアウト"
+msgstr "爆发"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx:18
 msgid "Pick the metric you want to see"
-msgstr "見たいメトリクスを選ぶ"
+msgstr "选择你要查看的指标"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx:18
 #: frontend/src/metabase/query_builder/components/view/sidebars/BreakoutSidebar.jsx:12
 msgid "Pick a column to group by"
-msgstr "集約するためのキー列を選ぶ"
+msgstr "选择分组的列"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx:24
 msgid "Pick your starting data"
-msgstr "開始するデータを選択してください"
+msgstr "选择您的起始数据"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
 msgid "Select None"
-msgstr "選択解除"
+msgstr "全不选"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx:43
 msgid "Select All"
-msgstr "すべて選択"
+msgstr "全选"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:148
 msgid "Pick a table..."
-msgstr "テーブルを選ぶ..."
+msgstr "选择数据表…"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/LimitStep.jsx:23
 msgid "Enter a limit"
-msgstr "最大行数を入力"
+msgstr "输入限制条件"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:159
+#, fuzzy
 msgid "Brackets around a {0} create an optional clause in the template. If \"variable\" is set, then the entire clause is placed into the template. If not, then the entire clause is ignored."
-msgstr ""
+msgstr "{0}周围的括号在模板中创建可选子句。 如果设置了“variable”，则将整个子句放入模板中。 如果不是，则忽略整个子句。"
 
 #: frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx:176
 msgid "When using a Field Filter, the column name should not be included in the SQL. Instead, the variable should be mapped to a field in the side panel."
-msgstr "フィールドフィルターを使用する場合、列名をSQLに含めないでください。 代わりに、変数をサイドパネルのフィールドにマッピングする必要があります。"
+msgstr "当某字段被用作筛选条件后, SQL语句中不应再包含该列明. 相应的在侧边栏上, 变量应该映射到一个字段上."
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:16
 msgid "View the native query"
-msgstr "ネイティブクエリを表示する"
+msgstr "查看原生查询"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:17
 msgid "Native query for this question"
-msgstr "この質問のネイティブクエリ"
+msgstr "这个问题的原生查询"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:18
 msgid "Convert this question to a native query"
-msgstr "この質問をネイティブクエリに変換する"
+msgstr "将这个问题转换为原生查询"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:22
 msgid "SQL for this question"
-msgstr "この質問のSQL"
+msgstr "这个查询的SQL语句"
 
 #: frontend/src/metabase/query_builder/components/view/NativeQueryButton.jsx:23
 msgid "Convert this question to SQL"
-msgstr "この質問をSQLに変換します"
+msgstr "将这个查询转换为SQL"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionAlertWidget.jsx:53
 msgid "Get alerts"
-msgstr "アラートを受け取る"
+msgstr "获取提醒告警"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:31
+#, fuzzy
 msgid "{0} breakout"
 msgid_plural "{0} breakouts"
-msgstr[0] ""
+msgstr[0] "[[CreateTimestamp]]按星期几"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:36
 msgid "Hide filters"
-msgstr "フィルターを非表示"
+msgstr "隐藏过滤器"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx:70
 msgid "Show filters"
-msgstr "フィルターを表示する"
+msgstr "显示过滤器"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionLineage.jsx:10
 msgid "Started from"
-msgstr "から開始"
+msgstr "从这开始"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:21
 msgid "{0} row"
 msgid_plural "{0} rows"
-msgstr[0] "{0}行"
+msgstr[0] "{0} 行"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:29
 msgid "Show all rows"
-msgstr "全ての行を表示する"
+msgstr "展示所有行"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:30
 msgid "Show {0}"
-msgstr "{0}を表示する"
+msgstr "展示 {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:35
 msgid "Showing first {0}"
-msgstr "最初の{0}を表示しています"
+msgstr "展示前 {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionRowCount.jsx:36
 msgid "Showing {0}"
-msgstr "{0}を表示しています"
+msgstr "展示 {0}"
 
 #: frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx:34
 msgid "Summarized"
-msgstr "要約された"
+msgstr "聚合"
 
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
 msgid "Hide editor"
-msgstr "エディターを非表示にする"
+msgstr "隐藏编辑器"
 
 #: frontend/src/metabase/query_builder/components/view/ViewHeader.jsx:216
 msgid "Show editor"
-msgstr "エディターを表示する"
+msgstr "显示编辑器"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/AggregationSidebar.jsx:14
 msgid "Pick the metric you'd like to see"
-msgstr "あなたの見たい指標を選ぶ"
+msgstr "选择你要查看的指标"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx:21
 msgid "{0} options"
-msgstr ""
+msgstr "选项"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx:44
 msgid "Choose a visualization"
-msgstr "可視化方法を選択する"
+msgstr "选择可视化方法"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/FilterSidebar.jsx:38
 msgid "Filter by"
-msgstr "フィルター項目"
+msgstr "筛选条件"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:57
 msgid "Summarize by"
-msgstr "集約方法"
+msgstr "聚合条件"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:83
 msgid "Group by"
-msgstr "集約キー"
+msgstr "分组条件"
 
 #: frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar.jsx:167
 msgid "Add a metric"
-msgstr "メトリクスを追加する"
+msgstr "添加指标"
 
 #: frontend/src/metabase/user/components/UserSettings.jsx:57
 msgid "Profile"
-msgstr "プロフィール"
+msgstr "主页"
 
 #: frontend/src/metabase/visualizations/components/Visualization.jsx:548
 msgid "This is usually pretty fast but seems to be taking a while right now."
-msgstr "これはたいていの場合はとても速いですが、現在は時間がかかっているようです。"
+msgstr "这通常很快，但现在似乎需要一段时间。"
 
 #: frontend/src/metabase/visualizations/visualizations/ComboChart.jsx:16
 msgid "Combo"
-msgstr ""
+msgstr "组合"
 
 #: frontend/src/metabase/visualizations/visualizations/RowChart.jsx:13
 msgid "Row"
@@ -12660,455 +12848,480 @@ msgstr "行"
 
 #: frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx:22
 msgid "Trend"
-msgstr "トレンド"
+msgstr "趋势"
 
 #: frontend/src/metabase-lib/lib/DimensionOptions.js:129
 msgid "Boolean"
-msgstr "真偽値"
+msgstr "布尔值"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:59
 msgid "Unknown Segment"
-msgstr "不明なセグメント"
+msgstr "未知的划分"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Filter.js:68
 msgid "Unknown Filter"
-msgstr "不明なフィルター"
+msgstr "未知过滤器"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:22
 msgid "Left outer join"
-msgstr "左外部結合"
+msgstr "Left outer join"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:23
 msgid "Right outer join"
-msgstr "右外部結合"
+msgstr "Right outer join"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:24
 msgid "Inner join"
-msgstr "内部結合"
+msgstr "Inner join"
 
 #: frontend/src/metabase-lib/lib/queries/structured/Join.js:25
 msgid "Full outer join"
-msgstr "完全外部結合"
+msgstr "Full outer join"
 
 #: src/metabase/api/card.clj
 msgid "Card results metadata passed in to API is MISSING. Running query to fetch correct metadata."
-msgstr ""
+msgstr "传递给API的卡片结果元数据丢失。 运行查询以获取正确的元数据。"
 
 #: src/metabase/api/session.clj
 msgid "Problem connecting to LDAP server, will fall back to local authentication"
-msgstr "LDAPサーバーへの接続に問題があり、ローカル認証にフォールバックします"
+msgstr "连接LDAP服务器失败, 将使用本地认证."
 
 #: src/metabase/api/setup.clj
 msgid "Cannot create Database: cannot find driver {0}."
-msgstr "データベースが作成できません: {0} ドライバーが見つかりません"
+msgstr "无法创建数据库: 找不到驱动程序 {0}."
 
 #: src/metabase/api/tiles.clj
 msgid "Query failed"
-msgstr "クエリが失敗しました"
+msgstr "查询失败"
 
 #: src/metabase/async/util.clj
+#, fuzzy
 msgid "Warning: {0} returned `nil`"
-msgstr "警告: {0} がnilを返しました"
+msgstr "以下是Google Analytics中[[this]]数据的概述"
 
 #: src/metabase/async/util.clj
 msgid "Unexpected error writing result to output channel: already closed"
-msgstr "出力チャンネルへの結果の書き込みで予期しないエラーが発生しました: すでに閉じています"
+msgstr "将结果写入输出通道时出现意外错误：已关闭"
 
 #: src/metabase/async/util.clj
 msgid "Unexpected error writing exception to output channel: already closed"
-msgstr "出力チャンネルへの例外の書き込み中に予期しないエラーが発生しました: すでに閉じています"
+msgstr "将异常写入输出通道时出现意外错误：已关闭"
 
 #: src/metabase/async/util.clj
 msgid "Request canceled, canceling future."
-msgstr "リクエストがキャンセルされたため、フューチャーをキャンセルしています。"
+msgstr "请求已取消，以后将会取消。"
 
 #: src/metabase/cmd/load_from_h2.clj
 msgid "Metabase can only transfer data from H2 to Postgres or MySQL/MariaDB."
-msgstr "MetabaseはH2からPostgresまたはMySQL/MariaDBへのデータ移行のみをサポートしています。"
+msgstr "Metabase只能将数据从H2传输到Postgres或MySQL / MariaDB。"
 
 #: src/metabase/db.clj
 msgid "WARNING: Using Metabase with an H2 application database is not recommended for production deployments."
-msgstr "警告: 本番環境で、MetabaseをH2アプリケーションデータベースと共に使用することはお勧めできません。"
+msgstr "警告：不推荐将Metabase与H2应用数据库一起用于生产环境部署。"
 
 #: src/metabase/db.clj
 msgid "Application database setup"
-msgstr "アプリケーションデータベース セットアップ"
+msgstr "应用数据库设置"
 
 #: src/metabase/driver.clj
 msgid "Could not find {0} driver."
-msgstr "{0}のドライバーが見つかりませんでした"
+msgstr "找不到驱动程序 {0}."
 
 #: src/metabase/driver.clj
 msgid "Abstract drivers cannot derive from concrete parent drivers."
-msgstr ""
+msgstr "抽象驱动程序无法从具体的父驱动程序派生。"
 
 #: src/metabase/driver/mysql.clj
 msgid "You may need to add 'trustServerCertificate=true' to the additional connection options to connect with SSL."
-msgstr "SSLで接続するには、追加の接続オプションに `trustServerCertificate=true` を追加する必要がある場合があります。"
+msgstr "您可能需要将参数“trustServerCertificate = true”添加到其他连接选项以连接SSL"
 
 #: src/metabase/driver/sql/util.clj
+#, fuzzy
 msgid "Don't know how to alias {0}, expected an Identifer."
-msgstr ""
+msgstr "以下是您[[this]]的概述"
 
 #: src/metabase/driver/sql_jdbc/execute.clj
 msgid "Client closed connection, canceling query"
-msgstr "クライアントが接続を閉じ、クエリをキャンセルします"
+msgstr "客户端关闭连接，取消查询"
 
 #: src/metabase/integrations/ldap.clj
 msgid "{0} is not a valid DN."
-msgstr "{0}は有効なDNではありません"
+msgstr "{0} 不是一个有效的 DN"
 
 #: src/metabase/middleware/log.clj
 msgid "Error logging API request"
-msgstr "APIリクエストのロギングエラー"
+msgstr "错误的日志API请求"
 
 #: src/metabase/middleware/misc.clj
 msgid "Failed to set site-url"
-msgstr "サイトURLのセットに失敗しました"
+msgstr "设置站点url失败"
 
 #: src/metabase/models/database.clj
 msgid "Error destroying thread pool for DB."
-msgstr "DBのスレッドプール終了エラー"
+msgstr "销毁数据库线程池时出错。"
 
 #: src/metabase/models/humanization.clj
+#, fuzzy
 msgid "Updating display name for {0} ''{1}'': ''{2}'' -> ''{3}''"
-msgstr ""
+msgstr "更新{0}''{1}''的显示名称：''{2}'' - >''{3}''"
 
 #: src/metabase/models/humanization.clj
+#, fuzzy
 msgid "Invalid humanization strategy ''{0}''. Valid strategies are: {1}"
-msgstr ""
+msgstr "无效的非人化策略“{0}”。 有效的策略是：{1}"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
+#, fuzzy
 msgid "Chaning Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr ""
+msgstr "更改表和字段将人性化策略从“{0}”更改为“{1}”"
 
 #: src/metabase/models/task_history.clj src/metabase/sync/util.clj
 msgid "Error saving task history"
-msgstr ""
+msgstr "保存任务历史失败"
 
 #: src/metabase/plugins.clj
 msgid "spark-deps.jar is no longer needed by Metabase 0.32.0+. You can delete it from the plugins directory."
-msgstr "spark-deps.jarはMetabase 0.32.0以降では必要ありません。プラグインディレクトリから削除して構いません。"
+msgstr "0.32.0 及以上版本的Metabase不再需要spark-deps.jar了. 您可以从插件目录中删除它."
 
 #: src/metabase/plugins/classloader.clj
+#, fuzzy
 msgid "Using NEWLY CREATED classloader as shared context classloader: {0}"
-msgstr "「新しく作成された」クラスローダーを共有コンテキストクラスローダーとして使用: {0}"
+msgstr "使用NEWLY CREATED类加载器作为共享上下文类加载器：{0}"
 
 #: src/metabase/plugins/files.clj
 msgid "Failed to copy file"
-msgstr "ファイルのコピーに失敗しました"
+msgstr "复制文件失败"
 
 #: src/metabase/public_settings.clj
 msgid "Invalid site URL: {0}"
-msgstr "無効なサイトURL: {0}"
+msgstr "无效的站点URL: {0}"
 
 #: src/metabase/public_settings.clj
 msgid "site-url is invalid; returning nil for now. Will be reset on next request."
-msgstr "サイトURLが無効です; 現在はnilを返しています。次のリクエストでリセットされます。"
+msgstr "网站的URL无效; 现在返回nil。 下次请求时将被重置。"
 
 #: src/metabase/pulse/render/body.clj
 msgid "More results have been included as a file attachment"
-msgstr "より多くの結果が添付ファイルとして含まれています"
+msgstr "其它的结果被放在附件中"
 
 #: src/metabase/pulse/render/body.clj
 msgid "This question has been included as a file attachment"
-msgstr "この質問は添付ファイルとして含まれています"
+msgstr "这个问题包含在附件中"
 
 #: src/metabase/pulse/render/body.clj
 msgid "We were unable to display this Pulse."
-msgstr "このパルスを表示することができませんでした。"
+msgstr "我们无法展示这个定时任务"
 
 #: src/metabase/pulse/render/body.clj
 msgid "Please view this card in Metabase."
-msgstr "このカードをMetabaseでご覧ください。"
+msgstr "请在metabase中查看这个卡片"
 
 #: src/metabase/pulse/render/body.clj
 msgid "An error occurred while displaying this card."
-msgstr "このカードの表示中にエラーが発生しました。"
+msgstr "展示卡片发生错误"
 
 #: src/metabase/query_processor.clj
+#, fuzzy
 msgid "Can only determine expected columns for MBQL queries."
-msgstr "MBQLクエリの予想列のみを決定できます。"
+msgstr "只能确定MBQL查询的预期列。"
 
 #: src/metabase/query_processor.clj
 msgid "No columns returned."
-msgstr "返される列はありません。"
+msgstr "没有列返回。"
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Warining: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
-msgstr "警告: `source-metadata`も含めない限り、明示的な` source-query`のフィールドを決定できません。"
+msgstr "警告：无法确定一个明确的‘source-query’（数据源查询）字段，除非您也包含'source-metadata'（数据源元数据）。"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
+#, fuzzy
 msgid "Cannot resolve {0}: Field does not exist, or its Table belongs to a different Database."
-msgstr "{0}を解決できません: フィールドが存在しないか、テーブルな異なるデータベースに属しています"
+msgstr "这里仔细看看[[this]]字段"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
+#, fuzzy
 msgid "Cannot resolve :field-literal inside :fk-> unless inside join with explicit :alias."
-msgstr ""
+msgstr "以下是对每个国家[[this]]的详细介绍"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
+#, fuzzy
 msgid "Cannot find Table ID for {0}"
-msgstr "{0}に対するテーブルIDが見つかりません"
+msgstr "找不到{0}的表ID"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "No matching info found."
-msgstr "合致する情報が見つかりません"
+msgstr "未找到匹配的值."
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Could not resolve {0}"
-msgstr "{0}を解決できませんでした"
+msgstr "无法解析 {0}"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
 msgid "Invalid fk-> clause: nowhere to add corresponding join."
-msgstr ""
+msgstr "无效的外键子句：无处添加相应的连接。"
 
 #: src/metabase/query_processor/middleware/add_implicit_joins.clj
+#, fuzzy
 msgid "{0} driver does not support foreign keys."
-msgstr "{0}ドライバーは外部キーをサポートしていません"
+msgstr "[[CreateDate]]按星期几"
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
 msgid "Cannot infer `:source-metadata` for source query with native source query without source metadata."
-msgstr ""
+msgstr "在没有数据源元数据的情况下，无法使用本机数据源查询推断数据源查询的元数据。"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Query processor error: number of columns returned by driver does not match results."
-msgstr "クエリプロセッサエラー: ドライバーから返された列の数が結果と一致しません。"
+msgstr "查询处理器错误：驱动程序返回的列数与结果不匹配。"
 
 #: src/metabase/query_processor/middleware/annotate.clj
+#, fuzzy
 msgid "Expected {0} columns, but first row of resuls has {1} columns."
-msgstr "{0}列の結果が期待されますが、結果の最初の行は{1}列有しています。"
+msgstr "看起来你的[[this]]有交易，所以这里看看它们"
 
 #: src/metabase/query_processor/middleware/annotate.clj
+#, fuzzy
 msgid "No expression named {0} found. Found: {1}"
-msgstr ""
+msgstr "这里仔细看看你的[[this]]每个州"
 
 #: src/metabase/query_processor/middleware/annotate.clj
+#, fuzzy
 msgid "Distinct values of {0}"
-msgstr "{0}の重複を除いた値"
+msgstr "[[CreateDate]]按月份的日期"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Average of {0}"
-msgstr "{0}の平均値"
+msgstr "{0}的平均值"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Sum of {0}"
-msgstr "{0}の合計値"
+msgstr "{0}的总和"
 
 #: src/metabase/query_processor/middleware/annotate.clj
+#, fuzzy
 msgid "SD of {0}"
-msgstr "{0}の標準偏差"
+msgstr "SD的{0}"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Min of {0}"
-msgstr "{0}の最小値"
+msgstr "{0}的最小值"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Max of {0}"
-msgstr "{0}の最大値"
+msgstr "{0}的最大值"
 
 #. until we have a way to generate good names for filters we'll just have to say 'matching condition' for now
 #: src/metabase/query_processor/middleware/annotate.clj
+#, fuzzy
 msgid "Sum of {0} matching condition"
-msgstr "条件に合致する{0}の合計値"
+msgstr "[[CreateTime]]按小时计算"
 
 #: src/metabase/query_processor/middleware/annotate.clj
+#, fuzzy
 msgid "Share of rows matching condition"
-msgstr ""
+msgstr "随着时间的推移，您可以仔细查看[[this]]"
 
 #: src/metabase/query_processor/middleware/annotate.clj
 msgid "Count of rows matching condition"
-msgstr "条件に合致する行の数"
+msgstr "符合条件的行数"
 
 #: src/metabase/query_processor/middleware/async.clj
+#, fuzzy
 msgid "Request already canceled, will not run synchronous QP code."
-msgstr "要求はすでにキャンセルされており、同期QPコードは実行されません。"
+msgstr "[[CreateDate]]按季度计算"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unexpectedly got `nil` Query Processor response."
-msgstr "予期せず `nil`クエリプロセッサの応答がありました。"
+msgstr "意外地得到了‘nil’的查询处理器响应。"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Got InterruptedException. Canceling query."
-msgstr "InterruptedException が発生しました。 クエリをキャンセルしています。"
+msgstr "发生中断异常. 正在取消查询."
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, exepected `catch-exceptions` middleware to handle it."
-msgstr ""
+msgstr "未处理的异常，期望“catch-exceptions”中间件来处理它。"
 
 #: src/metabase/query_processor/middleware/async.clj
+#, fuzzy
 msgid "Query timed out after %s"
-msgstr ""
+msgstr "查询在%s秒后超时"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
+#, fuzzy
 msgid "Creating new query thread pool for Database {0}"
-msgstr "データベース{0}に対する新しいクエリスレッドプールを作成中です"
+msgstr "{0}被自动更正为{1}"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Destroying query thread pool for Database {0}"
-msgstr "データベース{0}に対するクエリスレッドプールを削除中です"
+msgstr "正在清理数据库 {0} 的查询线程池"
 
 #: src/metabase/query_processor/middleware/async_wait.clj
 msgid "Request canceled, canceling pending query"
-msgstr "リクエストをキャンセルし、保留中のクエリをキャンセルします"
+msgstr "请求取消, 正在取消等待中的查询"
 
 #: src/metabase/query_processor/middleware/binning.clj
 msgid "Cannot update binned field: query is missing source-metadata"
-msgstr "ビニングされたフィールドを更新できません: クエリに source-metadata がありません"
+msgstr "无法更新分组字段: 查询缺少源字段的元数据"
 
 #: src/metabase/query_processor/middleware/binning.clj
+#, fuzzy
 msgid "Cannot update binned field: could not find matching source metadata for Field ''{0}''"
-msgstr "ビニングされたフィールドを更新できません: フィールド ''{0}''の一致するソースメタデータが見つかりませんでした"
+msgstr "等待{0}后没有响应。取消请求。"
 
 #: src/metabase/query_processor/middleware/cache.clj
+#, fuzzy
 msgid "Using query processor cache backend: {0}"
-msgstr ""
+msgstr "当前线程已经拥有{0}的许可，不会等待获取另一个"
 
 #: src/metabase/query_processor/middleware/expand_macros.clj
 msgid "Invalid metric: {0} reason: {1}"
-msgstr "無効なメトリック: {0} 理由: {1}"
+msgstr "无效指标: {0}, 原因: {1}"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unknown error"
-msgstr "未知のエラー"
+msgstr "未知错误"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Unexpected nil response from query processor."
-msgstr "クエリプロセッサからの予期しないnil応答。"
+msgstr "来自查询处理器的意外零（空）响应。"
 
 #: src/metabase/query_processor/middleware/process_userland_query.clj
 msgid "Query canceled"
-msgstr "クエリがキャンセルされました"
+msgstr "查询已取消"
 
 #: src/metabase/query_processor/middleware/resolve_driver.clj
 msgid "Unable to resolve driver for query: missing or invalid `:database` ID."
-msgstr "クエリのドライバーを解決できません: `:database` IDが見つからないか無効です。"
+msgstr "无法解析该查询的连接驱动: 缺少或无效的 `:database` 标识."
 
 #: src/metabase/query_processor/middleware/resolve_driver.clj
 msgid "Unable to resolve driver for query: Database {0} does not exist."
-msgstr "クエリに対するドライバーを解決することができません: データベース{0}が存在しません。"
+msgstr "无法解析该查询的连接驱动: 数据库 {0} 不存在."
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
+#, fuzzy
 msgid "Cannot use :fields :all in join against source query unless it has :source-metadata."
-msgstr ""
+msgstr "这是你最近的{0}张卡片："
 
 #: src/metabase/query_processor/middleware/resolve_joins.clj
+#, fuzzy
 msgid "Bad :joined-field clause: join with alias ''{0}'' does not exist. Found: {1}"
-msgstr ""
+msgstr "{0}数据库''{1}''同步/分析时间表已更改！"
 
 #: src/metabase/query_processor/middleware/resolve_source_table.clj
+#, fuzzy
 msgid "Invalid :source-table ''{0}'': should be resolved to a Table ID by now."
-msgstr ""
+msgstr "同步元数据是：''{0}''现在是：''{1}''"
 
 #: src/metabase/query_processor/store.clj
 msgid "Cannot store Tables or Fields before Database is stored."
-msgstr "データベースが保存される前にテーブルまたはフィールドを保存できません。"
+msgstr "在数据库保存之前无法保存表或字段。"
 
 #: src/metabase/query_processor/store.clj
 msgid "Attempting to fetch second Database. Queries can only reference one Database."
-msgstr "2番目のデータベースを取得しようとしています。 クエリは1つのデータベースのみを参照できます。"
+msgstr "试图获取另一个数据库的数据。 查询只能引用一个数据库。"
 
 #: src/metabase/query_processor/store.clj
 msgid "Failed to fetch Table {0}: Table does not exist, or belongs to a different Database."
-msgstr "テーブル{0}のフェッチに失敗しました: テーブルが存在しないか、テーブルが異なるデータベースに属しています。"
+msgstr "查询表{0}数据失败：表不存在，或者属于另一个数据库"
 
 #: src/metabase/query_processor/store.clj
 msgid "Failed to fetch Field {0}: Field does not exist, or belongs to a different Database."
-msgstr "フィールド{0}のフェッチに失敗しました: フィールドが存在しないか、フィールドが異なるデータベースに属しています。"
+msgstr "查询字段{0}失败：字段不存在，或者属于另一个数据库"
 
 #: src/metabase/routes/index.clj
 msgid "Failed to load template ''{0}''. Did you remember to build the Metabase frontend?"
-msgstr "テンプレート ''{0}''の読み込みに失敗しました。 Metabaseフロントエンドをビルドすることを覚えていましたか？"
+msgstr "加载模板{0}失败。你是否记得构建metabse的前端？"
 
 #: src/metabase/sample_data.clj
 msgid "Sample dataset DB file ''{0}'' cannot be found."
-msgstr "サンプルデータセットDBファイル ''{0}''が見つかりません。"
+msgstr "数据库样列文件\"{0}\"不存在"
 
 #: src/metabase/sample_data.clj
 msgid "Loading sample dataset..."
-msgstr "サンプルデータセットをロードしています..."
+msgstr "加载样本数据"
 
 #: src/metabase/sample_data.clj
 msgid "Failed to load sample dataset"
-msgstr "サンプルデータセットのロードに失敗しました"
+msgstr "加载样本数据失败"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Found new tables:"
-msgstr "新しいテーブルが見つかりました:"
+msgstr "发现新表"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Marking tables as inactive:"
-msgstr "テーブルを非アクティブとしてマークする:"
+msgstr "标记表格为非活跃状态"
 
 #: src/metabase/sync/sync_metadata/tables.clj
 msgid "Updating description for tables:"
-msgstr "テーブルの説明の更新:"
+msgstr "更新表格的描述"
 
 #: src/metabase/task.clj
 msgid "Rescheduling job {0}"
-msgstr ""
+msgstr "重新调度任务"
 
 #: src/metabase/task.clj
 msgid "Error rescheduling job"
-msgstr "ジョブのスケジュール変更エラー"
+msgstr "重新调度任务发生错误"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Starting Pulse Execution: {0}"
-msgstr "パルスの実行を始めています: {0}"
+msgstr "报告任务开始执行"
 
 #: src/metabase/task/send_pulses.clj
 msgid "Finished Pulse Execution: {0}"
-msgstr "パルスの実行が終了しました: {0}"
+msgstr "报告任务执行结束"
 
 #: src/metabase/task/sync_databases.clj
 msgid "Failed to schedule tasks for Database {0}"
-msgstr "データベース{0}に対する定期タスクのスケジューリングに失敗しました"
+msgstr "数据库任务调度失败"
 
 #: src/metabase/util/schema.clj
 msgid "All elements must be distinct."
-msgstr "全ての項目が一意でなければなりません"
+msgstr "所有元素必须唯一"
 
 #: 
 msgctxt "Modal for selecting columns in source data or when doing a join."
 msgid "Pick the columns you want to include"
-msgstr "含めたい列を選ぶ"
+msgstr "选择需要包含的列"
 
 #: frontend/src/metabase/components/DatabaseDetailsForm.jsx:320
 msgid "When this is on, Metabase will automatically run queries when users do simple explorations with the Summarize and Filter buttons when viewing a table or chart. You can turn this off if querying this database is slow. This setting doesn’t affect drill-throughs or SQL queries."
-msgstr "これを有効にすることにより、ユーザーがチャートやテーブルを見るときに要約やフィルターボタンを利用して簡単な探索を行った場合に、Metabaseが自動的にクエリを実行するようになります。このデータベースへのクエリが遅い場合は、この設定を無効にすることができます。この設定によってドリルスルーやSQLクエリが影響を受けることはありません。"
+msgstr "这个选项开启时，当用户在查看表格或图表时使用“汇总”和“过滤”按钮进行简单数据探索时，Metabase将自动运行查询。 如果查询此数据库的速度很慢，可以将该选项关闭。 此设置不会影响数据钻探或SQL查询。"
 
 #: frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx:97
 msgid "Change join type"
-msgstr "JOINの形式を変える"
+msgstr "更改join类型"
 
 #: src/metabase/driver/sql/util.clj
 msgid "Don't know how to alias {0}, expected an Identifier."
-msgstr ""
+msgstr "不知道如何重命名{0}，缺少标识"
 
 #: src/metabase/integrations/common.clj
 msgid "Error adding User {0} to Group {1}"
-msgstr "ユーザ{0}をグループ{1}に追加する際にエラーが発生しました"
+msgstr "添加用户{0}到组{1}失败"
 
 #. now rehumanize all the Tables and Fields using the new strategy.
 #. TODO: Should we do this in a background thread because it is potentially slow?
 #: src/metabase/models/humanization.clj
 msgid "Changing Table & Field names humanization strategy from ''{0}'' to ''{1}''"
-msgstr ""
+msgstr "更改表和字段名字策略从\"{0}\"到\"{1}\""
 
 #: src/metabase/query_processor.clj
 msgid "Infinite loop detected: recursively preprocessed query {0} times."
-msgstr "無限ループが検知されました: クエリに対する再帰的な前処理が{0}回行われました。"
+msgstr "无限循环：递归查询了{0}次了"
 
 #: src/metabase/query_processor/middleware/add_implicit_clauses.clj
 msgid "Warning: cannot determine fields for an explicit `source-query` unless you also include `source-metadata`."
-msgstr "警告: `source-metadata`も含めない限り、明示的な` source-query`のフィールドを決定できません。"
+msgstr "警告：如果你不提供`source-metadata`，无法决定哪个字段执行`source-query`"
 
 #: src/metabase/query_processor/middleware/add_source_metadata.clj
 msgid "Error determining expected columns for query"
-msgstr "クエリの予想列の決定エラー"
+msgstr "确定查询的预期列时出错"
 
 #: src/metabase/query_processor/middleware/async.clj
 msgid "Unhandled exception, expected `catch-exceptions` middleware to handle it."
-msgstr ""
+msgstr "无法处理的异常,  希望`catch-exceptions`能够处理它."
 


### PR DESCRIPTION
Persian (fa.po) and Chinese (zh.po) are back to 100% translated on [POEditor](https://poeditor.com/projects/view?order=trans_desc&id=200535), so this adds them back in to 0.33.3. It also updates strings for our other included languages.