### PR TITLE
New tests for TIMESTAMP WITH TIME ZONE fields

### DIFF
--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -81,7 +81,7 @@
   "Create a new C3P0 `ComboPooledDataSource` for connecting to the given `database`."
   [{:keys [id details], driver :engine, :as database}]
   {:pre [(map? database)]}
-  (log/debug (u/format-color 'cyan (trs "Creating new connection pool for {0} database {1} ...") driver id))
+  (log/debug (u/format-color 'cyan (trs "Creating new connection pool for {0} database {1} ..." driver id)))
   (let [details-with-tunnel (ssh/include-ssh-tunnel details) ;; If the tunnel is disabled this returned unchanged
         spec                (connection-details->spec driver details-with-tunnel)
         properties          (data-warehouse-connection-pool-properties driver)]

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -65,10 +65,12 @@
     [(driver/dispatch-on-initialized-driver driver) (.getColumnType resultset-metadata i)])
   :hierarchy #'driver/hierarchy)
 
-(defmethod read-column :default [_ _, ^ResultSet resultset, _, ^Integer i]
+(defmethod read-column :default
+  [_ _, ^ResultSet resultset, _, ^Integer i]
   (.getObject resultset i))
 
-(defmethod read-column [::driver/driver Types/DATE] [_, ^Calendar cal, ^ResultSet resultset, _, ^Integer i]
+(defmethod read-column [::driver/driver Types/DATE]
+  [_, ^Calendar cal, ^ResultSet resultset, _, ^Integer i]
   (if-not cal
     (.getObject resultset i)
     (try
@@ -76,7 +78,8 @@
       (catch SQLException e
         (parse-date-as-string cal resultset i)))))
 
-(defmethod read-column [::driver/driver Types/TIMESTAMP] [_, ^Calendar cal, ^ResultSet resultset, _, ^Integer i]
+(defmethod read-column [::driver/driver Types/TIMESTAMP]
+  [_, ^Calendar cal, ^ResultSet resultset, _, ^Integer i]
   (if-not cal
     (.getObject resultset i)
     (try
@@ -84,7 +87,8 @@
       (catch SQLException e
         (parse-date-as-string cal resultset i)))))
 
-(defmethod read-column [::driver/driver Types/TIME] [driver, _, ^ResultSet resultset, _, ^Integer i]
+(defmethod read-column [::driver/driver Types/TIME]
+  [driver, _, ^ResultSet resultset, _, ^Integer i]
   ;; .getTime will be something like 1970-01-01-09:14:00 when it comes back from the DB for normal DBs (i.e., already
   ;; in UTC), so always pass in UTC Calendar -- otherwise the normal behavior is to try to apply the default calendar,
   ;; which uses the default timezone, which is either the report timezone or system timezone, and not what we want.
@@ -121,8 +125,7 @@
 
 ;; TODO - this should be a multimethod like `read-column`. Perhaps named `set-parameter`
 (defn- set-parameters-with-timezone
-  "Returns a function that will set date/timestamp PreparedStatement
-  parameters with the correct timezone"
+  "Returns a function that will set Date/Timestamp PreparedStatement parameters with the correct timezone"
   [^TimeZone tz]
   (fn [^PreparedStatement stmt params]
     (mapv (fn [^Integer i value]
@@ -278,13 +281,14 @@
 
 (defn execute-query
   "Process and run a native (raw SQL) `query`."
-  [driver {settings :settings, query :native, :as outer-query}]
+  [driver {{:keys [report-timezone], :as settings} :settings, query :native, :as outer-query}]
   (let [query (assoc query
-                :remark   (qputil/query->remark outer-query)
-                :max-rows (or (mbql.u/query->max-rows-limit outer-query) qp.i/absolute-max-results))]
+                     :remark   (qputil/query->remark outer-query)
+                     :max-rows (or (mbql.u/query->max-rows-limit outer-query) qp.i/absolute-max-results))]
     (do-with-try-catch
       (fn []
-        (let [db-connection (sql-jdbc.conn/db->pooled-connection-spec (qp.store/database))]
-          ((if (seq (:report-timezone settings))
-             run-query-with-timezone
-             run-query-without-timezone) driver settings db-connection query))))))
+        (let [db-connection (sql-jdbc.conn/db->pooled-connection-spec (qp.store/database))
+              run-query*    (if (seq report-timezone)
+                              run-query-with-timezone
+                              run-query-without-timezone)]
+          (run-query* driver settings db-connection query))))))

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -1,8 +1,9 @@
 (ns metabase.query-processor-test.timezones-test
-  (:require [metabase
+  (:require [clojure.test :refer :all]
+            [metabase
              [driver :as driver]
              [query-processor :as qp]
-             [query-processor-test :as qpt]]
+             [query-processor-test :as qp.test]]
             [metabase.models
              [field :refer [Field]]
              [table :refer [Table]]]
@@ -10,7 +11,7 @@
              [data :as data]
              [util :as tu]]
             [metabase.test.data
-             [datasets :refer [expect-with-drivers]]
+             [datasets :as datasets]
              [sql :as sql.tx]]
             [toucan.db :as db]))
 
@@ -34,13 +35,13 @@
 
 ;; Query PG using a report-timezone set to pacific time. Should adjust the query parameter using that report timezone
 ;; and should return the timestamp in pacific time as well
-(expect-with-drivers [:postgres :mysql]
+(datasets/expect-with-drivers [:postgres :mysql]
   default-pacific-results
   (with-tz-db
     (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
       (-> (data/run-mbql-query users
             {:filter [:between $last_login "2014-08-02T03:00:00.000000" "2014-08-02T06:00:00.000000"]})
-          qpt/rows
+          qp.test/rows
           set))))
 
 (defn- table-identifier [table-key]
@@ -55,10 +56,10 @@
         field-name (db/select-one-field :name Field, :id (apply data/id table-key field-keys))]
     (sql.tx/qualify-and-quote driver/*driver* (:name (data/db)) table-name field-name)))
 
-(def ^:private query-rows-set (comp set qpt/rows qp/process-query))
+(def ^:private query-rows-set (comp set qp.test/rows qp/process-query))
 
 ;; Test that native dates are parsed with the report timezone (when supported)
-(expect-with-drivers [:postgres :mysql]
+(datasets/expect-with-drivers [:postgres :mysql]
   default-pacific-results-for-params
   (with-tz-db
     (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
@@ -76,7 +77,7 @@
                      {:type "date/single" :target ["variable" ["template-tag" "date2"]] :value "2014-08-02T06:00:00.000000"}]}))))
 
 ;; This does not currently work for MySQL
-(expect-with-drivers [:postgres :mysql]
+(datasets/expect-with-drivers [:postgres :mysql]
   default-pacific-results-for-params
   (with-tz-db
     (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
@@ -93,7 +94,7 @@
         :parameters [{:type "date/range", :target ["dimension" ["template-tag" "ts_range"]], :value "2014-08-02~2014-08-03"}]}))))
 
 ;; Querying using a single date
-(expect-with-drivers [:postgres :mysql]
+(datasets/expect-with-drivers [:postgres :mysql]
   default-pacific-results-for-params
   (with-tz-db
     (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
@@ -111,31 +112,49 @@
 
 ;; This is the same answer as above but uses timestamp with the timezone included. The report timezone is still
 ;; pacific though, so it should return as pacific regardless of how the filter was specified
-(expect-with-drivers [:postgres :mysql]
+(datasets/expect-with-drivers [:postgres :mysql]
   default-pacific-results
   (with-tz-db
     (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
       (-> (data/run-mbql-query users
             {:filter [:between $last_login "2014-08-02T10:00:00.000000Z" "2014-08-02T13:00:00.000000Z"]})
-          qpt/rows
+          qp.test/rows
           set))))
 
 ;; Checking UTC report timezone filtering and responses
-(expect-with-drivers [:postgres :bigquery :mysql]
+(datasets/expect-with-drivers [:postgres :bigquery :mysql]
   default-utc-results
   (with-tz-db
     (tu/with-temporary-setting-values [report-timezone "UTC"]
       (-> (data/run-mbql-query users
             {:filter [:between $last_login "2014-08-02T10:00:00.000000" "2014-08-02T13:00:00.000000"]})
-          qpt/rows
+          qp.test/rows
           set))))
 
 ;; With no report timezone, the JVM timezone is used. For our tests this is UTC so this should be the same as
 ;; specifying UTC for a report timezone
-(expect-with-drivers [:postgres :bigquery :mysql]
+(datasets/expect-with-drivers [:postgres :bigquery :mysql]
   default-utc-results
   (with-tz-db
     (-> (data/run-mbql-query users
           {:filter [:between $last_login "2014-08-02T10:00:00.000000" "2014-08-02T13:00:00.000000"]})
-        qpt/rows
+        qp.test/rows
         set)))
+
+(defn- rows-on-july-30 []
+  (data/dataset test-data-with-timezones
+    (qp.test/rows
+      (data/run-mbql-query users
+        {:fields   [$id $last_login]
+         :filter   [:= $last_login "2014-07-03"]
+         :order-by [[:asc $last_login]]}))))
+
+(deftest result-rows-test
+  (datasets/test-drivers (qp.test/non-timeseries-drivers-with-feature :set-timezone)
+    (doseq [[timezone expected-rows] {"UTC"        [[12 "2014-07-03T01:30:00.000Z"]
+                                                    [10 "2014-07-03T19:30:00.000Z"]]
+                                      "US/Pacific" [[10 "2014-07-03T12:30:00.000-07:00"]]}]
+      (tu/with-temporary-setting-values [report-timezone timezone]
+        (is (= expected-rows
+               (rows-on-july-30))
+            (format "There should be %d checkins on July 30th in the %s timezone" (count expected-rows) timezone))))))


### PR DESCRIPTION
I seems like our timezone behavior is working correctly for `TIMESTAMP WITH TIME ZONE` fields. It's the ones without timezones where behavior is completely wacko. But here are some extra tests for the `TIMESTAMP WITH TIME ZONE` columns