### PR TITLE
Google Auth error messages

### DIFF
--- a/frontend/src/metabase/auth/containers/LoginApp.jsx
+++ b/frontend/src/metabase/auth/containers/LoginApp.jsx
@@ -18,7 +18,7 @@ import Utils from "metabase/lib/utils";
 import * as authActions from "../auth";
 
 const GOOGLE_AUTH_ERRORS = {
-  popup_closed_by_user: t`The window was closed before completing Google Authentication`,
+  popup_closed_by_user: t`The window was closed before completing Google Authentication.`,
 };
 
 const mapStateToProps = (state, props) => {
@@ -91,7 +91,7 @@ export default class LoginApp extends Component {
               this.setState({
                 errorMessage:
                   GOOGLE_AUTH_ERRORS[error.error] ||
-                  `Google Authentication error occurred: ${error.error}`,
+                  t`There was an issue signing in with Google. Pleast contact an administrator.`,
               });
             },
           );
@@ -147,8 +147,14 @@ export default class LoginApp extends Component {
             >
               <h2 className="Login-header mb2">{t`Sign in to Metabase`}</h2>
 
+              {errorMessage && (
+                <div className="bg-error p1 rounded text-white text-bold mt3">
+                  {errorMessage}
+                </div>
+              )}
+
               {Settings.ssoEnabled() && !preferUsernameAndPassword && (
-                <div className="py3 relative my4">
+                <div className="py3 relative my3">
                   <div className="relative border-bottom pb4">
                     <SSOLoginButton provider="google" ref="ssoLoginButton" />
                     {/*<div className="g-signin2 ml1 relative z2" id="g-signin2"></div>*/}
@@ -261,10 +267,6 @@ export default class LoginApp extends Component {
                     >{t`I seem to have forgotten my password`}</Link>
                   </div>
                 </div>
-              )}
-
-              {errorMessage && (
-                <div className="text-error text-centered">{errorMessage}</div>
               )}
             </form>
           </div>


### PR DESCRIPTION
Shows errors on the login page if Google Authentication isn't successful, e.x.:

<img width="1069" alt="Screenshot 2019-10-18 01 11 42" src="https://user-images.githubusercontent.com/18193/67077511-42112200-f144-11e9-94f0-7902e0a563a4.png">

We just get error names so we need to add strings for the common ones here https://github.com/metabase/metabase/pull/11168/files#diff-bf4737af6509a161955611831bb0d020R21

It looks like other ones include `access_denied` and `immediate_failed`: https://developers.google.com/identity/sign-in/web/reference