### PR TITLE
needs triage label to simplify triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'Type:Bug'
+labels: 'Type:Bug','.Needs Triage'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: 'Type:New Feature'
+labels: 'Type:New Feature','.Needs Triage'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/questions-and-help.md
+++ b/.github/ISSUE_TEMPLATE/questions-and-help.md
@@ -2,7 +2,7 @@
 name: Questions and help
 about: If you think you need help with something related to Metabase
 title: ''
-labels: 'Type:Question'
+labels: 'Type:Question','.Needs Triage'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/security-issue.md
+++ b/.github/ISSUE_TEMPLATE/security-issue.md
@@ -2,7 +2,7 @@
 name: Security Issue
 about: If you think you found a security vulnerability with Metabase
 title: ''
-labels: 'Security'
+labels: 'Security','.Needs Triage'
 assignees: ''
 
 ---


### PR DESCRIPTION
Before I would just search for issues without a label to triage them.

This lets us mark new issues as needing triage, as well as bulk assigning old issues for re-triage if things need to be updated. 