### PR TITLE
when adding question to dashboard only show writeable dashboards

### DIFF
--- a/frontend/src/metabase/containers/AddToDashSelectDashModal.jsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal.jsx
@@ -55,7 +55,7 @@ export default class AddToDashSelectDashModal extends Component {
           title={t`Add this question to a dashboard`}
           onClose={this.props.onClose}
         >
-          <DashboardPicker onChange={this.addToDashboard} />
+          <DashboardPicker onChange={this.addToDashboard} writeable={true} />
           <Link
             mt={1}
             onClick={() => this.setState({ shouldCreateDashboard: true })}

--- a/frontend/src/metabase/containers/ItemPicker.jsx
+++ b/frontend/src/metabase/containers/ItemPicker.jsx
@@ -69,7 +69,14 @@ export default class ItemPicker extends React.Component {
   }
 
   render() {
-    const { value, onChange, collectionsById, style, className } = this.props;
+    const {
+      value,
+      onChange,
+      collectionsById,
+      style,
+      className,
+      writeable,
+    } = this.props;
     const { parentId, searchMode, searchString } = this.state;
 
     const models = new Set(this.props.models);
@@ -172,7 +179,7 @@ export default class ItemPicker extends React.Component {
                   ) : null;
                 })
               : null}
-            {(modelsIncludeNonCollections || searchString) && (
+            {(modelsIncludeNonCollections || searchString || writeable) && (
               <EntityListLoader
                 entityType="search"
                 entityQuery={{
@@ -182,6 +189,7 @@ export default class ItemPicker extends React.Component {
                   ...(models.size === 1
                     ? { model: Array.from(models)[0] }
                     : {}),
+                  ...(writeable ? { writeable: true } : {}),
                 }}
                 wrapped
               >

--- a/frontend/src/metabase/entities/search.js
+++ b/frontend/src/metabase/entities/search.js
@@ -43,7 +43,6 @@ export default createEntity({
         })).map(item => ({
           collection_id: canonicalCollectionId(collection),
           archived: archived || false,
-          writeable: writeable || false,
           ...item,
         }));
       } else {

--- a/frontend/src/metabase/entities/search.js
+++ b/frontend/src/metabase/entities/search.js
@@ -22,20 +22,30 @@ export default createEntity({
   api: {
     list: async (query = {}) => {
       if (query.collection) {
-        const { collection, archived, model, ...unsupported } = query;
+        const {
+          collection,
+          archived,
+          model,
+          writeable,
+          ...unsupported
+        } = query;
         if (Object.keys(unsupported).length > 0) {
           throw new Error(
             "search with `collection` filter does not support these filters: " +
               Object.keys(unsupported).join(", "),
           );
         }
-        return (await collectionList({ collection, archived, model })).map(
-          item => ({
-            collection_id: canonicalCollectionId(collection),
-            archived: archived || false,
-            ...item,
-          }),
-        );
+        return (await collectionList({
+          collection,
+          archived,
+          model,
+          writeable,
+        })).map(item => ({
+          collection_id: canonicalCollectionId(collection),
+          archived: archived || false,
+          writeable: writeable || false,
+          ...item,
+        }));
       } else {
         return searchList(query);
       }


### PR DESCRIPTION
resolves https://github.com/metabase/metabase/issues/8996

The idea is to send an optional `writeable` query string param to `/api/collection/:id/items` to specify that you only want items that are writeable.

@tlrobinson did I do this right? :D
