### PR TITLE
Remove .git from .dockerignore so bin/version gets the correct branch/hash

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .babel_cache/*
-.git/*
 docs/*
 OSX/*
 target/*


### PR DESCRIPTION
Fixes stats not showing the branch/commit hash in the version panel.