### PR TITLE
Use correct JSON base/special type for MySQL

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -272,6 +272,13 @@
    ;; strip off " UNSIGNED" from end if present
    (keyword (str/replace (name database-type) #"\sUNSIGNED$" ""))))
 
+(defmethod sql-jdbc.sync/column->special-type :mysql
+  [_ database-type _]
+  ;; Used when syncing. If it's :JSON type then it's :type/SerializedJSON special-type
+  (case database-type
+    "JSON" :type/SerializedJSON
+    nil))
+
 (def ^:private default-connection-args
   "Map of args for the MySQL/MariaDB JDBC connection string."
   { ;; 0000-00-00 dates are valid in MySQL; convert these to `null` when they come back because they're illegal in Java

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -250,6 +250,7 @@
     :FLOAT      :type/Float
     :INT        :type/Integer
     :INTEGER    :type/Integer
+    :JSON       :type/Text
     :LONGBLOB   :type/*
     :LONGTEXT   :type/Text
     :MEDIUMBLOB :type/*


### PR DESCRIPTION
Removes warning on sync and sets Field Type correctly, which I should probably have tested :man_facepalming: 
Simply just stole from the Postgres driver.
Addendum to #11286, as noted in https://github.com/metabase/metabase/issues/9800#issuecomment-552158818