### PR TITLE
Use pixel width rather than grid width for compact formatting

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
@@ -33,6 +33,10 @@ function legacyScalarSettingsToFormatOptions(settings) {
     .value();
 }
 
+// used below to determine whether we show compact formatting
+const COMPACT_MAX_WIDTH = 250;
+const COMPACT_MIN_LENGTH = 6;
+
 // Scalar visualization shows a single number
 // Multiseries Scalar is transformed to a Funnel
 export default class Scalar extends Component {
@@ -176,10 +180,10 @@ export default class Scalar extends Component {
       ],
       isDashboard,
       onChangeCardAndRun,
-      gridSize,
       settings,
       visualizationIsClickable,
       onVisualizationClick,
+      width,
     } = this.props;
 
     const columnIndex = this._getColumnIndex(cols, settings);
@@ -198,8 +202,10 @@ export default class Scalar extends Component {
       compact: true,
     });
 
+    // use the compact version of formatting if the component is narrower than
+    // the cutoff and the formatted value is longer than the cutoff
     const displayCompact =
-      fullScalarValue.length > 6 && gridSize && gridSize.width < 4;
+      fullScalarValue.length > COMPACT_MIN_LENGTH && width < COMPACT_MAX_WIDTH;
     const displayValue = displayCompact ? compactScalarValue : fullScalarValue;
 
     const clicked = { value, column };

--- a/frontend/test/metabase/visualizations/visualizations/Scalar.unit.spec.js
+++ b/frontend/test/metabase/visualizations/visualizations/Scalar.unit.spec.js
@@ -36,7 +36,7 @@ describe("MetricForm", () => {
         series={series(12345)}
         settings={settings}
         visualizationIsClickable={() => false}
-        gridSize={{ width: 3 }}
+        width={230}
       />,
     );
     getByText("12,345"); // with compact formatting, we'd have 1
@@ -48,7 +48,7 @@ describe("MetricForm", () => {
         series={series(12345.6)}
         settings={settings}
         visualizationIsClickable={() => false}
-        gridSize={{ width: 3 }}
+        width={230}
       />,
     );
     getByText("12.3k");


### PR DESCRIPTION
Resolves #10716

Previously we switched scalars to compact formatting when the occupied three horizontal grid cells and the non-compact value was more than 6 characters. This breaks down on narrower screens since we extend each card to full width and don't set the grid dimensions. As the issue points out, mobiles are narrow and should also show compact formatting.

The approach makes sense in that too little pixel width is what makes the text feel cramped. The major downside is that the formatting can now change as dashboard viewers resize their windows. 

I pretty arbitrarily picked the 250px cutoff.

Above the cutoff:
![image](https://user-images.githubusercontent.com/691495/65191701-dc495180-da42-11e9-9cdd-ba59ca56ec23.png)

Below the cutoff:
![image](https://user-images.githubusercontent.com/691495/65191736-f420d580-da42-11e9-81b0-4c5a06167c8a.png)
