### PR TITLE
Test code improvements

### DIFF
--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -1,12 +1,15 @@
 (ns dev
   "Put everything needed for REPL development within easy reach"
-  (:require [metabase
+  (:require [clojure.set :as set]
+            [metabase
              [core :as mbc]
              [db :as mdb]
              [handler :as handler]
              [plugins :as pluguns]
+             [query-processor-test :as qp.test]
              [server :as server]]
-            [metabase.api.common :as api-common]))
+            [metabase.api.common :as api-common]
+            [metabase.test.data.env :as tx.env]))
 
 (defn init!
   []
@@ -38,7 +41,8 @@
     (ns-unmap a-namespace symb)))
 
 (defmacro require-model
-  "Rather than requiring all models inn the ns declaration, make it easy to require the ones you need for your current session"
+  "Rather than requiring all models inn the ns declaration, make it easy to require the ones you need for your current
+  session"
   [model-sym]
   `(require [(symbol (str "metabase.models." (quote ~model-sym))) :as (quote ~model-sym)]))
 
@@ -46,3 +50,26 @@
   [permissions & body]
   `(binding [api-common/*current-user-permissions-set* (delay ~permissions)]
      ~@body))
+
+(defn do-with-test-drivers [test-drivers thunk]
+  {:pre [((some-fn sequential? set?) test-drivers)]}
+  (with-redefs [tx.env/test-drivers            (atom (set test-drivers))
+                qp.test/non-timeseries-drivers (atom (set/difference
+                                                      (set test-drivers)
+                                                      (var-get #'qp.test/timeseries-drivers)))]
+    (thunk)))
+
+(defmacro with-test-drivers
+  "Temporarily change the drivers that Metabase tests will run against as if you had set the `DRIVERS` env var.
+
+    ;; my-test will run against any non-timeseries driver (i.e., anything except for Druid) that is listed in the
+    ;; `DRIVERS` env var
+    (deftest my-test
+      (datasets/test-drivers @qp.test/non-timeseries-drivers
+        ...))
+
+    ;; Run `my-test` against H2 and Postgres regardless of what's in the `DRIVERS` env var
+    (dev/with-test-drivers #{:h2 :postgres}
+      (my-test))"
+  [test-drivers & body]
+  `(do-with-test-drivers ~test-drivers (fn [] ~@body)))

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,8 @@
    "test"                              ["with-profile" "+test" "test"]
    "bikeshed"                          ["with-profile" "+bikeshed" "bikeshed"
                                         "--max-line-length" "205"
-                                        "--exclude-profiles" "compare-h2-dbs"]
+                                        ;; see https://github.com/dakrone/lein-bikeshed/issues/41
+                                        "--exclude-profiles" "compare-h2-dbs,dev"]
    "check-namespace-decls"             ["with-profile" "+check-namespace-decls" "check-namespace-decls"]
    "eastwood"                          ["with-profile" "+eastwood" "eastwood"]
    "check-reflection-warnings"         ["with-profile" "+reflection-warnings" "check"]

--- a/src/metabase/query_processor/middleware/async.clj
+++ b/src/metabase/query_processor/middleware/async.clj
@@ -73,9 +73,9 @@
   ;; prod but for test and dev purposes we want to fail faster because it usually means I broke something in the QP
   ;; code
   (cond
-    config/is-prod? (* 20 60 1000)  ; twenty minutes
-    config/is-test? (* 30 1000)     ; 30 seconds
-    config/is-dev?  (* 5 60 1000))) ; 5 minutes
+    config/is-prod? (du/minutes->ms 20)
+    config/is-test? (du/seconds->ms 30)
+    config/is-dev?  (du/minutes->ms 3)))
 
 (defn- wait-for-result [out-chan]
   (let [[result port] (a/alts!! [out-chan (a/timeout query-timeout-ms)])]

--- a/src/metabase/sync/sync_metadata/fields.clj
+++ b/src/metabase/sync/sync_metadata/fields.clj
@@ -110,7 +110,7 @@
 
 (s/defn sync-fields! :- (s/maybe {:updated-fields su/IntGreaterThanOrEqualToZero
                                   :total-fields   su/IntGreaterThanOrEqualToZero})
-  "Sync the Fields in the Metabase application database for all the Tables in a DATABASE."
+  "Sync the Fields in the Metabase application database for all the Tables in a `database`."
   [database :- i/DatabaseInstance]
   (let [tables (sync-util/db->sync-tables database)]
     (apply merge-with + (for [table tables]

--- a/src/metabase/util/date.clj
+++ b/src/metabase/util/date.clj
@@ -478,3 +478,18 @@
   [begin-time :- (s/protocol coerce/ICoerce)
    end-time :- (s/protocol coerce/ICoerce)]
   (- (coerce/to-long end-time) (coerce/to-long begin-time)))
+
+(defn seconds->ms
+  "Convert `seconds` to milliseconds. More readable than doing this math inline."
+  [seconds]
+  (* seconds 1000))
+
+(defn minutes->seconds
+  "Convert `minutes` to seconds. More readable than doing this math inline."
+  [minutes]
+  (* 60 minutes))
+
+(defn minutes->ms
+  "Convert `minutes` to milliseconds. More readable than doing this math inline."
+  [minutes]
+  (-> minutes minutes->seconds seconds->ms))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -207,7 +207,7 @@
     :features           (map u/qualified-name (driver.u/features ::test-driver))}))
 
 (defn- all-test-data-databases []
-  (for [driver (conj tx.env/test-drivers :h2)
+  (for [driver (conj @tx.env/test-drivers :h2)
         ;; GA has no test extensions impl and thus data/db doesn't work with it
         ;; Also it doesn't work for Druid either because DB must be flattened
         :when  (not (#{:googleanalytics :druid} driver))]

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -287,7 +287,7 @@
                          "FROM \"PUBLIC\".\"VENUES\" "
                          "LIMIT 1048576")
             :params nil}
-           ((test-users/user->client :rasta) :post "dataset/native"
+           ((test-users/user->client :rasta) :post 200 "dataset/native"
             (data/mbql-query venues
               {:fields [$id $name]}))))
     (is (= {:query (str "SELECT \"PUBLIC\".\"CHECKINS\".\"ID\" AS \"ID\" FROM \"PUBLIC\".\"CHECKINS\" "
@@ -295,7 +295,7 @@
                         " AND \"PUBLIC\".\"CHECKINS\".\"DATE\" < timestamp '2015-11-14T00:00:00.000Z') "
                         "LIMIT 1048576")
             :params nil}
-           ((test-users/user->client :rasta) :post "dataset/native"
+           ((test-users/user->client :rasta) :post 200 "dataset/native"
             (data/mbql-query checkins
               {:fields [$id]
                :filter [:= $date "2015-11-13"]})))

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -276,8 +276,11 @@
       (hydrate :dimensions)
       :dimensions))
 
-(defn- create-dimension-via-API! {:style/indent 1} [field-id map-to-post]
-  ((test-users/user->client :crowberto) :post 200 (format "field/%d/dimension" field-id) map-to-post))
+(defn- create-dimension-via-API!
+  {:style/indent 1}
+  [field-id map-to-post & {:keys [expected-status-code]
+                           :or   {expected-status-code 200}}]
+  ((test-users/user->client :crowberto) :post expected-status-code (format "field/%d/dimension" field-id) map-to-post))
 
 ;; test that we can do basic field update work, including unsetting some fields such as special-type
 (expect
@@ -334,9 +337,11 @@
 
 ;; External remappings require a human readable field id
 (expect
-  clojure.lang.ExceptionInfo
-  (tt/with-temp* [Field [{field-id-1 :id} {:name "Field Test 1"}]]
-    (create-dimension-via-API! field-id-1 {:name "some dimension name", :type "external"})))
+  "Foreign key based remappings require a human readable field id"
+  (tt/with-temp* [Field [{field-id :id} {:name "Field Test 1"}]]
+    (create-dimension-via-API! field-id
+      {:name "some dimension name", :type "external"}
+      :expected-status-code 400)))
 
 ;; Non-admin users can't update dimension, :field_id trues
 (expect

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -13,9 +13,12 @@
             [metabase.models
              [database :refer [Database]]
              [user :refer [User]]]
-            [metabase.test.data.users :as test-users]
-            [metabase.test.util :as tu]
+            [metabase.test
+             [fixtures :as fixtures]
+             [util :as tu]]
             [toucan.db :as db]))
+
+(use-fixtures :once (fixtures/initialize :test-users))
 
 ;; ## POST /api/setup/user
 ;;
@@ -25,7 +28,6 @@
       (try
         ;; make sure the default test users are created before running this test, otherwise we're going to run into
         ;; issues if it attempts to delete this user and it is the only admin test user
-        (test-users/create-users-if-needed!)
         (tu/discard-setting-changes [site-name anon-tracking-enabled admin-email]
           (let [api-response (http/client :post 200 "setup" {:token (setup/create-token!)
                                                              :prefs {:site_name "Metabase Test"}

--- a/test/metabase/db/metadata_queries_test.clj
+++ b/test/metabase/db/metadata_queries_test.clj
@@ -13,33 +13,34 @@
             [toucan.util.test :as tt]))
 
 ;; Redshift tests are randomly failing -- see https://github.com/metabase/metabase/issues/2767
-(def ^:private ^:const metadata-queries-test-drivers
-  (disj qp-test/non-timeseries-drivers :redshift))
+(def ^:private metadata-queries-test-drivers
+  (delay
+    (disj @qp-test/non-timeseries-drivers :redshift)))
 
 ;; ### FIELD-DISTINCT-COUNT
-(datasets/expect-with-drivers metadata-queries-test-drivers
+(datasets/expect-with-drivers @metadata-queries-test-drivers
   100
   (field-distinct-count (Field (id :checkins :venue_id))))
 
-(datasets/expect-with-drivers metadata-queries-test-drivers
+(datasets/expect-with-drivers @metadata-queries-test-drivers
   15
   (field-distinct-count (Field (id :checkins :user_id))))
 
 
 ;; ### FIELD-COUNT
-(datasets/expect-with-drivers metadata-queries-test-drivers
+(datasets/expect-with-drivers @metadata-queries-test-drivers
   1000
   (field-count (Field (id :checkins :venue_id))))
 
 
 ;; ### TABLE-ROW-COUNT
-(datasets/expect-with-drivers metadata-queries-test-drivers
+(datasets/expect-with-drivers @metadata-queries-test-drivers
   1000
   (table-row-count (Table (id :checkins))))
 
 
 ;; ### FIELD-DISTINCT-VALUES
-(datasets/expect-with-drivers metadata-queries-test-drivers
+(datasets/expect-with-drivers @metadata-queries-test-drivers
   [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
   (map int (field-distinct-values (Field (id :checkins :user_id)))))
 

--- a/test/metabase/driver/sql_jdbc_test.clj
+++ b/test/metabase/driver/sql_jdbc_test.clj
@@ -24,7 +24,7 @@
   (delay
    (du/profile "resolve @metabase.driver.sql-jdbc-test/sql-jdbc-drivers"
      (set
-      (for [driver tx.env/test-drivers
+      (for [driver @tx.env/test-drivers
             :when  (isa? driver/hierarchy (driver/the-driver driver) (driver/the-driver :sql-jdbc))]
         (tx/the-driver-with-test-extensions driver))))))
 

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -25,15 +25,7 @@
              [hydrate :refer [hydrate]]]
             [toucan.util.test :as tt]))
 
-(use-fixtures :once (fixtures/initialize :db))
-
-(defn force-create-personal-collections!
-  "Force the creation of the Personal Collections for our various test users. They are eventually going to get
-  automatically created anyway as soon as those Users' permissions get calculated in `user/permissions-set`; better to
-  do it now so the test results will be consistent."
-  []
-  (doseq [username [:rasta :lucky :crowberto :trashbird]]
-    (collection/user->personal-collection (test-users/user->id username))))
+(use-fixtures :once (fixtures/initialize :db :test-users :test-users-personal-collections))
 
 (defn- lucky-collection-children-location []
   (collection/children-location (collection/user->personal-collection (test-users/user->id :lucky))))
@@ -341,7 +333,6 @@
               (u/get-id (group/metabot))   {:root :none}
               (u/get-id (group/admin))     {:root :write}}}
   (tu/with-non-admin-groups-no-root-collection-perms
-    (force-create-personal-collections!)
     (graph :clear-revisions? true)))
 
 ;; Make sure that if we try to be sneaky and edit a Personal Collection via the graph, an Exception is thrown

--- a/test/metabase/models/permissions_group_membership_test.clj
+++ b/test/metabase/models/permissions_group_membership_test.clj
@@ -1,30 +1,27 @@
 (ns metabase.models.permissions-group-membership-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
+            [expectations :refer [expect]]
             [metabase.models
              [permissions-group :as group]
              [permissions-group-membership :as pgm :refer [PermissionsGroupMembership]]
              [user :refer [User]]]
-            [metabase.test.data.users :as test-users]
+            [metabase.test.fixtures :as fixtures]
             [metabase.util :as u]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
 
+(use-fixtures :once (fixtures/initialize :test-users))
+
 ;; when you create a PermissionsGroupMembership for a User in the admin group, it should set their `is_superuser` flag
 (expect
   true
-  (do
-    ;; make sure the test users are Created, otherwise `with-temp` will fail when it tries to delete the temporary
-    ;; user, because deleting the last admin user is disallowed
-    (test-users/create-users-if-needed!)
-    (tt/with-temp User [user]
-      (db/insert! PermissionsGroupMembership {:user_id (u/get-id user), :group_id (u/get-id (group/admin))})
-      (db/select-one-field :is_superuser User :id (u/get-id user)))))
+  (tt/with-temp User [user]
+    (db/insert! PermissionsGroupMembership {:user_id (u/get-id user), :group_id (u/get-id (group/admin))})
+    (db/select-one-field :is_superuser User :id (u/get-id user))))
 
 ;; when you delete a PermissionsGroupMembership for a User in the admin group, it should set their `is_superuser` flag
 (expect
   false
-  (do
-    (test-users/create-users-if-needed!)
-    (tt/with-temp User [user {:is_superuser true}]
-      (db/delete! PermissionsGroupMembership :user_id (u/get-id user), :group_id (u/get-id (group/admin)))
-      (db/select-one-field :is_superuser User :id (u/get-id user)))))
+  (tt/with-temp User [user {:is_superuser true}]
+    (db/delete! PermissionsGroupMembership :user_id (u/get-id user), :group_id (u/get-id (group/admin)))
+    (db/select-one-field :is_superuser User :id (u/get-id user))))

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -1,13 +1,14 @@
 (ns metabase.models.permissions-test
-  (:require [expectations :refer :all]
+  (:require [expectations :refer [expect]]
             [metabase.models
              [collection :as collection :refer [Collection]]
-             [collection-test :as collection-test]
              [database :refer [Database]]
              [permissions :as perms :refer [Permissions]]
              [permissions-group :as group :refer [PermissionsGroup]]
              [table :refer [Table]]]
-            [metabase.test.data :as data]
+            [metabase.test
+             [data :as data]
+             [initialize :as initialize]]
             [metabase.test.data.users :as test-users]
             [metabase.util :as u]
             [toucan.db :as db]
@@ -630,7 +631,7 @@
 (expect
   Exception
   (do
-    (collection-test/force-create-personal-collections!)
+    (initialize/initialize-if-needed! :test-users-personal-collections)
     (perms/revoke-collection-permissions!
       (group/all-users)
       (u/get-id (db/select-one 'Collection :personal_owner_id (test-users/user->id :lucky))))))
@@ -649,7 +650,7 @@
 (expect
   Exception
   (do
-    (collection-test/force-create-personal-collections!)
+    (initialize/initialize-if-needed! :test-users-personal-collections)
     (perms/grant-collection-read-permissions!
      (group/all-users)
      (u/get-id (db/select-one 'Collection :personal_owner_id (test-users/user->id :lucky))))))
@@ -669,7 +670,7 @@
 (expect
   Exception
   (do
-    (collection-test/force-create-personal-collections!)
+    (initialize/initialize-if-needed! :test-users-personal-collections)
     (perms/grant-collection-readwrite-permissions!
      (group/all-users)
      (u/get-id (db/select-one 'Collection :personal_owner_id (test-users/user->id :lucky))))))

--- a/test/metabase/query_processor/middleware/parameters/mbql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
@@ -141,13 +141,15 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;; for some reason param substitution tests fail on Redshift so just don't run those for now
-(def ^:private params-test-drivers (disj @qp.test/non-timeseries-drivers :redshift))
+(def ^:private params-test-drivers
+  (delay (disj @qp.test/non-timeseries-drivers :redshift)))
 
 ;; check that date ranges work correctly
 (datasets/expect-with-drivers @params-test-drivers
   [29]
   (do
-    ;; Prevent an issue with Snowflake were a previous connection's report-timezone setting can affect this test's results
+    ;; Prevent an issue with Snowflake were a previous connection's report-timezone setting can affect this test's
+    ;; results
     (when (= :snowflake driver/*driver*)
       (driver/notify-database-updated driver/*driver* (data/id)))
     (qp.test/first-row

--- a/test/metabase/query_processor/middleware/parameters/mbql_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
@@ -141,10 +141,10 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;; for some reason param substitution tests fail on Redshift so just don't run those for now
-(def ^:private params-test-drivers (disj qp.test/non-timeseries-drivers :redshift))
+(def ^:private params-test-drivers (disj @qp.test/non-timeseries-drivers :redshift))
 
 ;; check that date ranges work correctly
-(datasets/expect-with-drivers params-test-drivers
+(datasets/expect-with-drivers @params-test-drivers
   [29]
   (do
     ;; Prevent an issue with Snowflake were a previous connection's report-timezone setting can affect this test's results
@@ -162,7 +162,7 @@
                            :value  "2015-04-01~2015-05-01"}]}))))))
 
 ;; check that IDs work correctly (passed in as numbers)
-(datasets/expect-with-drivers params-test-drivers
+(datasets/expect-with-drivers @params-test-drivers
   [1]
   (qp.test/first-row
     (qp.test/format-rows-by [int]
@@ -176,7 +176,7 @@
                          :value  100}]})))))
 
 ;; check that IDs work correctly (passed in as strings, as the frontend is wont to do; should get converted)
-(datasets/expect-with-drivers params-test-drivers
+(datasets/expect-with-drivers @params-test-drivers
   [1]
   (qp.test/first-row
     (qp.test/format-rows-by [int]
@@ -190,7 +190,7 @@
                          :value  "100"}]})))))
 
 ;; check that Categories work correctly (passed in as strings, as the frontend is wont to do; should get converted)
-(datasets/expect-with-drivers params-test-drivers
+(datasets/expect-with-drivers @params-test-drivers
   [[6]]
   (qp.test/format-rows-by [int]
     (qp.test/rows
@@ -203,7 +203,7 @@
                          :value  "4"}]})))))
 
 ;; test that we can inject a basic `WHERE id = 9` type param (`id` type)
-(datasets/expect-with-drivers params-test-drivers
+(datasets/expect-with-drivers @params-test-drivers
   [[9 "Nils Gotam"]]
   (qp.test/format-rows-by [int str]
     (qp.test/rows
@@ -215,7 +215,7 @@
                          :value  9}]})))))
 
 ;; test that we can do the same thing but with a `category` type
-(datasets/expect-with-drivers params-test-drivers
+(datasets/expect-with-drivers @params-test-drivers
   [[6]]
   (qp.test/format-rows-by [int]
     (qp.test/rows
@@ -231,7 +231,7 @@
 ;; Make sure that *multiple* values work. This feature was added in 0.28.0. You are now allowed to pass in an array of
 ;; parameter values instead of a single value, which should stick them together in a single MBQL `:=` clause, which
 ;; ends up generating a SQL `*or*` clause
-(datasets/expect-with-drivers params-test-drivers
+(datasets/expect-with-drivers @params-test-drivers
   [[19]]
   (qp.test/format-rows-by [int]
     (qp.test/rows
@@ -293,7 +293,7 @@
       "make sure that :id type params get converted to numbers when appropriate"))
 
 ;; Make sure we properly handle paramters that have `fk->` forms in `:dimension` targets (#9017)
-(datasets/expect-with-drivers (filter #(driver/supports? % :foreign-keys) params-test-drivers)
+(datasets/expect-with-drivers (filter #(driver/supports? % :foreign-keys) @params-test-drivers)
   [[31 "Bludso's BBQ" 5 33.8894 -118.207 2]
    [32 "Boneyard Bistro" 5 34.1477 -118.428 3]
    [33 "My Brother's Bar-B-Q" 5 34.167 -118.595 2]

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -29,14 +29,15 @@
 
 (def non-timeseries-drivers
   "Set of engines for non-timeseries DBs (i.e., every driver except `:druid`)."
-  (set/difference tx.env/test-drivers timeseries-drivers))
+  (delay
+    (set/difference @tx.env/test-drivers timeseries-drivers)))
 
 (defn non-timeseries-drivers-with-feature
   "Set of engines that support a given `feature`. If additional features are given, it will ensure all features are
   supported."
   [feature & more-features]
   (let [features (set (cons feature more-features))]
-    (set (for [driver non-timeseries-drivers
+    (set (for [driver @non-timeseries-drivers
                :let   [driver (tx/the-driver-with-test-extensions driver)]
                :when  (set/subset? features (driver.u/features driver))]
            driver))))
@@ -44,24 +45,24 @@
 (defn non-timeseries-drivers-without-feature
   "Return a set of all non-timeseries engines (e.g., everything except Druid) that DO NOT support `feature`."
   [feature]
-  (set/difference non-timeseries-drivers (non-timeseries-drivers-with-feature feature)))
+  (set/difference @non-timeseries-drivers (non-timeseries-drivers-with-feature feature)))
 
 (defmacro ^:deprecated expect-with-non-timeseries-dbs
   "DEPRECATED — Use `deftest` + `test-drivers` + `non-timeseries-drivers` instead.
 
     (deftest my-test
-      (datasets/test-drivers qp.test/non-timeseries-drivers
+      (datasets/test-drivers @qp.test/non-timeseries-drivers
         (is (= ...))))"
   {:style/indent 0}
   [expected actual]
-  `(datasets/expect-with-drivers non-timeseries-drivers
+  `(datasets/expect-with-drivers @non-timeseries-drivers
      ~expected
      ~actual))
 
 (defn non-timeseries-drivers-except
   "Return the set of all drivers except Druid, Google Analytics, and those in `excluded-drivers`."
   [excluded-drivers]
-  (set/difference non-timeseries-drivers (set excluded-drivers)))
+  (set/difference @non-timeseries-drivers (set excluded-drivers)))
 
 (defmacro ^:deprecated expect-with-non-timeseries-dbs-except
   "DEPRECATED — Use `deftest` + `test-drivers` + `non-timeseries-drivers-except` instead.

--- a/test/metabase/query_processor_test/aggregation_test.clj
+++ b/test/metabase/query_processor_test/aggregation_test.clj
@@ -138,7 +138,7 @@
 ;; TODO - this isn't tested against Mongo because those driver doesn't currently work correctly with multiple columns
 ;; with the same name. It seems like it would be pretty easy to take the stuff we have for BigQuery and generalize it
 ;; so we can use it with Mongo
-(datasets/expect-with-drivers (disj qp.test/non-timeseries-drivers :mongo)
+(datasets/expect-with-drivers (disj @qp.test/non-timeseries-drivers :mongo)
   [(qp.test/aggregate-col :count)
    (assoc (qp.test/aggregate-col :count) :name "count_2", :field_ref [:aggregation 1])]
   (qp.test/cols

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -990,7 +990,7 @@
 
 (deftest additional-unit-filtering-tests
   (testing "Additional tests for filtering against various datetime bucketing units that aren't tested above"
-    (datasets/test-drivers qp.test/non-timeseries-drivers
+    (datasets/test-drivers @qp.test/non-timeseries-drivers
       (doseq [[expected-count unit filter-value] addition-unit-filtering-vals]
         (testing unit
           (let [result (count-of-checkins unit filter-value)]

--- a/test/metabase/query_processor_test/order_by_test.clj
+++ b/test/metabase/query_processor_test/order_by_test.clj
@@ -78,7 +78,7 @@
          :order-by    [[:asc [:aggregation 0]]]}))))
 
 (deftest order-by-average-aggregation-test
-  (datasets/test-drivers qp.test/non-timeseries-drivers
+  (datasets/test-drivers @qp.test/non-timeseries-drivers
     (let [{:keys [rows cols]}    (qp.test/rows-and-cols
                                    (qp.test/format-rows-by [int 1.0]
                                      (data/run-mbql-query venues

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.query-processor-test.timezones-test
-  (:require [clojure.test :refer :all]
-            [metabase
+  (:require [metabase
              [driver :as driver]
              [query-processor :as qp]
              [query-processor-test :as qp.test]]

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -1,8 +1,9 @@
 (ns metabase.query-processor-test.timezones-test
-  (:require [metabase
+  (:require [clojure.test :refer :all]
+            [metabase
              [driver :as driver]
              [query-processor :as qp]
-             [query-processor-test :as qpt]]
+             [query-processor-test :as qp.test]]
             [metabase.models
              [field :refer [Field]]
              [table :refer [Table]]]
@@ -10,7 +11,7 @@
              [data :as data]
              [util :as tu]]
             [metabase.test.data
-             [datasets :refer [expect-with-drivers]]
+             [datasets :as datasets]
              [sql :as sql.tx]]
             [toucan.db :as db]))
 
@@ -34,13 +35,13 @@
 
 ;; Query PG using a report-timezone set to pacific time. Should adjust the query parameter using that report timezone
 ;; and should return the timestamp in pacific time as well
-(expect-with-drivers [:postgres :mysql]
+(datasets/expect-with-drivers [:postgres :mysql]
   default-pacific-results
   (with-tz-db
     (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
       (-> (data/run-mbql-query users
             {:filter [:between $last_login "2014-08-02T03:00:00.000000" "2014-08-02T06:00:00.000000"]})
-          qpt/rows
+          qp.test/rows
           set))))
 
 (defn- table-identifier [table-key]
@@ -55,10 +56,10 @@
         field-name (db/select-one-field :name Field, :id (apply data/id table-key field-keys))]
     (sql.tx/qualify-and-quote driver/*driver* (:name (data/db)) table-name field-name)))
 
-(def ^:private query-rows-set (comp set qpt/rows qp/process-query))
+(def ^:private query-rows-set (comp set qp.test/rows qp/process-query))
 
 ;; Test that native dates are parsed with the report timezone (when supported)
-(expect-with-drivers [:postgres :mysql]
+(datasets/expect-with-drivers [:postgres :mysql]
   default-pacific-results-for-params
   (with-tz-db
     (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
@@ -76,7 +77,7 @@
                      {:type "date/single" :target ["variable" ["template-tag" "date2"]] :value "2014-08-02T06:00:00.000000"}]}))))
 
 ;; This does not currently work for MySQL
-(expect-with-drivers [:postgres :mysql]
+(datasets/expect-with-drivers [:postgres :mysql]
   default-pacific-results-for-params
   (with-tz-db
     (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
@@ -93,7 +94,7 @@
         :parameters [{:type "date/range", :target ["dimension" ["template-tag" "ts_range"]], :value "2014-08-02~2014-08-03"}]}))))
 
 ;; Querying using a single date
-(expect-with-drivers [:postgres :mysql]
+(datasets/expect-with-drivers [:postgres :mysql]
   default-pacific-results-for-params
   (with-tz-db
     (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
@@ -111,31 +112,61 @@
 
 ;; This is the same answer as above but uses timestamp with the timezone included. The report timezone is still
 ;; pacific though, so it should return as pacific regardless of how the filter was specified
-(expect-with-drivers [:postgres :mysql]
+(datasets/expect-with-drivers [:postgres :mysql]
   default-pacific-results
   (with-tz-db
     (tu/with-temporary-setting-values [report-timezone "America/Los_Angeles"]
       (-> (data/run-mbql-query users
             {:filter [:between $last_login "2014-08-02T10:00:00.000000Z" "2014-08-02T13:00:00.000000Z"]})
-          qpt/rows
+          qp.test/rows
           set))))
 
 ;; Checking UTC report timezone filtering and responses
-(expect-with-drivers [:postgres :bigquery :mysql]
+(datasets/expect-with-drivers [:postgres :bigquery :mysql]
   default-utc-results
   (with-tz-db
     (tu/with-temporary-setting-values [report-timezone "UTC"]
       (-> (data/run-mbql-query users
             {:filter [:between $last_login "2014-08-02T10:00:00.000000" "2014-08-02T13:00:00.000000"]})
-          qpt/rows
+          qp.test/rows
           set))))
 
 ;; With no report timezone, the JVM timezone is used. For our tests this is UTC so this should be the same as
 ;; specifying UTC for a report timezone
-(expect-with-drivers [:postgres :bigquery :mysql]
+(datasets/expect-with-drivers [:postgres :bigquery :mysql]
   default-utc-results
   (with-tz-db
     (-> (data/run-mbql-query users
           {:filter [:between $last_login "2014-08-02T10:00:00.000000" "2014-08-02T13:00:00.000000"]})
-        qpt/rows
+        qp.test/rows
         set)))
+
+(defn- rows-on-july-30 []
+  (qp.test/rows
+    (data/run-mbql-query users
+      {:fields   [$id $last_login]
+       :filter   [:= $last_login "2014-07-03"]
+       :order-by [[:asc $last_login]]})))
+
+(deftest result-rows-test
+  (datasets/test-drivers (qp.test/non-timeseries-drivers-with-feature :set-timezone)
+    (testing "timezone-aware columns"
+      (data/dataset test-data-with-timezones
+        (doseq [[timezone expected-rows] {"UTC"        [[12 "2014-07-03T01:30:00.000Z"]
+                                                        [10 "2014-07-03T19:30:00.000Z"]]
+                                          "US/Pacific" [[10 "2014-07-03T12:30:00.000-07:00"]]}]
+          (tu/with-temporary-setting-values [report-timezone timezone]
+            (is (= expected-rows
+                   (rows-on-july-30))
+                (format "There should be %d checkins on July 30th in the %s timezone" (count expected-rows) timezone))))))
+    (testing "non-timezone-aware columns"
+      (doseq [[timezone expected-rows] {"UTC"        [[12 "2014-07-03T01:30:00.000Z"]
+                                                      [10 "2014-07-03T19:30:00.000Z"]]
+                                        ;; I think the results should be test same for any timezone??????? If the
+                                        ;; column is not timezone aware (?)
+                                        "US/Pacific" [[12 "2014-07-03T01:30:00.000Z"]
+                                                      [10 "2014-07-03T19:30:00.000Z"]]}]
+        (tu/with-temporary-setting-values [report-timezone timezone]
+          (is (= expected-rows
+                 (rows-on-july-30))
+              (format "There should be %d checkins on July 30th in the %s timezone" (count expected-rows) timezone)))))))

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -140,33 +140,3 @@
           {:filter [:between $last_login "2014-08-02T10:00:00.000000" "2014-08-02T13:00:00.000000"]})
         qp.test/rows
         set)))
-
-(defn- rows-on-july-30 []
-  (qp.test/rows
-    (data/run-mbql-query users
-      {:fields   [$id $last_login]
-       :filter   [:= $last_login "2014-07-03"]
-       :order-by [[:asc $last_login]]})))
-
-(deftest result-rows-test
-  (datasets/test-drivers (qp.test/non-timeseries-drivers-with-feature :set-timezone)
-    (testing "timezone-aware columns"
-      (data/dataset test-data-with-timezones
-        (doseq [[timezone expected-rows] {"UTC"        [[12 "2014-07-03T01:30:00.000Z"]
-                                                        [10 "2014-07-03T19:30:00.000Z"]]
-                                          "US/Pacific" [[10 "2014-07-03T12:30:00.000-07:00"]]}]
-          (tu/with-temporary-setting-values [report-timezone timezone]
-            (is (= expected-rows
-                   (rows-on-july-30))
-                (format "There should be %d checkins on July 30th in the %s timezone" (count expected-rows) timezone))))))
-    (testing "non-timezone-aware columns"
-      (doseq [[timezone expected-rows] {"UTC"        [[12 "2014-07-03T01:30:00.000Z"]
-                                                      [10 "2014-07-03T19:30:00.000Z"]]
-                                        ;; I think the results should be test same for any timezone??????? If the
-                                        ;; column is not timezone aware (?)
-                                        "US/Pacific" [[12 "2014-07-03T01:30:00.000Z"]
-                                                      [10 "2014-07-03T19:30:00.000Z"]]}]
-        (tu/with-temporary-setting-values [report-timezone timezone]
-          (is (= expected-rows
-                 (rows-on-july-30))
-              (format "There should be %d checkins on July 30th in the %s timezone" (count expected-rows) timezone)))))))

--- a/test/metabase/sync/analyze/table_row_count_test.clj
+++ b/test/metabase/sync/analyze/table_row_count_test.clj
@@ -12,7 +12,7 @@
 ;; test that syncing table row counts works
 ;; TODO - write a Druid version of this test. Works slightly differently since Druid doesn't have a 'venues' table
 ;; TODO - not sure why this doesn't work on Oracle. Seems to be an issue with the test rather than with the Oracle driver
-(datasets/expect-with-drivers (disj qp-test/non-timeseries-drivers :oracle)
+(datasets/expect-with-drivers (disj @qp-test/non-timeseries-drivers :oracle)
   100
   (tu/with-temp-vals-in-db Table (data/id :venues) {:rows 0}
       (table-row-count/update-row-count! (Table (data/id :venues)))

--- a/test/metabase/task/follow_up_emails_test.clj
+++ b/test/metabase/task/follow_up_emails_test.clj
@@ -1,9 +1,11 @@
 (ns metabase.task.follow-up-emails-test
-  (:require [expectations :refer :all]
+  (:require [clojure.test :refer :all]
+            [expectations :refer [expect]]
             [metabase.email-test :refer [inbox with-fake-inbox]]
             [metabase.task.follow-up-emails :as follow-up-emails]
-            [metabase.test.data.users :as test-users]
             [metabase.test.util :as tu]))
+
+(use-fixtures :once (fixtures/initialize :test-users))
 
 ;; Make sure that `send-follow-up-email!` only sends a single email instead even when triggered multiple times (#4253)
 ;; follow-up emails get sent to the oldest admin
@@ -11,7 +13,6 @@
   1
   (tu/with-temporary-setting-values [anon-tracking-enabled true
                                      follow-up-email-sent  false]
-    (test-users/create-users-if-needed!)
     (with-fake-inbox
       (#'follow-up-emails/send-follow-up-email!)
       (#'follow-up-emails/send-follow-up-email!)

--- a/test/metabase/task/follow_up_emails_test.clj
+++ b/test/metabase/task/follow_up_emails_test.clj
@@ -3,7 +3,9 @@
             [expectations :refer [expect]]
             [metabase.email-test :refer [inbox with-fake-inbox]]
             [metabase.task.follow-up-emails :as follow-up-emails]
-            [metabase.test.util :as tu]))
+            [metabase.test
+             [fixtures :as fixtures]
+             [util :as tu]]))
 
 (use-fixtures :once (fixtures/initialize :test-users))
 

--- a/test/metabase/test/data/datasets.clj
+++ b/test/metabase/test/data/datasets.clj
@@ -1,22 +1,31 @@
 (ns metabase.test.data.datasets
-  "Interface + implementations for loading test datasets for different drivers, and getting information about the
-  dataset's tables, fields, etc.
+  "Utility functions and macros for running tests against multiple drivers. When writing a test, you normally define all
+  the drivers it *can* run against, e.g.
 
-  TODO - rename this to `metabase.driver.test-extensions.expect` or `metabase.driver.test` or something like that"
+    (deftest my-test
+      ;; run tests against all drivers except Druid
+      (datasets/test-drivers qp.test/non-timeseries-drivers
+        ...))
+
+  When the test suite is ran, those tests will be ran against the subset of those drivers that are present in the
+  `DRIVERS` env var.
+
+  TODO - this namespace name really doesn't make a lot of sense. How about `metabase.test.driver` or something like
+  that?"
   (:require [clojure.test :as t]
             [metabase.driver :as driver]
             [metabase.test.data
              [env :as tx.env]
              [interface :as tx]]))
 
-;; # Helper Macros
-
 (defn do-when-testing-driver
-  "Call function `f` (always with no arguments) *only* if we are currently testing against `driver`.
-   (This does NOT bind `*driver*`; use `driver/with-driver` if you want to do that.)"
+  "Call function `f` (always with no arguments) *only* if we are currently testing against `driver` (i.e., if `driver`
+  is listed in the `DRIVERS` env var.)
+
+  (This does NOT bind `*driver*`; use `driver/with-driver` if you want to do that.)"
   {:style/indent 1}
   [driver f]
-  (when (contains? tx.env/test-drivers driver)
+  (when (contains? @tx.env/test-drivers driver)
     (f)))
 
 (defmacro when-testing-driver
@@ -89,7 +98,7 @@
   "Execute body (presumably containing tests) against all drivers we're currently testing against."
   {:style/indent 0}
   [& body]
-  `(test-drivers tx.env/test-drivers ~@body))
+  `(test-drivers @tx.env/test-drivers ~@body))
 
 (defmacro ^:deprecated expect-with-all-drivers
   "Generate unit tests for all drivers specified in env var `DRIVERS`. `*driver*` is bound to the current driver inside
@@ -102,4 +111,4 @@
         (is (= ...))))"
   {:style/indent 0}
   [expected actual]
-  `(expect-with-drivers tx.env/test-drivers ~expected ~actual))
+  `(expect-with-drivers @tx.env/test-drivers ~expected ~actual))

--- a/test/metabase/test/data/env.clj
+++ b/test/metabase/test/data/env.clj
@@ -14,11 +14,12 @@
             [metabase.test.data.env.impl :as impl]
             [metabase.test.initialize :as initialize]))
 
-(defonce ^{:doc (str "Set of names of drivers we should run tests against. By default, this only contains `:h2` but can"
-                     " be overriden by setting env var `DRIVERS`.")}
+(defonce ^{:doc "Set of names of drivers we should run tests against. By default, this only contains `:h2` but can be
+  overriden by setting env var `DRIVERS`."}
   test-drivers
-  (let [drivers (impl/get-test-drivers)]
-    (log/info (color/cyan "Running QP tests against these drivers: " drivers))
-    (when-not (= drivers #{:h2})
-      (initialize/initialize-if-needed! :plugins))
-    drivers))
+  (delay
+    (let [drivers (impl/get-test-drivers)]
+      (log/info (color/cyan "Running QP tests against these drivers: " drivers))
+      (when-not (= drivers #{:h2})
+        (initialize/initialize-if-needed! :plugins))
+      drivers)))

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -20,6 +20,7 @@
             [metabase.plugins.classloader :as classloader]
             [metabase.query-processor.middleware.annotate :as annotate]
             [metabase.query-processor.store :as qp.store]
+            [metabase.test.initialize :as initialize]
             [metabase.util
              [date :as du]
              [schema :as su]]
@@ -153,6 +154,7 @@
   "Like `driver/the-driver`, but guaranteed to return a driver with test extensions loaded, throwing an Exception
   otherwise. Loads driver and test extensions automatically if not already done."
   [driver]
+  (initialize/initialize-if-needed! :plugins)
   (let [driver (driver/the-initialized-driver driver)]
     (load-test-extensions-namespace-if-needed driver)
     driver))

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -44,7 +44,7 @@
                :password "birdseed"
                :active   false}})
 
-(def ^:private usernames
+(def usernames
   (set (keys user->info)))
 
 (def ^:private TestUserName
@@ -80,16 +80,6 @@
     (fetch-user :rasta) -> {:id 100 :first_name \"Rasta\" ...}"
   [username :- TestUserName]
   (m/mapply fetch-or-create-user! (user->info username)))
-
-(s/defn create-users-if-needed!
-  "Force creation of the test users if they don't already exist."
-  ([]
-   (apply create-users-if-needed! usernames))
-
-  ([& usernames :- [TestUserName]]
-   (doseq [username usernames]
-     ;; fetch-user will force creation of users
-     (fetch-user username))))
 
 (def ^{:arglists '([username])} user->id
   "Memoized fn that returns the ID of User associated with `username`. Creates user if needed.
@@ -155,7 +145,7 @@
 
      ((user->client) :get 200 \"meta/table\")"
   [username :- TestUserName]
-  (create-users-if-needed! username)
+  (fetch-user username) ; force creation of the user if not already created
   (partial client-fn username))
 
 (s/defn do-with-test-user

--- a/test/metabase/test/initialize/test_users.clj
+++ b/test/metabase/test/initialize/test_users.clj
@@ -1,0 +1,9 @@
+(ns metabase.test.initialize.test-users
+  (:require [metabase.test.data.users :as test-users]))
+
+(defn init!
+  "Force creation of the test users if they don't already exist."
+  []
+  (doseq [username test-users/usernames]
+    ;; fetch-user will force creation of users
+    (test-users/fetch-user username)))

--- a/test/metabase/test/initialize/test_users_personal_collections.clj
+++ b/test/metabase/test/initialize/test_users_personal_collections.clj
@@ -1,0 +1,11 @@
+(ns metabase.test.initialize.test-users-personal-collections
+  (:require [metabase.models.collection :as collection]
+            [metabase.test.data.users :as test-users]))
+
+(defn init!
+  "Force the creation of the Personal Collections for our various test users. They are eventually going to get
+  automatically created anyway as soon as those Users' permissions get calculated in `user/permissions-set`; better to
+  do it now so the test results will be consistent."
+  []
+  (doseq [username test-users/usernames]
+    (collection/user->personal-collection (test-users/user->id username))))


### PR DESCRIPTION
*  Replace `force-create-personal-collections!` and `test-users/create-users-if-needed!` with `metabase.test.initialize/initialize-if-needed!` methods which can be used with `clojure.test` test fixtures (e.g. `(use-fixtures :once (metabase.test.fixtures/initialize :test-users))`)

*  Add `with-test-drivers` macro to `dev` namespace, which lets you run tests against certain DBs as if you had set `DRIVERS` from the REPL

*  Test HTTP client now treats expected status codes as simple test assertions instead of throwing an Exception if the actual status code differs. Makes debugging easier.