### PR TITLE
Validate trs/tru args counts at macroexpansion time

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -423,7 +423,7 @@
 
     :else
     (throw
-     (ex-info (tru "Don't know how to handle aggregation {0}" ag)
+     (ex-info (tru "Don''t know how to handle aggregation {0}" ag)
        {:type :invalid-query, :clause ag}))))
 
 (defn- unwrap-named-ag [[ag-type arg :as ag]]

--- a/project.clj
+++ b/project.clj
@@ -275,7 +275,7 @@
       ;; Turn this off temporarily until we finish removing self-deprecated functions & macros
       :exclude-linters    [:deprecations]}}]
 
-   ;; run `lein check-reflection-warnings` to check for reflection warnings
+   ;; run ./bin/reflection-linter to check for reflection warnings
    :reflection-warnings
    [:include-all-drivers
     {:global-vars {*warn-on-reflection* true}}]

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -72,7 +72,7 @@
 
     (check test1 code1 message1
            test2 code2 message2)"
-  {:style/indent 1, :arglists '([test [code message] & more] [test code message & more])}
+  {:style/indent 1, :arglists '([condition [code message] & more] [condition code message & more])}
   [condition & args]
   (let [[code message & more] (if (sequential? (first args))
                                 (concat (first args) (rest args))

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -41,11 +41,20 @@
 
 ;;; ---------------------------------------- Precondition checking helper fns ----------------------------------------
 
+(defn- check-one [condition code message]
+  (when-not condition
+    (let [[message info] (if (and (map? message)
+                                  (not (ui18n/localized-string? message)))
+                           [(:message message) message]
+                           [message])]
+      (throw (ex-info (str message) (assoc info :status-code code)))))
+  condition)
+
 (defn check
   "Assertion mechanism for use inside API functions.
   Checks that `test` is true, or throws an `ExceptionInfo` with `status-code` and `message`.
 
-  MESSAGE can be either a plain string error message, or a map including the key `:message` and any additional
+  `message` can be either a plain string error message, or a map including the key `:message` and any additional
   details, such as an `:error_code`.
 
   This exception is automatically caught in the body of `defendpoint` functions, and the appropriate HTTP response is
@@ -63,18 +72,15 @@
 
     (check test1 code1 message1
            test2 code2 message2)"
-  {:style/indent 1}
-  ([tst code-or-code-message-pair & rest-args]
-   (let [[[code message] rest-args] (if (vector? code-or-code-message-pair)
-                                      [code-or-code-message-pair rest-args]
-                                      [[code-or-code-message-pair (first rest-args)] (rest rest-args)])]
-     (when-not tst
-       (throw (if (and (map? message)
-                       (not (ui18n/localized-string? message)))
-                (ui18n/ex-info (:message message) (assoc message :status-code code))
-                (ui18n/ex-info message            {:status-code code}))))
-     (if (empty? rest-args) tst
-         (recur (first rest-args) (second rest-args) (drop 2 rest-args))))))
+  {:style/indent 1, :arglists '([test [code message] & more] [test code message & more])}
+  [condition & args]
+  (let [[code message & more] (if (sequential? (first args))
+                                (concat (first args) (rest args))
+                                args)]
+    (check-one condition code message)
+    (if (seq more)
+      (recur (first more) (rest more))
+      condition)))
 
 (defn check-exists?
   "Check that object with ID (or other key/values) exists in the DB, or throw a 404."
@@ -95,7 +101,7 @@
 (defn throw-invalid-param-exception
   "Throw an `ExceptionInfo` that contains information about an invalid API params in the expected format."
   [field-name message]
-  (throw (ui18n/ex-info (tru "Invalid field: {0}" field-name)
+  (throw (ex-info (tru "Invalid field: {0}" field-name)
            {:status-code 400
             :errors      {(keyword field-name) message}})))
 
@@ -191,7 +197,7 @@
 (defn throw-403
   "Throw a generic 403 (no permissions) error response."
   []
-  (throw (ui18n/ex-info (tru "You don''t have permissions to do that.") {:status-code 403})))
+  (throw (ex-info (tru "You don''t have permissions to do that.") {:status-code 403})))
 
 ;; #### GENERIC 500 RESPONSE HELPERS
 ;; For when you don't feel like writing something useful

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -113,7 +113,7 @@
   [^String value]
   (try (Integer/parseInt value)
        (catch NumberFormatException _
-         (throw (ui18n/ex-info (tru "Not a valid integer: ''{0}''" value) {:status-code 400})))))
+         (throw (ex-info (tru "Not a valid integer: ''{0}''" value) {:status-code 400})))))
 
 (def ^:dynamic *auto-parse-types*
   "Map of `param-type` -> map with the following keys:
@@ -220,7 +220,7 @@
   [field-name value schema]
   (try (s/validate schema value)
        (catch Throwable e
-         (throw (ui18n/ex-info (tru "Invalid field: {0}" field-name)
+         (throw (ex-info (tru "Invalid field: {0}" field-name)
                   {:status-code 400
                    :errors      {(keyword field-name) (or (su/api-error-message schema)
                                                           (:message (ex-data e))

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -128,7 +128,7 @@
   [key]
   {key su/NonBlankString}
   (let [url (or (get-in (custom-geojson) [(keyword key) :url])
-                (throw (ui18n/ex-info (tru "Invalid custom GeoJSON key: {0}" key)
+                (throw (ex-info (tru "Invalid custom GeoJSON key: {0}" key)
                          {:status-code 400})))]
     ;; TODO - it would be nice if we could also avoid returning our usual cache-busting headers with the response here
     (-> (rr/response (ReaderInputStream. (io/reader url)))

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -76,7 +76,7 @@
         (when-not (ldap/verify-password user-info password)
           ;; Since LDAP knows about the user, fail here to prevent the local strategy to be tried with a possibly
           ;; outdated password
-          (throw (ui18n/ex-info password-fail-message
+          (throw (ex-info (str password-fail-message)
                    {:status-code 400
                     :errors      {:password password-fail-snippet}})))
         ;; password is ok, return new session
@@ -109,7 +109,7 @@
       ;; If nothing succeeded complain about it
       ;; Don't leak whether the account doesn't exist or the password was incorrect
       (throw
-       (ui18n/ex-info password-fail-message
+       (ex-info (str password-fail-message)
          {:status-code 400
           :errors      {:password password-fail-snippet}}))))
 
@@ -255,10 +255,10 @@
 (defn- google-auth-token-info [^String token]
   (let [{:keys [status body]} (http/post (str "https://www.googleapis.com/oauth2/v3/tokeninfo?id_token=" token))]
     (when-not (= status 200)
-      (throw (ui18n/ex-info (tru "Invalid Google Auth token.") {:status-code 400})))
+      (throw (ex-info (tru "Invalid Google Auth token.") {:status-code 400})))
     (u/prog1 (json/parse-string body keyword)
       (when-not (= (:email_verified <>) "true")
-        (throw (ui18n/ex-info (tru "Email is not verified.") {:status-code 400}))))))
+        (throw (ex-info (tru "Email is not verified.") {:status-code 400}))))))
 
 ;; TODO - are these general enough to move to `metabase.util`?
 (defn- email->domain ^String [email]
@@ -279,7 +279,7 @@
     ;; Use some wacky status code (428 - Precondition Required) so we will know when to so the error screen specific
     ;; to this situation
     (throw
-     (ui18n/ex-info (tru "You''ll need an administrator to create a Metabase account before you can use Google to log in.")
+     (ex-info (tru "You''ll need an administrator to create a Metabase account before you can use Google to log in.")
        {:status-code 428}))))
 
 (s/defn ^:private google-auth-create-new-user!

--- a/src/metabase/api/task.clj
+++ b/src/metabase/api/task.clj
@@ -13,13 +13,13 @@
 (defn- check-valid-limit [limit offset]
   (when (and offset (not limit))
     (throw
-     (ui18n/ex-info (tru "When including an offset, a limit must also be included.")
+     (ex-info (tru "When including an offset, a limit must also be included.")
        {:status-code 400}))))
 
 (defn- check-valid-offset [limit offset]
   (when (and limit (not offset))
     (throw
-     (ui18n/ex-info (tru "When including a limit, an offset must also be included.")
+     (ex-info (tru "When including a limit, an offset must also be included.")
        {:status-code 400}))))
 
 (api/defendpoint GET "/"

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -1014,7 +1014,7 @@
                                       (format "%s#show=all" (:url root)))
                  :transient_filters (:query-filter context)
                  :param_fields      (->> context :query-filter (filter-referenced-fields root)))))
-    (throw (ui18n/ex-info (trs "Can''t create dashboard for {0}" full-name)
+    (throw (ex-info (trs "Can''t create dashboard for {0}" full-name)
              {:root            root
               :available-rules (map :rule (or (some-> rule rules/get-rule vector)
                                               (rules/get-rules rules-prefix)))}))))

--- a/src/metabase/automagic_dashboards/rules.clj
+++ b/src/metabase/automagic_dashboards/rules.clj
@@ -6,7 +6,7 @@
             [metabase.util :as u]
             [metabase.util
              [files :as files]
-             [i18n :refer [deferred-trs deferred-tru LocalizedString]]
+             [i18n :as i18n :refer [deferred-trs LocalizedString]]
              [schema :as su]
              [yaml :as yaml]]
             [schema
@@ -266,7 +266,8 @@
                           [(if (-> table-type ->entity table-type?)
                              (->entity table-type)
                              (->type table-type))])))
-    LocalizedString #(deferred-tru %)}))
+    LocalizedString (fn [s]
+                      (i18n/->UserLocalizedString (namespace-munge *ns*) s nil))}))
 
 (def ^:private rules-dir "automagic_dashboards/")
 

--- a/src/metabase/db/migrations.clj
+++ b/src/metabase/db/migrations.clj
@@ -348,7 +348,7 @@
       (doseq [group-id non-admin-group-ids]
         (perms/revoke-collection-permissions! group-id new-collection))
       ;; 4. move everything not in this Collection to a new Collection
-      (log/info (trs "Moving instances of {0} that aren't in a Collection to {1} Collection {2}"
+      (log/info (trs "Moving instances of {0} that aren''t in a Collection to {1} Collection {2}"
                      (name model) new-collection-name (u/get-id new-collection)))
       (db/update-where! model {:collection_id nil}
         :collection_id (u/get-id new-collection)))))

--- a/src/metabase/driver/sql/util.clj
+++ b/src/metabase/driver/sql/util.clj
@@ -75,7 +75,7 @@
 
       :else
       (do
-        (log/error (trs "Don't know how to alias {0}, expected an Identifier." col))
+        (log/error (trs "Don''t know how to alias {0}, expected an Identifier." col))
         [col col]))))
 
 (defn select-clause-deduplicate-aliases

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -92,12 +92,12 @@
 
         (ids-already-seen source-card-id)
         (throw
-         (ui18n/ex-info (tru "Cannot save Question: source query has circular references.")
+         (ex-info (tru "Cannot save Question: source query has circular references.")
            {:status-code 400}))
 
         :else
         (recur (or (db/select-one-field :dataset_query Card :id source-card-id)
-                   (throw (ui18n/ex-info (tru "Card {0} does not exist." source-card-id)
+                   (throw (ex-info (tru "Card {0} does not exist." source-card-id)
                             {:status-code 404})))
                (conj ids-already-seen source-card-id))))))
 

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -44,13 +44,13 @@
 (defn- assert-valid-hex-color [^String hex-color]
   (when (or (not (string? hex-color))
             (not (re-matches hex-color-regex hex-color)))
-    (throw (ui18n/ex-info (tru "Invalid color")
+    (throw (ex-info (tru "Invalid color")
              {:status-code 400, :errors {:color (tru "must be a valid 6-character hex color code")}}))))
 
 (defn- slugify [collection-name]
   ;; double-check that someone isn't trying to use a blank string as the collection name
   (when (str/blank? collection-name)
-    (throw (ui18n/ex-info (tru "Collection name cannot be blank!")
+    (throw (ex-info (tru "Collection name cannot be blank!")
              {:status-code 400, :errors {:name (tru "cannot be blank")}})))
   (u/slugify collection-name collection-slug-max-length))
 
@@ -143,20 +143,20 @@
   (when (contains? collection :location)
     (when-not (valid-location-path? location)
       (throw
-       (ui18n/ex-info (tru "Invalid Collection location: path is invalid.")
+       (ex-info (tru "Invalid Collection location: path is invalid.")
          {:status-code 400
           :errors      {:location (tru "Invalid Collection location: path is invalid.")}})))
     ;; if this is a Personal Collection it's only allowed to go in the Root Collection: you can't put it anywhere else!
     (when (contains? collection :personal_owner_id)
       (when-not (= location "/")
         (throw
-         (ui18n/ex-info (tru "You cannot move a Personal Collection.")
+         (ex-info (tru "You cannot move a Personal Collection.")
            {:status-code 400
             :errors      {:location (tru "You cannot move a Personal Collection.")}}))))
     ;; Also make sure that all the IDs referenced in the Location path actually correspond to real Collections
     (when-not (all-ids-in-location-path-are-valid? location)
       (throw
-       (ui18n/ex-info (tru "Invalid Collection location: some or all ancestors do not exist.")
+       (ex-info (tru "Invalid Collection location: some or all ancestors do not exist.")
          {:status-code 404
           :errors      {:location (tru "Invalid Collection location: some or all ancestors do not exist.")}})))))
 
@@ -669,7 +669,7 @@
   ;; double-check and make sure it's not just the existing value getting passed back in for whatever reason
   (when (api/column-will-change? :personal_owner_id collection-before-updates collection-updates)
     (throw
-     (ui18n/ex-info (tru "You're not allowed to change the owner of a Personal Collection.")
+     (ex-info (tru "You're not allowed to change the owner of a Personal Collection.")
        {:status-code 400
         :errors      {:personal_owner_id (tru "You're not allowed to change the owner of a Personal Collection.")}})))
   ;;
@@ -680,13 +680,13 @@
   ;; You also definitely cannot *move* a Personal Collection
   (when (api/column-will-change? :location collection-before-updates collection-updates)
     (throw
-     (ui18n/ex-info (tru "You're not allowed to move a Personal Collection.")
+     (ex-info (tru "You're not allowed to move a Personal Collection.")
        {:status-code 400
         :errors      {:location (tru "You're not allowed to move a Personal Collection.")}})))
   ;; You also can't archive a Personal Collection
   (when (api/column-will-change? :archived collection-before-updates collection-updates)
     (throw
-     (ui18n/ex-info (tru "You cannot archive a Personal Collection.")
+     (ex-info (tru "You cannot archive a Personal Collection.")
        {:status-code 400
         :errors      {:archived (tru "You cannot archive a Personal Collection.")}}))))
 
@@ -697,7 +697,7 @@
   (when (api/column-will-change? :archived collection-before-updates collection-updates)
     ;; check to make sure we're not trying to change location at the same time
     (when (api/column-will-change? :location collection-before-updates collection-updates)
-      (throw (ui18n/ex-info (tru "You cannot move a Collection and archive it at the same time.")
+      (throw (ex-info (tru "You cannot move a Collection and archive it at the same time.")
                {:status-code 400
                 :errors      {:archived (tru "You cannot move a Collection and archive it at the same time.")}})))
     ;; ok, go ahead and do the archive/unarchive operation

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -84,7 +84,7 @@
   [{:keys [group_id]}]
   (when (and (= group_id (:id (group/admin)))
              (not *allow-admin-permissions-changes*))
-    (throw (ui18n/ex-info (tru "You cannot create or revoke permissions for the ''Admin'' group.")
+    (throw (ex-info (tru "You cannot create or revoke permissions for the ''Admin'' group.")
              {:status-code 400}))))
 
 (defn- assert-valid-object
@@ -623,7 +623,7 @@
    Return a 409 (Conflict) if the numbers don't match up."
   [old-graph new-graph]
   (when (not= (:revision old-graph) (:revision new-graph))
-    (throw (ui18n/ex-info (str (deferred-tru "Looks like someone else edited the permissions and your data is out of date.")
+    (throw (ex-info (str (deferred-tru "Looks like someone else edited the permissions and your data is out of date.")
                                " "
                                (deferred-tru "Please fetch new data and try again."))
              {:status-code 409}))))

--- a/src/metabase/models/permissions_group.clj
+++ b/src/metabase/models/permissions_group.clj
@@ -58,7 +58,7 @@
 (defn- check-name-not-already-taken
   [group-name]
   (when (exists-with-name? group-name)
-    (throw (ui18n/ex-info (tru "A group with that name already exists.") {:status-code 400}))))
+    (throw (ex-info (tru "A group with that name already exists.") {:status-code 400}))))
 
 (defn- check-not-magic-group
   "Make sure we're not trying to edit/delete one of the magic groups, or throw an exception."
@@ -68,7 +68,7 @@
                        (admin)
                        (metabot)]]
     (when (= id (:id magic-group))
-      (throw (ui18n/ex-info (tru "You cannot edit or delete the ''{0}'' permissions group!" (:name magic-group))
+      (throw (ex-info (tru "You cannot edit or delete the ''{0}'' permissions group!" (:name magic-group))
                {:status-code 400})))))
 
 

--- a/src/metabase/models/permissions_group_membership.clj
+++ b/src/metabase/models/permissions_group_membership.clj
@@ -12,7 +12,7 @@
   "Throw an Exception if we're trying to add or remove a user to the MetaBot group."
   [group-id]
   (when (= group-id (:id (group/metabot)))
-    (throw (ui18n/ex-info (tru "You cannot add or remove users to/from the ''MetaBot'' group.")
+    (throw (ex-info (tru "You cannot add or remove users to/from the ''MetaBot'' group.")
              {:status-code 400}))))
 
 (defonce ^:dynamic ^{:doc "Should we allow people to be added to or removed from the All Users permissions group? By
@@ -25,14 +25,14 @@
   [group-id]
   (when (= group-id (:id (group/all-users)))
     (when-not *allow-changing-all-users-group-members*
-      (throw (ui18n/ex-info (tru "You cannot add or remove users to/from the ''All Users'' group.")
+      (throw (ex-info (tru "You cannot add or remove users to/from the ''All Users'' group.")
                {:status-code 400})))))
 
 (defn- check-not-last-admin []
   (when (<= (db/count PermissionsGroupMembership
               :group_id (:id (group/admin)))
             1)
-    (throw (ui18n/ex-info (tru "You cannot remove the last member of the ''Admin'' group!")
+    (throw (ex-info (tru "You cannot remove the last member of the ''Admin'' group!")
              {:status-code 400}))))
 
 (defn- pre-delete [{:keys [group_id user_id]}]

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -202,7 +202,7 @@
                  (throw (Exception. (tru "Could not resolve Setting {0}/{1}" ns-symb setting-symb))))
         f    (var-get varr)]
     (assert (ifn? f)
-      (tru "Invalid Setting: {0)/{1}" ns-symb setting-symb))
+      (tru "Invalid Setting: {0}/{1}" ns-symb setting-symb))
     (f)))
 
 ;; TODO - it seems like it would be a nice performance win to cache this a little bit

--- a/src/metabase/pulse/render/color.clj
+++ b/src/metabase/pulse/render/color.clj
@@ -23,7 +23,7 @@
     ;; assertion till look for the javascript file at startup and fail if it doesn't find it. This is to avoid a big
     ;; delay in finding out that the system is broken
     (assert (get-classpath-resource js-file-path)
-      (trs "Can't find JS color selector at ''{0}''" js-file-path))
+      (trs "Can''t find JS color selector at ''{0}''" js-file-path))
     (delay
      (with-open [stream (get-classpath-resource js-file-path)]
        (make-js-engine-with-script (slurp stream))))))
@@ -49,7 +49,8 @@
   (let [^Invocable engine @js-engine
         ;; Ideally we'd convert everything to JS data before invoking the function below, but converting rows would be
         ;; expensive. The JS code is written to deal with `rows` in it's native Nashorn format but since `cols` and
-        ;; `viz-settings` are small, pass those as JSON so that they can be deserialized to pure JS objects once in JS code
+        ;; `viz-settings` are small, pass those as JSON so that they can be deserialized to pure JS objects once in JS
+        ;; code
         js-fn-args (object-array [rows (json/generate-string cols) (json/generate-string viz-settings)])]
     (.invokeFunction engine "makeCellBackgroundGetter" js-fn-args)))
 

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -192,8 +192,9 @@
 
     ;; we should never reach this if our patterns are written right so this is more to catch code mistakes than
     ;; something the user should expect to see
-    _ (throw (ex-info (tru "Don't know how to get information about Field:" " " &match)
-               {:field &match}))))
+    _
+    (throw (ex-info (tru "Don''t know how to get information about Field: {0}" &match)
+             {:field &match}))))
 
 
 ;;; ---------------------------------------------- Aggregate Field Info ----------------------------------------------

--- a/src/metabase/query_processor/middleware/async.clj
+++ b/src/metabase/query_processor/middleware/async.clj
@@ -86,7 +86,7 @@
       (not= port out-chan)
       (do
         (a/close! out-chan)
-        (throw (TimeoutException. (tru "Query timed out after %s" (du/format-milliseconds query-timeout-ms)))))
+        (throw (TimeoutException. (tru "Query timed out after {0}" (du/format-milliseconds query-timeout-ms)))))
 
       :else
       result)))

--- a/src/metabase/query_processor/middleware/parameters/native/values.clj
+++ b/src/metabase/query_processor/middleware/parameters/native/values.clj
@@ -91,7 +91,7 @@
      ;; TODO - shouldn't this use the QP Store?
      {:field (or (db/select-one [Field :name :parent_id :table_id :base_type]
                    :id (field-filter->field-id field-filter))
-                 (throw (Exception. (tru "Can't find field with ID: {0}"
+                 (throw (Exception. (tru "Can''t find field with ID: {0}"
                                          (field-filter->field-id field-filter)))))
       :value (if-let [value-info-or-infos (or
                                            ;; look in the sequence of params we were passed to see if there's anything

--- a/src/metabase/util/embed.clj
+++ b/src/metabase/util/embed.clj
@@ -97,7 +97,7 @@
         (throw (ex-info (.getMessage e) {:status-code 400}))))))
 
 (defn get-in-unsigned-token-or-throw
-  "Find KEYSEQ in the UNSIGNED-TOKEN (a JWT token decoded by `unsign`) or throw a 400."
+  "Find `keyseq` in the `unsigned-token` (a JWT token decoded by `unsign`) or throw a 400."
   [unsigned-token keyseq]
   (or (get-in unsigned-token keyseq)
-      (throw (ex-info (tru "Token is missing value for keypath" " " keyseq) {:status-code 400}))))
+      (throw (ex-info (tru "Token is missing value for keypath {0}" keyseq) {:status-code 400}))))


### PR DESCRIPTION
One of the cool things you can do with Clojure macros: validate the arguments to a function call at compile time.

In this case, we can check that `trs`/`tru` and the like are called with the correct number of arguments for their format string during macroexpansion. This catches bugs, for example me forgetting that you have to escape single quotes in the i18n format strings