### PR TITLE
Improve query builder startup latency

### DIFF
--- a/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
+++ b/frontend/src/metabase/new_query/containers/NewQueryOptions.jsx
@@ -96,7 +96,7 @@ export class NewQueryOptions extends Component {
 }
 
 export default compose(
-  Database.loadList(),
+  Database.loadList({ query: { include_tables: true, include_cards: true } }),
   connect(
     mapStateToProps,
     null,

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -308,7 +308,7 @@ export const initializeQB = (location, params) => {
 
     // always start the QB by loading up the databases for the application
     try {
-      await dispatch(
+      dispatch(
         Databases.actions.fetchList({
           include_tables: true,
           include_cards: true,


### PR DESCRIPTION
`/api/database?include_tables=true&include_cards=true` can be slow to load if you have many saved questions / tables. Ideally we wouldn't load as much data up front, but that's a larger change described in #10163

This PR does two things to improve the situation in the short term:

1. to improve **new question** latency: in `/question/new` we optimistically start loading `/api/database?include_tables=true&include_cards=true` to reduce the latency when loading the actual query builder (which loads the same thing)
2. to improve **saved question** latency: in the query builder don't block `initializeQB` on loading `/api/database?include_tables=true&include_cards=true`, which allows saved questions (including query itself) to begin loading immediately

I think we can consider this resolving #10938 since the larger change is described by #10163