### PR TITLE
Require custom expression name

### DIFF
--- a/frontend/src/metabase/query_builder/components/AggregationPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/AggregationPopover.jsx
@@ -178,6 +178,9 @@ export default class AggregationPopover extends Component {
     return item.isSelected(A_DEPRECATED.getContent(aggregation));
   }
 
+  isValid = () =>
+    !this.state.error && Boolean(A_DEPRECATED.getName(this.state.aggregation));
+
   renderItemExtra(item, itemIndex) {
     if (item.aggregation && item.aggregation.description) {
       return (
@@ -383,12 +386,12 @@ export default class AggregationPopover extends Component {
                     : aggregation,
                 })
               }
-              placeholder={t`Name (optional)`}
+              placeholder={t`Name (required)`}
             />
             <Button
               className="full"
               primary
-              disabled={this.state.error}
+              disabled={!this.isValid()}
               onClick={() => this.commitAggregation(this.state.aggregation)}
             >
               {t`Done`}


### PR DESCRIPTION
Resolves #10985

As @mazameli [suggested](https://github.com/metabase/metabase/issues/10985#issuecomment-535152085), it seemed easiest to sidestep the bug and require custom expressions to have a name.

There's not much additional UI to indicate this change. I just switched the place holder text (optional -> required) and disabled the button until text is entered.

![image](https://user-images.githubusercontent.com/691495/66245156-f4270380-e6d9-11e9-9c83-02b4970ec9ab.png)
