### PR TITLE
Only show object detail for single rows

### DIFF
--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -18,6 +18,7 @@ export const DATE_TIME = "DATE_TIME";
 export const LOCATION = "LOCATION";
 export const COORDINATE = "COORDINATE";
 export const FOREIGN_KEY = "FOREIGN_KEY";
+export const PRIMARY_KEY = "PRIMARY_KEY";
 
 // other types used for various purporses
 export const ENTITY = "ENTITY";
@@ -59,6 +60,9 @@ const TYPES = {
   },
   [FOREIGN_KEY]: {
     special: [TYPE.FK],
+  },
+  [PRIMARY_KEY]: {
+    special: [TYPE.PK],
   },
   [SUMMABLE]: {
     include: [NUMBER],
@@ -118,8 +122,8 @@ export function getFieldType(field) {
     DATE_TIME,
     LOCATION,
     COORDINATE,
-    ENTITY,
     FOREIGN_KEY,
+    PRIMARY_KEY,
     NUMBER,
     STRING,
     STRING_LIKE,
@@ -411,7 +415,7 @@ const FILTER_OPERATORS_BY_TYPE_ORDERED = {
     { name: "not-null", verboseName: t`Not empty` },
   ],
   [FOREIGN_KEY]: DEFAULT_FILTER_OPERATORS,
-  [ENTITY]: DEFAULT_FILTER_OPERATORS,
+  [PRIMARY_KEY]: DEFAULT_FILTER_OPERATORS,
   [UNKNOWN]: DEFAULT_FILTER_OPERATORS,
 };
 

--- a/frontend/src/metabase/lib/schema_metadata.js
+++ b/frontend/src/metabase/lib/schema_metadata.js
@@ -118,6 +118,7 @@ export function getFieldType(field) {
     DATE_TIME,
     LOCATION,
     COORDINATE,
+    ENTITY,
     FOREIGN_KEY,
     NUMBER,
     STRING,
@@ -410,6 +411,7 @@ const FILTER_OPERATORS_BY_TYPE_ORDERED = {
     { name: "not-null", verboseName: t`Not empty` },
   ],
   [FOREIGN_KEY]: DEFAULT_FILTER_OPERATORS,
+  [ENTITY]: DEFAULT_FILTER_OPERATORS,
   [UNKNOWN]: DEFAULT_FILTER_OPERATORS,
 };
 

--- a/frontend/src/metabase/modes/lib/modes.js
+++ b/frontend/src/metabase/modes/lib/modes.js
@@ -33,21 +33,23 @@ export function getMode(question: ?Question): ?QueryMode {
     const filters = query.filters();
 
     if (aggregations.length === 0 && breakouts.length === 0) {
-      const isPKFilter = filter => {
+      const isPKFilterWithOneID = filter => {
         if (filter.isFieldFilter()) {
           const field = filter.field();
           if (
             field &&
             field.isPK() &&
             field.table &&
-            field.table.id === query.sourceTableId()
+            field.table.id === query.sourceTableId() &&
+            filter.operatorName() === "=" &&
+            filter.arguments().length === 1
           ) {
             return true;
           }
         }
         return false;
       };
-      if (filters.some(isPKFilter)) {
+      if (filters.some(isPKFilterWithOneID)) {
         return ObjectMode;
       } else {
         return SegmentMode;

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -180,14 +180,8 @@ export const getMode = createSelector(
 );
 
 export const getIsObjectDetail = createSelector(
-  [getMode, getQueryResults],
-  (mode, results) =>
-    // We've filtered by a PK,
-    mode &&
-    mode.name() === "object" &&
-    // and there's only one result.
-    results &&
-    results[0].data.rows.length === 1,
+  [getMode],
+  mode => mode && mode.name() === "object",
 );
 
 export const getIsDirty = createSelector(

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -180,8 +180,14 @@ export const getMode = createSelector(
 );
 
 export const getIsObjectDetail = createSelector(
-  [getMode],
-  mode => mode && mode.name() === "object",
+  [getMode, getQueryResults],
+  (mode, results) =>
+    // We've filtered by a PK,
+    mode &&
+    mode.name() === "object" &&
+    // and there's only one result.
+    results &&
+    results[0].data.rows.length === 1,
 );
 
 export const getIsDirty = createSelector(

--- a/frontend/test/metabase/lib/schema_metadata.unit.spec.js
+++ b/frontend/test/metabase/lib/schema_metadata.unit.spec.js
@@ -7,6 +7,7 @@ import {
   BOOLEAN,
   LOCATION,
   COORDINATE,
+  PRIMARY_KEY,
   foreignKeyCountsByOriginTable,
 } from "metabase/lib/schema_metadata";
 
@@ -47,6 +48,11 @@ describe("schema_metadata", () => {
       expect(
         getFieldType({ base_type: TYPE.Text, special_type: TYPE.URL }),
       ).toEqual(STRING);
+    });
+    it("should know a pk", () => {
+      expect(
+        getFieldType({ base_type: TYPE.Integer, special_type: TYPE.PK }),
+      ).toEqual(PRIMARY_KEY);
     });
     it("should know a bool", () => {
       expect(getFieldType({ base_type: TYPE.Boolean })).toEqual(BOOLEAN);

--- a/frontend/test/metabase/modes/lib/modes.unit.spec.js
+++ b/frontend/test/metabase/modes/lib/modes.unit.spec.js
@@ -1,0 +1,22 @@
+import { getMode } from "metabase/modes/lib/modes";
+import ObjectMode from "metabase/modes/components/modes/ObjectMode";
+import SegmentMode from "metabase/modes/components/modes/SegmentMode";
+
+import { ORDERS } from "__support__/sample_dataset_fixture";
+
+describe("modes", () => {
+  describe("getMode", () => {
+    it("should be in object mode when selecting one PK ID", () => {
+      const filter = ["=", ["field-id", ORDERS.ID.id], 42];
+      const query = ORDERS.query().filter(filter);
+      const question = ORDERS.question().setQuery(query);
+      expect(getMode(question)).toBe(ObjectMode);
+    });
+    it("should be in segment mode when selecting multiple PK IDs", () => {
+      const filter = ["=", ["field-id", ORDERS.ID.id], 42, 24];
+      const query = ORDERS.query().filter(filter);
+      const question = ORDERS.question().setQuery(query);
+      expect(getMode(question)).toBe(SegmentMode);
+    });
+  });
+});


### PR DESCRIPTION
Resolves #11162

The issue was that we displayed object details whenever using a PK filter. I refined that to PK filters that use the "=" operator and have one argument.

Separate from that main fix, I updated the primary key filter options so that they match foreign keys. Does that make sense to do? 
