### PR TITLE
Change max_series to 100

### DIFF
--- a/frontend/src/metabase/visualizations/lib/utils.js
+++ b/frontend/src/metabase/visualizations/lib/utils.js
@@ -7,7 +7,7 @@ import crossfilter from "crossfilter";
 
 import { isDimension, isMetric, isDate } from "metabase/lib/schema_metadata";
 
-export const MAX_SERIES = 20;
+export const MAX_SERIES = 100;
 
 const SPLIT_AXIS_UNSPLIT_COST = -100;
 const SPLIT_AXIS_COST_FACTOR = 2;

--- a/frontend/test/metabase/visualizations/lib/utils.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/utils.unit.spec.js
@@ -251,7 +251,7 @@ describe("metabase/visualization/lib/utils", () => {
         getDefaultDimensionsAndMetrics([
           {
             data: {
-              rows: _.range(0, 100).map(v => [0, v, v]),
+              rows: _.range(0, 101).map(v => [0, v, v]),
               cols: [
                 {
                   name: "count",


### PR DESCRIPTION
This is a reincarnation of https://github.com/metabase/metabase/pull/5592 for the purpose of discussion. It might be a while before we get the bandwidth to implement [a more elegant solution](https://github.com/metabase/metabase/issues/3656#issuecomment-512610895) for the problem of line/area/bar chars with more than 20 series, so I started playing around to see how much of a performance hit users would experience when trying to interact with or modify a chart with lots more series on it.

The short answer is: it depends on how many total points there are on the chart.

## How this felt in practice when I tried it out

I played around with a time series chart with a series breakout — count of orders by time and by user state, all-time (our sample data has about 3 or 4 years represented). This only resulted in **48 series** (for each of the lower 48 states in the USA). I then tried opening up the sidebars of the UI and hovering over points on the lines to see how the chart performed.

- At the **month** granularity (our default), things felt pretty darn good actually.
- At the **week** granularity, things were pretty usable, but with some noticeable slowdown.
- At the **day** granularity, things felt _technically_ usable, in that it didn't grind things to a halt, but if I started clicking around too fast or hovering on lots of points, things got slow. This didn't feel like a fun state to be in at all until I filtered down the time range.

[Here's a 4-minute screen capture](https://drive.google.com/file/d/1InctoBLUGyCg0ZGhXV4FdNmj6htDyHdU/view?usp=sharing) (Metabase email address required)

For other situations, like seeing orders per state by day-of-the-week, this felt pretty great:

![image](https://user-images.githubusercontent.com/2223916/68721309-cc437f00-0566-11ea-8cc7-6eb5c96221a0.png)


## Items for discussion
CC @salsakran @kdoh @paulrosenzweig 
- Should we do this as a way to relieve pressure in the short-term? I think the trade-off of allowing the potential for users to run into a chart with way too many data points might be acceptable for the benefit of having fewer situations where a line/area/bar chart just refuses to work _at all_.
- Is `100` the right limit for now? I'm not sure since in my tests I was using 48 series because I didn't have a column with cardinality `> 48 <= 100` at hand.
- The main problem here is line/area/bar chart performance. Improving its performance so that it re-renders faster would also make the GUI experience better in general, but I'm sure this is a large project. Is it time to tackle this?
- This wouldn't fix the problem of too many items in our legends, but it also doesn't make that situation notably worse IMO.