### PR TITLE
call onResize during onResizeStart to set state

### DIFF
--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
@@ -112,6 +112,7 @@ export default class GridLayout extends Component {
 
   onResizeStart(i, { size }) {
     this.setState({ resizing: true });
+    this.onResize(i, { size });
   }
 
   onResize(i, { size }) {


### PR DESCRIPTION
Resolves #10949 

`onResizeEnd` assumes `placeholderLayout` is set in state. That was only getting set on drag events, so if you clicked and released the UI would break.

The fix here is to call `onResize` from `onResizeStart` to ensure `placeholderLayout` is alway set. 