### PR TITLE
Upgrade MariaDB Connector/J to 2.5.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -116,7 +116,7 @@
    [org.flatland/ordered "1.5.7"]                                     ; ordered maps & sets
    [org.liquibase/liquibase-core "3.6.3"                              ; migration management (Java lib)
     :exclusions [ch.qos.logback/logback-classic]]
-   [org.mariadb.jdbc/mariadb-java-client "2.5.1"]                     ; MySQL/MariaDB driver
+   [org.mariadb.jdbc/mariadb-java-client "2.5.1"]                     ; MySQL/MariaDB driver 
    [org.postgresql/postgresql "42.2.5"]                               ; Postgres driver
    [org.slf4j/slf4j-log4j12 "1.7.25"]                                 ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
    [org.tcrawley/dynapath "1.0.0"]                                    ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath

--- a/project.clj
+++ b/project.clj
@@ -116,7 +116,7 @@
    [org.flatland/ordered "1.5.7"]                                     ; ordered maps & sets
    [org.liquibase/liquibase-core "3.6.3"                              ; migration management (Java lib)
     :exclusions [ch.qos.logback/logback-classic]]
-   [org.mariadb.jdbc/mariadb-java-client "2.3.0"]                     ; MySQL/MariaDB driver
+   [org.mariadb.jdbc/mariadb-java-client "2.5.1"]                     ; MySQL/MariaDB driver
    [org.postgresql/postgresql "42.2.5"]                               ; Postgres driver
    [org.slf4j/slf4j-log4j12 "1.7.25"]                                 ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
    [org.tcrawley/dynapath "1.0.0"]                                    ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath


### PR DESCRIPTION
There has been several big changes lately to the [MariaDB Connector/J driver](https://github.com/MariaDB/mariadb-connector-j/releases):
- Support for `caching_sha2_password` (since 2.5.0), which means that it can connect with MySQL 8 without using `mysql_native_password`, which fixes #9820 (partially #10754) and makes [troubleshooting section](https://www.metabase.com/docs/latest/troubleshooting-guide/datawarehouse.html#mysql-unable-to-log-in-to-mysql-8-with-correct-credentials) obsolete.
- Support for `JSON` column type (since 2.4.0), which fixes #9800 and fixes #9801.

There's several other changes, and I have only done quick testing with a handful of databases (5.7, 8.0, 10.3, 10.4), but I haven't noticed any problems. And there doesn't seem to be any critical new issues with 2.5.1 when flipping through their JIRA: https://jira.mariadb.org/projects/CONJ/issues