### PR TITLE
Return timezone in query results [WIP]

### DIFF
--- a/modules/drivers/vertica/test/metabase/test/data/vertica.clj
+++ b/modules/drivers/vertica/test/metabase/test/data/vertica.clj
@@ -15,16 +15,18 @@
 
 (defmethod tx/sorts-nil-first? :vertica [_] false)
 
-(defmethod sql.tx/field-base-type->sql-type [:vertica :type/BigInteger] [_ _] "BIGINT")
-(defmethod sql.tx/field-base-type->sql-type [:vertica :type/Boolean]    [_ _] "BOOLEAN")
-(defmethod sql.tx/field-base-type->sql-type [:vertica :type/Char]       [_ _] "VARCHAR(254)")
-(defmethod sql.tx/field-base-type->sql-type [:vertica :type/Date]       [_ _] "DATE")
-(defmethod sql.tx/field-base-type->sql-type [:vertica :type/DateTime]   [_ _] "TIMESTAMP")
-(defmethod sql.tx/field-base-type->sql-type [:vertica :type/Decimal]    [_ _] "NUMERIC")
-(defmethod sql.tx/field-base-type->sql-type [:vertica :type/Float]      [_ _] "FLOAT")
-(defmethod sql.tx/field-base-type->sql-type [:vertica :type/Integer]    [_ _] "INTEGER")
-(defmethod sql.tx/field-base-type->sql-type [:vertica :type/Text]       [_ _] "VARCHAR(254)")
-(defmethod sql.tx/field-base-type->sql-type [:vertica :type/Time]       [_ _] "TIME")
+(doseq [[base-type sql-type] {:type/BigInteger     "BIGINT"
+                              :type/Boolean        "BOOLEAN"
+                              :type/Char           "VARCHAR(254)"
+                              :type/Date           "DATE"
+                              :type/DateTime       "TIMESTAMP"
+                              :type/DateTimeWithTZ "TIMESTAMP WITH TIME ZONE"
+                              :type/Decimal        "NUMERIC"
+                              :type/Float          "FLOAT"
+                              :type/Integer        "INTEGER"
+                              :type/Text           "VARCHAR(254)"
+                              :type/Time           "TIME"}]
+  (defmethod sql.tx/field-base-type->sql-type [:vertica base-type] [_ _] sql-type))
 
 (defn- db-name []
   (tx/db-test-env-var-or-throw :vertica :db "docker"))
@@ -47,11 +49,27 @@
 (defmethod sql.tx/create-db-sql         :vertica [& _] nil)
 (defmethod sql.tx/drop-db-if-exists-sql :vertica [& _] nil)
 
-(defmethod sql.tx/drop-table-if-exists-sql :vertica [& args]
+(defmethod sql.tx/drop-table-if-exists-sql :vertica
+  [& args]
   (apply sql.tx/drop-table-if-exists-cascade-sql args))
 
-(defmethod load-data/load-data! :vertica [& args]
-  (apply load-data/load-data-one-at-a-time-parallel! args))
+(defn- dbspec []
+  (sql-jdbc.conn/connection-details->spec :vertica @db-connection-details))
+
+(defmethod load-data/load-data! :vertica
+  [driver {:keys [database-name], :as dbdef} {:keys [table-name], :as tabledef}]
+  ;; try a few times to load the data, Vertica is very fussy and it doesn't always work the first time
+  (letfn [(load-data-with-retries! [retries]
+            (try
+              (load-data/load-data-one-at-a-time-parallel! driver dbdef tabledef)
+              (catch Throwable e
+                (when-not (pos? retries)
+                  (throw e))
+                (println (colorize/red "\n\nVertica failed to load data, let's try again...\n\n"))
+                (let [sql (format "TRUNCATE TABLE %s" (sql.tx/qualify-and-quote :vertica database-name table-name))]
+                  (jdbc/execute! (dbspec) sql))
+                (load-data-with-retries! (dec retries)))))]
+    (load-data-with-retries! 5)))
 
 (defmethod sql.tx/pk-sql-type :vertica [& _] "INTEGER")
 
@@ -61,29 +79,24 @@
 (defmethod tx/has-questionable-timezone-support? :vertica [_] true)
 
 
-(defn- dbspec []
-  (sql-jdbc.conn/connection-details->spec :vertica @db-connection-details))
-
-(defmethod tx/before-run :vertica [_]
+(defmethod tx/before-run :vertica
+  [_]
   ;; Close all existing sessions connected to our test DB
   (jdbc/query (dbspec) "SELECT CLOSE_ALL_SESSIONS();")
   ;; Increase the connection limit; the default is 5 or so which causes tests to fail when too many connections are made
   (jdbc/execute! (dbspec) (format "ALTER DATABASE \"%s\" SET MaxClientSessions = 10000;" (db-name))))
 
-(defmethod tx/create-db! :vertica [driver dbdef & options]
-  (letfn [(create-with-retries! [retries]
-            (let [results (try
-                            (apply (get-method tx/create-db! :sql-jdbc/test-extensions) driver dbdef options)
-                            (catch Throwable e
-                              (if (pos? retries)
-                                ::retry
-                                (throw e))))]
-              (if (not= results ::retry)
-                results
-                (do
-                  (println (colorize/red "\n\nVertica failed to create a DB, again. Let's try again...\n\n"))
-                  (jdbc/query (dbspec) "SELECT CLOSE_ALL_SESSIONS();")
-                  (recur (dec retries))))))]
-    ;; try a few times to create the DB. Vertica is very fussy and sometimes you need to try a few times to get it to
-    ;; work correctly.
-    (create-with-retries! 5)))
+(defmethod tx/create-db! :vertica
+  [driver dbdef & options]
+  ;; try a few times to create the DB. Vertica is very fussy and sometimes you need to try a few times to get it to
+  ;; work correctly.
+  (letfn [(create-db-with-retries! [retries]
+            (try
+              (apply (get-method tx/create-db! :sql-jdbc/test-extensions) driver dbdef options)
+              (catch Throwable e
+                (when-not (pos? retries)
+                  (throw e))
+                (println (colorize/red "\n\nVertica failed to create a DB, again. Let's try again...\n\n"))
+                (jdbc/query (dbspec) "SELECT CLOSE_ALL_SESSIONS();")
+                (create-db-with-retries! (dec retries)))))]
+    (create-db-with-retries! 5)))

--- a/project.clj
+++ b/project.clj
@@ -109,7 +109,6 @@
    [metabase/connection-pool "1.0.3"]                                 ; simple wrapper around C3P0. JDBC connection pools
    [metabase/mbql "1.3.6"]                                            ; MBQL language schema & util fns
    [metabase/throttle "1.0.2"]                                        ; Tools for throttling access to API endpoints and other code pathways
-   [methodical "0.9.4-alpha"]
    [net.sf.cssbox/cssbox "4.12" :exclusions [org.slf4j/slf4j-api]]    ; HTML / CSS rendering
    [org.apache.commons/commons-lang3 "3.9"]                           ; helper methods for working with java.lang stuff
    [org.clojars.pntblnk/clj-ldap "0.0.16"]                            ; LDAP client
@@ -165,6 +164,7 @@
 
     :dependencies
     [[clj-http-fake "1.0.3" :exclusions [slingshot]]                  ; Library to mock clj-http responses
+     [methodical "0.9.4-alpha"]
      [pjstadig/humane-test-output "0.9.0"]
      [ring/ring-mock "0.3.2"]]
 

--- a/project.clj
+++ b/project.clj
@@ -103,9 +103,9 @@
                  javax.jms/jms
                  com.sun.jdmk/jmxtools
                  com.sun.jmx/jmxri]]
-   [me.raynes/fs "1.4.6"]                                   ; FS tools
+   [me.raynes/fs "1.4.6"]                                             ; Filesystem tools
    [medley "1.2.0"]                                                   ; lightweight lib of useful functions
-   [metabase/connection-pool "1.0.2"]                                 ; simple wrapper around C3P0. JDBC connection pools
+   [metabase/connection-pool "1.0.3"]                                 ; simple wrapper around C3P0. JDBC connection pools
    [metabase/mbql "1.3.6"]                                            ; MBQL language schema & util fns
    [metabase/throttle "1.0.2"]                                        ; Tools for throttling access to API endpoints and other code pathways
    [methodical "0.9.4-alpha"]
@@ -251,7 +251,7 @@
    :bikeshed
    [:include-all-drivers
     {:plugins
-     [[lein-bikeshed "0.4.1"]]}]
+     [[lein-bikeshed "0.5.2"]]}]
 
    :eastwood
    [:include-all-drivers

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -75,7 +75,7 @@
   [results]
   (u/select-nested-keys
    results
-   [[:data :cols :rows :rows_truncated :insights] [:json_query :parameters] :status]))
+   [[:data :cols :rows :rows_truncated :insights] [:json_query :parameters] :status :report_timezone]))
 
 (defmethod transform-results :failed
   [{:keys [error], error-type :error_type, :as results}]

--- a/src/metabase/query_processor/middleware/add_settings.clj
+++ b/src/metabase/query_processor/middleware/add_settings.clj
@@ -7,11 +7,6 @@
   (when-let [report-timezone (driver.u/report-timezone-if-supported driver/*driver*)]
     {:report-timezone report-timezone}))
 
-(defn- add-settings* [query]
-  (if-let [settings (settings-for-current-driver)]
-    (assoc query :settings settings)
-    query))
-
 (defn add-settings
   "Adds the `:settings` map to the query which can contain any fixed properties that would be useful at execution time,
   and to the results of the query. Currently supports a settings object like:

--- a/src/metabase/query_processor/middleware/add_settings.clj
+++ b/src/metabase/query_processor/middleware/add_settings.clj
@@ -19,9 +19,9 @@
        {:report-timezone \"US/Pacific\"}"
   [qp]
   (fn [query]
-    (let [settings (settings-for-current-driver)
-          query    (cond-> query
-                     settings (assoc :settings settings))
-          results  (qp query)]
+    (let [{:keys [report-timezone], :as settings} (settings-for-current-driver)
+          query                                   (cond-> query
+                                                    settings (assoc :settings settings))
+          results                                 (qp query)]
       (cond-> results
-        settings (assoc :settings settings)))))
+        (seq report-timezone) (assoc :report_timezone report-timezone)))))

--- a/src/metabase/query_processor/middleware/add_settings.clj
+++ b/src/metabase/query_processor/middleware/add_settings.clj
@@ -3,15 +3,25 @@
   (:require [metabase.driver :as driver]
             [metabase.driver.util :as driver.u]))
 
+(defn- settings-for-current-driver []
+  (when-let [report-timezone (driver.u/report-timezone-if-supported driver/*driver*)]
+    {:report-timezone report-timezone}))
+
 (defn- add-settings* [query]
-  (if-let [report-timezone (driver.u/report-timezone-if-supported driver/*driver*)]
-    (assoc-in query [:settings :report-timezone] report-timezone)
+  (if-let [settings (settings-for-current-driver)]
+    (assoc query :settings settings)
     query))
 
 (defn add-settings
-  "Adds the `:settings` map to the query which can contain any fixed properties that would be useful at execution time.
-   Currently supports a settings object like:
+  "Adds the `:settings` map to the query which can contain any fixed properties that would be useful at execution time,
+  and to the results of the query. Currently supports a settings object like:
 
        {:report-timezone \"US/Pacific\"}"
   [qp]
-  (comp qp add-settings*))
+  (fn [query]
+    (let [settings (settings-for-current-driver)
+          query    (cond-> query
+                     settings (assoc :settings settings))
+          results  (qp query)]
+      (cond-> results
+        settings (assoc :settings settings)))))

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -74,7 +74,8 @@
                 :started_at             true
                 :running_time           true
                 :average_execution_time nil
-                :database_id            (data/id)}))
+                :database_id            (data/id)}
+               (format-response result)))
         (is (= {:hash         true
                 :row_count    1
                 :result_rows  1
@@ -89,7 +90,7 @@
                 :database_id  (data/id)
                 :started_at   true
                 :running_time true}
-               (format-response result)))))))
+               (format-response (most-recent-query-execution))))))))
 
 (deftest failure-test
   (testing "Even if a query fails we still expect a 200 response from the api"

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -23,13 +23,12 @@
              [util :as tu]]
             [metabase.test.data
              [dataset-definitions :as defs]
-             [datasets :refer [expect-with-driver]]
+             [datasets :as datasets :refer [expect-with-driver]]
              [users :as test-users]]
             [metabase.test.util.log :as tu.log]
             [schema.core :as s]
             [toucan.db :as db]
-            [toucan.util.test :as tt]
-            [metabase.test.data.datasets :as datasets])
+            [toucan.util.test :as tt])
   (:import com.fasterxml.jackson.core.JsonGenerator))
 
 (defn- format-response [m]

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -28,7 +28,8 @@
             [metabase.test.util.log :as tu.log]
             [schema.core :as s]
             [toucan.db :as db]
-            [toucan.util.test :as tt])
+            [toucan.util.test :as tt]
+            [metabase.test.data.datasets :as datasets])
   (:import com.fasterxml.jackson.core.JsonGenerator))
 
 (defn- format-response [m]
@@ -54,100 +55,86 @@
    :middleware  {:add-default-userland-constraints? true, :userland-query? true}
    :async?      true})
 
-;;; ## POST /api/meta/dataset
-;; Just a basic sanity check to make sure Query Processor endpoint is still working correctly.
-(expect
-  {:api-response
-   {:data                   {:rows        [[1000]]
-                             :cols        [(tu/obj->json->obj (qp.test/aggregate-col :count))]
-                             :native_form true}
-    :row_count              1
-    :status                 "completed"
-    :context                "ad-hoc"
-    :json_query             (-> (data/mbql-query checkins
-                                  {:aggregation [[:count]]})
-                                (assoc-in [:query :aggregation] [["count"]])
-                                (assoc :type "query")
-                                (merge query-defaults))
-    :started_at             true
-    :running_time           true
-    :average_execution_time nil
-    :database_id            (data/id)}
+(deftest basic-query-test
+  (testing "POST /api/meta/dataset"
+    (testing "Just a basic sanity check to make sure Query Processor endpoint is still working correctly."
+      (let [result ((test-users/user->client :rasta) :post 200 "dataset" (data/mbql-query checkins
+                                                                           {:aggregation [[:count]]}))]
+        (is (= {:data                   {:rows        [[1000]]
+                                         :cols        [(tu/obj->json->obj (qp.test/aggregate-col :count))]
+                                         :native_form true}
+                :row_count              1
+                :status                 "completed"
+                :context                "ad-hoc"
+                :json_query             (-> (data/mbql-query checkins
+                                              {:aggregation [[:count]]})
+                                            (assoc-in [:query :aggregation] [["count"]])
+                                            (assoc :type "query")
+                                            (merge query-defaults))
+                :started_at             true
+                :running_time           true
+                :average_execution_time nil
+                :database_id            (data/id)}))
+        (is (= {:hash         true
+                :row_count    1
+                :result_rows  1
+                :context      :ad-hoc
+                :executor_id  (test-users/user->id :rasta)
+                :native       false
+                :pulse_id     nil
+                :card_id      nil
+                :dashboard_id nil
+                :error        nil
+                :id           true
+                :database_id  (data/id)
+                :started_at   true
+                :running_time true}
+               (format-response result)))))))
 
-   :query-execution
-   {:hash         true
-    :row_count    1
-    :result_rows  1
-    :context      :ad-hoc
-    :executor_id  (test-users/user->id :rasta)
-    :native       false
-    :pulse_id     nil
-    :card_id      nil
-    :dashboard_id nil
-    :error        nil
-    :id           true
-    :database_id  (data/id)
-    :started_at   true
-    :running_time true}}
-  (let [result ((test-users/user->client :rasta) :post 200 "dataset" (data/mbql-query checkins
-                                                                       {:aggregation [[:count]]}))]
-    {:api-response
-     (format-response result)
-
-     :query-execution
-     (format-response (most-recent-query-execution))}))
-
-
-;; Even if a query fails we still expect a 200 response from the api
-(expect
-  {:api-response
-   {:data         {:rows    []
-                   :cols    []}
-    :row_count    0
-    :status       "failed"
-    :context      "ad-hoc"
-    :error        true
-    :json_query   (merge
-                   query-defaults
-                   {:database (data/id)
-                    :type     "native"
-                    :native   {:query "foobar"}})
-    :database_id  (data/id)
-    :started_at   true
-    :running_time true}
-
-   :query-execution
-   {:hash         true
-    :id           true
-    :result_rows  0
-    :row_count    0
-    :context      :ad-hoc
-    :error        true
-    :database_id  (data/id)
-    :started_at   true
-    :running_time true
-    :executor_id  (test-users/user->id :rasta)
-    :native       true
-    :pulse_id     nil
-    :card_id      nil
-    :dashboard_id nil}}
-  ;; Error message's format can differ a bit depending on DB version and the comment we prepend to it, so check that
-  ;; it exists and contains the substring "Syntax error in SQL statement"
-  (let [check-error-message (fn [output]
-                              (update output :error (fn [error-message]
-                                                      (some->>
-                                                       error-message
-                                                       (re-find #"Syntax error in SQL statement")
-                                                       boolean))))
-        result              (tu.log/suppress-output
-                              ((test-users/user->client :rasta) :post 200 "dataset" {:database (data/id)
-                                                                                     :type     "native"
-                                                                                     :native   {:query "foobar"}}))]
-    {:api-response
-     (check-error-message (dissoc (format-response result) :stacktrace))
-
-     :query-execution
-     (check-error-message (format-response (most-recent-query-execution)))}))
+(deftest failure-test
+  (testing "Even if a query fails we still expect a 200 response from the api"
+    ;; Error message's format can differ a bit depending on DB version and the comment we prepend to it, so check that
+    ;; it exists and contains the substring "Syntax error in SQL statement"
+    (let [check-error-message (fn [output]
+                                (update output :error (fn [error-message]
+                                                        (some->>
+                                                         error-message
+                                                         (re-find #"Syntax error in SQL statement")
+                                                         boolean))))
+          result              (tu.log/suppress-output
+                                ((test-users/user->client :rasta) :post 200 "dataset" {:database (data/id)
+                                                                                       :type     "native"
+                                                                                       :native   {:query "foobar"}}))]
+      (is (= {:data         {:rows    []
+                             :cols    []}
+              :row_count    0
+              :status       "failed"
+              :context      "ad-hoc"
+              :error        true
+              :json_query   (merge
+                             query-defaults
+                             {:database (data/id)
+                              :type     "native"
+                              :native   {:query "foobar"}})
+              :database_id  (data/id)
+              :started_at   true
+              :running_time true}
+             (check-error-message (dissoc (format-response result) :stacktrace))))
+      (is (= {:hash         true
+              :id           true
+              :result_rows  0
+              :row_count    0
+              :context      :ad-hoc
+              :error        true
+              :database_id  (data/id)
+              :started_at   true
+              :running_time true
+              :executor_id  (test-users/user->id :rasta)
+              :native       true
+              :pulse_id     nil
+              :card_id      nil
+              :dashboard_id nil}
+             (check-error-message (format-response (most-recent-query-execution))))))))
 
 
 ;;; Make sure that we're piggybacking off of the JSON encoding logic when encoding strange values in XLSX (#5145,
@@ -314,3 +301,12 @@
       ((test-users/user->client :rasta) :post "dataset/native"
        (data/mbql-query venues
          {:fields [$id $name]})))))
+
+(deftest report-timezone-test
+  (datasets/test-driver :postgres
+    (is (= {:report_timezone "US/Pacific"}
+           (tu/with-temporary-setting-values [report-timezone "US/Pacific"]
+             (let [results ((test-users/user->client :rasta) :post 200 "dataset" (data/mbql-query checkins
+                                                                                   {:aggregation [[:count]]}))]
+               (select-keys results [:report_timezone]))))
+        "report timezone should be returned as part of query results")))

--- a/test/metabase/query_processor/middleware/add_settings_test.clj
+++ b/test/metabase/query_processor/middleware/add_settings_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.middleware.add-settings-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
+            [expectations :refer [expect]]
             [metabase.driver :as driver]
             [metabase.query-processor.middleware.add-settings :as add-settings]
             [metabase.test.util :as tu]))
@@ -39,3 +40,14 @@
   {}
   (tu/with-temporary-setting-values [report-timezone "US/Mountain"]
     (add-settings ::no-timezone-driver {})))
+
+(deftest settings-in-results-test
+  (is (= {:settings {:results? true
+                     :settings {:report-timezone "US/Pacific"}}}
+         (tu/with-temporary-setting-values [report-timezone "US/Pacific"]
+           (driver/with-driver ::timezone-driver
+             (let [query        {:query? true}
+                   results      {:results? true}
+                   add-settings (add-settings/add-settings (constantly results))]
+               (add-settings query)))))
+      "`:settings` should get added to query results as well!"))


### PR DESCRIPTION
Needed to fix #5916.

WIP -- still need to update tests, and also change `{:settings {:report-timezone ...}}` to something more client friendly like `{report_timezone ...}`