### PR TITLE
Improve styling of Data tab for Line/Area/Bar charts

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -56,8 +56,6 @@ const ChartSettingFieldPicker = ({
         className={cx("ml1 text-medium text-brand-hover cursor-pointer", {
           "disabled hidden": !onRemove,
         })}
-        width={12}
-        height={12}
         onClick={onRemove}
       />
     </div>

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
@@ -45,8 +45,9 @@ const ChartSettingFieldsPicker = ({
       <span className="text-error">{t`error`}</span>
     )}
     {addAnother && (
-      <div className="mt1">
+      <div className="my2">
         <a
+          className="text-brand text-bold py1 px2 rounded bg-light bg-medium-hover"
           onClick={() => {
             const remaining = options.filter(o => value.indexOf(o.value) < 0);
             if (remaining.length === 1) {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
@@ -45,7 +45,7 @@ const ChartSettingFieldsPicker = ({
       <span className="text-error">{t`error`}</span>
     )}
     {addAnother && (
-      <div className="my2">
+      <div className="mt2 mb3">
         <a
           className="text-brand text-bold py1 px2 rounded bg-light bg-medium-hover"
           onClick={() => {


### PR DESCRIPTION
This changes the style of the "add series/breakout" links/buttons and bumps up the size of the `X` icon buttons slightly to make them look better next to the gears.

This whole panel is due for more of a true overhaul, but that's out of the range of my abilities, and I think this is a nice enough facelift.

## Before

![Screen Shot 2019-10-31 at 5 15 26 PM](https://user-images.githubusercontent.com/2223916/67994368-2ad13a80-fc02-11e9-9994-aafbab2f6c2c.png)

![Screen Shot 2019-10-31 at 5 15 48 PM](https://user-images.githubusercontent.com/2223916/67994378-34f33900-fc02-11e9-9e9c-b0bf7266a1d3.png)

## After

![Screen Shot 2019-10-31 at 5 14 26 PM](https://user-images.githubusercontent.com/2223916/67994389-476d7280-fc02-11e9-97ad-376aa150d27c.png)

![image](https://user-images.githubusercontent.com/2223916/67994406-61a75080-fc02-11e9-926b-7e574a2c67a0.png)
