### PR TITLE
Cleanup mouse blocker div

### DIFF
--- a/frontend/src/metabase/visualizations/components/CardRenderer.jsx
+++ b/frontend/src/metabase/visualizations/components/CardRenderer.jsx
@@ -72,8 +72,8 @@ export default class CardRenderer extends Component {
     this._deregisterChart();
 
     // reset the DOM:
-    for (const child of parent.children) {
-      parent.removeChild(child);
+    while (parent.firstChild) {
+      parent.removeChild(parent.firstChild);
     }
 
     // create a new container element


### PR DESCRIPTION
This PR fixes the issue that @flamber saw [here](https://github.com/metabase/metabase/pull/10931#issuecomment-533834527). The new div that blocks interaction wasn't removed successfully.

After some googling I'm still not sure why, but this for/of fails to remove all children. Somehow removing the first child prevents the loop from visiting the second.

```js
for (const child of parent.children) {
      parent.removeChild(child);
}
```

This works:

```js
 while (parent.firstChild) {
      parent.removeChild(parent.firstChild);
 }
```

I'm still totally baffled how this flaw had anything to do with what type of visualization.