### PR TITLE
ensure that list header icons inherit hover colors

### DIFF
--- a/frontend/src/metabase/css/components/list.css
+++ b/frontend/src/metabase/css/components/list.css
@@ -7,6 +7,10 @@
   color: var(--color-text-dark);
 }
 
+.List-section-header:hover .Icon {
+  color: inherit;
+}
+
 .List-item .Icon {
   color: var(--color-text-light);
 }


### PR DESCRIPTION
A small issue that has been bugging me for a long time. When hovering on list section headers (primarily something when going back and forth in data selector popovers) the icon would stay the old color although the intention was that it should match the hover color that was specified to help both the icon and text read as one element.

**Before (when hovering)**

<img width="358" alt="Screen Shot 2019-10-30 at 1 01 46 PM" src="https://user-images.githubusercontent.com/5248953/67894288-778b1780-fb15-11e9-8666-db218384612f.png">

**After (when hovering)**

<img width="355" alt="Screen Shot 2019-10-30 at 1 01 17 PM" src="https://user-images.githubusercontent.com/5248953/67894289-778b1780-fb15-11e9-94e0-f54411dfb44d.png">

