### PR TITLE
Cover visualization with "mouse blocker" if dashboard is being edited

### DIFF
--- a/frontend/src/metabase/visualizations/components/CardRenderer.jsx
+++ b/frontend/src/metabase/visualizations/components/CardRenderer.jsx
@@ -61,7 +61,8 @@ export default class CardRenderer extends Component {
   }
 
   renderChart() {
-    if (this.props.width == null || this.props.height == null) {
+    const { width, height, isDashboard, isEditing, isSettings } = this.props;
+    if (width == null || height == null) {
       return;
     }
 
@@ -79,9 +80,10 @@ export default class CardRenderer extends Component {
     const element = document.createElement("div");
     parent.appendChild(element);
 
-    if (this.props.isDashboard && this.props.isEditing) {
+    if (isDashboard && isEditing && !isSettings) {
       // If this card is a dashboard that's currently being edited, we cover the
-      // content to prevent interaction with the chart.
+      // content to prevent interaction with the chart. The !isSettings
+      // exception is to handle modals that appear above a dashboard.
       const mouseBlocker = document.createElement("div");
       mouseBlocker.classList = "spread";
       mouseBlocker.style = "pointer-events: all;";

--- a/frontend/src/metabase/visualizations/components/CardRenderer.jsx
+++ b/frontend/src/metabase/visualizations/components/CardRenderer.jsx
@@ -25,6 +25,8 @@ export default class CardRenderer extends Component {
     series: PropTypes.array.isRequired,
     renderer: PropTypes.func.isRequired,
     onRenderError: PropTypes.func.isRequired,
+    isEditing: PropTypes.bool,
+    isDashboard: PropTypes.bool,
   };
 
   _deregister: ?DeregisterFunction;
@@ -69,14 +71,22 @@ export default class CardRenderer extends Component {
     this._deregisterChart();
 
     // reset the DOM:
-    let element = parent.firstChild;
-    if (element) {
-      parent.removeChild(element);
+    for (const child of parent.children) {
+      parent.removeChild(child);
     }
 
     // create a new container element
-    element = document.createElement("div");
+    const element = document.createElement("div");
     parent.appendChild(element);
+
+    if (this.props.isDashboard && this.props.isEditing) {
+      // If this card is a dashboard that's currently being edited, we cover the
+      // content to prevent interaction with the chart.
+      const mouseBlocker = document.createElement("div");
+      mouseBlocker.classList = "spread";
+      mouseBlocker.style = "pointer-events: all;";
+      parent.appendChild(mouseBlocker);
+    }
 
     try {
       this._deregister = this.props.renderer(element, this.props);

--- a/frontend/src/metabase/visualizations/components/CardRenderer.jsx
+++ b/frontend/src/metabase/visualizations/components/CardRenderer.jsx
@@ -85,8 +85,8 @@ export default class CardRenderer extends Component {
       // content to prevent interaction with the chart. The !isSettings
       // exception is to handle modals that appear above a dashboard.
       const mouseBlocker = document.createElement("div");
-      mouseBlocker.classList = "spread";
-      mouseBlocker.style = "pointer-events: all;";
+      mouseBlocker.classList.add("spread");
+      mouseBlocker.style.setProperty("pointer-events", "all");
       parent.appendChild(mouseBlocker);
     }
 


### PR DESCRIPTION
Resolves #6888, Resolves #9445

This PR adds a div to `CardRenderer` that blocks interaction with the visualization. The div appears whenever the card is in a dashboard that's being edited but not in settings.

@tlrobinson, I think this is a different approach than [you suggested](https://github.com/metabase/metabase/issues/9445#issuecomment-499222017). It felt like the visualizations shouldn't need to be aware of the dashboard's editing state, so rather than explicitly disabling brushing I just block everything. Thoughts?

