### PR TITLE
Misc IE11 Fixes

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip.jsx
@@ -43,7 +43,7 @@ export default class ChartTooltip extends Component {
     const rows = this._getRows();
     const hasEventOrElement =
       hovered &&
-      ((hovered.element && document.contains(hovered.element)) ||
+      ((hovered.element && document.body.contains(hovered.element)) ||
         hovered.event);
     const isOpen = rows.length > 0 && !!hasEventOrElement;
     return (

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -97,7 +97,7 @@ const DOT_OVERLAP_RATIO = 0.1;
 const DOT_OVERLAP_DISTANCE = 8;
 
 function onRenderSetLineWidth(chart) {
-  const dots = chart.svg()[0][0].getElementsByClassName("dot");
+  const dots = chart.svg()[0][0].querySelectorAll(".dot");
   if (dots.length < MAX_DOTS_FOR_LINE_WIDTH_ADJUSTMENT) {
     const min = getMinElementSpacing(dots);
     if (min > 150) {

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -40,7 +40,7 @@
   <body>
     <div id="root"></div>
 
-    <!-- Using the Web Font Loader lets us load the fonts asynchronously for faster page loads -- see https://github.com/typekit/webfontloader -->
+    <!-- Using the Web Font Loader lets us load the fonts asynchronously for faster page loads – see https://github.com/typekit/webfontloader -->
     <!-- If you modify this script, make sure you update the whitelisted Content-Security-Policy hash in metabase.middleware.security -->
     <script type="text/javascript">{{{webFontConfigJS}}}</script>
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" async></script>


### PR DESCRIPTION
Resolves #10895, Resolves #9038

This fixes the bug in that issue and two other small ones:
1. `document.contains` fails, but `document.body.contains` works. This was breaking tooltips.
2. Weirdly, IE11 was rejecting a HTML document with "--" in the middle of a comment. I changed that to "–".