### PR TITLE
Test tweaks

### DIFF
--- a/src/metabase/models/permissions_group.clj
+++ b/src/metabase/models/permissions_group.clj
@@ -9,6 +9,7 @@
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase.models.setting :as setting]
+            [metabase.plugins.classloader :as classloader]
             [metabase.util :as u]
             [metabase.util.i18n :as ui18n :refer [trs tru]]
             [toucan
@@ -82,6 +83,7 @@
   (db/delete! 'Permissions                 :group_id id)
   (db/delete! 'PermissionsGroupMembership  :group_id id)
   ;; Remove from LDAP mappings
+  (classloader/require 'metabase.integrations.ldap)
   (setting/set-json! :ldap-group-mappings
     (when-let [mappings (setting/get-json :ldap-group-mappings)]
       (zipmap (keys mappings)

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -334,6 +334,7 @@
 
 (defn set-json!
   "Serialize `new-value` for `setting-or-name` as a JSON string and save it."
+  {:style/indent 1}
   [setting-or-name new-value]
   (set-string! setting-or-name (some-> new-value json/generate-string)))
 

--- a/test/expectations.clj
+++ b/test/expectations.clj
@@ -116,13 +116,15 @@
 
 (defmacro ^:deprecated expect
   "Simple macro that simulates converts an Expectations-style `expect` form into a `clojure.test` `deftest` form."
-  {:arglists '([actual] [actual expected])}
+  {:arglists '([actual] [actual expected] [test-name actual expected])}
   ([actual]
    `(expect ::truthy ~actual))
 
   ([expected actual]
-   (let [test-name (symbol (format "expect-%d" (hash &form)))]
-     `(t/deftest ~test-name
-        (t/testing (format ~(str (name (ns-name *ns*)) ":%d") (:line (meta #'~test-name)))
-          (t/is
-           (~'expect= ~expected ~actual)))))))
+   `(expect ~(symbol (format "expect-%d" (hash &form))) ~expected ~actual))
+
+  ([test-name expected actual]
+   `(t/deftest ~test-name
+      (t/testing (format ~(str (name (ns-name *ns*)) ":%d") (:line (meta #'~test-name)))
+        (t/is
+         (~'expect= ~expected ~actual))))))

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -18,8 +18,11 @@
             [metabase.test.util :as tu]
             [metabase.test.util.log :as tu.log]
             [toucan.db :as db]
+            [metabase.test.fixtures :as fixtures]
             [toucan.util.test :as tt])
   (:import java.util.UUID))
+
+(use-fixtures :once (fixtures/initialize :web-server))
 
 ;; ## POST /api/session
 ;; Test that we can login

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -13,12 +13,13 @@
             [metabase.models
              [session :refer [Session]]
              [user :refer [User]]]
+            [metabase.test
+             [fixtures :as fixtures]
+             [util :as tu]]
             [metabase.test.data.users :as test-users]
             [metabase.test.integrations.ldap :as ldap.test]
-            [metabase.test.util :as tu]
             [metabase.test.util.log :as tu.log]
             [toucan.db :as db]
-            [metabase.test.fixtures :as fixtures]
             [toucan.util.test :as tt])
   (:import java.util.UUID))
 

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -15,13 +15,17 @@
              [permissions-group :as group :refer [PermissionsGroup]]
              [pulse :refer [Pulse]]
              [user :refer [User]]]
+            [metabase.test
+             [fixtures :as fixtures]
+             [util :as tu]]
             [metabase.test.data.users :as test-users]
-            [metabase.test.util :as tu]
             [metabase.util :as u]
             [toucan
              [db :as db]
              [hydrate :refer [hydrate]]]
             [toucan.util.test :as tt]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (defn force-create-personal-collections!
   "Force the creation of the Personal Collections for our various test users. They are eventually going to get

--- a/test/metabase/models/dependency_test.clj
+++ b/test/metabase/models/dependency_test.clj
@@ -1,12 +1,16 @@
 (ns metabase.models.dependency-test
   (:require [expectations :refer [expect]]
             [metabase.models.dependency :as dep :refer [Dependency]]
+            [clojure.test :refer :all]
+            [metabase.test.fixtures :as fixtures]
             [metabase.test.util :as tu]
             [metabase.util.date :as du]
             [toucan
              [db :as db]
              [models :as models]]
             [toucan.util.test :as tt]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (models/defmodel ^:private Mock :mock)
 

--- a/test/metabase/models/dependency_test.clj
+++ b/test/metabase/models/dependency_test.clj
@@ -1,9 +1,10 @@
 (ns metabase.models.dependency-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
+            [expectations :refer [expect]]
             [metabase.models.dependency :as dep :refer [Dependency]]
-            [clojure.test :refer :all]
-            [metabase.test.fixtures :as fixtures]
-            [metabase.test.util :as tu]
+            [metabase.test
+             [fixtures :as fixtures]
+             [util :as tu]]
             [metabase.util.date :as du]
             [toucan
              [db :as db]

--- a/test/metabase/task_test.clj
+++ b/test/metabase/task_test.clj
@@ -1,13 +1,18 @@
 (ns metabase.task-test
-  (:require [clojurewerkz.quartzite
+  (:require [clojure.test :refer :all]
+            [clojurewerkz.quartzite
              [jobs :as jobs]
              [scheduler :as qs]
              [triggers :as triggers]]
             [clojurewerkz.quartzite.schedule.cron :as cron]
             [expectations :refer [expect]]
             [metabase.task :as task]
-            [metabase.test.util :as tu])
+            [metabase.test
+             [fixtures :as fixtures]
+             [util :as tu]])
   (:import [org.quartz CronTrigger JobDetail]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 ;; make sure we attempt to reschedule tasks so changes made in source are propogated to JDBC backend
 

--- a/test/metabase/test/fixtures.clj
+++ b/test/metabase/test/fixtures.clj
@@ -1,7 +1,9 @@
 (ns metabase.test.fixtures
   (:require [metabase.test.initialize :as initialize]))
 
-(defn initialize [& what]
+(defn initialize
+  {:arglists (list (vec (cons '& (disj (set (keys (methods initialize/initialize-if-needed!))) :many))))}
+  [& what]
   (fn [f]
     (apply initialize/initialize-if-needed! what)
     (f)))


### PR DESCRIPTION
*  Add explicit `use-fixtures` statements in some namespaces so running tests against just those namespaces works as expected
*  Add locking to the API test client authentication process so multiple tests can be run in parallel (theoretically)
