### PR TITLE
Fill data using timezone scale

### DIFF
--- a/frontend/src/metabase/visualizations/lib/fill_data.js
+++ b/frontend/src/metabase/visualizations/lib/fill_data.js
@@ -72,7 +72,6 @@ function fillMissingValuesInData(
       .ticks();
     getKey = m => m.toISOString();
   } else if (isQuantitative(settings) || isHistogram(settings)) {
-    // $fooFixMe
     const count = Math.abs((xDomain[1] - xDomain[0]) / xInterval);
     if (count > MAX_FILL_COUNT) {
       return rows;
@@ -80,11 +79,9 @@ function fillMissingValuesInData(
     let [start, end] = xDomain;
     if (isHistogramBar(props)) {
       // NOTE: intentionally add an end point for bar histograms
-      // $fooFixMe
       end += xInterval * 1.5;
     } else {
       // NOTE: avoid including endpoint due to floating point error
-      // $fooFixMe
       end += xInterval * 0.5;
     }
     xValues = d3.range(start, end, xInterval);

--- a/frontend/src/metabase/visualizations/lib/fill_data.js
+++ b/frontend/src/metabase/visualizations/lib/fill_data.js
@@ -9,7 +9,7 @@ import {
   isHistogram,
   isHistogramBar,
 } from "./renderer_utils";
-import { timeseriesScale } from "./timeseries";
+import { timeseriesScale, getTimezone } from "./timeseries";
 
 // max number of points to "fill"
 // TODO: base on pixel width of chart?
@@ -66,8 +66,7 @@ function fillMissingValuesInData(
       return rows;
     }
 
-    const { report_timezone = "Etc/UTC" } = singleSeries.card || {};
-    xValues = timeseriesScale(xInterval, report_timezone)
+    xValues = timeseriesScale(xInterval, getTimezone([singleSeries]))
       .domain(xDomain)
       .ticks();
     getKey = m => m.toISOString();

--- a/frontend/src/metabase/visualizations/lib/fill_data.js
+++ b/frontend/src/metabase/visualizations/lib/fill_data.js
@@ -66,7 +66,7 @@ function fillMissingValuesInData(
       return rows;
     }
 
-    xValues = timeseriesScale(xInterval, getTimezone([singleSeries]))
+    xValues = timeseriesScale(xInterval)
       .domain(xDomain)
       .ticks();
     getKey = m => m.toISOString();

--- a/frontend/src/metabase/visualizations/lib/fill_data.js
+++ b/frontend/src/metabase/visualizations/lib/fill_data.js
@@ -28,7 +28,9 @@ function fillMissingValues(rows, xValues, fillValue, getKey = v => v) {
       const row = map.get(key);
       if (row) {
         map.delete(key);
-        return [value, ...row.slice(1)];
+        const newRow = [value, ...row.slice(1)];
+        newRow._origin = row._origin;
+        return newRow;
       } else {
         return [value, ...fillValues];
       }

--- a/frontend/src/metabase/visualizations/lib/fill_data.js
+++ b/frontend/src/metabase/visualizations/lib/fill_data.js
@@ -9,7 +9,7 @@ import {
   isHistogram,
   isHistogramBar,
 } from "./renderer_utils";
-import { timeseriesScale, getTimezone } from "./timeseries";
+import { timeseriesScale } from "./timeseries";
 
 // max number of points to "fill"
 // TODO: base on pixel width of chart?

--- a/frontend/src/metabase/visualizations/lib/fill_data.js
+++ b/frontend/src/metabase/visualizations/lib/fill_data.js
@@ -2,7 +2,6 @@
 
 import { t } from "ttag";
 import d3 from "d3";
-import moment from "moment";
 
 import {
   isTimeseries,
@@ -10,6 +9,7 @@ import {
   isHistogram,
   isHistogramBar,
 } from "./renderer_utils";
+import { timeseriesScale } from "./timeseries";
 
 // max number of points to "fill"
 // TODO: base on pixel width of chart?
@@ -46,60 +46,52 @@ function fillMissingValues(rows, xValues, fillValue, getKey = v => v) {
 function fillMissingValuesInData(
   props,
   { xValues, xDomain, xInterval },
-  seriesSettings,
+  singleSeries,
   rows,
 ) {
   const { settings } = props;
-  if (
-    seriesSettings["line.missing"] === "zero" ||
-    seriesSettings["line.missing"] === "none"
-  ) {
-    const fillValue = seriesSettings["line.missing"] === "zero" ? 0 : null;
-    if (isTimeseries(settings)) {
-      // $FlowFixMe
-      const { interval, count } = xInterval;
-      if (count <= MAX_FILL_COUNT) {
-        // replace xValues with
-        xValues = d3.time[interval]
-          .range(xDomain[0], moment(xDomain[1]).add(1, "ms"), count)
-          .map(d => moment(d));
-        return fillMissingValues(
-          rows,
-          xValues,
-          fillValue,
-          m => d3.round(m.toDate().getTime(), -1), // sometimes rounds up 1ms?
-        );
-      }
-    }
-    if (isQuantitative(settings) || isHistogram(settings)) {
-      // $FlowFixMe
-      const count = Math.abs((xDomain[1] - xDomain[0]) / xInterval);
-      if (count <= MAX_FILL_COUNT) {
-        let [start, end] = xDomain;
-        if (isHistogramBar(props)) {
-          // NOTE: intentionally add an end point for bar histograms
-          // $FlowFixMe
-          end += xInterval * 1.5;
-        } else {
-          // NOTE: avoid including endpoint due to floating point error
-          // $FlowFixMe
-          end += xInterval * 0.5;
-        }
-        xValues = d3.range(start, end, xInterval);
-        return fillMissingValues(
-          rows,
-          xValues,
-          fillValue,
-          // NOTE: normalize to xInterval to avoid floating point issues
-          v => Math.round(v / xInterval),
-        );
-      }
-    } else {
-      return fillMissingValues(rows, xValues, fillValue);
-    }
-  } else {
+  const { "line.missing": lineMissing } = settings.series(singleSeries);
+
+  // return now if we're not filling with either 0 or null
+  if (!(lineMissing === "zero" || lineMissing === "none")) {
     return rows;
   }
+  let getKey;
+  const fillValue = lineMissing === "zero" ? 0 : null;
+  if (isTimeseries(settings)) {
+    const count = Math.abs(
+      xDomain[1].diff(xDomain[0], xInterval.interval) / xInterval.count,
+    );
+    if (count > MAX_FILL_COUNT) {
+      return rows;
+    }
+
+    const { report_timezone = "Etc/UTC" } = singleSeries.card || {};
+    xValues = timeseriesScale(xInterval, report_timezone)
+      .domain(xDomain)
+      .ticks();
+    getKey = m => m.toISOString();
+  } else if (isQuantitative(settings) || isHistogram(settings)) {
+    // $fooFixMe
+    const count = Math.abs((xDomain[1] - xDomain[0]) / xInterval);
+    if (count > MAX_FILL_COUNT) {
+      return rows;
+    }
+    let [start, end] = xDomain;
+    if (isHistogramBar(props)) {
+      // NOTE: intentionally add an end point for bar histograms
+      // $fooFixMe
+      end += xInterval * 1.5;
+    } else {
+      // NOTE: avoid including endpoint due to floating point error
+      // $fooFixMe
+      end += xInterval * 0.5;
+    }
+    xValues = d3.range(start, end, xInterval);
+    // NOTE: normalize to xInterval to avoid floating point issues
+    getKey = v => Math.round(v / xInterval);
+  }
+  return fillMissingValues(rows, xValues, fillValue, getKey);
 }
 
 export default function fillMissingValuesInDatas(
@@ -107,14 +99,12 @@ export default function fillMissingValuesInDatas(
   { xValues, xDomain, xInterval },
   datas,
 ) {
-  const { series, settings } = props;
-  return datas.map((rows, index) => {
-    const seriesSettings = settings.series(series[index]);
-    return fillMissingValuesInData(
+  return datas.map((rows, index) =>
+    fillMissingValuesInData(
       props,
       { xValues, xDomain, xInterval },
-      seriesSettings,
+      props.series[index],
       rows,
-    );
-  });
+    ),
+  );
 }

--- a/frontend/src/metabase/visualizations/lib/timeseries.js
+++ b/frontend/src/metabase/visualizations/lib/timeseries.js
@@ -201,7 +201,6 @@ export function computeTimeseriesTicksInterval(xDomain, xInterval, chartWidth) {
 }
 
 // moment-timezone based d3 scale
-// adapted from https://github.com/metocean/chronological
 export const timeseriesScale = (
   { count, interval, timezone },
   linear = d3.scale.linear(),
@@ -217,7 +216,7 @@ export const timeseriesScale = (
     linear.domain(x.map(ms));
     return s;
   };
-  s.ticks = (...args) => {
+  s.ticks = () => {
     const [start, end] = s.domain();
 
     const ticks = [];

--- a/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
@@ -136,4 +136,20 @@ describe("fillMissingValuesInDatas", () => {
 
     expect(filledData).toEqual([[t1, 1], [t2, 1]]);
   });
+
+  it("should use interval while filling numeric data", () => {
+    const [filledData] = fillMissingValuesInDatas(
+      {
+        series: [{}],
+        settings: {
+          "graph.x_axis.scale": "linear",
+          series: () => ({ "line.missing": "zero" }),
+        },
+      },
+      { xValues: [10, 30], xDomain: [10, 30], xInterval: 10 },
+      [[[10, 1], [30, 1]]],
+    );
+
+    expect(filledData).toEqual([[10, 1], [20, 0], [30, 1]]);
+  });
 });

--- a/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
@@ -1,0 +1,101 @@
+import moment from "moment";
+
+import fillMissingValuesInDatas from "metabase/visualizations/lib/fill_data";
+
+describe("fillMissingValuesInDatas", () => {
+  it("should fill missing days", () => {
+    const time1 = moment("2018-01-01");
+    const time2 = moment("2018-01-31");
+    const rows = [[time1, 1], [time2, 2]];
+    const [filledData] = fillMissingValuesInDatas(
+      {
+        series: [{}],
+        settings: {
+          "graph.x_axis.scale": "timeseries",
+          series: () => ({ "line.missing": "none" }),
+        },
+      },
+      {
+        xValues: [time1, time2],
+        xDomain: [time1, time2],
+        xInterval: { interval: "day", count: 1 },
+      },
+      [rows],
+    );
+
+    const yValues = filledData.map(d => d[1]);
+    expect(yValues).toEqual([1, ...new Array(29).fill(null), 2]);
+  });
+
+  it("should fill missing hours", () => {
+    const time1 = moment("2018-01-01");
+    const time2 = moment("2018-01-05");
+    const rows = [[time1, 1], [time2, 2]];
+    const [filledData] = fillMissingValuesInDatas(
+      {
+        series: [{}],
+        settings: {
+          "graph.x_axis.scale": "timeseries",
+          series: () => ({ "line.missing": "none" }),
+        },
+      },
+      {
+        xValues: [time1, time2],
+        xDomain: [time1, time2],
+        xInterval: { interval: "hour", count: 1 },
+      },
+      [rows],
+    );
+
+    const yValues = filledData.map(d => d[1]);
+    expect(yValues).toEqual([1, ...new Array(95).fill(null), 2]);
+  });
+
+  it("should fill linear data", () => {
+    const [filledData] = fillMissingValuesInDatas(
+      {
+        series: [{}],
+        settings: {
+          "graph.x_axis.scale": "linear",
+          series: () => ({ "line.missing": "none" }),
+        },
+      },
+      { xValues: [1, 3], xDomain: [1, 3], xInterval: 1 },
+      [[[1, 1], [3, 1]]],
+    );
+
+    expect(filledData).toEqual([[1, 1], [2, null], [3, 1]]);
+  });
+
+  it("should fill with zeros", () => {
+    const [filledData] = fillMissingValuesInDatas(
+      {
+        series: [{}],
+        settings: {
+          "graph.x_axis.scale": "linear",
+          series: () => ({ "line.missing": "zero" }),
+        },
+      },
+      { xValues: [1, 3], xDomain: [1, 3], xInterval: 1 },
+      [[[1, 1], [3, 1]]],
+    );
+
+    expect(filledData).toEqual([[1, 1], [2, 0], [3, 1]]);
+  });
+
+  it("shouldn't fill data when line.missing = interpolate", () => {
+    const [filledData] = fillMissingValuesInDatas(
+      {
+        series: [{}],
+        settings: {
+          "graph.x_axis.scale": "linear",
+          series: () => ({ "line.missing": "interpolate" }),
+        },
+      },
+      { xValues: [1, 3], xDomain: [1, 3], xInterval: 1 },
+      [[[1, 1], [3, 1]]],
+    );
+
+    expect(filledData).toEqual([[1, 1], [3, 1]]);
+  });
+});

--- a/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
@@ -4,8 +4,8 @@ import fillMissingValuesInDatas from "metabase/visualizations/lib/fill_data";
 
 describe("fillMissingValuesInDatas", () => {
   it("should fill missing days", () => {
-    const time1 = moment("2018-01-01");
-    const time2 = moment("2018-01-31");
+    const time1 = moment("2018-01-01T00:00:00Z");
+    const time2 = moment("2018-01-31T00:00:00Z");
     const rows = [[time1, 1], [time2, 2]];
     const [filledData] = fillMissingValuesInDatas(
       {
@@ -28,8 +28,8 @@ describe("fillMissingValuesInDatas", () => {
   });
 
   it("should fill missing hours", () => {
-    const time1 = moment("2018-01-01");
-    const time2 = moment("2018-01-05");
+    const time1 = moment("2018-01-01T00:00:00Z");
+    const time2 = moment("2018-01-05T00:00:00Z");
     const rows = [[time1, 1], [time2, 2]];
     const [filledData] = fillMissingValuesInDatas(
       {

--- a/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
@@ -152,4 +152,23 @@ describe("fillMissingValuesInDatas", () => {
 
     expect(filledData).toEqual([[10, 1], [20, 0], [30, 1]]);
   });
+
+  it("should maintain _origin on rows", () => {
+    // the _origin property is used in tooltips, so make sure it's carried over
+    const row = [1, 1];
+    row._origin = [1, 1, 2, 3];
+    const [[{ _origin }]] = fillMissingValuesInDatas(
+      {
+        series: [{}],
+        settings: {
+          "graph.x_axis.scale": "linear",
+          series: () => ({ "line.missing": "zero" }),
+        },
+      },
+      { xValues: [1], xDomain: [1, 1], xInterval: 1 },
+      [[row]],
+    );
+
+    expect(_origin).toEqual([1, 1, 2, 3]);
+  });
 });

--- a/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
@@ -98,4 +98,42 @@ describe("fillMissingValuesInDatas", () => {
 
     expect(filledData).toEqual([[1, 1], [3, 1]]);
   });
+
+  it("shouldn't fill data when the range is >10k", () => {
+    const [filledData] = fillMissingValuesInDatas(
+      {
+        series: [{}],
+        settings: {
+          "graph.x_axis.scale": "linear",
+          series: () => ({ "line.missing": "zero" }),
+        },
+      },
+      { xValues: [1, 11000], xDomain: [1, 11000], xInterval: 1 },
+      [[[1, 1], [11000, 1]]],
+    );
+
+    expect(filledData).toEqual([[1, 1], [11000, 1]]);
+  });
+
+  it("shouldn't fill data when the range is >10k for timeseries", () => {
+    const t1 = moment("2018-01-01T00:00:00Z");
+    const t2 = moment("2020-01-01T00:00:00Z");
+    const [filledData] = fillMissingValuesInDatas(
+      {
+        series: [{}],
+        settings: {
+          "graph.x_axis.scale": "timeseries",
+          series: () => ({ "line.missing": "zero" }),
+        },
+      },
+      {
+        xValues: [t1, t2],
+        xDomain: [t1, t2],
+        xInterval: { interval: "hour", count: 1 },
+      },
+      [[[t1, 1], [t2, 1]]],
+    );
+
+    expect(filledData).toEqual([[t1, 1], [t2, 1]]);
+  });
 });

--- a/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/fill_data.unit.spec.js
@@ -18,7 +18,7 @@ describe("fillMissingValuesInDatas", () => {
       {
         xValues: [time1, time2],
         xDomain: [time1, time2],
-        xInterval: { interval: "day", count: 1 },
+        xInterval: { interval: "day", count: 1, timezone: "Etc/UTC" },
       },
       [rows],
     );
@@ -42,7 +42,7 @@ describe("fillMissingValuesInDatas", () => {
       {
         xValues: [time1, time2],
         xDomain: [time1, time2],
-        xInterval: { interval: "hour", count: 1 },
+        xInterval: { interval: "hour", count: 1, timezone: "Etc/UTC" },
       },
       [rows],
     );
@@ -129,7 +129,7 @@ describe("fillMissingValuesInDatas", () => {
       {
         xValues: [t1, t2],
         xDomain: [t1, t2],
-        xInterval: { interval: "hour", count: 1 },
+        xInterval: { interval: "hour", count: 1, timezone: "Etc/UTC" },
       },
       [[[t1, 1], [t2, 1]]],
     );


### PR DESCRIPTION
This PR branches off of #11111 and uses `timeseriesScale` in `fill_data.js`.

I added some tests around the existing data filling behavior. These tests don't test the timeseries scale itself. For that we need the new test runner in #11090. I added a data filling test to that branch. When this and #11111 get merged, merging master into #11090 should fix all the failing tests.

There was also a bug where having more than 10k points to fill returned `undefined` and broke the chart. That's fixed here, but I didn't see an open issue related to that to close.

Another unrelated bug that was fixed in this PR: #11205 