### PR TITLE
Fix tooltip bug in pie charts

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -251,7 +251,10 @@ export default class PieChart extends Component {
     const [slices, others] = _.chain(rows)
       .map((row, index) => ({
         key: row[dimensionIndex],
+        // Value is used to determine arc size and is modified for very small
+        // other slices. We save displayValue for use in tooltips.
         value: row[metricIndex],
+        displayValue: row[metricIndex],
         percentage: row[metricIndex] / total,
         color: settings["pie._colors"][row[dimensionIndex]],
       }))
@@ -329,7 +332,7 @@ export default class PieChart extends Component {
           event: event && event.nativeEvent,
           data: others.map(o => ({
             key: formatDimension(o.key, false),
-            value: formatMetric(o.value, false),
+            value: formatMetric(o.displayValue, false),
           })),
         };
       } else {
@@ -343,7 +346,7 @@ export default class PieChart extends Component {
             },
             {
               key: getFriendlyName(cols[metricIndex]),
-              value: formatMetric(slice.value),
+              value: formatMetric(slice.displayValue),
             },
           ].concat(
             showPercentInTooltip && slice.percentage != null

--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -323,7 +323,7 @@ export default class PieChart extends Component {
       const slice = slices[index];
       if (!slice || slice.noHover) {
         return null;
-      } else if (slice === otherSlice) {
+      } else if (slice === otherSlice && others.length > 1) {
         return {
           index,
           event: event && event.nativeEvent,

--- a/frontend/test/metabase/visualizations/components/Visualization-pie.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/Visualization-pie.unit.spec.js
@@ -6,7 +6,6 @@ import { render, cleanup, fireEvent } from "@testing-library/react";
 import { NumberColumn, StringColumn } from "../__support__/visualizations";
 
 import Visualization from "metabase/visualizations/components/Visualization";
-import PieChart from "metabase/visualizations/visualizations/PieChart";
 
 const series = rows => {
   const cols = [
@@ -61,7 +60,7 @@ describe("pie chart", () => {
 
   it("shouldn't show a condensed tooltip for just one squashed slice", () => {
     const rows = [["foo", 0.5], ["bar", 0.49], ["baz", 0.002]];
-    const { container, getAllByText, queryAllByText } = render(
+    const { container, queryAllByText } = render(
       <Visualization rawSeries={series(rows)} />,
     );
     const paths = container.querySelectorAll("path");

--- a/frontend/test/metabase/visualizations/components/Visualization-pie.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/Visualization-pie.unit.spec.js
@@ -1,11 +1,12 @@
 jest.mock("metabase/components/ExplicitSize");
 
 import React from "react";
-import { render, cleanup } from "@testing-library/react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
 
 import { NumberColumn, StringColumn } from "../__support__/visualizations";
 
 import Visualization from "metabase/visualizations/components/Visualization";
+import PieChart from "metabase/visualizations/visualizations/PieChart";
 
 const series = rows => {
   const cols = [
@@ -39,5 +40,35 @@ describe("pie chart", () => {
     getAllByText("50%");
     getAllByText("49%");
     getAllByText("1%");
+  });
+
+  it("should show a condensed tooltip for squashed slices", () => {
+    const rows = [["foo", 0.5], ["bar", 0.49], ["baz", 0.002], ["qux", 0.008]];
+    const { container, getAllByText, queryAllByText } = render(
+      <Visualization rawSeries={series(rows)} />,
+    );
+    const paths = container.querySelectorAll("path");
+    const otherPath = paths[paths.length - 1];
+
+    // condensed tooltips display as "dimension: metric"
+    expect(queryAllByText("baz:").length).toBe(0);
+    expect(queryAllByText("qux:").length).toBe(0);
+    fireEvent.mouseMove(otherPath);
+    // these appear twice in the dom due to some popover weirdness
+    expect(getAllByText("baz:").length).toBe(2);
+    expect(getAllByText("qux:").length).toBe(2);
+  });
+
+  it("shouldn't show a condensed tooltip for just one squashed slice", () => {
+    const rows = [["foo", 0.5], ["bar", 0.49], ["baz", 0.002]];
+    const { container, getAllByText, queryAllByText } = render(
+      <Visualization rawSeries={series(rows)} />,
+    );
+    const paths = container.querySelectorAll("path");
+    const otherPath = paths[paths.length - 1];
+
+    fireEvent.mouseMove(otherPath);
+    // normal tooltips don't use this "dimension: metric" format
+    expect(queryAllByText("baz:").length).toBe(0);
   });
 });


### PR DESCRIPTION
Resolves #10914 

There were two small bugs in tooltips for pie charts:
1. We still showed the condensed form of tooltips when there was just one "other" slice. 
2. We displayed the mutated value that was bumped up to OTHER_SLICE_MIN_PERCENTAGE

Using the example from the issue where "N/A" is 1:

Before
![image](https://user-images.githubusercontent.com/691495/65711885-d7e4f000-e063-11e9-958d-3de4523c3257.png)


After
![image](https://user-images.githubusercontent.com/691495/65711829-bc79e500-e063-11e9-8ff2-339804eadfe3.png)
