### PR TITLE
update password complexity statement for more accuracy

### DIFF
--- a/frontend/src/metabase/lib/settings.js
+++ b/frontend/src/metabase/lib/settings.js
@@ -117,8 +117,8 @@ const MetabaseSettings = {
 
     const description =
       capitalize === false
-        ? t`must be` + " " + complexity.total + " " + t`characters long`
-        : t`Must be` + " " + complexity.total + " " + t`characters long`;
+        ? t`must be at least ${complexity.total} characters long`
+        : t`Must be at least ${complexity.total} characters long`;
     const clauses = [];
 
     ["lower", "upper", "digit", "special"].forEach(function(clause) {


### PR DESCRIPTION
The current text implies that a password must be _exactly_
`complexity.total` length, whereas that is actually the minimum length.

### Tests
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
