### PR TITLE
Needs triage label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'Type:Bug'
+labels: 'Type:Bug','.Needs Triage'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'Type:Bug','.Needs Triage'
+labels: ".Needs Triage, Type:Bug"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: 'Type:New Feature','.Needs Triage'
+labels: "Type:New Feature, .Needs Triage"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: 'Type:New Feature'
+labels: 'Type:New Feature','.Needs Triage'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/questions-and-help.md
+++ b/.github/ISSUE_TEMPLATE/questions-and-help.md
@@ -2,7 +2,7 @@
 name: Questions and help
 about: If you think you need help with something related to Metabase
 title: ''
-labels: 'Type:Question'
+labels: 'Type:Question','.Needs Triage'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/questions-and-help.md
+++ b/.github/ISSUE_TEMPLATE/questions-and-help.md
@@ -2,7 +2,7 @@
 name: Questions and help
 about: If you think you need help with something related to Metabase
 title: ''
-labels: 'Type:Question','.Needs Triage'
+labels: "Type:Question, .Needs Triage"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/security-issue.md
+++ b/.github/ISSUE_TEMPLATE/security-issue.md
@@ -2,7 +2,7 @@
 name: Security Issue
 about: If you think you found a security vulnerability with Metabase
 title: ''
-labels: 'Security'
+labels: 'Security','.Needs Triage'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/security-issue.md
+++ b/.github/ISSUE_TEMPLATE/security-issue.md
@@ -2,7 +2,7 @@
 name: Security Issue
 about: If you think you found a security vulnerability with Metabase
 title: ''
-labels: 'Security','.Needs Triage'
+labels: "Security, .Needs Triage"
 assignees: ''
 
 ---


### PR DESCRIPTION
Github apparently wants multiple labels in a single string (not a yaml array), separated by a comma and space, with double quotes (single quotes won't work).

