### PR TITLE
Display error message from setup submit

### DIFF
--- a/frontend/src/metabase/setup/components/PreferencesStep.jsx
+++ b/frontend/src/metabase/setup/components/PreferencesStep.jsx
@@ -10,6 +10,8 @@ import StepTitle from "./StepTitle";
 import CollapsedStep from "./CollapsedStep";
 
 export default class PreferencesStep extends Component {
+  state = { errorMessage: null };
+
   static propTypes = {
     stepNumber: PropTypes.number.isRequired,
     activeStep: PropTypes.number.isRequired,
@@ -31,7 +33,12 @@ export default class PreferencesStep extends Component {
     e.preventDefault();
 
     // okay, this is the big one.  we actually submit everything to the api now and complete the process.
-    this.props.submitSetup();
+    const { payload } = await this.props.submitSetup();
+    console.log("payload", payload);
+    // a successful payload is null
+    const errorMessage =
+      payload && payload.data ? getErrorMessage(payload.data) : null;
+    this.setState({ errorMessage });
 
     MetabaseAnalytics.trackEvent(
       "Setup",
@@ -109,10 +116,24 @@ export default class PreferencesStep extends Component {
             <div className="Form-actions">
               <button className="Button Button--primary">{t`Next`}</button>
               {/* FIXME: <mb-form-message form="usageForm"></mb-form-message>*/}
+              {this.state.errorMessage && (
+                <div className="text-error ml1">{this.state.errorMessage}</div>
+              )}
             </div>
           </form>
         </section>
       );
     }
   }
+}
+
+function getErrorMessage(data) {
+  const { errors, message } = data;
+  if (message) {
+    return message;
+  }
+  if (errors) {
+    return Object.values(errors)[0];
+  }
+  return null;
 }

--- a/frontend/src/metabase/setup/components/PreferencesStep.jsx
+++ b/frontend/src/metabase/setup/components/PreferencesStep.jsx
@@ -34,7 +34,6 @@ export default class PreferencesStep extends Component {
 
     // okay, this is the big one.  we actually submit everything to the api now and complete the process.
     const { payload } = await this.props.submitSetup();
-    console.log("payload", payload);
     // a successful payload is null
     const errorMessage =
       payload && payload.data ? getErrorMessage(payload.data) : null;


### PR DESCRIPTION
Resolves #10926

This adds an error message for the big submission at the end of the setup process. My assumption is that any easily handled errors were presented to the user earlier (e.g. bad password, db config issue).

This tries grab a message out of any errored response and plops it next to the "Next" button.
Specifically, it pulls out a `message` or the first value in an `errors` object. 

In my forced errors (below) the messages were either confusing (token isn't a user-facing concept) or really ugly (a raw SQL error response), but I figure it's better to give the user _something_ google-able rather than a generic error or silence.

I started writing a test for this, but for a one-off component like this I figure it doesn't really add much.
<img width="741" src="https://user-images.githubusercontent.com/691495/66085546-87780180-e53f-11e9-8650-e46d2c2e126d.png">

<img width="748" src="https://user-images.githubusercontent.com/691495/66085637-c7d77f80-e53f-11e9-82c9-8ccf741c3f9e.png">
