### PR TITLE
Parse timestamps only if either the scale or this dimension is timeseries

### DIFF
--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -8,7 +8,10 @@ import { datasetContainsNoResults } from "metabase/lib/dataset";
 import { parseTimestamp } from "metabase/lib/time";
 
 import { dimensionIsNumeric } from "./numeric";
-import { dimensionIsTimeseries } from "./timeseries";
+import {
+  dimensionIsTimeseries,
+  dimensionIsExplicitTimeseries,
+} from "./timeseries";
 import { getAvailableCanvasWidth, getAvailableCanvasHeight } from "./utils";
 import { invalidDateWarning, nullDimensionWarning } from "./warnings";
 
@@ -122,7 +125,11 @@ function getParseOptions({ settings, data }) {
   const columnIndex = getColumnIndex({ settings, data });
   return {
     isNumeric: dimensionIsNumeric(data, columnIndex),
-    isTimeseries: dimensionIsTimeseries(data, columnIndex),
+    isTimeseries:
+      // x axis scale is timeseries
+      isTimeseries(settings) ||
+      // column type is timeseries
+      dimensionIsExplicitTimeseries(data, columnIndex),
     isQuantitative: isQuantitative(settings),
     unit: data.cols[columnIndex].unit,
   };

--- a/frontend/src/metabase/visualizations/lib/timeseries.js
+++ b/frontend/src/metabase/visualizations/lib/timeseries.js
@@ -21,9 +21,15 @@ const TIMESERIES_UNITS = new Set([
 // investigate the response from a dataset query and determine if the dimension is a timeseries
 export function dimensionIsTimeseries({ cols, rows }, i = 0) {
   return (
-    (isDate(cols[i]) &&
-      (cols[i].unit == null || TIMESERIES_UNITS.has(cols[i].unit))) ||
+    dimensionIsExplicitTimeseries({ cols, rows, i }) ||
     moment(rows[0] && rows[0][i], moment.ISO_8601).isValid()
+  );
+}
+
+export function dimensionIsExplicitTimeseries({ cols }, i) {
+  return (
+    isDate(cols[i]) &&
+    (cols[i].unit == null || TIMESERIES_UNITS.has(cols[i].unit))
   );
 }
 

--- a/frontend/src/metabase/visualizations/lib/timeseries.js
+++ b/frontend/src/metabase/visualizations/lib/timeseries.js
@@ -21,7 +21,7 @@ const TIMESERIES_UNITS = new Set([
 // investigate the response from a dataset query and determine if the dimension is a timeseries
 export function dimensionIsTimeseries({ cols, rows }, i = 0) {
   return (
-    dimensionIsExplicitTimeseries({ cols, rows, i }) ||
+    dimensionIsExplicitTimeseries({ cols, rows }, i) ||
     moment(rows[0] && rows[0][i], moment.ISO_8601).isValid()
   );
 }


### PR DESCRIPTION
Resolves #11069

This bug occurred because we were parsing anything as a datetime if it looked like one. Many strings (e.g. "1000-01") are valid ISO 8601 but might not actually be dates.

With this PR we continue to default ISO 8601 strings to timeseries scales, but if the user changes it to an ordinal scale, we don't parse strings as datetimes.

However, when the column is a date type, we parse it as a datetime regardless of the scale. This is because even with ordinal scales, we still want to show appropriately formatted ticks and tooltips if we know it's a date.