### PR TITLE
Fix up back buttons in Data Model

### DIFF
--- a/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
@@ -44,7 +44,6 @@ import { rescanFieldValues, discardFieldValues } from "../field";
 // LIB
 import Metadata from "metabase-lib/lib/metadata/Metadata";
 import { has_field_values_options } from "metabase/lib/core";
-import { color } from "metabase/lib/colors";
 import { getGlobalSettingsForColumn } from "metabase/visualizations/lib/settings/column";
 import { isCurrency } from "metabase/lib/schema_metadata";
 

--- a/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
@@ -200,9 +200,9 @@ export default class FieldApp extends React.Component {
           <AdminLayout
             sidebar={
               <div>
-                <Header>
+                <div className="flex align-center mb2">
                   <BackButton databaseId={databaseId} tableId={tableId} />
-                </Header>
+                </div>
                 <LeftNavPane>
                   <LeftNavPaneItem
                     name={t`General`}
@@ -218,23 +218,21 @@ export default class FieldApp extends React.Component {
             }
           >
             <div className="wrapper">
-              <Header>
-                <div className="mb4 py1 ml-auto mr-auto">
-                  <Breadcrumbs
-                    crumbs={[
-                      [db.name, `/admin/datamodel/database/${db.id}`],
-                      [
-                        table.display_name,
-                        `/admin/datamodel/database/${db.id}/table/${table.id}`,
-                      ],
-                      t`${field.display_name} – Field Settings`,
-                    ]}
-                  />
-                </div>
-                <div className="absolute top right mt4 mr4">
-                  <SaveStatus ref={ref => (this.saveStatus = ref)} />
-                </div>
-              </Header>
+              <div className="mb4 pt2 ml-auto mr-auto">
+                <Breadcrumbs
+                  crumbs={[
+                    [db.name, `/admin/datamodel/database/${db.id}`],
+                    [
+                      table.display_name,
+                      `/admin/datamodel/database/${db.id}/table/${table.id}`,
+                    ],
+                    t`${field.display_name} – Field Settings`,
+                  ]}
+                />
+              </div>
+              <div className="absolute top right mt4 mr4">
+                <SaveStatus ref={ref => (this.saveStatus = ref)} />
+              </div>
 
               {section == null || section === "general" ? (
                 <FieldGeneralPane
@@ -263,10 +261,6 @@ export default class FieldApp extends React.Component {
     );
   }
 }
-
-const Header = ({ children, height = 50 }) => (
-  <div style={{ height }}>{children}</div>
-);
 
 const FieldGeneralPane = ({
   field,
@@ -388,8 +382,7 @@ export const BackButton = ({
 }) => (
   <Link
     to={`/admin/datamodel/database/${databaseId}/table/${tableId}`}
-    className="circle text-white p2 flex align-center justify-center inline"
-    style={{ backgroundColor: color("bg-dark") }}
+    className="circle text-white p2 flex align-center justify-center bg-dark bg-brand-hover"
   >
     <Icon name="arrow_back" />
   </Link>


### PR DESCRIPTION
The back buttons on the table and field setting pages in the data model didn't have their arrows aligned correctly, and weren't perfectly circular. They also didn't have a hover color, so this PR adds that, too.

## Before

![Screen Shot 2019-10-31 at 1 17 21 PM](https://user-images.githubusercontent.com/2223916/67983787-a58a5d80-fbe2-11e9-9676-39b76bcf479f.png)

![Screen Shot 2019-10-31 at 1 15 22 PM](https://user-images.githubusercontent.com/2223916/67983805-ae7b2f00-fbe2-11e9-87c3-9fdd0dc73e91.png)

## After

![Screen Shot 2019-10-31 at 1 28 03 PM](https://user-images.githubusercontent.com/2223916/67983770-9c998c00-fbe2-11e9-9e8a-eb9e7fd2bd69.png)

![Screen Shot 2019-10-31 at 1 15 40 PM](https://user-images.githubusercontent.com/2223916/67983795-aae7a800-fbe2-11e9-8647-bef7e7afc254.png)

