### PR TITLE
Don't use column settings when formatting pie chart legend percentages

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -281,20 +281,19 @@ export default class PieChart extends Component {
       slices.map(s => s.percentage),
       { style: "percent", maximumSignificantDigits: 3 },
     );
-    const formatPercent = (percent, jsx = true) =>
+    const formatPercent = percent =>
       formatValue(percent, {
-        ...settings.column(cols[metricIndex]),
-        jsx,
+        column: cols[metricIndex],
+        jsx: true,
         majorWidth: 0,
         number_style: "percent",
-        _numberFormatter: undefined, // remove the passed formatter
         decimals,
       });
 
     const legendTitles = slices.map(slice => [
       slice.key === "Other" ? slice.key : formatDimension(slice.key, true),
       settings["pie.show_legend_perecent"]
-        ? formatPercent(slice.percentage, true)
+        ? formatPercent(slice.percentage)
         : undefined,
     ]);
     const legendColors = slices.map(slice => slice.color);

--- a/frontend/test/metabase/visualizations/components/Visualization-pie.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/Visualization-pie.unit.spec.js
@@ -41,7 +41,6 @@ describe("pie chart", () => {
     getAllByText("1%");
   });
 
-
   it("should not use column formatting in the legend", () => {
     const cols = [
       StringColumn({ name: "name" }),

--- a/frontend/test/metabase/visualizations/components/Visualization-pie.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/Visualization-pie.unit.spec.js
@@ -40,4 +40,21 @@ describe("pie chart", () => {
     getAllByText("49%");
     getAllByText("1%");
   });
+
+  it("should not use column formatting in the legend", () => {
+    const cols = [
+      StringColumn({ name: "name" }),
+      NumberColumn({ name: "count" }),
+    ];
+    const column_settings = { '["name","count"]': { scale: 123 } };
+    const series = [
+      {
+        card: { display: "pie", visualization_settings: { column_settings } },
+        data: { rows: [["foo", 1]], cols },
+      },
+    ];
+    const { getAllByText } = render(<Visualization rawSeries={series} />);
+    getAllByText("100%"); // shouldn't multiply legend percent by `scale`
+    getAllByText("123"); // should multiply the count in the center by `scale`
+  });
 });


### PR DESCRIPTION
Resolves #9004

In both the examples below, `scale` is set to 10. It should affect the count in the center of the pie, but the percentages shouldn't change.

Before

<img width="999" src="https://user-images.githubusercontent.com/691495/65455111-8e529600-de14-11e9-9725-bf52bf4f2696.png">

After

<img width="999" src="https://user-images.githubusercontent.com/691495/65455117-914d8680-de14-11e9-8665-9f40f0818543.png">
