### PR TITLE
Support truncating a datetime to `:second`

### DIFF
--- a/src/metabase/util/date.clj
+++ b/src/metabase/util/date.clj
@@ -347,11 +347,14 @@
      ;; -> #inst \"2015-11-01T00:00:00\""
   (^java.sql.Timestamp [unit]
    (date-trunc unit (System/currentTimeMillis) "UTC"))
+
   (^java.sql.Timestamp [unit date]
    (date-trunc unit date "UTC"))
+
   (^java.sql.Timestamp [unit date timezone-id]
    (case unit
      ;; For minute and hour truncation timezone should not be taken into account
+     :second  (trunc-with-floor date 1000)
      :minute  (trunc-with-floor date (* 60 1000))
      :hour    (trunc-with-floor date (* 60 60 1000))
      :day     (trunc-with-format "yyyy-MM-dd'T'ZZ" date timezone-id)

--- a/test/metabase/util/date_test.clj
+++ b/test/metabase/util/date_test.clj
@@ -1,85 +1,111 @@
 (ns metabase.util.date-test
-  (:require [expectations :refer :all]
-            [metabase.util.date :refer :all]))
+  (:require [clojure.test :refer :all]
+            [metabase.util.date :as du]))
 
-;;; Date stuff
+(def ^:private saturday-the-31st #inst "2005-12-31T19:05:55")
+(def ^:private sunday-the-1st    #inst "2006-01-01T04:18:26")
+(def ^:private with-milliseconds #inst "2019-09-24T15:07:30.555")
 
-(def ^:private ^:const saturday-the-31st   #inst "2005-12-31T19:05:55")
-(def ^:private ^:const sunday-the-1st #inst "2006-01-01T04:18:26")
+(deftest is-temporal-test
+  (are [expected arg] (= expected
+                         (du/is-temporal? arg))
+    false nil
+    false 123
+    false "abc"
+    false [1 2 3]
+    false {:a "b"}
+    true  saturday-the-31st))
 
-(expect false (is-temporal? nil))
-(expect false (is-temporal? 123))
-(expect false (is-temporal? "abc"))
-(expect false (is-temporal? [1 2 3]))
-(expect false (is-temporal? {:a "b"}))
-(expect true (is-temporal? saturday-the-31st))
+(deftest ->Timestamp-test
+  (are [actual] (= saturday-the-31st
+                   actual)
+    (du/->Timestamp (du/->Date saturday-the-31st))
+    (du/->Timestamp (du/->Calendar saturday-the-31st))
+    (du/->Timestamp (du/->Calendar (.getTime saturday-the-31st)))
+    (du/->Timestamp (.getTime saturday-the-31st))
+    (du/->Timestamp "2005-12-31T19:05:55+00:00" du/utc)))
 
-(expect saturday-the-31st (->Timestamp (->Date saturday-the-31st)))
-(expect saturday-the-31st (->Timestamp (->Calendar saturday-the-31st)))
-(expect saturday-the-31st (->Timestamp (->Calendar (.getTime saturday-the-31st))))
-(expect saturday-the-31st (->Timestamp (.getTime saturday-the-31st)))
-(expect saturday-the-31st (->Timestamp "2005-12-31T19:05:55+00:00" utc))
-
-(expect nil (->iso-8601-datetime nil nil))
-(expect "2005-12-31T19:05:55.000Z" (->iso-8601-datetime saturday-the-31st nil))
-(expect "2005-12-31T11:05:55.000-08:00" (->iso-8601-datetime saturday-the-31st "US/Pacific"))
-(expect "2006-01-01T04:05:55.000+09:00" (->iso-8601-datetime saturday-the-31st "Asia/Tokyo"))
-
-
-(expect 5    (date-extract :minute-of-hour  saturday-the-31st   "UTC"))
-(expect 19   (date-extract :hour-of-day     saturday-the-31st   "UTC"))
-(expect 7    (date-extract :day-of-week     saturday-the-31st   "UTC"))
-(expect 1    (date-extract :day-of-week     sunday-the-1st      "UTC"))
-(expect 31   (date-extract :day-of-month    saturday-the-31st   "UTC"))
-(expect 365  (date-extract :day-of-year     saturday-the-31st   "UTC"))
-(expect 53   (date-extract :week-of-year    saturday-the-31st   "UTC"))
-(expect 12   (date-extract :month-of-year   saturday-the-31st   "UTC"))
-(expect 4    (date-extract :quarter-of-year saturday-the-31st   "UTC"))
-(expect 2005 (date-extract :year            saturday-the-31st   "UTC"))
-
-(expect 5    (date-extract :minute-of-hour  saturday-the-31st   "US/Pacific"))
-(expect 11   (date-extract :hour-of-day     saturday-the-31st   "US/Pacific"))
-(expect 7    (date-extract :day-of-week     saturday-the-31st   "US/Pacific"))
-(expect 7    (date-extract :day-of-week     sunday-the-1st      "US/Pacific"))
-(expect 31   (date-extract :day-of-month    saturday-the-31st   "US/Pacific"))
-(expect 365  (date-extract :day-of-year     saturday-the-31st   "US/Pacific"))
-(expect 53   (date-extract :week-of-year    saturday-the-31st   "US/Pacific"))
-(expect 12   (date-extract :month-of-year   saturday-the-31st   "US/Pacific"))
-(expect 4    (date-extract :quarter-of-year saturday-the-31st   "US/Pacific"))
-(expect 2005 (date-extract :year            saturday-the-31st   "US/Pacific"))
-
-(expect 5    (date-extract :minute-of-hour  saturday-the-31st   "Asia/Tokyo"))
-(expect 4    (date-extract :hour-of-day     saturday-the-31st   "Asia/Tokyo"))
-(expect 1    (date-extract :day-of-week     saturday-the-31st   "Asia/Tokyo"))
-(expect 1    (date-extract :day-of-week     sunday-the-1st      "Asia/Tokyo"))
-(expect 1    (date-extract :day-of-month    saturday-the-31st   "Asia/Tokyo"))
-(expect 1    (date-extract :day-of-year     saturday-the-31st   "Asia/Tokyo"))
-(expect 1    (date-extract :week-of-year    saturday-the-31st   "Asia/Tokyo"))
-(expect 1    (date-extract :month-of-year   saturday-the-31st   "Asia/Tokyo"))
-(expect 1    (date-extract :quarter-of-year saturday-the-31st   "Asia/Tokyo"))
-(expect 2006 (date-extract :year            saturday-the-31st   "Asia/Tokyo"))
+(deftest ->iso-8601-datetime-test
+  (are [expected inst timezone] (= expected
+                                   (du/->iso-8601-datetime inst timezone))
+    nil                             nil               nil
+    "2005-12-31T19:05:55.000Z"      saturday-the-31st nil
+    "2005-12-31T11:05:55.000-08:00" saturday-the-31st "US/Pacific"
+    "2006-01-01T04:05:55.000+09:00" saturday-the-31st "Asia/Tokyo"))
 
 
-(expect #inst "2005-12-31T19:05" (date-trunc :minute  saturday-the-31st   "UTC"))
-(expect #inst "2005-12-31T19:00" (date-trunc :hour    saturday-the-31st   "UTC"))
-(expect #inst "2005-12-31"       (date-trunc :day     saturday-the-31st   "UTC"))
-(expect #inst "2005-12-25"       (date-trunc :week    saturday-the-31st   "UTC"))
-(expect #inst "2006-01-01"       (date-trunc :week    sunday-the-1st      "UTC"))
-(expect #inst "2005-12-01"       (date-trunc :month   saturday-the-31st   "UTC"))
-(expect #inst "2005-10-01"       (date-trunc :quarter saturday-the-31st   "UTC"))
+(deftest date-extract-test
+  (testing "UTC timezone"
+    (are [expected unit inst] (= expected
+                                 (du/date-extract unit inst "UTC"))
+      5    :minute-of-hour  saturday-the-31st
+      19   :hour-of-day     saturday-the-31st
+      7    :day-of-week     saturday-the-31st
+      1    :day-of-week     sunday-the-1st
+      31   :day-of-month    saturday-the-31st
+      365  :day-of-year     saturday-the-31st
+      53   :week-of-year    saturday-the-31st
+      12   :month-of-year   saturday-the-31st
+      4    :quarter-of-year saturday-the-31st
+      2005 :year            saturday-the-31st))
+  (testing "US/Pacific timezone"
+    (are [expected unit inst] (= expected
+                                 (du/date-extract unit inst "US/Pacific"))
+      5    :minute-of-hour  saturday-the-31st
+      11   :hour-of-day     saturday-the-31st
+      7    :day-of-week     saturday-the-31st
+      7    :day-of-week     sunday-the-1st
+      31   :day-of-month    saturday-the-31st
+      365  :day-of-year     saturday-the-31st
+      53   :week-of-year    saturday-the-31st
+      12   :month-of-year   saturday-the-31st
+      4    :quarter-of-year saturday-the-31st
+      2005 :year            saturday-the-31st))
+  (testing "Asia/Tokyo timezone"
+    (are [expected unit inst] (= expected
+                                 (du/date-extract unit inst "Asia/Tokyo"))
+      5    :minute-of-hour  saturday-the-31st
+      4    :hour-of-day     saturday-the-31st
+      1    :day-of-week     saturday-the-31st
+      1    :day-of-week     sunday-the-1st
+      1    :day-of-month    saturday-the-31st
+      1    :day-of-year     saturday-the-31st
+      1    :week-of-year    saturday-the-31st
+      1    :month-of-year   saturday-the-31st
+      1    :quarter-of-year saturday-the-31st
+      2006 :year            saturday-the-31st)))
 
-(expect #inst "2005-12-31T19:05" (date-trunc :minute  saturday-the-31st   "Asia/Tokyo"))
-(expect #inst "2005-12-31T19:00" (date-trunc :hour    saturday-the-31st   "Asia/Tokyo"))
-(expect #inst "2006-01-01+09:00" (date-trunc :day     saturday-the-31st   "Asia/Tokyo"))
-(expect #inst "2006-01-01+09:00" (date-trunc :week    saturday-the-31st   "Asia/Tokyo"))
-(expect #inst "2006-01-01+09:00" (date-trunc :week    sunday-the-1st      "Asia/Tokyo"))
-(expect #inst "2006-01-01+09:00" (date-trunc :month   saturday-the-31st   "Asia/Tokyo"))
-(expect #inst "2006-01-01+09:00" (date-trunc :quarter saturday-the-31st   "Asia/Tokyo"))
-
-(expect #inst "2005-12-31T19:05" (date-trunc :minute  saturday-the-31st   "US/Pacific"))
-(expect #inst "2005-12-31T19:00" (date-trunc :hour    saturday-the-31st   "US/Pacific"))
-(expect #inst "2005-12-31-08:00" (date-trunc :day     saturday-the-31st   "US/Pacific"))
-(expect #inst "2005-12-25-08:00" (date-trunc :week    saturday-the-31st   "US/Pacific"))
-(expect #inst "2005-12-25-08:00" (date-trunc :week    sunday-the-1st      "US/Pacific"))
-(expect #inst "2005-12-01-08:00" (date-trunc :month   saturday-the-31st   "US/Pacific"))
-(expect #inst "2005-10-01-08:00" (date-trunc :quarter saturday-the-31st   "US/Pacific"))
+(deftest date-trunc-test
+  (testing "UTC timezone"
+    (are [expected unit inst] (= expected
+                                 (du/date-trunc unit inst "UTC"))
+      #inst "2019-09-24T15:07:30" :second  with-milliseconds
+      #inst "2005-12-31T19:05"    :minute  saturday-the-31st
+      #inst "2005-12-31T19:00"    :hour    saturday-the-31st
+      #inst "2005-12-31"          :day     saturday-the-31st
+      #inst "2005-12-25"          :week    saturday-the-31st
+      #inst "2006-01-01"          :week    sunday-the-1st
+      #inst "2005-12-01"          :month   saturday-the-31st
+      #inst "2005-10-01"          :quarter saturday-the-31st))
+  (testing "US/Pacific timezone"
+    (are [expected unit inst] (= expected
+                                 (du/date-trunc unit inst "US/Pacific"))
+      #inst "2019-09-24T15:07:30" :second  with-milliseconds
+      #inst "2005-12-31T19:05"    :minute  saturday-the-31st
+      #inst "2005-12-31T19:00"    :hour    saturday-the-31st
+      #inst "2005-12-31-08:00"    :day     saturday-the-31st
+      #inst "2005-12-25-08:00"    :week    saturday-the-31st
+      #inst "2005-12-25-08:00"    :week    sunday-the-1st
+      #inst "2005-12-01-08:00"    :month   saturday-the-31st
+      #inst "2005-10-01-08:00"    :quarter saturday-the-31st))
+  (testing "Asia/Tokyo timezone"
+    (are [expected unit inst] (= expected
+                                 (du/date-trunc unit inst "Asia/Tokyo"))
+      #inst "2019-09-24T15:07:30" :second  with-milliseconds
+      #inst "2005-12-31T19:05"    :minute  saturday-the-31st
+      #inst "2005-12-31T19:00"    :hour    saturday-the-31st
+      #inst "2006-01-01+09:00"    :day     saturday-the-31st
+      #inst "2006-01-01+09:00"    :week    saturday-the-31st
+      #inst "2006-01-01+09:00"    :week    sunday-the-1st
+      #inst "2006-01-01+09:00"    :month   saturday-the-31st
+      #inst "2006-01-01+09:00"    :quarter saturday-the-31st)))


### PR DESCRIPTION
In the `metabase.util.date/date-trunc` function. Also rewrite `metabase.util.date-test` namespace to be more idiomatic `clojure.test`-style.