### PR TITLE
Suppress noisy `ls` errors

### DIFF
--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -120,7 +120,7 @@ if [ ! -z "$JAVA_TIMEZONE" ]; then
 fi
 
 # Initialize the Metabase db from H2 dump, if available
-INITIAL_DB=$(ls /app/initial*.db | head -n 1)
+INITIAL_DB=$(ls /app/initial*.db 2> /dev/null | head -n 1)
 if [ -f "${INITIAL_DB}" ]; then
     echo "Initializing Metabase database from H2 database ${INITIAL_DB}..."
     chmod o+r ${INITIAL_DB}


### PR DESCRIPTION
Avoids `ls: /app/initial*.db: No such file or directory` messages in logs when no initial db is present.