### PR TITLE
add hover style to question description

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -109,7 +109,7 @@ export class ViewTitleHeader extends React.Component {
               {description && (
                 <Icon
                   name="info"
-                  className="text-light mx1"
+                  className="text-light mx1 cursor-pointer text-brand-hover"
                   size={18}
                   tooltip={description}
                 />


### PR DESCRIPTION
Real small tweak to add a nicer hover state to the question description.

Before:
![Screen Shot 2019-09-30 at 12 21 45 PM](https://user-images.githubusercontent.com/5248953/65909182-e6d9e400-e37c-11e9-82e5-2762f9749202.png)


After:
![Screen Shot 2019-09-30 at 12 20 45 PM](https://user-images.githubusercontent.com/5248953/65909129-c14cda80-e37c-11e9-88d8-dd6d635e7564.png)
