### PR TITLE
New test macro sigils

### DIFF
--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -99,7 +99,7 @@
       (qp.test/format-rows-by [int]
         (data/run-mbql-query checkins
           {:aggregation [[:count]]
-           :filter      [:between [:datetime-field $date :day] "2015-04-01" "2015-05-01"]})))))
+           :filter      [:between d$day.date "2015-04-01" "2015-05-01"]})))))
 
 ;;; FILTER -- "OR", "<=", "="
 (qp.test/expect-with-non-timeseries-dbs

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -124,11 +124,22 @@
   Cheatsheet:
 
   *  `$`  = wrapped Field ID
-  *  `$$` = table ID
-  *  `%`  = raw Field ID
-  *  `*`  = field-literal for Field in app DB; `*field/type` for others
-  *  `&`  = wrap in `joined-field`
-  *  `!`  = wrap in `:datetime-field`
+  *  `$$` or `t$` = _T_able ID
+  *  `%`  or `r$` = _R_aw field ID
+  *  `*`  or `l$` = field _L_iteral for field in app DB; `*field/type` for others
+  *  `&`  or `j$` = wrap in _J_oined field clause
+  *  `!`  or `d$` = wrap in _D_atetime field clause
+
+  Examples:
+
+    $field         = [:field-id (data/id <table> :field)]
+    $$table        = (data/id :table)
+    r$field        = (data/id <table> :field)
+    l$field        = [:field-literal (db/select-one-field :name Field :id (data/id <table> :field))
+                                     (data/select-one-field :base_type Field :id (data/id <table> :field))]
+    l$field/Number = [:field-literal (db/select-one-field :name Field :id (data/id <table> :field)) :type/Number]
+    j$cat.field    = [:joined-field \"cat\" [:field-id (data/id <table> :field)]]
+    d$month.field  = [:datetime-field [:field-id (data/id <table> :field)] :month]
 
   (The 'cheatsheet' above is listed first so I can easily look at it with `autocomplete-mode` in Emacs.) This macro
   does the following:
@@ -136,7 +147,11 @@
   *  Expands symbols like `$field` into calls to `id`, and wraps them in `:field-id`. See the dox for `$ids` for
      complete details.
   *  Wraps 'inner' query with the standard `{:database (data/id), :type :query, :query {...}}` boilerplate
-  *  Adds `:source-table` clause if `:source-table` or `:source-query` is not already present"
+  *  Adds `:source-table` clause if `:source-table` or `:source-query` is not already present.
+
+  For the sigils that offer either `symbol` or `char$` options, the `char$` sigil should be preferred; the former
+  should be considered deprecated. The former sigils were added first, but have proven absolutely impossible to
+  remember. You don't even need a cheatsheet for the new sigils! Use those instead."
   {:style/indent 1}
   ([table-name]
    `(mbql-query ~table-name {}))


### PR DESCRIPTION
Writing parts of MBQL like 

```clj
(let [f (Field (data/id :categories :name))]
  [:joined-field \"cat\" [:field-literal (:name f) (:base_type f)]])
```

by hand when writing tests is totally preposterous. So a very long time ago I introduced a macro, `$ids` (and related macros such as `mbql-query`) that replace symbols that start with a `$` sigil with `:field-id` clauses:

```clj
(data/$ids venues [:= $name "Cam's Toucannery"])
;; -> [:= [:field-id (data/id :venues :name)] "Cam's Toucannery"]
```

(`(data/id :venues :name)` looks up field ID of `venues.name` for the current driver + test dataset)

That was a massive timesaver and the biggest win in history, and was widely regarded as an exceptionally tasteful use of macros. But what was easy and simple to use because less simple when I added new sigils for other clauses besides `:field-id`:

```clj
(data/$ids venues [:= *name "Cam's Toucannery"])
;; -> [:=
;;     [:field-literal
;;      (db/select-one-field :name Field :id (data/id :venues :name))
;;      (db/select-one-field :base_type Field :id (data/id :venues :name))]
;;     "Cam's Toucannery"]
```
But the fact that `*` meant `:field-literal` was neither easy to remember, nor was it readable, regardless; I had to refer back to the docstring all the time.

This PR replaces those sigils with memonic ones starting with the letter of the clause they expand to:

  * `t$` = **T**able ID
  *  `r$` = **R**aw field ID
  *  `l$` = field **L**iteral for field in app DB; `*field/type` for others
  * `j$` = wrap in **J**oined field clause
  * `d$` = wrap in **D**atetime field clause

 Examples:

```clj
$field         => [:field-id (data/id <table> :field)]
$$table        => (data/id :table)
r$field        => (data/id <table> :field)
l$field        => [:field-literal (db/select-one-field :name Field :id (data/id <table> :field))
                                 (data/select-one-field :base_type Field :id (data/id <table> :field))]
l$field/Number => [:field-literal (db/select-one-field :name Field :id (data/id <table> :field)) :type/Number]
j$cat.field    => [:joined-field \"cat\" [:field-id (data/id <table> :field)]]
d$month.field  => [:datetime-field [:field-id (data/id <table> :field)] :month]
```