### PR TITLE
Return a default y axis title for multiseries

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -507,9 +507,24 @@ export const GRAPH_AXIS_SETTINGS = {
     widget: "input",
     getHidden: (series, vizSettings) =>
       vizSettings["graph.y_axis.labels_enabled"] === false,
-    getDefault: (series, vizSettings) =>
-      series.length === 1 ? vizSettings.series(series[0]).title : null,
-    readDependencies: ["series"],
+    getDefault: (series, vizSettings) => {
+      if (series.length === 1) {
+        return vizSettings.series(series[0]).title;
+      }
+      // If there are multiple series, we check if the metric names match.
+      // If they do, we use that as the default y axis label.
+      const [metric] = vizSettings["graph.metrics"];
+      const metricNames = Array.from(
+        new Set(
+          series.map(({ data: { cols } }) => {
+            const metricCol = cols.find(c => c.name === metric);
+            return metricCol && metricCol.display_name;
+          }),
+        ),
+      );
+      return metricNames.length === 1 ? metricNames[0] : null;
+    },
+    readDependencies: ["series", "graph.metrics"],
   },
   // DEPRECATED" replaced with "label" series setting
   "graph.series_labels": {},

--- a/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
@@ -100,7 +100,7 @@ describe("visualization_settings", () => {
         expect(settings["graph.y_axis.title_text"]).toBe("col2");
       });
 
-      it("should use the metric name all series match", () => {
+      it("should use the metric name if all series match", () => {
         const card = { visualization_settings: {}, display: "bar" };
         const data1 = {
           cols: [

--- a/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
@@ -61,6 +61,68 @@ describe("visualization_settings", () => {
           }),
         ));
     });
+    describe("graph.y_axis.title_text", () => {
+      const data = {
+        cols: [
+          DateTimeColumn({ unit: "month", name: "col1" }),
+          NumberColumn({ name: "col2" }),
+        ],
+        rows: [[0, 0]],
+      };
+      it("should use the card name if there's one series", () => {
+        const card = {
+          visualization_settings: {},
+          display: "bar",
+          name: "card name",
+        };
+        const settings = getComputedSettingsForSeries([{ card, data }]);
+        expect(settings["graph.y_axis.title_text"]).toBe("card name");
+      });
+
+      it("should use the series title if set", () => {
+        const card = {
+          visualization_settings: {
+            series_settings: { foo: { title: "some title" } },
+          },
+          display: "bar",
+          name: "foo",
+        };
+        const settings = getComputedSettingsForSeries([{ card, data }]);
+        expect(settings["graph.y_axis.title_text"]).toBe("some title");
+      });
+
+      it("should use the metric name all series match", () => {
+        const card = { visualization_settings: {}, display: "bar" };
+        const settings = getComputedSettingsForSeries([
+          { card, data },
+          { card, data },
+        ]);
+        expect(settings["graph.y_axis.title_text"]).toBe("col2");
+      });
+
+      it("should use the metric name all series match", () => {
+        const card = { visualization_settings: {}, display: "bar" };
+        const data1 = {
+          cols: [
+            DateTimeColumn({ unit: "month", name: "col1" }),
+            NumberColumn({ name: "col2a" }),
+          ],
+          rows: [[0, 0]],
+        };
+        const data2 = {
+          cols: [
+            DateTimeColumn({ unit: "month", name: "col1" }),
+            NumberColumn({ name: "col2b" }),
+          ],
+          rows: [[0, 0]],
+        };
+        const settings = getComputedSettingsForSeries([
+          { card, data: data1 },
+          { card, data: data2 },
+        ]);
+        expect(settings["graph.y_axis.title_text"]).toBe(null);
+      });
+    });
   });
 
   describe("getStoredSettingsForSeries", () => {

--- a/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
@@ -91,7 +91,7 @@ describe("visualization_settings", () => {
         expect(settings["graph.y_axis.title_text"]).toBe("some title");
       });
 
-      it("should use the metric name all series match", () => {
+      it("should use the metric name if all series match", () => {
         const card = { visualization_settings: {}, display: "bar" };
         const settings = getComputedSettingsForSeries([
           { card, data },


### PR DESCRIPTION
Resolves #10765

`graph.y_axis.title_text`'s `getDefault` method previously returned `null` if there were multiple series. Now, we check if all the series have the same metric display name and use that. 