### PR TITLE
Change setCardAndRun to onChangeCardAndRun in LeafletMap

### DIFF
--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -131,7 +131,7 @@ export default class LeafletMap extends Component {
         },
       ],
       settings,
-      setCardAndRun,
+      onChangeCardAndRun,
     } = this.props;
 
     const latitudeColumn = _.findWhere(cols, {
@@ -141,9 +141,13 @@ export default class LeafletMap extends Component {
       name: settings["map.longitude_column"],
     });
 
-    setCardAndRun(
-      updateLatLonFilter(card, latitudeColumn, longitudeColumn, bounds),
+    const nextCard = updateLatLonFilter(
+      card,
+      latitudeColumn,
+      longitudeColumn,
+      bounds,
     );
+    onChangeCardAndRun({ nextCard });
 
     this.props.onFiltering(false);
   };


### PR DESCRIPTION
Resolves #9314

@tlrobinson how does this change look? I'm not sure of the history with these functions, but I saw that `setCardAndRun` was gone and `onChangeCardAndRun` was there. I switched it over and it seemed to work. 🤷‍♂ 