### PR TITLE
fix the problem with downloading a dep that's been plaguing CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ jobs:
       - restore-fe-deps-cache
       - run:
           name: Install gettext
-          command: sudo apt-get install gettext
+          command: sudo apt-get update && sudo apt-get install gettext
       - run:
           name: Verify i18n .po files
           command: ./bin/i18n/build-translation-resources


### PR DESCRIPTION
This fixes the issue with the `verify-i18n-files` CI step 