### PR TITLE
Fix legacy auto datetime bucketing filtering

### DIFF
--- a/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
+++ b/test/metabase/query_processor/middleware/auto_bucket_datetimes_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.middleware.auto-bucket-datetimes-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
+            [expectations :refer [expect]]
             [metabase.models.field :refer [Field]]
             [metabase.query-processor.middleware.auto-bucket-datetimes :as auto-bucket-datetimes]
             [metabase.test.data :as data]
@@ -184,3 +185,15 @@
       (auto-bucket-mbql
        {:source-table $$incidents
         :breakout     [$timestamp]}))))
+
+(deftest relative-datetime-test
+  (is (= (->
+          (data/mbql-query checkins
+            {:filter [:= [:datetime-field $date :day] [:relative-datetime :current]]})
+          :query :filter)
+         (->
+          (auto-bucket
+           (data/mbql-query checkins
+             {:filter [:= $date [:relative-datetime :current]]}))
+          :query :filter))
+      "Fields being compared against `:relative-datetime`s should be subject to auto-bucketing. (#9014)"))


### PR DESCRIPTION
Fix regression where MBQL queries that filtered against a `relative-datetime` (e.g. "today"), created with Metabase UI < v0.31.0, were not properly auto-bucketed.

Fixes #9014