### PR TITLE
Fix bugs with stacked charts and log scales

### DIFF
--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -401,15 +401,22 @@ export function applyChartYAxis(chart, series, yExtent, axisName) {
       // TODO: right axis?
       chart.elasticY(true);
     } else {
-      if (
-        !(
-          (yExtent[0] < 0 && yExtent[1] < 0) ||
-          (yExtent[0] > 0 && yExtent[1] > 0)
-        )
-      ) {
+      const [min, max] = yExtent;
+      if (!((min < 0 && max < 0) || (min > 0 && max > 0))) {
         throw "Y-axis must not cross 0 when using log scale.";
       }
-      scale.domain(yExtent);
+
+      // With chart.elasticY, the y axis adjusts to show the beginning of the
+      // bars. If there are any bar series, we try to do the same with the log
+      // scale. We start at ±1 because things get wacky in (0, ±1].
+      const noBarSeries = series.every(s => s.card.display !== "bar");
+      if (noBarSeries) {
+        scale.domain([min, max]);
+      } else if (min < 0) {
+        scale.domain([min, -1]);
+      } else {
+        scale.domain([1, max]);
+      }
     }
     axis.scale(scale);
   } else {

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer-bar.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer-bar.unit.spec.js
@@ -256,6 +256,22 @@ describe("LineAreaBarRenderer-bar", () => {
     const tick = element.querySelector(".axis.x .tick text");
     expect(tick.textContent).toEqual("(empty)");
   });
+
+  it(`should render a stacked chart on a logarithmic y scale`, async () => {
+    const settings = {
+      "stackable.stack_type": "stacked",
+      "graph.y_axis.scale": "log",
+    };
+    renderLineAreaBar(element, [
+      MainSeries("bar", settings, { value: 100 }),
+      ExtraSeries(1000),
+    ]);
+    const ticks = qsa(".axis.y .tick text").map(n => n.textContent);
+    const lastTickValue = parseInt(ticks[ticks.length - 1]);
+    // if there are no ticks above 500, we're incorrectly using only the
+    // first series to determine the y axis domain
+    expect(lastTickValue > 500).toBe(true);
+  });
 });
 
 function getDataKeyValues(hover) {

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.unit.spec.js
@@ -341,7 +341,6 @@ describe("LineAreaBarRenderer", () => {
 
       const {
         groups,
-        dimension,
         yExtents,
       } = getDimensionsAndGroupsAndUpdateSeriesDisplayNames(props, data, warn);
 
@@ -360,7 +359,6 @@ describe("LineAreaBarRenderer", () => {
 
       const {
         groups,
-        dimension,
         yExtents,
       } = getDimensionsAndGroupsAndUpdateSeriesDisplayNames(props, data, warn);
 

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.unit.spec.js
@@ -14,7 +14,9 @@ import {
 } from "../__support__/visualizations";
 
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
-import lineAreaBarRenderer from "metabase/visualizations/lib/LineAreaBarRenderer";
+import lineAreaBarRenderer, {
+  getDimensionsAndGroupsAndUpdateSeriesDisplayNames,
+} from "metabase/visualizations/lib/LineAreaBarRenderer";
 
 const formatTz = offset =>
   (offset < 0 ? "-" : "+") + d3.format("02d")(Math.abs(offset)) + ":00";
@@ -314,6 +316,59 @@ describe("LineAreaBarRenderer", () => {
     });
   });
 
+  describe("getDimensionsAndGroupsAndUpdateSeriesDisplayNames", () => {
+    it("should group a single row", () => {
+      const props = { settings: {}, chartType: "bar" };
+      const data = [[["a", 1]]];
+      const warn = jest.fn();
+
+      const {
+        groups,
+        dimension,
+        yExtents,
+      } = getDimensionsAndGroupsAndUpdateSeriesDisplayNames(props, data, warn);
+
+      expect(warn).not.toBeCalled();
+      expect(groups[0][0].all()[0]).toEqual({ key: "a", value: 1 });
+      expect(dimension.top(1)).toEqual([["a", 1]]);
+      expect(yExtents).toEqual([[1, 1]]);
+    });
+
+    it("should group multiple series", () => {
+      const props = { settings: {}, chartType: "bar" };
+      const data = [[["a", 1], ["b", 2]], [["a", 2], ["b", 3]]];
+      const warn = jest.fn();
+
+      const {
+        groups,
+        dimension,
+        yExtents,
+      } = getDimensionsAndGroupsAndUpdateSeriesDisplayNames(props, data, warn);
+
+      expect(warn).not.toBeCalled();
+      expect(groups.length).toEqual(2);
+      expect(yExtents).toEqual([[1, 2], [2, 3]]);
+    });
+
+    it("should group stacked series", () => {
+      const props = {
+        settings: { "stackable.stack_type": "stacked" },
+        chartType: "bar",
+      };
+      const data = [[["a", 1], ["b", 2]], [["a", 2], ["b", 3]]];
+      const warn = jest.fn();
+
+      const {
+        groups,
+        dimension,
+        yExtents,
+      } = getDimensionsAndGroupsAndUpdateSeriesDisplayNames(props, data, warn);
+
+      expect(warn).not.toBeCalled();
+      expect(groups.length).toEqual(1);
+      expect(yExtents).toEqual([[3, 5]]);
+    });
+  });
   // querySelector shortcut
   const qs = selector => element.querySelector(selector);
 


### PR DESCRIPTION
This PR fixes two separate but connected bugs:
1. We didn't correctly compute yExtents for stacked charts.
The new code sums up the individual values to get the total height of each bar.
2. We didn't show the bottom of bars displayed on a log scale.
Now we explicitly pin the y range to start at 1 (or -1) when any series is a bar chart.

Incorrectly computing yExtents was mostly benign because for most charts we use dc.js's chart.elasticY to provide y axis auto scaling. Only charts with a log scale use the auto scaling logic in our code.

Resolves #10384
