### PR TITLE
Fix file loader public path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,7 +85,7 @@ const config = (module.exports = {
       },
       {
         test: /\.(eot|woff2?|ttf|svg|png)$/,
-        use: [{ loader: "file-loader", options: { publicPath: "" } }],
+        use: [{ loader: "file-loader", options: { publicPath: "./" } }],
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
My fix in #11174 broke file loading. The presented most obviously as broken fonts.

Here's a history of the issues with this setting:

## Situation 1

`publicPath`: "app/dist/"

file-loader files ended up with this public path duplicated. e.g. "app/dist/app/dist/image.svg". This causes 404's when it tries to load these assets.

## Situation 2

`publicPath`: "/app/dist/"

Everything works! ...unless you host Metabase with a path prefix. In that case everything breaks.

## Situation 3

`publicPath`: "app/dist/"
file-loader's `publicPath`: ""

The 404's from the first situation disappear, so I assume it works. However, the files are now referenced without "app/dist/" at all! The server returns a 200, but not the file we want.

## This PR

`publicPath`: "app/dist/"
file-loader's `publicPath`: "./"

This seems to actually load the files correctly! It was taken from [this Stack Overflow answer](https://stackoverflow.com/a/36474805/607070).




