### PR TITLE
Pull field from state into FieldValuesWidget

### DIFF
--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -16,6 +16,8 @@ import { defer } from "metabase/lib/promise";
 import { debounce } from "underscore";
 import { stripId } from "metabase/lib/formatting";
 
+import Fields from "metabase/entities/fields";
+
 import type Field from "metabase-lib/lib/metadata/Field";
 import type { FieldId } from "metabase/meta/types/Field";
 import type { Value } from "metabase/meta/types/Dataset";
@@ -28,6 +30,12 @@ const mapDispatchToProps = {
   addRemappings,
   fetchFieldValues,
 };
+
+function mapStateToProps(state, { field }) {
+  return {
+    field: field && Fields.selectors.getObject(state, { entityId: field.id }),
+  };
+}
 
 type Props = {
   value: Value[],
@@ -380,6 +388,6 @@ const OptionsMessage = ({ message }) => (
 );
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps,
 )(FieldValuesWidget);


### PR DESCRIPTION
Resolves #11120

The issue was due to the metadata classes not being connected to state like normal props. The field prop in `FieldValuesWidget` started its life as part of a filter in `ColumnFilterDrill` based off of the columns field ref. 

On mounting, `FieldValuesWidget` correctly realizes that its field doesn't have any values and fetches them. However, when state is updated with the values, they don't make their way to the field prop until the popover is dismissed and reopened.



---

The solution here is a bit of a hack. Maybe we could make this hack slightly more legit by abstracting it like this?

```js
@connectPropsToState(['field'])
class MyComponent extends React.Component {
```