### PR TITLE
Update the it's-ok-to-play-with-saved-questions modal

### DIFF
--- a/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx
@@ -1,21 +1,26 @@
 import React, { Component } from "react";
 
 import Modal from "metabase/components/Modal";
+import ModalContent from "metabase/components/ModalContent";
 import { t } from "ttag";
 
 export default class SavedQuestionIntroModal extends Component {
   render() {
     return (
       <Modal isOpen={this.props.isShowingNewbModal}>
-        <h2 className="pt4 pb2">{t`It's okay to play around with saved questions`}</h2>
-        <div className="pb2 text-paragraph">{t`You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question.`}</div>
-        <div className="Form-actions flex justify-center py1">
-          <button
-            data-metabase-event={"QueryBuilder;IntroModal"}
-            className="Button Button--primary"
-            onClick={() => this.props.onClose()}
-          >{t`Okay`}</button>
-        </div>
+        <ModalContent
+          title={t`It's okay to play around with saved questions`}
+          className="Modal-content text-centered py2"
+        >
+          <div className="px2 pb2 text-paragraph">{t`You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question.`}</div>
+          <div className="Form-actions flex justify-center py1">
+            <button
+              data-metabase-event={"QueryBuilder;IntroModal"}
+              className="Button Button--primary"
+              onClick={() => this.props.onClose()}
+            >{t`Okay`}</button>
+          </div>
+        </ModalContent>
       </Modal>
     );
   }

--- a/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx
@@ -6,21 +6,15 @@ import { t } from "ttag";
 export default class SavedQuestionIntroModal extends Component {
   render() {
     return (
-      <Modal small isOpen={this.props.isShowingNewbModal}>
-        <div className="Modal-content Modal-content--small NewForm">
-          <div className="Modal-header">
-            <h2 className="pb2 text-dark">{t`It's okay to play around with saved questions`}</h2>
-
-            <div className="pb1 text-medium">{t`You won't make any permanent changes to a saved question unless you click the edit icon in the top-right.`}</div>
-          </div>
-
-          <div className="Form-actions flex justify-center py1">
-            <button
-              data-metabase-event={"QueryBuilder;IntroModal"}
-              className="Button Button--primary"
-              onClick={() => this.props.onClose()}
-            >{t`Okay`}</button>
-          </div>
+      <Modal isOpen={this.props.isShowingNewbModal}>
+        <h2 className="pt4 pb2">{t`It's okay to play around with saved questions`}</h2>
+        <div className="pb2 text-paragraph">{t`You won't make any permanent changes to a saved question unless you click Save and choose to replace the original question.`}</div>
+        <div className="Form-actions flex justify-center py1">
+          <button
+            data-metabase-event={"QueryBuilder;IntroModal"}
+            className="Button Button--primary"
+            onClick={() => this.props.onClose()}
+          >{t`Okay`}</button>
         </div>
       </Modal>
     );


### PR DESCRIPTION
Fixes #11103. Adds spacing and updates the microcopy to reflect the reality of the new query builder (there's no longer a manual edit state you can enter).

@kdoh the way I did this was mostly by stripping out what looked like a bunch of old classes to me. LMK if this is in line with the recent modal changes you made.

To test this, you can remove the second conditional (`&& currentUser.is_qbnewb`) on line 374 of `frontend/src/metabase/query_builder/actions.js`

## Before
![image](https://user-images.githubusercontent.com/2223916/66504895-0bba0f80-ea7f-11e9-8d5a-6e3c062e9c7c.png)


## After
![image](https://user-images.githubusercontent.com/2223916/66504882-05c42e80-ea7f-11e9-930b-c82f3aeb4e8f.png)
