### PR TITLE
Only show am/pm if locale uses 12-hour clock

### DIFF
--- a/frontend/src/metabase/lib/i18n.js
+++ b/frontend/src/metabase/lib/i18n.js
@@ -25,6 +25,13 @@ export function setLocalization(translationsObject) {
   moment.locale(locale);
 }
 
+// Format a fixed timestamp in local time to see if the current locale defaults
+// to using a 24 hour clock.
+export function isLocale24Hour() {
+  const formattedTime = moment("2000-01-01T13:00:00").format("LT");
+  return /^13:/.test(formattedTime);
+}
+
 // we delete msgid property since it's redundant, but have to add it back in to
 // make ttag happy
 function addMsgIds(translationsObject) {

--- a/frontend/src/metabase/query_builder/components/filters/pickers/HoursMinutesInput.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/HoursMinutesInput.jsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import NumericInput from "metabase/components/NumericInput";
 import Icon from "metabase/components/Icon";
+import { isLocale24Hour } from "metabase/lib/i18n";
 
 import cx from "classnames";
 import moment from "moment";
@@ -12,7 +13,7 @@ const HoursMinutesInput = ({
   onChangeHours,
   onChangeMinutes,
   onClear,
-  is24HourMode = false,
+  is24HourMode = isLocale24Hour(),
 }) => (
   <div className="flex align-center">
     <NumericInput

--- a/frontend/test/metabase/lib/i18n.unit.spec.js
+++ b/frontend/test/metabase/lib/i18n.unit.spec.js
@@ -1,0 +1,25 @@
+import moment from "moment";
+
+import { isLocale24Hour } from "metabase/lib/i18n";
+
+describe("isLocale24Hour", () => {
+  const testCases = [
+    ["en", false],
+    ["en-us", false],
+    ["en-gb", true],
+    ["fr", true],
+    ["zh-cn", true],
+  ];
+  for (const [locale, is24] of testCases) {
+    it(`should return ${is24} for '${locale}'`, () => {
+      // save locale before changing it
+      const startingLocale = moment.locale();
+
+      moment.locale(locale);
+      expect(isLocale24Hour()).toBe(is24);
+
+      // reset locale
+      moment.locale(startingLocale);
+    });
+  }
+});


### PR DESCRIPTION
Resolves #11014

AM/PM doesn't convert directly to other locales. Here's moment's logic for displaying meridiem in Chinese.
```js
function (hour, minute, isLower) {
    var hm = hour * 100 + minute;
    if (hm < 600) {
        return '凌晨';
    } else if (hm < 900) {
        return '早上';
    } else if (hm < 1130) {
        return '上午';
    } else if (hm < 1230) {
        return '中午';
    } else if (hm < 1800) {
        return '下午';
    } else {
        return '晚上';
    }
}
```

That implementation led to a bug specific to how we call `meridiem`. We don't pass `minute`, so `hm` was `NaN` and both times we called it hit the final else.

We could work around that bug by passing `minute`. That would fix the obvious bug where we repeated 晚上 (evening). However, the result would still be wrong. We'd show 凌晨 (early morning) for midnight through noon and 中午 (noon) after that.

I think the right thing to do is to only display a meridiem selector for time input if the locale uses a 12-hour clock. Using meridiem as part of time input doesn't make sense in Chinese, but that locale also defaults to using a 24-hour clock. My assumption is that those attributes of a locale will always agree.

The slightly awkward thing about this is that there's an instance setting to pick 12/24 hour clock. This logic ignores that setting and just depends on the locale. I think that's better because time entry relies on pulling info from the locale.

---

Repeated 晚上 bug:

<img width="297" src="https://user-images.githubusercontent.com/691495/66135956-b7b7b280-e5c8-11e9-9359-e52b14983225.png">

Checking locale's clock, we hide it for "zh-cn":
<img width="296" src="https://user-images.githubusercontent.com/691495/66136065-db7af880-e5c8-11e9-96b2-3c3b089ce0b7.png">

But, we still show it for "en-us":

<img width="296" src="https://user-images.githubusercontent.com/691495/66136117-eb92d800-e5c8-11e9-8274-62c003ae0b04.png">



