### PR TITLE
Move MBQL filter negation/desugaring logic to MBQL lib

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -318,21 +318,16 @@
 (defmethod parse-filter :or  [[_ & args]] {$or (mapv parse-filter args)})
 
 
-;; This is somewhat silly but MongoDB doesn't support `not` as a top-level so we have to go in and negate things
-;; ourselves. Ick. Maybe we could pull this logic up into `mbql.u` so other people could use it?
+;; MongoDB doesn't support negating top-level filter clauses. So we can leverage the MBQL lib's `negate-filter-clause`
+;; to negate everything, with the exception of the string filter clauses, which we will convert to a `{not <regex}`
+;; clause (see `->rvalue` for `::not` above). `negate` below wraps the MBQL lib function
 (defmulti ^:private negate first)
 
-(defmethod negate :not [[_ subclause]]    subclause)
+(defmethod negate :default [clause]
+  (mbql.u/negate-filter-clause clause))
+
 (defmethod negate :and [[_ & subclauses]] (apply vector :or  (map negate subclauses)))
 (defmethod negate :or  [[_ & subclauses]] (apply vector :and (map negate subclauses)))
-(defmethod negate :=   [[_ field value]]  [:!= field value])
-(defmethod negate :!=  [[_ field value]]  [:=  field value])
-(defmethod negate :>   [[_ field value]]  [:<= field value])
-(defmethod negate :<   [[_ field value]]  [:>= field value])
-(defmethod negate :>=  [[_ field value]]  [:<  field value])
-(defmethod negate :<=  [[_ field value]]  [:>  field value])
-
-(defmethod negate :between [[_ field min max]] [:or [:< field min] [:> field max]])
 
 (defmethod negate :contains    [[_ field v opts]] [:contains field [::not v] opts])
 (defmethod negate :starts-with [[_ field v opts]] [:starts-with field [::not v] opts])

--- a/project.clj
+++ b/project.clj
@@ -106,7 +106,7 @@
    [me.raynes/fs "1.4.6"]                                   ; FS tools
    [medley "1.2.0"]                                                   ; lightweight lib of useful functions
    [metabase/connection-pool "1.0.2"]                                 ; simple wrapper around C3P0. JDBC connection pools
-   [metabase/mbql "1.3.5"]                                            ; MBQL language schema & util fns
+   [metabase/mbql "1.3.6"]                                            ; MBQL language schema & util fns
    [metabase/throttle "1.0.2"]                                        ; Tools for throttling access to API endpoints and other code pathways
    [methodical "0.9.4-alpha"]
    [net.sf.cssbox/cssbox "4.12" :exclusions [org.slf4j/slf4j-api]]    ; HTML / CSS rendering

--- a/src/metabase/handler.clj
+++ b/src/metabase/handler.clj
@@ -24,13 +24,14 @@
 
 (def app
   "The primary entry point to the Ring HTTP server."
-  ;; ▼▼▼ POST-PROCESSING ▼▼▼ happens from TOP-TO-BOTTOM
   (->
-   ;; when running TESTS use the var so we can redefine routes as needed. No need to waste time with repetitive var
-   ;; lookups when running normally
-   (if config/is-test?
-     #'routes/routes
-     routes/routes)
+   ;; in production, dereference routes now because they will not change at runtime, so we don't need to waste time
+   ;; dereferencing the var on every request. For dev & test, use the var instead so it can be tweaked without having
+   ;; to restart the web server
+   (if config/is-prod?
+     routes/routes
+     #'routes/routes)
+   ;; ▼▼▼ POST-PROCESSING ▼▼▼ happens from TOP-TO-BOTTOM
    mw.exceptions/catch-uncaught-exceptions ; catch any Exceptions that weren't passed to `raise`
    mw.exceptions/catch-api-exceptions      ; catch exceptions and return them in our expected format
    mw.log/log-api-call

--- a/src/metabase/query_processor/middleware/desugar.clj
+++ b/src/metabase/query_processor/middleware/desugar.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.middleware.desugar
   (:require [metabase.mbql
+             [predicates :as mbql.preds]
              [schema :as mbql.s]
              [util :as mbql.u]]
             [metabase.util :as u]
@@ -9,8 +10,8 @@
   [query]
   (u/update-when query :query (fn [query]
                                 (mbql.u/replace query
-                                  (m :guard (every-pred map? :filter))
-                                  (update m :filter mbql.u/desugar-filter-clause)))))
+                                  (filter-clause :guard mbql.preds/Filter?)
+                                  (mbql.u/desugar-filter-clause filter-clause)))))
 
 (defn desugar
   "Middleware that uses MBQL lib functions to replace high-level 'syntactic sugar' clauses like `time-interval` and

--- a/src/metabase/query_processor/middleware/desugar.clj
+++ b/src/metabase/query_processor/middleware/desugar.clj
@@ -5,91 +5,16 @@
             [metabase.util :as u]
             [schema.core :as s]))
 
-(defn- desugar-inside [query]
-  (mbql.u/replace query
-    [:inside lat-field lon-field lat-max lon-min lat-min lon-max]
-    [:and
-     [:between lat-field lat-min lat-max]
-     [:between lon-field lon-min lon-max]]))
-
-(defn- desugar-is-null-and-not-null [query]
-  (mbql.u/replace query
-    [:is-null field]  [:=  field nil]
-    [:not-null field] [:!= field nil]))
-
-(defn- desugar-time-interval [query]
-  (mbql.u/replace query
-    [:time-interval field n unit] (recur [:time-interval field n unit nil])
-
-    ;; replace current/last/next with corresponding value of n and recur
-    [:time-interval field :current unit options] (recur [:time-interval field  0 unit options])
-    [:time-interval field :last    unit options] (recur [:time-interval field -1 unit options])
-    [:time-interval field :next    unit options] (recur [:time-interval field  1 unit options])
-
-    [:time-interval field (n :guard #{-1}) unit (_ :guard :include-current)]
-    [:between [:datetime-field field unit] [:relative-datetime n unit] [:relative-datetime 0 unit]]
-
-    [:time-interval field (n :guard #{1}) unit (_ :guard :include-current)]
-    [:between [:datetime-field field unit] [:relative-datetime 0 unit] [:relative-datetime n unit]]
-
-    [:time-interval field (n :guard #{-1 0 1}) unit _]
-    [:= [:datetime-field field unit] [:relative-datetime n unit]]
-
-    [:time-interval field (n :guard neg?) unit (_ :guard :include-current)]
-    [:between [:datetime-field field unit] [:relative-datetime n unit] [:relative-datetime 0 unit]]
-
-    [:time-interval field (n :guard neg?) unit _]
-    [:between [:datetime-field field unit] [:relative-datetime n unit] [:relative-datetime -1 unit]]
-
-    [:time-interval field n unit (_ :guard :include-current)]
-    [:between [:datetime-field field unit] [:relative-datetime 0 unit] [:relative-datetime n unit]]
-
-    [:time-interval field n unit _]
-    [:between [:datetime-field field unit] [:relative-datetime 1 unit] [:relative-datetime n unit]]))
-
-(defn- desugar-does-not-contain [query]
-  (mbql.u/replace query
-    [:does-not-contain & args]
-    [:not (vec (cons :contains args))]))
-
-(defn- desugar-equals-and-not-equals-with-extra-args
-  "`:=` and `!=` clauses with more than 2 args automatically get rewritten as compound filters.
-
-     [:= field x y]  -> [:or  [:=  field x] [:=  field y]]
-     [:!= field x y] -> [:and [:!= field x] [:!= field y]]"
-  [query]
-  (mbql.u/replace query
-    [:= field x y & more]
-    (apply vector :or (for [x (concat [x y] more)]
-                        [:= field x]))
-
-    [:!= field x y & more]
-    (apply vector :and (for [x (concat [x y] more)]
-                         [:!= field x]))))
-
-(defn- desugar-current-relative-datetime
-  "Replace `relative-datetime` clauses like `[:relative-datetime :current]` with `[:relative-datetime 0 <unit>]`.
-  `<unit>` is inferred from the `:datetime-field` the clause is being compared to (if any), otherwise falls back to
-  `default.`"
-  [query]
-  (mbql.u/replace query
-    [clause field [:relative-datetime :current & _]]
-    [clause field [:relative-datetime 0 (or (mbql.u/match-one field [:datetime-field _ unit] unit)
-                                            :default)]]))
-
 (s/defn ^:private desugar* :- mbql.s/Query
   [query]
-  (u/update-when query :query (comp mbql.u/simplify-compound-filter
-                                    desugar-inside
-                                    desugar-is-null-and-not-null
-                                    desugar-time-interval
-                                    desugar-does-not-contain
-                                    desugar-equals-and-not-equals-with-extra-args
-                                    desugar-current-relative-datetime)))
+  (u/update-when query :query (fn [query]
+                                (mbql.u/replace query
+                                  (m :guard (every-pred map? :filter))
+                                  (update m :filter mbql.u/desugar-filter-clause)))))
 
 (defn desugar
-  "Middleware that replaces high-level 'syntactic sugar' clauses with lower-level clauses. This is done to minimize the
-  amount of MBQL individual drivers need to support. For your convenience, clauses replaced by this middleware are
-  marked `^:sugar` in the MBQL schema."
+  "Middleware that uses MBQL lib functions to replace high-level 'syntactic sugar' clauses like `time-interval` and
+  `inside` with lower-level clauses like `between`. This is done to minimize the number of MBQL clauses individual
+  drivers need to support. Clauses replaced by this middleware are marked `^:sugar` in the MBQL schema."
   [qp]
   (comp qp desugar*))

--- a/test/metabase/query_processor/middleware/desugar_test.clj
+++ b/test/metabase/query_processor/middleware/desugar_test.clj
@@ -1,231 +1,37 @@
 (ns metabase.query-processor.middleware.desugar-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
             [metabase.query-processor.middleware.desugar :as desugar]))
 
-(def ^:private ^{:arglists '([query])} desugar
-  (desugar/desugar identity))
-
-;; TODO - test `inside`
-
-;; TODO - test `is-null`
-
-;; TODO - test `not-null`
-
-;;; --------------------------------------- desugaring `time-interval` clauses ---------------------------------------
-
-;; `time-interval` with value > 1 or < -1 should generate a `between` clause
-(expect
-  {:database 1
-   :type     :query
-   :query    {:source-table 1
-              :filter       [:between
-                             [:datetime-field [:field-id 1] :month]
-                             [:relative-datetime 1 :month]
-                             [:relative-datetime 2 :month]]}}
-  (desugar
-   {:database 1
-    :type     :query
-    :query    {:source-table 1
-               :filter       [:time-interval [:field-id 1] 2 :month]}}))
-
-;; test the `include-current` option -- interval should start or end at `0` instead of `1`
-(expect
-  {:database 1
-   :type     :query
-   :query    {:source-table 1
-              :filter       [:between
-                             [:datetime-field [:field-id 1] :month]
-                             [:relative-datetime 0 :month]
-                             [:relative-datetime 2 :month]]}}
-  (desugar
-   {:database 1
-    :type     :query
-    :query    {:source-table 1
-               :filter       [:time-interval [:field-id 1] 2 :month {:include-current true}]}}))
-
-
-;; `time-interval` with value = 1 or = -1 should generate an `=` clause
-(expect
-  {:database 1
-   :type     :query
-   :query    {:source-table 1
-              :filter       [:=
-                             [:datetime-field [:field-id 1] :month]
-                             [:relative-datetime 1 :month]]}}
-  (desugar
-   {:database 1
-    :type     :query
-    :query    {:source-table 1
-               :filter       [:time-interval [:field-id 1] 1 :month]}}))
-
-(expect
-  {:database 1
-   :type     :query
-   :query    {:source-table 1
-              :filter       [:=
-                             [:datetime-field [:field-id 1] :week]
-                             [:relative-datetime -1 :week]]}}
-  (desugar
-   {:database 1
-    :type     :query
-    :query    {:source-table 1
-               :filter       [:time-interval [:field-id 1] -1 :week]}}))
-
-
-;; test the `include-current` option -- interval with value = 1 or = -1 should generate a `between` clause
-(expect
-  {:database 1
-   :type     :query
-   :query    {:source-table 1
-              :filter       [:between
-                             [:datetime-field [:field-id 1] :month]
-                             [:relative-datetime 0 :month]
-                             [:relative-datetime 1 :month]]}}
-  (desugar
-   {:database 1
-    :type     :query
-    :query    {:source-table 1
-               :filter       [:time-interval [:field-id 1] 1 :month {:include-current true}]}}))
-
-(expect
-  {:database 1
-   :type     :query
-   :query    {:source-table 1
-              :filter       [:between
-                             [:datetime-field [:field-id 1] :day]
-                             [:relative-datetime -1 :day]
-                             [:relative-datetime 0 :day]]}}
-  (desugar
-   {:database 1
-    :type     :query
-    :query    {:source-table 1
-               :filter       [:time-interval [:field-id 1] -1 :day {:include-current true}]}}))
-
-
-;; test using keywords like `:current`
-(expect
-  {:database 1
-   :type     :query
-   :query    {:source-table 1
-              :filter       [:=
-                             [:datetime-field [:field-id 1] :week]
-                             [:relative-datetime 0 :week]]}}
-
-  (desugar
-   {:database 1
-    :type     :query
-    :query    {:source-table 1
-               :filter       [:time-interval [:field-id 1] :current :week]}}))
-
-
-;; TODO - test `does-not-contain`
-
-;;; ------------------------------------------ `=` and `!=` with extra args ------------------------------------------
-
-(expect
-  {:database 1
-   :type     :query
-   :query    {:source-table 1
-              :filter       [:or
-                             [:= [:field-id 1] 2]
-                             [:= [:field-id 1] 3]
-                             [:= [:field-id 1] 4]
-                             [:= [:field-id 1] 5]]}}
-  (desugar
-   {:database 1
-    :type     :query
-    :query    {:source-table 1
-               :filter       [:= [:field-id 1] 2 3 4 5]}}))
-
-;; TODO - test `!=` with extra args
-
-
-;;; ---------------------------- desugaring `:relative-datetime` clauses with `:current` -----------------------------
-
-;; for cases when `:relative-datetime` is being compared to a `:datetime-field` clause, it should take the unit of the
-;; clause it's being compared to
-(expect
-  {:database 1
-   :type     :query
-   :query    {:source-table 1
-              :filter       [:=
-                             [:datetime-field [:field-id 1] :minute]
-                             [:relative-datetime 0 :minute]]}}
-  (desugar
-   {:database 1
-    :type     :query
-    :query    {:source-table 1
-               :filter       [:=
-                              [:datetime-field [:field-id 1] :minute]
-                              [:relative-datetime :current]]}}))
-
-;; otherwise it should just get a unit of `:default`
-(expect
-  {:database 1
-   :type     :query
-   :query    {:source-table 1
-              :filter       [:=
-                             [:field-id 1]
-                             [:relative-datetime 0 :default]]}}
-  (desugar
-   {:database 1
-    :type     :query
-    :query    {:source-table 1
-               :filter       [:=
-                              [:field-id 1]
-                              [:relative-datetime :current]]}}))
-
-;; ok, we should be able to handle datetime fields even if they are nested inside another clause
-(expect
-  {:database 1
-   :type     :query
-   :query    {:source-table 1
-              :filter       [:=
-                             [:binning-strategy [:datetime-field [:field-id 1] :week] :default]
-                             [:relative-datetime 0 :week]]}}
-  (desugar
-   {:database 1
-    :type     :query
-    :query    {:source-table 1
-               :filter       [:=
-                              [:binning-strategy [:datetime-field [:field-id 1] :week] :default]
-                              [:relative-datetime :current]]}}))
-
-
-;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                            Putting it all together                                             |
-;;; +----------------------------------------------------------------------------------------------------------------+
-
-;; filters should get re-simplified after desugaring (if applicable)
-(expect
-  {:database 1
-   :type     :query
-   :query    {:source-table 1
-              :filter       [:and
-                             [:= [:field-id 1] "Run Query"]
-                             [:between
-                              [:datetime-field [:field-id 2] :day]
-                              [:relative-datetime -30 :day]
-                              [:relative-datetime -1 :day]]
-                             [:!= [:field-id 3] "(not set)"]
-                             [:!= [:field-id 3] "url"]]
-              :aggregation  [[:share [:and
-                                      [:= [:field-id 1] "Run Query"]
-                                      [:between
-                                       [:datetime-field [:field-id 2] :day]
-                                       [:relative-datetime -30 :day]
-                                       [:relative-datetime -1 :day]]
-                                      [:!= [:field-id 3] "(not set)"]
-                                      [:!= [:field-id 3] "url"]]]]}}
-  (desugar
-   {:database 1
-    :type     :query
-    :query    {:source-table 1
-               :filter       [:and
-                              [:= [:field-id 1] "Run Query"]
-                              [:time-interval [:field-id 2] -30 :day]
-                              [:!= [:field-id 3] "(not set)" "url"]]
-               :aggregation  [[:share [:and
-                                       [:= [:field-id 1] "Run Query"]
-                                       [:time-interval [:field-id 2] -30 :day]
-                                       [:!= [:field-id 3] "(not set)" "url"]]]]}}))
+;; actual desugaring logic and tests are in the MBQL lib
+(deftest e2e-test
+  (is (= {:database 1
+          :type     :query
+          :query    {:source-table 1
+                     :filter       [:and
+                                    [:= [:field-id 1] "Run Query"]
+                                    [:between
+                                     [:datetime-field [:field-id 2] :day]
+                                     [:relative-datetime -30 :day]
+                                     [:relative-datetime -1 :day]]
+                                    [:!= [:field-id 3] "(not set)"]
+                                    [:!= [:field-id 3] "url"]]
+                     :aggregation  [[:share [:and
+                                             [:= [:field-id 1] "Run Query"]
+                                             [:between
+                                              [:datetime-field [:field-id 2] :day]
+                                              [:relative-datetime -30 :day]
+                                              [:relative-datetime -1 :day]]
+                                             [:!= [:field-id 3] "(not set)"]
+                                             [:!= [:field-id 3] "url"]]]]}}
+         ((desugar/desugar identity)
+          {:database 1
+           :type     :query
+           :query    {:source-table 1
+                      :filter       [:and
+                                     [:= [:field-id 1] "Run Query"]
+                                     [:time-interval [:field-id 2] -30 :day]
+                                     [:!= [:field-id 3] "(not set)" "url"]]
+                      :aggregation  [[:share [:and
+                                              [:= [:field-id 1] "Run Query"]
+                                              [:time-interval [:field-id 2] -30 :day]
+                                              [:!= [:field-id 3] "(not set)" "url"]]]]}}))))


### PR DESCRIPTION
Merged into MBQL 1.3.6 as part of https://github.com/metabase/mbql/pull/21. These are core MBQL transformations and similar operations already live in the MBQL lib.