### PR TITLE
Upgrade prettier to 1.18.2

### DIFF
--- a/frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentForm.jsx
@@ -106,9 +106,7 @@ export default class SegmentForm extends Component {
             title={isNewRecord ? t`Create Your Segment` : t`Edit Your Segment`}
             description={
               isNewRecord
-                ? t`Select and add filters to create your new segment for the ${
-                    table.display_name
-                  } table`
+                ? t`Select and add filters to create your new segment for the ${table.display_name} table`
                 : t`Make changes to your segment and leave an explanatory note.`
             }
           >

--- a/frontend/src/metabase/admin/permissions/selectors.js
+++ b/frontend/src/metabase/admin/permissions/selectors.js
@@ -119,16 +119,10 @@ function getPermissionWarning(
   const perm = value || getter(permissions, groupId, entityId);
   const defaultPerm = getter(permissions, defaultGroup.id, entityId);
   if (perm === "controlled" && defaultPerm === "controlled") {
-    return t`The "${
-      defaultGroup.name
-    }" group may have access to a different set of ${entityType} than this group, which may give this group additional access to some ${entityType}.`;
+    return t`The "${defaultGroup.name}" group may have access to a different set of ${entityType} than this group, which may give this group additional access to some ${entityType}.`;
   }
   if (hasGreaterPermissions(defaultPerm, perm)) {
-    return t`The "${
-      defaultGroup.name
-    }" group has a higher level of access than this, which will override this setting. You should limit or revoke the "${
-      defaultGroup.name
-    }" group's access to this item.`;
+    return t`The "${defaultGroup.name}" group has a higher level of access than this, which will override this setting. You should limit or revoke the "${defaultGroup.name}" group's access to this item.`;
   }
   return null;
 }

--- a/frontend/src/metabase/components/BrowseApp.jsx
+++ b/frontend/src/metabase/components/BrowseApp.jsx
@@ -152,9 +152,7 @@ export class TableBrowser extends React.Component {
                                   </Link>
                                 ),
                                 <Link
-                                  to={`reference/databases/${dbId}/tables/${
-                                    table.id
-                                  }`}
+                                  to={`reference/databases/${dbId}/tables/${table.id}`}
                                   data-metabase-event={`${ANALYTICS_CONTEXT};Table Item;Reference Click`}
                                   className="link--icon ml1"
                                 >

--- a/frontend/src/metabase/components/CollectionLanding.jsx
+++ b/frontend/src/metabase/components/CollectionLanding.jsx
@@ -591,9 +591,7 @@ const PinnedItem = ({ item, index, collection }) => (
           <Box
             ml="auto"
             className="hover-child"
-            data-metabase-event={`${ANALYTICS_CONTEXT};Pinned Item;Unpin;${
-              item.model
-            }`}
+            data-metabase-event={`${ANALYTICS_CONTEXT};Pinned Item;Unpin;${item.model}`}
             onClick={ev => {
               ev.preventDefault();
               item.setPinned(false);

--- a/frontend/src/metabase/components/Tooltip.jsx
+++ b/frontend/src/metabase/components/Tooltip.jsx
@@ -73,9 +73,7 @@ export default class Tooltip extends Component {
       elem.addEventListener("mouseup", this._onMouseUp, true);
     } else {
       console.warn(
-        `Tooltip::componentDidMount: no DOM node for tooltip ${
-          this.props.tooltip
-        }`,
+        `Tooltip::componentDidMount: no DOM node for tooltip ${this.props.tooltip}`,
       );
     }
 
@@ -114,9 +112,7 @@ export default class Tooltip extends Component {
       elem.removeEventListener("mouseup", this._onMouseUp, true);
     } else {
       console.warn(
-        `Tooltip::componentWillUnmount: no DOM node for tooltip ${
-          this.props.tooltip
-        }`,
+        `Tooltip::componentWillUnmount: no DOM node for tooltip ${this.props.tooltip}`,
       );
     }
     if (this._element) {

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -134,9 +134,7 @@ class Overworld extends React.Component {
                         key={`${pin.model}-${pin.id}`}
                       >
                         <Link
-                          data-metabase-event={`Homepage;Pinned Item Click;Pin Type ${
-                            pin.model
-                          }`}
+                          data-metabase-event={`Homepage;Pinned Item Click;Pin Type ${pin.model}`}
                           to={Urls.dashboard(pin.id)}
                           hover={{ color: color("brand") }}
                         >
@@ -182,12 +180,8 @@ class Overworld extends React.Component {
                 </Box>
                 <h3 className="text-medium">
                   {user.is_superuser
-                    ? t`Save dashboards, questions, and collections in "${
-                        ROOT_COLLECTION.name
-                      }"`
-                    : t`Access dashboards, questions, and collections in "${
-                        ROOT_COLLECTION.name
-                      }"`}
+                    ? t`Save dashboards, questions, and collections in "${ROOT_COLLECTION.name}"`
+                    : t`Access dashboards, questions, and collections in "${ROOT_COLLECTION.name}"`}
                 </h3>
               </Box>
             )}
@@ -224,9 +218,7 @@ class Overworld extends React.Component {
                         <Link
                           to={`browse/${database.id}`}
                           hover={{ color: color("brand") }}
-                          data-metabase-event={`Homepage;Browse DB Clicked; DB Type ${
-                            database.engine
-                          }`}
+                          data-metabase-event={`Homepage;Browse DB Clicked; DB Type ${database.engine}`}
                         >
                           <Box
                             p={3}

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -172,9 +172,7 @@ export default class SaveQuestionModal extends Component {
             onChange={value => this.onChange("saveType", value)}
             options={[
               {
-                name: t`Replace original question, "${
-                  this.props.originalCard.name
-                }"`,
+                name: t`Replace original question, "${this.props.originalCard.name}"`,
                 value: "overwrite",
               },
               { name: t`Save as new question`, value: "create" },

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -239,9 +239,7 @@ export function createEntity(def: EntityDefinition): Entity {
   const UPDATE_ACTION = `metabase/entities/${entity.name}/UPDATE`;
   const DELETE_ACTION = `metabase/entities/${entity.name}/DELETE`;
   const FETCH_LIST_ACTION = `metabase/entities/${entity.name}/FETCH_LIST`;
-  const INVALIDATE_LISTS_ACTION = `metabase/entities/${
-    entity.name
-  }/INVALIDATE_LISTS`;
+  const INVALIDATE_LISTS_ACTION = `metabase/entities/${entity.name}/INVALIDATE_LISTS`;
 
   entity.actionTypes = {
     CREATE: CREATE_ACTION,

--- a/frontend/src/metabase/pulse/components/PulseEditChannels.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditChannels.jsx
@@ -279,9 +279,7 @@ export default class PulseEditChannels extends Component {
           <ul className="bg-light px3">{channels}</ul>
         ) : channels.length > 0 && !channelSpec.configured ? (
           <div className="p4 text-centered">
-            <h3 className="mb2">{t`${
-              channelSpec.name
-            } needs to be set up by an administrator.`}</h3>
+            <h3 className="mb2">{t`${channelSpec.name} needs to be set up by an administrator.`}</h3>
             <ChannelSetupMessage user={user} channels={[channelSpec.name]} />
           </div>
         ) : null}

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
@@ -154,9 +154,7 @@ const DashboardEmbedQueryButton = ({
 }) => (
   <DownloadButton
     method="GET"
-    url={`api/embed/dashboard/${token}/dashcard/${dashcardId}/card/${
-      card.id
-    }/${type}`}
+    url={`api/embed/dashboard/${token}/dashcard/${dashcardId}/card/${card.id}/${type}`}
     extensions={[type]}
     params={params}
   >

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
@@ -123,7 +123,7 @@ export default class NotebookStep extends React.Component {
             mr={isLastStep ? 2 : 1}
             mt={isLastStep ? 2 : null}
             large={largeActionButtons}
-            {...STEP_UI[action.type] || {}}
+            {...(STEP_UI[action.type] || {})}
             onClick={() => action.action({ query: step.query, openStep })}
           />
         ),

--- a/frontend/src/metabase/reference/components/FieldsToGroupBy.jsx
+++ b/frontend/src/metabase/reference/components/FieldsToGroupBy.jsx
@@ -75,9 +75,7 @@ export default class FieldsToGroupBy extends Component {
                   secondaryOnClick={event => {
                     event.stopPropagation();
                     onChangeLocation(
-                      `/reference/databases/${databaseId}/tables/${
-                        field.table_id
-                      }/fields/${field.id}`,
+                      `/reference/databases/${databaseId}/tables/${field.table_id}/fields/${field.id}`,
                     );
                   }}
                 />

--- a/frontend/src/metabase/reference/databases/FieldList.jsx
+++ b/frontend/src/metabase/reference/databases/FieldList.jsx
@@ -169,9 +169,7 @@ export default class FieldList extends Component {
                           <Field
                             field={entity}
                             foreignKeys={foreignKeys}
-                            url={`/reference/databases/${table.db_id}/tables/${
-                              table.id
-                            }/fields/${entity.id}`}
+                            url={`/reference/databases/${table.db_id}/tables/${table.id}/fields/${entity.id}`}
                             icon={getIconForField(entity)}
                             isEditing={isEditing}
                             formField={fields[entity.id]}

--- a/frontend/src/metabase/reference/databases/FieldSidebar.jsx
+++ b/frontend/src/metabase/reference/databases/FieldSidebar.jsx
@@ -31,12 +31,8 @@ const FieldSidebar = ({ database, table, field, style, className }) => (
         />
       </div>
       <SidebarItem
-        key={`/reference/databases/${database.id}/tables/${table.id}/fields/${
-          field.id
-        }`}
-        href={`/reference/databases/${database.id}/tables/${table.id}/fields/${
-          field.id
-        }`}
+        key={`/reference/databases/${database.id}/tables/${table.id}/fields/${field.id}`}
+        href={`/reference/databases/${database.id}/tables/${table.id}/fields/${field.id}`}
         icon="document"
         name={t`Details`}
       />

--- a/frontend/src/metabase/reference/databases/TableSidebar.jsx
+++ b/frontend/src/metabase/reference/databases/TableSidebar.jsx
@@ -41,9 +41,7 @@ const TableSidebar = ({ database, table, style, className }) => (
       />
       <SidebarItem
         key={`/reference/databases/${database.id}/tables/${table.id}/questions`}
-        href={`/reference/databases/${database.id}/tables/${
-          table.id
-        }/questions`}
+        href={`/reference/databases/${database.id}/tables/${table.id}/questions`}
         icon="all"
         name={t`Questions about this table`}
       />

--- a/frontend/src/metabase/reference/segments/SegmentFieldList.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldList.jsx
@@ -170,9 +170,7 @@ export default class SegmentFieldList extends Component {
                           <Field
                             field={entity}
                             foreignKeys={foreignKeys}
-                            url={`/reference/segments/${segment.id}/fields/${
-                              entity.id
-                            }`}
+                            url={`/reference/segments/${segment.id}/fields/${entity.id}`}
                             icon={getIconForField(entity)}
                             isEditing={isEditing}
                             formField={fields[entity.id]}

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
@@ -239,9 +239,7 @@ const GraphSection = ({
       <polygon
         opacity={1 - index * (0.9 / (infos.length + 1))}
         fill={DEFAULT_COLORS[0]}
-        points={`0 ${info.graph.startBottom}, 0 ${info.graph.startTop}, 1 ${
-          info.graph.endTop
-        }, 1 ${info.graph.endBottom}`}
+        points={`0 ${info.graph.startBottom}, 0 ${info.graph.startTop}, 1 ${info.graph.endTop}, 1 ${info.graph.endBottom}`}
       />
     </svg>
   );

--- a/frontend/test/legacy-selenium/auth/login.spec.js
+++ b/frontend/test/legacy-selenium/auth/login.spec.js
@@ -68,15 +68,11 @@ describeE2E("auth/login", () => {
 
     it("loads the qb", async () => {
       await driver.get(
-        `${
-          server.host
-        }/question#eyJuYW1lIjpudWxsLCJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJ0eXBlIjoibmF0aXZlIiwibmF0aXZlIjp7InF1ZXJ5Ijoic2VsZWN0ICdvaCBoYWkgZ3Vpc2Ug8J-QsScifSwicGFyYW1ldGVycyI6W119LCJkaXNwbGF5Ijoic2NhbGFyIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319`,
+        `${server.host}/question#eyJuYW1lIjpudWxsLCJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJ0eXBlIjoibmF0aXZlIiwibmF0aXZlIjp7InF1ZXJ5Ijoic2VsZWN0ICdvaCBoYWkgZ3Vpc2Ug8J-QsScifSwicGFyYW1ldGVycyI6W119LCJkaXNwbGF5Ijoic2NhbGFyIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319`,
       );
       await waitForUrl(
         driver,
-        `${
-          server.host
-        }/question#eyJuYW1lIjpudWxsLCJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJ0eXBlIjoibmF0aXZlIiwibmF0aXZlIjp7InF1ZXJ5Ijoic2VsZWN0ICdvaCBoYWkgZ3Vpc2Ug8J-QsScifSwicGFyYW1ldGVycyI6W119LCJkaXNwbGF5Ijoic2NhbGFyIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319`,
+        `${server.host}/question#eyJuYW1lIjpudWxsLCJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJ0eXBlIjoibmF0aXZlIiwibmF0aXZlIjp7InF1ZXJ5Ijoic2VsZWN0ICdvaCBoYWkgZ3Vpc2Ug8J-QsScifSwicGFyYW1ldGVycyI6W119LCJkaXNwbGF5Ijoic2NhbGFyIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319`,
       );
       await screenshot(driver, "screenshots/qb.png");
     });

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "postcss-import": "^9.0.0",
     "postcss-loader": "^2.0.8",
     "postcss-url": "^6.0.4",
-    "prettier": "^1.17.0",
+    "prettier": "1.18.2",
     "promise-loader": "^1.0.0",
     "raf": "^3.4.0",
     "react-test-renderer": "15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10826,10 +10826,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@^1.17.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
-  integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==
+prettier@1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 pretty-error@^2.0.2:
   version "2.1.1"


### PR DESCRIPTION
We should specify exact versions of prettier in `package.json`. Enterprise got upgraded to `1.18.2` before OSS because we specified `^1.17.0` which means minor versions greater than `1.17.0` are allowed.