### PR TITLE
Fix filtering by month-of-year and month in MongoDB; lots of new tests

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -242,7 +242,7 @@
                      (stringify format-string value))
                     ([format-string v]
                      {:___date (du/format-date format-string v)}))
-        extract   (u/rpartial du/date-extract value)]
+        extract   #(du/date-extract % value)]
     (case (or unit :default)
       :default         value
       :minute          (stringify "yyyy-MM-dd'T'HH:mm:00")
@@ -256,10 +256,10 @@
       :week            (stringify "yyyy-MM-dd" (du/date-trunc :week value))
       :week-of-year    (extract :week-of-year)
       :month           (stringify "yyyy-MM")
-      :month-of-year   (extract :month)
+      :month-of-year   (extract :month-of-year)
       :quarter         (stringify "yyyy-MM" (du/date-trunc :quarter value))
       :quarter-of-year (extract :quarter-of-year)
-      :year            (stringify "yyyy-01-01"))))
+      :year            (stringify "yyyy"))))
 
 
 ;; TODO - where's the part where we handle include-current?

--- a/project.clj
+++ b/project.clj
@@ -244,7 +244,8 @@
     {:include-drivers :all}]
 
    :repl
-   [:include-all-drivers]
+   [:include-all-drivers
+    {:jvm-opts ["-Duser.timezone=UTC"]}] ; so running the tests doesn't give you different answers
 
    :bikeshed
    [:include-all-drivers

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -46,26 +46,43 @@
   [feature]
   (set/difference non-timeseries-drivers (non-timeseries-drivers-with-feature feature)))
 
-;; TODO - should be renamed to `expect-with-non-timeseries-drivers`
-(defmacro expect-with-non-timeseries-dbs
+(defmacro ^:deprecated expect-with-non-timeseries-dbs
+  "DEPRECATED — Use `deftest` + `test-drivers` + `non-timeseries-drivers` instead.
+
+    (deftest my-test
+      (datasets/test-drivers qp.test/non-timeseries-drivers
+        (is (= ...))))"
   {:style/indent 0}
   [expected actual]
   `(datasets/expect-with-drivers non-timeseries-drivers
      ~expected
      ~actual))
 
-(defmacro expect-with-non-timeseries-dbs-except
+(defn non-timeseries-drivers-except
+  "Return the set of all drivers except Druid, Google Analytics, and those in `excluded-drivers`."
+  [excluded-drivers]
+  (set/difference non-timeseries-drivers (set excluded-drivers)))
+
+(defmacro ^:deprecated expect-with-non-timeseries-dbs-except
+  "DEPRECATED — Use `deftest` + `test-drivers` + `non-timeseries-drivers-except` instead.
+
+    (deftest my-test
+      (datasets/test-drivers (qp.test/non-timeseries-drivers-except #{:snowflake})
+        (is (= ...))))"
   {:style/indent 1}
-  [excluded-engines expected actual]
-  `(datasets/expect-with-drivers (set/difference non-timeseries-drivers (set ~excluded-engines))
+  [excluded-drivers expected actual]
+  `(datasets/expect-with-drivers (non-timeseries-drivers-except ~excluded-drivers)
      ~expected
      ~actual))
 
 (defmacro ^:deprecated qp-expect-with-all-drivers
   "Wraps `expected` form in the 'wrapped' query results (includes `:status` and `:row_count`.)
 
-  DEPRECATED -- If you don't care about `:status` and `:row_count` (you usually don't) use `qp.test/rows` or
-  `qp.test/rows-and-columns` instead."
+  DEPRECATED — If you don't care about `:status` and `:row_count` (you usually don't) use `qp.test/rows` or
+  `qp.test/rows-and-columns` instead.
+
+  DEPRECATED x2 - You also shouldn't use this because it ultimately uses `expectations`-style `expect` -- see
+  docstring for `expect-with-non-timeseries-dbs for suggested alternative."
   {:style/indent 0}
   [data query-form & post-process-fns]
   `(expect-with-non-timeseries-dbs

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -17,9 +17,12 @@
   (:require [clj-time
              [core :as time]
              [format :as tformat]]
+            [clojure
+             [string :as str]
+             [test :refer :all]]
             [metabase
              [driver :as driver]
-             [query-processor-test :as qp.test :refer :all]
+             [query-processor-test :as qp.test]
              [util :as u]]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.test
@@ -46,7 +49,8 @@
             {:aggregation [[:count]]
              :breakout    [[:datetime-field $timestamp unit]]
              :limit       10}))
-        rows (qp.test/format-rows-by [->long-if-number int])))
+        qp.test/rows
+        (qp.test/format-rows-by [->long-if-number int])))
   ([unit, ^DateTimeZone tz]
    (tu/with-temporary-setting-values [report-timezone (.getID tz)]
      (sad-toucan-incidents-with-bucketing unit))))
@@ -127,7 +131,7 @@
     (sad-toucan-result (source-date-formatter pacific-tz) (result-date-formatter pacific-tz))
 
     ;; When the reporting timezone is applied, the same datetime value is returned, but set in the pacific timezone
-    (supports-report-timezone? driver/*driver*)
+    (qp.test/supports-report-timezone? driver/*driver*)
     (sad-toucan-result (source-date-formatter utc-tz) (result-date-formatter pacific-tz))
 
     ;; Databases that don't support report timezone will always return the time using the JVM's timezone setting Our
@@ -147,7 +151,7 @@
     (sad-toucan-result (source-date-formatter eastern-tz) (result-date-formatter eastern-tz))
 
     ;; The time instant is the same as UTC (or pacific) but should be offset by the eastern timezone
-    (supports-report-timezone? driver/*driver*)
+    (qp.test/supports-report-timezone? driver/*driver*)
     (sad-toucan-result (source-date-formatter utc-tz) (result-date-formatter eastern-tz))
 
     ;; The change in report timezone has no affect on this group
@@ -171,7 +175,7 @@
     (sad-toucan-result (source-date-formatter eastern-tz) (result-date-formatter eastern-tz))
 
     ;; The JVM timezone should have no impact on a database that uses a report timezone
-    (supports-report-timezone? driver/*driver*)
+    (qp.test/supports-report-timezone? driver/*driver*)
     (sad-toucan-result (source-date-formatter utc-tz) (result-date-formatter eastern-tz))
 
     :else
@@ -195,7 +199,7 @@
     (qp.test/tz-shifted-driver-bug? driver/*driver*)
     (sad-toucan-result (source-date-formatter pacific-tz) (result-date-formatter pacific-tz))
 
-    (supports-report-timezone? driver/*driver*)
+    (qp.test/supports-report-timezone? driver/*driver*)
     (sad-toucan-result (source-date-formatter utc-tz) (result-date-formatter pacific-tz))
 
     :else
@@ -259,7 +263,7 @@
     (qp.test/tz-shifted-driver-bug? driver/*driver*)
     (results-by-hour (source-date-formatter pacific-tz) (result-date-formatter pacific-tz))
 
-    (supports-report-timezone? driver/*driver*)
+    (qp.test/supports-report-timezone? driver/*driver*)
     (results-by-hour (source-date-formatter utc-tz) (result-date-formatter pacific-tz))
 
     :else
@@ -279,7 +283,7 @@
 ;; UTC results (i.e. pacific is 7 hours back of UTC at that time)
 (qp.test/expect-with-non-timeseries-dbs
   (if (and (not (qp.test/tz-shifted-driver-bug? driver/*driver*))
-           (supports-report-timezone? driver/*driver*))
+           (qp.test/supports-report-timezone? driver/*driver*))
     [[0 8] [1 9] [2 7] [3 10] [4 10] [5 9] [6 6] [7 5] [8 7] [9 7]]
     [[0 13] [1 8] [2 4] [3 7] [4 5] [5 13] [6 10] [7 8] [8 9] [9 7]])
   (sad-toucan-incidents-with-bucketing :hour-of-day pacific-tz))
@@ -313,7 +317,7 @@
                          [:datetime-field $timestamp :default]
                          start-date-str
                          end-date-str]}))
-      rows
+      qp.test/rows
       first
       second
       (or 0)))
@@ -387,7 +391,7 @@
                     (result-date-formatter pacific-tz)
                     [6 10 4 9 9 8 8 9 7 9])
 
-    (supports-report-timezone? driver/*driver*)
+    (qp.test/supports-report-timezone? driver/*driver*)
     (results-by-day (tformat/with-zone date-formatter-without-time pacific-tz)
                     (result-date-formatter pacific-tz)
                     [8 9 9 4 11 8 6 10 6 10])
@@ -420,7 +424,7 @@
                     (result-date-formatter eastern-tz)
                     [6 10 4 9 9 8 8 9 7 9])
 
-    (supports-report-timezone? driver/*driver*)
+    (qp.test/supports-report-timezone? driver/*driver*)
     (results-by-day (tformat/with-zone date-formatter-without-time eastern-tz)
                     (result-date-formatter eastern-tz)
                     [7 9 7 6 12 6 7 9 8 10])
@@ -453,7 +457,7 @@
                     (result-date-formatter pacific-tz)
                     [6 10 4 9 9 8 8 9 7 9])
 
-    (supports-report-timezone? driver/*driver*)
+    (qp.test/supports-report-timezone? driver/*driver*)
     (results-by-day (tformat/with-zone date-formatter-without-time pacific-tz)
                     (result-date-formatter pacific-tz)
                     [8 9 9 4 11 8 6 10 6 10])
@@ -474,7 +478,7 @@
 
 (qp.test/expect-with-non-timeseries-dbs
   (if (and (not (qp.test/tz-shifted-driver-bug? driver/*driver*))
-           (supports-report-timezone? driver/*driver*))
+           (qp.test/supports-report-timezone? driver/*driver*))
     [[1 29] [2 36] [3 33] [4 29] [5 13] [6 38] [7 22]]
     [[1 28] [2 38] [3 29] [4 27] [5 24] [6 30] [7 24]])
   (sad-toucan-incidents-with-bucketing :day-of-week pacific-tz))
@@ -491,7 +495,7 @@
 
 (qp.test/expect-with-non-timeseries-dbs
   (if (and (not (qp.test/tz-shifted-driver-bug? driver/*driver*))
-           (supports-report-timezone? driver/*driver*))
+           (qp.test/supports-report-timezone? driver/*driver*))
     [[1 8] [2 9] [3 9] [4 4] [5 11] [6 8] [7 6] [8 10] [9 6] [10 10]]
     [[1 6] [2 10] [3 4] [4 9] [5  9] [6 8] [7 8] [8  9] [9 7] [10  9]])
   (sad-toucan-incidents-with-bucketing :day-of-month pacific-tz))
@@ -508,7 +512,7 @@
 
 (qp.test/expect-with-non-timeseries-dbs
   (if (and (not (qp.test/tz-shifted-driver-bug? driver/*driver*))
-           (supports-report-timezone? driver/*driver*))
+           (qp.test/supports-report-timezone? driver/*driver*))
     [[152 8] [153 9] [154 9] [155 4] [156 11] [157 8] [158 6] [159 10] [160 6] [161 10]]
     [[152 6] [153 10] [154 4] [155 9] [156  9] [157  8] [158 8] [159  9] [160 7] [161  9]])
   (sad-toucan-incidents-with-bucketing :day-of-year pacific-tz))
@@ -582,7 +586,7 @@
                      (result-date-formatter pacific-tz)
                      [46 47 40 60 7])
 
-    (supports-report-timezone? driver/*driver*)
+    (qp.test/supports-report-timezone? driver/*driver*)
     (results-by-week (tformat/with-zone date-formatter-without-time pacific-tz)
                      (result-date-formatter pacific-tz)
                      [49 47 39 58 7])
@@ -614,7 +618,7 @@
                      (result-date-formatter eastern-tz)
                      [46 47 40 60 7])
 
-    (supports-report-timezone? driver/*driver*)
+    (qp.test/supports-report-timezone? driver/*driver*)
     (results-by-week (tformat/with-zone date-formatter-without-time eastern-tz)
                      (result-date-formatter eastern-tz)
                      [47 48 39 59 7])
@@ -643,7 +647,7 @@
                      (result-date-formatter pacific-tz)
                      [46 47 40 60 7])
 
-    (supports-report-timezone? driver/*driver*)
+    (qp.test/supports-report-timezone? driver/*driver*)
     (results-by-week (tformat/with-zone date-formatter-without-time pacific-tz)
                      (result-date-formatter pacific-tz)
                      [49 47 39 58 7])
@@ -670,7 +674,7 @@
     (#{:sqlserver :sqlite :oracle :sparksql} driver/*driver*)
     [[23 54] [24 46] [25 39] [26 61]]
 
-    (and (supports-report-timezone? driver/*driver*)
+    (and (qp.test/supports-report-timezone? driver/*driver*)
          (not (= :redshift driver/*driver*)))
     [[23 49] [24 47] [25 39] [26 58] [27 7]]
 
@@ -691,7 +695,7 @@
       (= :sqlite driver/*driver*)
       "2015-06-01"
 
-      (supports-report-timezone? driver/*driver*)
+      (qp.test/supports-report-timezone? driver/*driver*)
       "2015-06-01T00:00:00.000-07:00"
 
       :else
@@ -704,7 +708,7 @@
       (= :sqlite driver/*driver*)
       "2015-06-01"
 
-      (supports-report-timezone? driver/*driver*)
+      (qp.test/supports-report-timezone? driver/*driver*)
       "2015-06-01T00:00:00.000-04:00"
 
       :else
@@ -732,7 +736,7 @@
   [[(cond (= :sqlite driver/*driver*)
           "2015-04-01"
 
-          (supports-report-timezone? driver/*driver*)
+          (qp.test/supports-report-timezone? driver/*driver*)
           "2015-04-01T00:00:00.000-07:00"
 
           :else
@@ -744,7 +748,7 @@
   [[(cond (= :sqlite driver/*driver*)
           "2015-04-01"
 
-          (supports-report-timezone? driver/*driver*)
+          (qp.test/supports-report-timezone? driver/*driver*)
           "2015-04-01T00:00:00.000-04:00"
 
           :else
@@ -762,7 +766,7 @@
   [[2 200]]
   (sad-toucan-incidents-with-bucketing :quarter-of-year pacific-tz))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;e
 ;;
 ;; Grouping by year tests
 ;;
@@ -773,7 +777,7 @@
       (= :sqlite driver/*driver*)
       "2015-01-01"
 
-      (supports-report-timezone? driver/*driver*)
+      (qp.test/supports-report-timezone? driver/*driver*)
       "2015-01-01T00:00:00.000-08:00"
       :else
       "2015-01-01T00:00:00.000Z")
@@ -961,3 +965,35 @@
           {:aggregation [[:count]]
            :filter      [:= [:field-id $timestamp] (str (du/format-date "yyyy-MM-dd" (du/date-trunc :day))
                                                         "T14:16:00.000Z")]})))))
+
+
+(deftest additional-unit-filtering-tests
+  (testing "Additional tests for filtering against various datetime bucketing units that aren't tested above"
+    (datasets/test-drivers qp.test/non-timeseries-drivers
+      (are [expected-count unit filter-value]
+          (let [allowed-counts (if (integer? expected-count)
+                                 #{expected-count}
+                                 (set expected-count))]
+            (testing unit
+              (let [result (ffirst
+                            (qp.test/format-rows-by [int]
+                              (qp.test/rows
+                                (data/run-mbql-query checkins
+                                  {:aggregation [[:count]]
+                                   :filter      [:= [:datetime-field $date unit] filter-value]}))))]
+                (is (contains? allowed-counts result)
+                    (format "count of rows where (= (%s date) %s) should be one of: %s"
+                            (name unit) filter-value (str/join ", " (sort allowed-counts)))))))
+        ;; for whatever reason some of these return different values for different drivers. They're close enough so
+        ;; we'll consider them acceptable.
+        3          :day             "2014-03-03"
+        #{136 143} :day-of-week     "1"
+        42         :day-of-month    "1"
+        2          :day-of-year     "1"
+        11         :week            "2014-03-03"
+        #{8 9}     :week-of-year    "1"
+        48         :month           "2014-03"
+        38         :month-of-year   "1"
+        107        :quarter         "2014-01"
+        200        :quarter-of-year "1"
+        498        :year            "2014"))))

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -17,9 +17,7 @@
   (:require [clj-time
              [core :as time]
              [format :as tformat]]
-            [clojure
-             [string :as str]
-             [test :refer :all]]
+            [clojure.test :refer :all]
             [metabase
              [driver :as driver]
              [query-processor-test :as qp.test]
@@ -970,30 +968,25 @@
 (deftest additional-unit-filtering-tests
   (testing "Additional tests for filtering against various datetime bucketing units that aren't tested above"
     (datasets/test-drivers qp.test/non-timeseries-drivers
-      (are [expected-count unit filter-value]
-          (let [allowed-counts (if (integer? expected-count)
-                                 #{expected-count}
-                                 (set expected-count))]
-            (testing unit
-              (let [result (ffirst
-                            (qp.test/format-rows-by [int]
-                              (qp.test/rows
-                                (data/run-mbql-query checkins
-                                  {:aggregation [[:count]]
-                                   :filter      [:= [:datetime-field $date unit] filter-value]}))))]
-                (is (contains? allowed-counts result)
-                    (format "count of rows where (= (%s date) %s) should be one of: %s"
-                            (name unit) filter-value (str/join ", " (sort allowed-counts)))))))
+      (are [expected-count unit filter-value] (is (= expected-count
+                                                     (ffirst
+                                                      (qp.test/format-rows-by [int]
+                                                        (qp.test/rows
+                                                          (data/run-mbql-query checkins
+                                                            {:aggregation [[:count]]
+                                                             :filter      [:= [:datetime-field $date unit] filter-value]})))))
+                                                  (format "count of rows where (= (%s date) %s) should be %d"
+                                                          (name unit) filter-value expected-count))
         ;; for whatever reason some of these return different values for different drivers. They're close enough so
         ;; we'll consider them acceptable.
-        3          :day             "2014-03-03"
-        #{136 143} :day-of-week     "1"
-        42         :day-of-month    "1"
-        2          :day-of-year     "1"
-        11         :week            "2014-03-03"
-        #{8 9}     :week-of-year    "1"
-        48         :month           "2014-03"
-        38         :month-of-year   "1"
-        107        :quarter         "2014-01"
-        200        :quarter-of-year "1"
-        498        :year            "2014"))))
+        3   :day             "2014-03-03"
+        135 :day-of-week     1
+        36  :day-of-month    1
+        9   :day-of-year     214
+        11  :week            "2014-03-03"
+        8   :week-of-year    2
+        48  :month           "2014-03"
+        38  :month-of-year   1
+        107 :quarter         "2014-01"
+        200 :quarter-of-year 1
+        498 :year            "2014"))))

--- a/test/metabase/test/data/datasets.clj
+++ b/test/metabase/test/data/datasets.clj
@@ -56,7 +56,11 @@
   "Generate unit tests for all drivers in env var `DRIVERS`; each test will only run if we're currently testing the
   corresponding driver. `*driver*` is bound to the current driver inside each test.
 
-  DEPRECATED: use `deftest` with `test-drivers` instead."
+  DEPRECATED: use `deftest` with `test-drivers` instead.
+
+    (deftest my-test
+      (datasets/test-drivers #{:h2 :postgres}
+        (is (= ...))))"
   {:style/indent 1}
   [drivers expected actual]
   ;; Make functions to get expected/actual so the code is only compiled one time instead of for every single driver
@@ -71,19 +75,30 @@
   "Generate a unit test that only runs if we're currently testing against `driver`, and that binds `*driver*` when it
   runs.
 
-  DEPRECATED: Use `deftest` with `test-driver` instead."
+  DEPRECATED: Use `deftest` with `test-driver` instead.
+
+    (deftest my-test
+      (datasets/test-driver :mysql
+        (is (= ...))))"
   {:style/indent 1}
   [driver expected actual]
   `(expect-with-drivers [~driver] ~expected ~actual))
 
 (defmacro test-all-drivers
   "Execute body (presumably containing tests) against all drivers we're currently testing against."
+  {:style/indent 0}
   [& body]
   `(test-drivers tx.env/test-drivers ~@body))
 
 (defmacro ^:deprecated expect-with-all-drivers
   "Generate unit tests for all drivers specified in env var `DRIVERS`. `*driver*` is bound to the current driver inside
-  each test. DEPRECATED: Use `test-all-drivers` instead."
+  each test.
+
+  DEPRECATED: Use `test-all-drivers` instead.
+
+    (deftest my-test
+      (datasets/test-all-drivers
+        (is (= ...))))"
   {:style/indent 0}
   [expected actual]
   `(expect-with-drivers tx.env/test-drivers ~expected ~actual))


### PR DESCRIPTION
`clojure.test` actually makes it easier to write a ton of tests at once than `expectations` so I was feeling inclined to add some missing coverage to filtering and caught an additional bug: #10954 

The switch is already paying dividends.

Fixes #10683 
Fixes #10954