### PR TITLE
[WIP] Permission logging

### DIFF
--- a/src/metabase/models/permissions/parse.clj
+++ b/src/metabase/models/permissions/parse.clj
@@ -20,7 +20,7 @@
 
   collection  = <'/collection/'> #'[^/]*' <'/'> ('read' <'/'>)?")
 
-(def ^:private parser
+(def parser
   "Function thqat parses permission strings"
   (insta/parser grammar))
 
@@ -28,7 +28,7 @@
   [id]
   (if (= id "root") :root (Integer/parseInt id)))
 
-(defn- path
+(defn path
   "Recursively build permission path from parse tree"
   [tree]
   (match/match tree

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -683,3 +683,16 @@
     (perms/grant-collection-readwrite-permissions!
      (group/all-users)
      collection)))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                 Describe permissions                                                           |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(tt/expect-with-temp [Database         [{db_id :id}    {:name "the_db"}]
+                      Table            [{table_id :id} {:db_id db_id :name "the_table"}]]
+  [{:permission-string  (format "/db/%d/schema/PUBLIC/table/%d/" db_id table_id),
+    :permission-details [{:db-id db_id :db-name "the_db"}
+                         :schemas
+                         "PUBLIC"
+                         {:table-id table_id :table-name "the_table"}]}]
+  (perms/missing-permissions #{} #{(format "/db/%d/schema/PUBLIC/table/%d/" db_id table_id)}))


### PR DESCRIPTION
One step toward describing permissions issues, as suggested in #11004 .

The idea I'm considering is logging authorization failures in a way that would help us help users debug issues, and would help admin users give their clients/users the correct permissions.

This PR is only meant as a starting point for us to discuss possible ways to achieve that goal. It introduces a function, `missing-permissions`, that decorates permission strings with the names of the databases, tables, and collections referenced in the permission string. It has a test that's currently failing because the database and table lookup aren't working for some reason.