### PR TITLE
Drop `special_type` when aggregating PKs and FKs

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -821,6 +821,8 @@ export class ExpressionDimension extends Dimension {
   }
 }
 
+const UNAGGREGATED_SPECIAL_TYPES = new Set([TYPE.FK, TYPE.PK]);
+
 /**
  * Aggregation reference, `["aggregation", aggregation-index]`
  */
@@ -841,8 +843,10 @@ export class AggregationDimension extends Dimension {
 
   column(extra = {}) {
     const aggregation = this.aggregation();
+    const { special_type, ...column } = super.column();
     return {
-      ...super.column(),
+      ...column,
+      ...(!UNAGGREGATED_SPECIAL_TYPES.has(special_type) && { special_type }),
       base_type: aggregation ? aggregation.baseType() : TYPE.Float,
       source: "aggregation",
       ...extra,

--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -821,6 +821,9 @@ export class ExpressionDimension extends Dimension {
   }
 }
 
+// These types aren't aggregated. e.g. if you take the distinct count of a FK
+// column, you now have a normal integer and should see relevant filters for
+// that type.
 const UNAGGREGATED_SPECIAL_TYPES = new Set([TYPE.FK, TYPE.PK]);
 
 /**
@@ -846,6 +849,7 @@ export class AggregationDimension extends Dimension {
     const { special_type, ...column } = super.column();
     return {
       ...column,
+      // don't pass through `special_type` when aggregating these types
       ...(!UNAGGREGATED_SPECIAL_TYPES.has(special_type) && { special_type }),
       base_type: aggregation ? aggregation.baseType() : TYPE.Float,
       source: "aggregation",

--- a/frontend/test/__support__/sample_dataset_fixture.json
+++ b/frontend/test/__support__/sample_dataset_fixture.json
@@ -521,7 +521,7 @@
       "6": {
         "description": "The total billed amount.",
         "table_id": 1,
-        "special_type": null,
+        "special_type": "type/Currency",
         "name": "TOTAL",
         "caveats": null,
         "fk_target_field_id": null,

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -1,5 +1,11 @@
 import Dimension, { FKDimension } from "metabase-lib/lib/Dimension";
-import { metadata, ORDERS, PRODUCTS } from "__support__/sample_dataset_fixture";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+import {
+  metadata,
+  ORDERS,
+  PRODUCTS,
+  SAMPLE_DATASET,
+} from "__support__/sample_dataset_fixture";
 
 describe("Dimension", () => {
   describe("STATIC METHODS", () => {
@@ -195,7 +201,7 @@ describe("Dimension", () => {
           name: "TOTAL",
           display_name: "Total",
           base_type: "type/Float",
-          special_type: null,
+          special_type: "type/Currency",
           field_ref: ["field-id", ORDERS.TOTAL.id],
         });
       });
@@ -392,7 +398,7 @@ describe("Dimension", () => {
           name: "TOTAL",
           display_name: "Total",
           base_type: "type/Float",
-          special_type: null,
+          special_type: "type/Currency",
           field_ref: [
             "binning-strategy",
             ["field-id", ORDERS.TOTAL.id],
@@ -486,7 +492,7 @@ describe("Dimension", () => {
           name: "TOTAL",
           display_name: "Total",
           base_type: "type/Float",
-          special_type: null,
+          special_type: "type/Currency",
           field_ref: ["joined-field", "join1", ["field-id", ORDERS.TOTAL.id]],
         });
       });
@@ -500,6 +506,32 @@ describe("Dimension", () => {
       describe("mbql()", () => {
         it('returns an "aggregation" clause', () => {
           expect(dimension.mbql()).toEqual(["aggregation", 1]);
+        });
+      });
+
+      describe("column()", () => {
+        function sumOf(column) {
+          const query = new StructuredQuery(ORDERS.question(), {
+            type: "query",
+            database: SAMPLE_DATASET.id,
+            query: {
+              "source-table": ORDERS.id,
+              aggregation: [["sum", ["field-id", column.id]]],
+            },
+          });
+          return Dimension.parseMBQL(["aggregation", 0], metadata, query);
+        }
+
+        it("should clear unaggregated special types", () => {
+          const { special_type } = sumOf(ORDERS.PRODUCT_ID).column();
+
+          expect(special_type).toBe(undefined);
+        });
+
+        it("should retain aggregated special types", () => {
+          const { special_type } = sumOf(ORDERS.TOTAL).column();
+
+          expect(special_type).toBe("type/Currency");
         });
       });
     });


### PR DESCRIPTION
Resolves #11208

The issue occurred because we always kept the base field's special type through an aggregation. In @sbelak's example from the issue, Product ID's 'type/FK' was retained when aggregated as "count distinct". That doesn't make sense and led to confusing post aggregation filter options.

The fix here drops the special type when aggregating PKs and FKs.

Though that solves the problem in the issue, I don't think it's enough. PKs and FKs should probably never keep their type through aggregation. The possible exception to this is min/max since that produces a value in the original set. That would still be a weird use case IMO. 

Other types should probably drop their type only for some aggregations. For example, you can sum a currency without changing the type. However, if you count the values in a currency column, you no longer have a currency. 

Questions
* Where besides post-aggregation filter options does this matter?
* Is it worth making this code more nuanced? (e.g. counted currencies are not currencies)