### PR TITLE
Client timezone tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -677,6 +677,9 @@ workflows:
       - fe-tests-integration:
           requires:
             - fe-deps
+      - fe-tests-timezones:
+          requires:
+            - fe-deps
       - build-uberjar:
           requires:
             - be-deps
@@ -723,6 +726,7 @@ workflows:
 
             - fe-tests-e2e
             - fe-tests-integration
+            - fe-tests-timezones
             - fe-tests-karma
             - fe-tests-unit
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,6 +423,13 @@ jobs:
           command-name: Run frontend integration tests
           command: run test-integration
 
+  fe-tests-timezones:
+    executor: node
+    steps:
+      - run-yarn-command:
+          command-name: Run frontend timezone tests
+          command: run test-timezones
+
   build-uberjar:
     executor: clojure-and-node
     steps:

--- a/frontend/test/__runner__/run_timezone_tests
+++ b/frontend/test/__runner__/run_timezone_tests
@@ -12,7 +12,8 @@ set -eu
 # America/Phoenix           −07:00           −07:00
 # America/Los_Angeles       −08:00           −07:00
 
-DEFAULT_TIMEZONES="Etc/UTC Europe/London America/Los_Angeles America/Phoenix"
+# DEFAULT_TIMEZONES="Etc/UTC Europe/London America/Los_Angeles America/Phoenix"
+DEFAULT_TIMEZONES="Etc/UTC"
 
 tzs=${TIMEZONES:-$DEFAULT_TIMEZONES}
 

--- a/frontend/test/__runner__/run_timezone_tests
+++ b/frontend/test/__runner__/run_timezone_tests
@@ -11,9 +11,11 @@ set -eu
 # Europe/London             +00:00           +01:00
 # America/Phoenix           −07:00           −07:00
 # America/Los_Angeles       −08:00           −07:00
+# Asia/Kathmandu            +05:45           +05:45
+# Asia/Hong_Kong            +08:00           +08:00
 
-# DEFAULT_TIMEZONES="Etc/UTC Europe/London America/Los_Angeles America/Phoenix"
-DEFAULT_TIMEZONES="Etc/UTC"
+
+DEFAULT_TIMEZONES="Etc/UTC Europe/London America/Los_Angeles America/Phoenix Asia/Kathmandu Asia/Hong_Kong"
 
 tzs=${TIMEZONES:-$DEFAULT_TIMEZONES}
 

--- a/frontend/test/__runner__/run_timezone_tests
+++ b/frontend/test/__runner__/run_timezone_tests
@@ -23,7 +23,7 @@ failed=""
 
 for tz in $tzs; do
   echo "Running unit tests in timezone $tz"
-  if TZ="$tz" METABASE_TEST_TIMEZONES="$tzs" yarn run test-unit tz.unit; then
+  if TZ="$tz" METABASE_TEST_TIMEZONES="$tzs" yarn run test-timezones-unit; then
     passed="$passed $tz"
     results="$results \e[32m✓\e[0m $tz\n"
   else

--- a/frontend/test/__runner__/run_timezone_tests
+++ b/frontend/test/__runner__/run_timezone_tests
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# Test a variety of timezones with/without DST
+# https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+#
+# TZ                    UTC offset   UTC DST offset
+# =================================================
+# Etc/UTC                   +00:00           +00:00
+# Europe/London             +00:00           +01:00
+# America/Phoenix           −07:00           −07:00
+# America/Los_Angeles       −08:00           −07:00
+
+DEFAULT_TIMEZONES="Etc/UTC Europe/London America/Los_Angeles America/Phoenix"
+
+tzs=${TIMEZONES:-$DEFAULT_TIMEZONES}
+
+results=""
+passed=""
+failed=""
+
+for tz in $tzs; do
+  echo "Running unit tests in timezone $tz"
+  if TZ="$tz" METABASE_TEST_TIMEZONES="$tzs" yarn run test-unit tz.unit; then
+    passed="$passed $tz"
+    results="$results \e[32m✓\e[0m $tz\n"
+  else
+    failed="$failed $tz"
+    results="$results \e[31m✕\e[0m $tz\n"
+  fi
+done
+
+echo "Timezone tests:"
+printf "$results"
+
+if [[ ! -z "$failed" ]]; then
+  exit 1
+fi

--- a/frontend/test/__support__/timezones.js
+++ b/frontend/test/__support__/timezones.js
@@ -1,0 +1,16 @@
+export default function testAcrossTimezones(runTests) {
+  // run_timezone_tests sets "TZ" environment variable to change the timezone
+  const clientTz = process.env["TZ"] || "[default]";
+  // run_timezone_tests also sets "METABASE_TEST_TIMEZONES" to list of timezones
+  const reportTzs = (process.env["METABASE_TEST_TIMEZONES"] || "Etc/UTC").split(
+    " ",
+  );
+
+  describe(`client timezone ${clientTz}`, () => {
+    reportTzs.map(reportTz => {
+      describe(`report timezone ${reportTz}`, () => {
+        runTests(reportTz);
+      });
+    });
+  });
+}

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.tz.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.tz.unit.spec.js
@@ -141,7 +141,7 @@ describe("LineAreaBarRenderer-bar", () => {
             moment()
               .tz(reportTz)
               .startOf(interval)
-              .toISOString(),
+              .toISOString(true),
             1,
           ],
           [
@@ -149,7 +149,7 @@ describe("LineAreaBarRenderer-bar", () => {
               .tz(reportTz)
               .startOf(interval)
               .add(1, interval)
-              .toISOString(),
+              .toISOString(true),
             1,
           ],
         ];
@@ -198,7 +198,7 @@ function renderTimeseries(element, unit, timezone, rows, props = {}) {
       },
       data: {
         cols: [
-          DateTimeColumn({ name: "CREATED_AT", unit, timezone }),
+          DateTimeColumn({ name: "CREATED_AT", unit }),
           NumberColumn({ name: "count" }),
         ],
         rows,
@@ -249,7 +249,7 @@ function generateRowsInTz(tz) {
       .tz(tz)
       .startOf("month")
       .add(month, "months")
-      .toISOString(),
+      .toISOString(true),
     0,
   ]);
 }

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.tz.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.tz.unit.spec.js
@@ -11,9 +11,6 @@ import {
   getFormattedTooltips,
 } from "../__support__/visualizations";
 
-import lineAreaBarRenderer from "metabase/visualizations/lib/LineAreaBarRenderer";
-import { formatValue } from "metabase/lib/formatting";
-
 // make WIDTH big enough that ticks aren't skipped
 const WIDTH = 4000;
 const HEIGHT = 1000;
@@ -79,9 +76,9 @@ describe("LineAreaBarRenderer-bar", () => {
   // run_timezone_tests sets "TZ" environment variable to change the timezone
   const clientTz = process.env["TZ"] || "[default]";
   // run_timezone_tests also sets "METABASE_TEST_TIMEZONES" to list of timezones
-  const reportTzs = (
-    process.env["METABASE_TEST_TIMEZONES"] || "America/Los_Angeles"
-  ).split(" ");
+  const reportTzs = (process.env["METABASE_TEST_TIMEZONES"] || "Etc/UTC").split(
+    " ",
+  );
 
   describe(`client timezone ${clientTz}`, () => {
     reportTzs.map(reportTz => {

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.tz.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.tz.unit.spec.js
@@ -194,7 +194,7 @@ function renderTimeseries(element, unit, timezone, rows, props = {}) {
       card: {
         display: "bar",
         visualization_settings: { ...DEFAULT_SETTINGS },
-        actual_timezone: timezone,
+        results_timezone: timezone,
       },
       data: {
         cols: [

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.tz.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.tz.unit.spec.js
@@ -1,0 +1,272 @@
+import "__support__/mocks"; // included explicitly whereas with integrated tests it comes with __support__/integrated_tests
+
+import _ from "underscore";
+import moment from "moment-timezone";
+
+import {
+  NumberColumn,
+  DateTimeColumn,
+  dispatchUIEvent,
+} from "../__support__/visualizations";
+
+import lineAreaBarRenderer from "metabase/visualizations/lib/LineAreaBarRenderer";
+import { formatValue } from "metabase/lib/formatting";
+
+// make WIDTH big enough that ticks aren't skipped
+const WIDTH = 4000;
+const HEIGHT = 1000;
+
+describe("LineAreaBarRenderer-bar", () => {
+  let element;
+  let onHoverChange;
+
+  const qsa = selector => [...element.querySelectorAll(selector)];
+
+  function setupFixture() {
+    document.body.style.width = `${WIDTH}px`;
+    document.body.style.height = `${HEIGHT}px`;
+    document.body.insertAdjacentHTML(
+      "afterbegin",
+      `<div id="fixture" style="height: ${HEIGHT}px; width: ${WIDTH}px;">`,
+    );
+    element = document.getElementById("fixture");
+  }
+
+  function teardownFixture() {
+    document.body.removeChild(element);
+  }
+
+  const activateTooltips = () =>
+    qsa(".bar").map(bar => dispatchUIEvent(bar, "mousemove"));
+
+  const getXAxisLabelsText = () =>
+    qsa(".axis.x .tick text").map(t => t.textContent);
+  const getTooltipDimensionValueText = () =>
+    onHoverChange.mock.calls.map(([{ data }]) =>
+      formatValue(data[0].value, {
+        column: data[0].col,
+      }),
+    );
+
+  const getSVGElementMiddle = element => {
+    return (
+      parseFloat(element.getAttribute("x")) +
+      parseFloat(element.getAttribute("width")) / 2
+    );
+  };
+  const getSVGElementTransformMiddle = element => {
+    const transform = element.getAttribute("transform");
+    const match = transform.match(/translate\(([0-9\.]+)/);
+    return parseFloat(match[1]);
+  };
+
+  const MAX_DELTA = 0;
+
+  const getClosestLabelText = bar => {
+    // get the horizontal center of the target element
+    const barCenter = getSVGElementMiddle(bar);
+    let closest;
+    let minDelta = Infinity;
+    for (const label of qsa(".axis.x .tick")) {
+      const labelCenter = getSVGElementTransformMiddle(label);
+      const delta = Math.abs(barCenter - labelCenter);
+      if (delta < minDelta) {
+        closest = label;
+        minDelta = delta;
+      }
+    }
+    return closest && minDelta <= MAX_DELTA ? closest.textContent : null;
+  };
+
+  // run_timezone_tests sets "TZ" environment variable to change the timezone
+  const clientTz = process.env["TZ"] || "[default]";
+  // run_timezone_tests also sets "METABASE_TEST_TIMEZONES" to list of timezones
+  const reportTzs = (
+    process.env["METABASE_TEST_TIMEZONES"] || "America/Los_Angeles"
+  ).split(" ");
+
+  describe(`client timezone ${clientTz}`, () => {
+    reportTzs.map(reportTz => {
+      describe(`report timezone ${reportTz}`, () => {
+        const rows = generateRowsInTz(reportTz);
+        console.log(rows.map(row => row[0]).join("\n"));
+
+        sharedMonthTests(rows.slice(0, 2), "months in standard time");
+        sharedMonthTests(rows.slice(6, 8), "months in daylights saving time");
+        sharedMonthTests(
+          rows.slice(2, 4),
+          "months starting in standard time, ending in daylights saving time",
+        );
+        sharedMonthTests(
+          rows.slice(10, 12),
+          "months starting in daylights saving time, ending in standard time",
+        );
+        sharedMonthTests(rows, "all months");
+
+        sharedIntervalTests("hour", "h A - MMMM D, YYYY");
+        sharedIntervalTests("day", "MMMM D, YYYY");
+        // sharedIntervalTests("week", "wo - gggg"); // weeks have differing formats for ticks and tooltips, disable this test for now
+        sharedIntervalTests("month", "MMMM YYYY");
+        sharedIntervalTests("quarter", "[Q]Q - YYYY");
+        sharedIntervalTests("year", "YYYY");
+
+        function sharedMonthTests(rows, description) {
+          describe(`with ${description}`, () => {
+            beforeAll(() => {
+              setupFixture();
+              onHoverChange = jest.fn();
+              renderTimeseries(element, "month", reportTz, rows, {
+                onHoverChange,
+              });
+              // hover each bar to trigger onHoverChange
+              activateTooltips();
+            });
+            afterAll(teardownFixture);
+
+            it("should have sequential months in labels", () => {
+              // check that the labels are sequential months
+              assertSequentialMonths(getXAxisLabelsText());
+            });
+            it("should have sequential months in tooltips", () => {
+              // check that the resulting tooltips are sequential
+              assertSequentialMonths(getTooltipDimensionValueText());
+              // check that the number of tooltips matches the number of rows
+              expect(getTooltipDimensionValueText().length).toBe(rows.length);
+            });
+            it("should have tooltips that match source data", () => {
+              expect(getTooltipDimensionValueText()).toEqual(
+                rows.map(([timestamp]) =>
+                  moment.tz(timestamp, reportTz).format("MMMM YYYY"),
+                ),
+              );
+            });
+            it("should have labels that match tooltips", () => {
+              expect(qsa(".bar").map(getClosestLabelText)).toEqual(
+                getTooltipDimensionValueText(),
+              );
+            });
+          });
+        }
+
+        function sharedIntervalTests(interval, expectedFormat) {
+          describe(`with ${interval}s`, () => {
+            const rows = [
+              [
+                moment()
+                  .tz(reportTz)
+                  .startOf(interval),
+                1,
+              ],
+              [
+                moment()
+                  .tz(reportTz)
+                  .startOf(interval)
+                  .add(1, interval),
+                1,
+              ],
+            ];
+            beforeAll(() => {
+              setupFixture();
+              onHoverChange = jest.fn();
+              renderTimeseries(element, interval, reportTz, rows, {
+                onHoverChange,
+              });
+              // hover each bar to trigger onHoverChange
+              activateTooltips();
+            });
+            afterAll(teardownFixture);
+            it("should have tooltips that match source data", () => {
+              expect(getTooltipDimensionValueText()).toEqual(
+                rows.map(([timestamp]) =>
+                  moment.tz(timestamp, reportTz).format(expectedFormat),
+                ),
+              );
+            });
+            it("should have labels that match tooltips", () => {
+              expect(qsa(".bar").map(getClosestLabelText)).toEqual(
+                getTooltipDimensionValueText(),
+              );
+            });
+          });
+        }
+      });
+    });
+  });
+});
+
+const DEFAULT_SETTINGS = {
+  "graph.x_axis.scale": "ordinal",
+  "graph.y_axis.scale": "linear",
+  "graph.x_axis.axis_enabled": true,
+  "graph.y_axis.axis_enabled": true,
+  "graph.colors": ["#00FF00", "#FF0000"],
+};
+
+function renderTimeseries(element, unit, timezone, rows, props = {}) {
+  lineAreaBarRenderer(element, {
+    chartType: "bar",
+    series: [
+      {
+        card: {},
+        data: {
+          cols: [
+            DateTimeColumn({ name: "CREATED_AT", unit, timezone }),
+            NumberColumn({ name: "count" }),
+          ],
+          rows,
+        },
+      },
+    ],
+    settings: {
+      ...DEFAULT_SETTINGS,
+      "graph.x_axis.scale": "timeseries",
+    },
+    ...props,
+  });
+}
+
+// just hard code these to make sure we don't accidentally generate incorrect month labels
+const MONTHS_IN_ORDER = [
+  "October 2015",
+  "November 2015",
+  "December 2015",
+  "January 2016",
+  "February 2016",
+  "March 2016",
+  "April 2016",
+  "May 2016",
+  "June 2016",
+  "July 2016",
+  "August 2016",
+  "September 2016",
+  "October 2016",
+  "November 2016",
+  "December 2016",
+  "January 2017",
+];
+
+function assertSequentialMonths(months) {
+  const firstIndex = MONTHS_IN_ORDER.indexOf(months[0]);
+  if (firstIndex < 0 || firstIndex + months.length > MONTHS_IN_ORDER.length) {
+    throw new Error(
+      "Month out of range! Update MONTHS_IN_ORDER. " +
+        months[0] +
+        " - " +
+        months[months.length - 1],
+    );
+  }
+  expect(months).toEqual(
+    MONTHS_IN_ORDER.slice(firstIndex, firstIndex + months.length),
+  );
+}
+
+function generateRowsInTz(tz) {
+  return _.range(0, 12).map(month => [
+    moment("2016-01-01")
+      .tz(tz)
+      .startOf("month")
+      .add(month, "months")
+      .format(),
+    0,
+  ]);
+}

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.tz.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.tz.unit.spec.js
@@ -194,6 +194,7 @@ function renderTimeseries(element, unit, timezone, rows, props = {}) {
       card: {
         display: "bar",
         visualization_settings: { ...DEFAULT_SETTINGS },
+        actual_timezone: timezone,
       },
       data: {
         cols: [

--- a/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.tz.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/LineAreaBarRenderer.tz.unit.spec.js
@@ -194,9 +194,9 @@ function renderTimeseries(element, unit, timezone, rows, props = {}) {
       card: {
         display: "bar",
         visualization_settings: { ...DEFAULT_SETTINGS },
-        results_timezone: timezone,
       },
       data: {
+        results_timezone: timezone,
         cols: [
           DateTimeColumn({ name: "CREATED_AT", unit }),
           NumberColumn({ name: "count" }),

--- a/frontend/test/metabase/visualizations/lib/fill_data.tz.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/fill_data.tz.unit.spec.js
@@ -1,0 +1,47 @@
+import moment from "moment";
+
+import fillMissingValuesInDatas from "metabase/visualizations/lib/fill_data";
+
+// run_timezone_tests sets "TZ" environment variable to change the timezone
+const clientTz = process.env["TZ"] || "[default]";
+// run_timezone_tests also sets "METABASE_TEST_TIMEZONES" to list of timezones
+const reportTzs = (process.env["METABASE_TEST_TIMEZONES"] || "Etc/UTC").split(
+  " ",
+);
+
+describe(`client timezone ${clientTz}`, () => {
+  reportTzs.map(reportTz => {
+    describe(`report timezone ${reportTz}`, () => {
+      describe("fillMissingValuesInDatas", () => {
+        it("should fill zeros for timeseries across DST boundary", () => {
+          const time1 = moment("2019-03-01T00:00:00").tz(reportTz, true);
+          const time2 = moment("2019-03-30T00:00:00").tz(reportTz, true);
+          const time3 = moment("2019-03-31T00:00:00").tz(reportTz, true);
+          const rows = [[time1, 1], [time2, 2], [time3, 3]];
+          const [filledData] = fillMissingValuesInDatas(
+            {
+              series: [{}],
+              settings: {
+                "graph.x_axis.scale": "timeseries",
+                series: () => ({ "line.missing": "zero" }),
+              },
+            },
+            {
+              xValues: [time1, time2, time3],
+              xDomain: [time1, time3],
+              xInterval: { interval: "day", count: 1 },
+            },
+            [rows],
+          );
+
+          expect(filledData.map(r => r[1])).toEqual([
+            1,
+            ...new Array(28).fill(0),
+            2,
+            3,
+          ]);
+        });
+      });
+    });
+  });
+});

--- a/frontend/test/metabase/visualizations/lib/fill_data.tz.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/fill_data.tz.unit.spec.js
@@ -13,7 +13,7 @@ testAcrossTimezones(reportTz => {
       const rows = [[time1, 1], [time2, 2], [time3, 3]];
       const [filledData] = fillMissingValuesInDatas(
         {
-          series: [{}],
+          series: [{ card: { actual_timezone: reportTz } }],
           settings: {
             "graph.x_axis.scale": "timeseries",
             series: () => ({ "line.missing": "zero" }),

--- a/frontend/test/metabase/visualizations/lib/fill_data.tz.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/fill_data.tz.unit.spec.js
@@ -13,7 +13,7 @@ testAcrossTimezones(reportTz => {
       const rows = [[time1, 1], [time2, 2], [time3, 3]];
       const [filledData] = fillMissingValuesInDatas(
         {
-          series: [{ card: { actual_timezone: reportTz } }],
+          series: [{ card: { results_timezone: reportTz } }],
           settings: {
             "graph.x_axis.scale": "timeseries",
             series: () => ({ "line.missing": "zero" }),

--- a/frontend/test/metabase/visualizations/lib/fill_data.tz.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/fill_data.tz.unit.spec.js
@@ -1,47 +1,38 @@
+import testAcrossTimezones from "__support__/timezones";
+
 import moment from "moment";
 
 import fillMissingValuesInDatas from "metabase/visualizations/lib/fill_data";
 
-// run_timezone_tests sets "TZ" environment variable to change the timezone
-const clientTz = process.env["TZ"] || "[default]";
-// run_timezone_tests also sets "METABASE_TEST_TIMEZONES" to list of timezones
-const reportTzs = (process.env["METABASE_TEST_TIMEZONES"] || "Etc/UTC").split(
-  " ",
-);
+testAcrossTimezones(reportTz => {
+  describe("fillMissingValuesInDatas", () => {
+    it("should fill zeros for timeseries across DST boundary", () => {
+      const time1 = moment("2019-03-01T00:00:00").tz(reportTz, true);
+      const time2 = moment("2019-03-30T00:00:00").tz(reportTz, true);
+      const time3 = moment("2019-03-31T00:00:00").tz(reportTz, true);
+      const rows = [[time1, 1], [time2, 2], [time3, 3]];
+      const [filledData] = fillMissingValuesInDatas(
+        {
+          series: [{}],
+          settings: {
+            "graph.x_axis.scale": "timeseries",
+            series: () => ({ "line.missing": "zero" }),
+          },
+        },
+        {
+          xValues: [time1, time2, time3],
+          xDomain: [time1, time3],
+          xInterval: { interval: "day", count: 1 },
+        },
+        [rows],
+      );
 
-describe(`client timezone ${clientTz}`, () => {
-  reportTzs.map(reportTz => {
-    describe(`report timezone ${reportTz}`, () => {
-      describe("fillMissingValuesInDatas", () => {
-        it("should fill zeros for timeseries across DST boundary", () => {
-          const time1 = moment("2019-03-01T00:00:00").tz(reportTz, true);
-          const time2 = moment("2019-03-30T00:00:00").tz(reportTz, true);
-          const time3 = moment("2019-03-31T00:00:00").tz(reportTz, true);
-          const rows = [[time1, 1], [time2, 2], [time3, 3]];
-          const [filledData] = fillMissingValuesInDatas(
-            {
-              series: [{}],
-              settings: {
-                "graph.x_axis.scale": "timeseries",
-                series: () => ({ "line.missing": "zero" }),
-              },
-            },
-            {
-              xValues: [time1, time2, time3],
-              xDomain: [time1, time3],
-              xInterval: { interval: "day", count: 1 },
-            },
-            [rows],
-          );
-
-          expect(filledData.map(r => r[1])).toEqual([
-            1,
-            ...new Array(28).fill(0),
-            2,
-            3,
-          ]);
-        });
-      });
+      expect(filledData.map(r => r[1])).toEqual([
+        1,
+        ...new Array(28).fill(0),
+        2,
+        3,
+      ]);
     });
   });
 });

--- a/frontend/test/metabase/visualizations/lib/fill_data.tz.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/fill_data.tz.unit.spec.js
@@ -1,15 +1,15 @@
 import testAcrossTimezones from "__support__/timezones";
 
-import moment from "moment";
+import moment from "moment-timezone";
 
 import fillMissingValuesInDatas from "metabase/visualizations/lib/fill_data";
 
 testAcrossTimezones(reportTz => {
   describe("fillMissingValuesInDatas", () => {
     it("should fill zeros for timeseries across DST boundary", () => {
-      const time1 = moment("2019-03-01T00:00:00").tz(reportTz, true);
-      const time2 = moment("2019-03-30T00:00:00").tz(reportTz, true);
-      const time3 = moment("2019-03-31T00:00:00").tz(reportTz, true);
+      const time1 = moment.tz("2019-03-01T00:00:00", reportTz);
+      const time2 = moment.tz("2019-03-30T00:00:00", reportTz);
+      const time3 = moment.tz("2019-03-31T00:00:00", reportTz);
       const rows = [[time1, 1], [time2, 2], [time3, 3]];
       const [filledData] = fillMissingValuesInDatas(
         {

--- a/frontend/test/metabase/visualizations/lib/fill_data.tz.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/fill_data.tz.unit.spec.js
@@ -13,7 +13,7 @@ testAcrossTimezones(reportTz => {
       const rows = [[time1, 1], [time2, 2], [time3, 3]];
       const [filledData] = fillMissingValuesInDatas(
         {
-          series: [{ card: { results_timezone: reportTz } }],
+          series: [{}],
           settings: {
             "graph.x_axis.scale": "timeseries",
             series: () => ({ "line.missing": "zero" }),
@@ -22,7 +22,7 @@ testAcrossTimezones(reportTz => {
         {
           xValues: [time1, time2, time3],
           xDomain: [time1, time3],
-          xInterval: { interval: "day", count: 1 },
+          xInterval: { interval: "day", count: 1, timezone: reportTz },
         },
         [rows],
       );

--- a/frontend/test/metabase/visualizations/lib/timeseries.tz.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/timeseries.tz.unit.spec.js
@@ -1,0 +1,37 @@
+import moment from "moment-timezone";
+
+import { computeTimeseriesDataInverval } from "metabase/visualizations/lib/timeseries";
+
+// run_timezone_tests sets "TZ" environment variable to change the timezone
+const clientTz = process.env["TZ"] || "[default]";
+// run_timezone_tests also sets "METABASE_TEST_TIMEZONES" to list of timezones
+const reportTzs = (process.env["METABASE_TEST_TIMEZONES"] || "Etc/UTC").split(
+  " ",
+);
+
+describe(`client timezone ${clientTz}`, () => {
+  reportTzs.map(reportTz => {
+    describe(`report timezone ${reportTz}`, () => {
+      describe("computeTimeseriesDataInvervalIndex", () => {
+        [
+          ["hour", 6, ["2015-01-01T00:00:00", "2016-05-04T06:00:00"]],
+          ["hour", 12, ["2015-01-01T00:00:00", "2016-05-04T12:00:00"]],
+          ["day", 1, ["2019-03-01T00:00:00", "2019-03-16T00:00:00"]],
+          ["week", 1, ["2019-03-01T00:00:00", "2019-03-15T00:00:00"]],
+          ["month", 1, ["2015-03-01T00:00:00", "2019-02-01T00:00:00"]],
+          ["month", 3, ["2019-01-01T00:00:00", "2019-04-01T00:00:00"]],
+        ].map(([expectedInterval, expectedCount, data]) => {
+          it(`should return ${expectedCount} ${expectedInterval}`, () => {
+            // parse timestamps in reporting timezone and serialize with
+            const xValues = data.map(d => moment.tz(d, reportTz).format());
+
+            const { interval, count } = computeTimeseriesDataInverval(xValues);
+
+            expect(interval).toBe(expectedInterval);
+            expect(count).toBe(expectedCount);
+          });
+        });
+      });
+    });
+  });
+});

--- a/frontend/test/metabase/visualizations/lib/timeseries.tz.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/timeseries.tz.unit.spec.js
@@ -1,36 +1,27 @@
+import testAcrossTimezones from "__support__/timezones";
+
 import moment from "moment-timezone";
 
 import { computeTimeseriesDataInverval } from "metabase/visualizations/lib/timeseries";
 
-// run_timezone_tests sets "TZ" environment variable to change the timezone
-const clientTz = process.env["TZ"] || "[default]";
-// run_timezone_tests also sets "METABASE_TEST_TIMEZONES" to list of timezones
-const reportTzs = (process.env["METABASE_TEST_TIMEZONES"] || "Etc/UTC").split(
-  " ",
-);
+testAcrossTimezones(reportTz => {
+  describe("computeTimeseriesDataInvervalIndex", () => {
+    [
+      ["hour", 6, ["2015-01-01T00:00:00", "2016-05-04T06:00:00"]],
+      ["hour", 12, ["2015-01-01T00:00:00", "2016-05-04T12:00:00"]],
+      ["day", 1, ["2019-03-01T00:00:00", "2019-03-16T00:00:00"]],
+      ["week", 1, ["2019-03-01T00:00:00", "2019-03-15T00:00:00"]],
+      ["month", 1, ["2015-03-01T00:00:00", "2019-02-01T00:00:00"]],
+      ["month", 3, ["2019-01-01T00:00:00", "2019-04-01T00:00:00"]],
+    ].map(([expectedInterval, expectedCount, data]) => {
+      it(`should return ${expectedCount} ${expectedInterval}`, () => {
+        // parse timestamps in reporting timezone and serialize
+        const xValues = data.map(d => moment.tz(d, reportTz).format());
 
-describe(`client timezone ${clientTz}`, () => {
-  reportTzs.map(reportTz => {
-    describe(`report timezone ${reportTz}`, () => {
-      describe("computeTimeseriesDataInvervalIndex", () => {
-        [
-          ["hour", 6, ["2015-01-01T00:00:00", "2016-05-04T06:00:00"]],
-          ["hour", 12, ["2015-01-01T00:00:00", "2016-05-04T12:00:00"]],
-          ["day", 1, ["2019-03-01T00:00:00", "2019-03-16T00:00:00"]],
-          ["week", 1, ["2019-03-01T00:00:00", "2019-03-15T00:00:00"]],
-          ["month", 1, ["2015-03-01T00:00:00", "2019-02-01T00:00:00"]],
-          ["month", 3, ["2019-01-01T00:00:00", "2019-04-01T00:00:00"]],
-        ].map(([expectedInterval, expectedCount, data]) => {
-          it(`should return ${expectedCount} ${expectedInterval}`, () => {
-            // parse timestamps in reporting timezone and serialize with
-            const xValues = data.map(d => moment.tz(d, reportTz).format());
+        const { interval, count } = computeTimeseriesDataInverval(xValues);
 
-            const { interval, count } = computeTimeseriesDataInverval(xValues);
-
-            expect(interval).toBe(expectedInterval);
-            expect(count).toBe(expectedCount);
-          });
-        });
+        expect(interval).toBe(expectedInterval);
+        expect(count).toBe(expectedCount);
       });
     });
   });

--- a/jest.tz.unit.conf.json
+++ b/jest.tz.unit.conf.json
@@ -1,0 +1,30 @@
+{
+  "moduleNameMapper": {
+    "\\.(css|less)$": "<rootDir>/frontend/test/__mocks__/styleMock.js",
+    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/frontend/test/__mocks__/fileMock.js",
+    "^promise-loader\\?global\\!metabase\\/lib\\/ga-metadata$": "<rootDir>/frontend/src/metabase/lib/ga-metadata.js"
+  },
+  "testPathIgnorePatterns": [
+    "<rootDir>/frontend/test/legacy-karma",
+    "<rootDir>/frontend/test/legacy-selenium"
+  ],
+  "testMatch": ["<rootDir>/frontend/test/**/*.tz.unit.spec.js?(x)"],
+  "modulePaths": ["<rootDir>/frontend/test", "<rootDir>/frontend/src"],
+  "setupFiles": [
+    "<rootDir>/frontend/test/jest-setup.js",
+    "<rootDir>/frontend/test/enzyme-setup.js",
+    "<rootDir>/frontend/test/metabase-bootstrap.js"
+  ],
+  "globals": {
+    "ace": {},
+    "ga": {},
+    "document": {}
+  },
+  "coverageDirectory": "./",
+  "coverageReporters": ["text", "json-summary"],
+  "collectCoverageFrom": ["frontend/src/**/*.js", "frontend/src/**/*.jsx"],
+  "coveragePathIgnorePatterns": [
+    "/node_modules/",
+    "/frontend/src/metabase/visualizations/lib/errors.js"
+  ]
+}

--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -6,15 +6,11 @@
   },
   "testPathIgnorePatterns": [
     "<rootDir>/frontend/test/legacy-karma",
-    "<rootDir>/frontend/test/legacy-selenium"
+    "<rootDir>/frontend/test/legacy-selenium",
+    "<rootDir>/frontend/test/.*/.*.tz.unit.spec.js"
   ],
-  "testMatch": [
-    "<rootDir>/frontend/test/**/*.unit.spec.js?(x)"
-  ],
-  "modulePaths": [
-    "<rootDir>/frontend/test",
-    "<rootDir>/frontend/src"
-  ],
+  "testMatch": ["<rootDir>/frontend/test/**/*.unit.spec.js?(x)"],
+  "modulePaths": ["<rootDir>/frontend/test", "<rootDir>/frontend/src"],
   "setupFiles": [
     "<rootDir>/frontend/test/jest-setup.js",
     "<rootDir>/frontend/test/enzyme-setup.js",
@@ -28,5 +24,8 @@
   "coverageDirectory": "./",
   "coverageReporters": ["text", "json-summary"],
   "collectCoverageFrom": ["frontend/src/**/*.js", "frontend/src/**/*.jsx"],
-  "coveragePathIgnorePatterns": ["/node_modules/", "/frontend/src/metabase/visualizations/lib/errors.js"]
+  "coveragePathIgnorePatterns": [
+    "/node_modules/",
+    "/frontend/src/metabase/visualizations/lib/errors.js"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "lint-eslint": "yarn && eslint --ext .js --ext .jsx --rulesdir frontend/lint/eslint-rules --max-warnings 0 frontend/src frontend/test",
     "lint-prettier": "yarn && prettier -l 'frontend/**/*.{js,jsx,css}' || (echo '\nThese files are not formatted correctly. Did you forget to \"yarn prettier\"?' && false)",
     "flow": "yarn && flow check",
-    "test": "yarn test-unit && yarn test-integration && yarn test-e2e && yarn test-karma",
+    "test": "yarn test-unit && yarn test-timezones && yarn test-integration && yarn test-e2e && yarn test-karma",
     "test-unit": "yarn && jest --maxWorkers=8 --config jest.unit.conf.json",
     "test-unit-watch": "yarn test-unit --watch",
     "test-unit-update-snapshot": "yarn test-unit --updateSnapshot",

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "test-karma": "yarn && karma start frontend/test/karma.conf.js --single-run",
     "test-karma-watch": "yarn && karma start frontend/test/karma.conf.js --auto-watch --reporters nyan",
     "test-integrated": "echo 'test-integrated renamed to test-e2e'; exit 1",
+    "test-timezones-unit": "yarn && jest --maxWorkers=8 --config jest.tz.unit.conf.json",
     "test-timezones": "yarn && ./frontend/test/__runner__/run_timezone_tests",
     "build": "yarn && webpack --bail",
     "build-watch": "yarn && webpack --watch",

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "test-karma": "yarn && karma start frontend/test/karma.conf.js --single-run",
     "test-karma-watch": "yarn && karma start frontend/test/karma.conf.js --auto-watch --reporters nyan",
     "test-integrated": "echo 'test-integrated renamed to test-e2e'; exit 1",
+    "test-timezones": "yarn && ./frontend/test/__runner__/run_timezone_tests",
     "build": "yarn && webpack --bail",
     "build-watch": "yarn && webpack --watch",
     "build-hot": "yarn && NODE_ENV=hot webpack-dev-server --progress",


### PR DESCRIPTION
This PR extracts some of the client tests from #7247 and tweaks them to work with current code.

These tests run with different client/reporting timezones. This lets us catch bugs that only occur when the browser is in a DST timezone. 

Currently, the tests only work when the client and reporting timezone are UTC. This is expected with the bugs we have. After #11067 and #11111 code gets merged, I can merge master in and fix these.
