### PR TITLE
Better messaging for Sparkpost SMTP auth error in Email setup

### DIFF
--- a/src/metabase/api/email.clj
+++ b/src/metabase/api/email.clj
@@ -33,6 +33,10 @@
           creds-error {:errors {:email-smtp-username "Wrong username or password"
                                 :email-smtp-password "Wrong username or password"}}]
       (condp re-matches message
+        ;; https://www.sparkpost.com/docs/faq/error-messages-smtp/
+        #"^No matching clause: 535 5.7.8 Sorry.*$"
+        {:message "There is some problem with the authentication credentials. API key, user name, etc." }
+
         ;; bad host = "Unknown SMTP host: foobar"
         #"^Unknown SMTP host:.*$"
         conn-error


### PR DESCRIPTION
An attempt to get a better error message for a SMTP issue described [here](https://discourse.metabase.com/t/no-matching-clause-535-5-7-8/6936). I tried to echo the other types of errors we catch but this message doesn't seem to actually ever trigger, but I wanted to get the ball rolling cause I'm sure it's a simple thing I just haven't grok'd.

@camsaul / @flyingmachine et al feel free to let me know what I'm doing wrong here.