### PR TITLE
Clarify temporal type hierarchy; new test dataset & timezone tests; mysql fixes

### DIFF
--- a/modules/drivers/druid/src/metabase/driver/druid.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid.clj
@@ -135,7 +135,7 @@
                      ;; every Druid table is an event stream w/ a timestamp field
                      [{:name          "timestamp"
                        :database-type "timestamp"
-                       :base-type     :type/DateTime
+                       :base-type     :type/Instant
                        :pk?           true}]
                      (for [[field-name field-info] (dissoc columns :__time)]
                        (describe-table-field field-name field-info))))})))

--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -16,6 +16,7 @@
              [timezone :as qp.timezone]]
             [metabase.query-processor.middleware.annotate :as annotate]
             [metabase.util :as u]
+            [metabase.types :as types]
             [metabase.util
              [date-2 :as u.date]
              [i18n :as ui18n :refer [tru]]]
@@ -999,12 +1000,12 @@
                                                                             :desc :descending
                                                                             :asc  :ascending)}))))
 (defn- datetime-field?
-  "Similar to `mbql.u/datetime-field?` but works on field ids wrapped in a datetime or on fields that happen to be a
+  "Similar to `types/temporal-field?` but works on field ids wrapped in a datetime or on fields that happen to be a
   datetime"
   [field]
   (when field
     (or (mbql.u/is-clause? :datetime-field field)
-        (mbql.u/datetime-field? (qp.store/field (second field))))))
+        (types/temporal-field? (qp.store/field (second field))))))
 
 ;; Handle order by timstamp field
 (defn- handle-order-by-timestamp

--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -6,6 +6,9 @@
             [clojure.tools.logging :as log]
             [flatland.ordered.map :as ordered-map]
             [java-time :as t]
+            [metabase
+             [types :as types]
+             [util :as u]]
             [metabase.driver.druid.js :as js]
             [metabase.mbql
              [schema :as mbql.s]
@@ -15,8 +18,6 @@
              [store :as qp.store]
              [timezone :as qp.timezone]]
             [metabase.query-processor.middleware.annotate :as annotate]
-            [metabase.util :as u]
-            [metabase.types :as types]
             [metabase.util
              [date-2 :as u.date]
              [i18n :as ui18n :refer [tru]]]

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -88,12 +88,7 @@
 (extend-protocol m.conversion/ConvertFromDBObject
   java.util.Date
   (from-db-object [t _]
-    (t/instant t))
-  #_java.time.LocalTime
-  #_java.time.LocalDateTime
-  #_java.time.OffsetTime
-  #_java.time.OffsetDateTime
-  #_java.time.ZonedDateTime)
+    (t/instant t)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                    QP Impl                                                     |

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -175,11 +175,11 @@
   [[{:special_type :type/PK,        :base_type :type/Integer,  :name "_id"}
     {:special_type :type/Name,      :base_type :type/Text,     :name "name"}]
    [{:special_type :type/PK,        :base_type :type/Integer,  :name "_id"}
-    {:special_type nil,             :base_type :type/DateTime, :name "date"}
+    {:special_type nil,             :base_type :type/Instant,  :name "date"}
     {:special_type :type/Category,  :base_type :type/Integer,  :name "user_id"}
     {:special_type nil,             :base_type :type/Integer,  :name "venue_id"}]
    [{:special_type :type/PK,        :base_type :type/Integer,  :name "_id"}
-    {:special_type nil,             :base_type :type/DateTime, :name "last_login"}
+    {:special_type nil,             :base_type :type/Instant,  :name "last_login"}
     {:special_type :type/Name,      :base_type :type/Text,     :name "name"}
     {:special_type :type/Category,  :base_type :type/Text,     :name "password"}]
    [{:special_type :type/PK,        :base_type :type/Integer,  :name "_id"}

--- a/modules/drivers/mongo/test/metabase/test/data/mongo.clj
+++ b/modules/drivers/mongo/test/metabase/test/data/mongo.clj
@@ -1,14 +1,14 @@
 (ns metabase.test.data.mongo
   (:require [metabase.driver.mongo.util :refer [with-mongo-connection]]
             [metabase.test.data.interface :as tx]
-            [metabase.util :as u]
             [monger
              [collection :as mc]
              [core :as mg]]))
 
 (tx/add-test-extensions! :mongo)
 
-(defmethod tx/dbdef->connection-details :mongo [_ _ dbdef]
+(defmethod tx/dbdef->connection-details :mongo
+  [_ _ dbdef]
   {:dbname (tx/escaped-name dbdef)
    :host   "localhost"})
 
@@ -29,6 +29,8 @@
           (let [row (for [v row]
                       ;; Conver all the java.sql.Timestamps to java.util.Date, because the Mongo driver insists on
                       ;; being obnoxious and going from using Timestamps in 2.x to Dates in 3.x
+                      ;;
+                      ;; TIMEZONE FIXME — stop using legacy types
                       (if (instance? java.sql.Timestamp v)
                         (java.util.Date. (.getTime ^java.sql.Timestamp v))
                         v))]
@@ -38,7 +40,6 @@
                                                       :_id (inc i)))
               ;; If row already exists then nothing to do
               (catch com.mongodb.MongoException _))))))))
-
 
 (defmethod tx/format-name :mongo
   [_ table-or-field-name]

--- a/modules/drivers/oracle/test/metabase/test/data/oracle.clj
+++ b/modules/drivers/oracle/test/metabase/test/data/oracle.clj
@@ -7,7 +7,6 @@
             [metabase.driver.sql-jdbc
              [connection :as sql-jdbc.conn]
              [sync :as sql-jdbc.sync]]
-            [metabase.plugins.classloader :as classloader]
             [metabase.test.data
              [interface :as tx]
              [sql :as sql.tx]
@@ -47,15 +46,19 @@
 
 (defmethod tx/sorts-nil-first? :oracle [_] false)
 
-(doseq [[base-type sql-type] {:type/BigInteger     "NUMBER(*,0)"
-                              :type/Boolean        "NUMBER(1)"
-                              :type/Date           "DATE"
-                              :type/DateTime       "TIMESTAMP"
-                              :type/DateTimeWithTZ "TIMESTAMP WITH TIME ZONE"
-                              :type/Decimal        "DECIMAL"
-                              :type/Float          "BINARY_FLOAT"
-                              :type/Integer        "INTEGER"
-                              :type/Text           "VARCHAR2(4000)"}]
+(doseq [[base-type sql-type] {:type/BigInteger             "NUMBER(*,0)"
+                              :type/Boolean                "NUMBER(1)"
+                              :type/Date                   "DATE"
+                              :type/Temporal               "TIMESTAMP"
+                              :type/DateTime               "TIMESTAMP"
+                              :type/DateTimeWithTZ         "TIMESTAMP WITH TIME ZONE"
+                              :type/DateTimeWithLocalTZ    "TIMESTAMP WITH LOCAL TIME ZONE"
+                              :type/DateTimeWithZoneOffset "TIMESTAMP WITH TIME ZONE"
+                              :type/DateTimeWithZoneID     "TIMESTAMP WITH TIME ZONE"
+                              :type/Decimal                "DECIMAL"
+                              :type/Float                  "BINARY_FLOAT"
+                              :type/Integer                "INTEGER"
+                              :type/Text                   "VARCHAR2(4000)"}]
   (defmethod sql.tx/field-base-type->sql-type [:oracle base-type] [_ _] sql-type))
 
 ;; If someone tries to run Time column tests with Oracle give them a heads up that Oracle does not support it

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -32,7 +32,7 @@
     :date             :type/Date
     :datetime         :type/DateTime
     :datetime2        :type/DateTime
-    :datetimeoffset   :type/DateTime
+    :datetimeoffset   :type/DateTimeWithZoneOffset
     :decimal          :type/Decimal
     :float            :type/Float
     :geography        :type/*

--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -21,7 +21,8 @@
 
 (driver/register! :vertica, :parent #{:sql-jdbc ::legacy/use-legacy-classes-for-read-and-set})
 
-(defmethod sql-jdbc.sync/database-type->base-type :vertica [_ database-type]
+(defmethod sql-jdbc.sync/database-type->base-type :vertica
+  [_ database-type]
   ({:Boolean                   :type/Boolean
      :Integer                   :type/Integer
      :Bigint                    :type/BigInteger
@@ -35,9 +36,9 @@
      :Float                     :type/Float
      :Date                      :type/Date
      :Time                      :type/Time
-     :TimeTz                    :type/Time
+     :TimeTz                    :type/TimeWithLocalTZ
      :Timestamp                 :type/DateTime
-     :TimestampTz               :type/DateTime
+     :TimestampTz               :type/DateTimeWithLocalTZ
      :AUTO_INCREMENT            :type/Integer
      (keyword "Long Varchar")   :type/Text
      (keyword "Long Varbinary") :type/*} database-type))

--- a/project.clj
+++ b/project.clj
@@ -182,9 +182,15 @@
      (try (require 'metabase.test.redefs)
           (catch Throwable _))]
 
-    :env      {:mb-run-mode       "dev"
-               :mb-test-setting-1 "ABCDEFG"}
-    :jvm-opts ["-Dlogfile.path=target/log"]}
+    :env
+    {:mb-run-mode       "dev"
+     :mb-test-setting-1 "ABCDEFG"}
+
+    :jvm-opts
+    ["-Dlogfile.path=target/log"]
+
+    :repl-options
+    {:init-ns user}} ; starting in the user namespace is a lot faster than metabase.core since it has less deps
 
    :ci
    {:jvm-opts ["-Xmx2500m"]}

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -7,10 +7,10 @@
              [driver :as driver]
              [related :as related]
              [sync :as sync]
+             [types :as types]
              [util :as u]]
             [metabase.api.common :as api]
             [metabase.driver.util :as driver.u]
-            [metabase.mbql.util :as mbql.u]
             [metabase.models
              [card :refer [Card]]
              [field :refer [Field]]
@@ -172,7 +172,7 @@
 (defn- supports-date-binning?
   "Time fields don't support binning, returns true if it's a DateTime field and not a time field"
   [{:keys [base_type], :as field}]
-  (and (mbql.u/datetime-field? field)
+  (and (types/temporal-field? field)
        (not (isa? base_type :type/Time))))
 
 (defn- assoc-field-dimension-options [driver {:keys [base_type special_type fingerprint] :as field}]

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -304,7 +304,7 @@
                     id                 [:field-id id]
                     :else              [:field-literal name base_type])]
     (cond
-      (isa? base_type :type/DateTime)
+      (isa? base_type :type/Temporal)
       [:datetime-field reference (or aggregation
                                      (optimal-datetime-resolution field))]
 
@@ -1142,7 +1142,7 @@
   [root [_ field-reference value]]
   (let [field      (field-reference->field root field-reference)
         field-name (field-name field)]
-    (if (or (isa? (:base_type field) :type/DateTime)
+    (if (or (isa? (:base_type field) :type/Temporal)
             (field/unix-timestamp? field))
       (tru "{0} is {1}" field-name (humanize-datetime value (:unit field)))
       (tru "{0} is {1}" field-name value))))

--- a/src/metabase/automagic_dashboards/filters.clj
+++ b/src/metabase/automagic_dashboards/filters.clj
@@ -50,11 +50,12 @@
                  identity)
        (filter field-reference?)))
 
+;; TODO — this function name is inaccurate, rename to `temporal?`
 (defn datetime?
-  "Is `field` a datetime?"
+  "Does `field` represent a temporal value, i.e. a date, time, or datetime?"
   [field]
   (and (not ((disj metabase.util.date/date-extract-units :year) (:unit field)))
-       (or (isa? (:base_type field) :type/DateTime)
+       (or (isa? (:base_type field) :type/Temporal)
            (field/unix-timestamp? field))))
 
 (defn- interestingness
@@ -64,8 +65,8 @@
     (some-> fingerprint :global :distinct-count (> 20)) dec
     ((descendants :type/Category) special_type)         inc
     (field/unix-timestamp? field)                       inc
-    (isa? base_type :type/DateTime)                     inc
-    ((descendants :type/DateTime) special_type)         inc
+    (isa? base_type :type/Temporal)                     inc
+    ((descendants :type/Temporal) special_type)         inc
     (isa? special_type :type/CreationTimestamp)         inc
     (#{:type/State :type/Country} special_type)         inc))
 

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -244,7 +244,7 @@
     ;; java.sql types and Joda-Time types should be considered DEPRECATED
     java.sql.Date                  :type/Date
     java.sql.Timestamp             :type/DateTime
-    java.util.Date                 :type/DateTime
+    java.util.Date                 :type/Date
     DateTime                       :type/DateTime
     ;; shouldn't this be :type/UUID ?
     java.util.UUID                 :type/Text
@@ -253,10 +253,10 @@
     java.time.LocalDate            :type/Date
     java.time.LocalTime            :type/Time
     java.time.LocalDateTime        :type/DateTime
-    java.time.OffsetTime           :type/Time
-    java.time.OffsetDateTime       :type/DateTimeWithTZ
-    java.time.ZonedDateTime        :type/DateTimeWithTZ
-    java.time.Instant              :type/DateTime
+    java.time.OffsetTime           :type/TimeWithTZ
+    java.time.OffsetDateTime       :type/DateTimeWithZoneOffset
+    java.time.ZonedDateTime        :type/DateTimeWithZoneID
+    java.time.Instant              :type/Instant
     ;; TODO - this should go in the Postgres driver implementation of this method rather than here
     org.postgresql.util.PGobject   :type/*
     ;; all-NULL columns in DBs like Mongo w/o explicit types

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -253,8 +253,12 @@
     java.time.LocalDate            :type/Date
     java.time.LocalTime            :type/Time
     java.time.LocalDateTime        :type/DateTime
+    ;; `OffsetTime` and `OffsetDateTime` should be mapped to one of `type/TimeWithLocalTZ`/`type/TimeWithZoneOffset`
+    ;; and `type/DateTimeWithLocalTZ`/`type/DateTimeWithZoneOffset` respectively. We can't really tell how they're
+    ;; stored in the DB based on class alone, so drivers should return more specific types where possible. See
+    ;; discussion in the `metabase.types` namespace.
     java.time.OffsetTime           :type/TimeWithTZ
-    java.time.OffsetDateTime       :type/DateTimeWithZoneOffset
+    java.time.OffsetDateTime       :type/DateTimeWithTZ
     java.time.ZonedDateTime        :type/DateTimeWithZoneID
     java.time.Instant              :type/Instant
     ;; TODO - this should go in the Postgres driver implementation of this method rather than here

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -298,4 +298,4 @@
   "Is field a UNIX timestamp?"
   [{:keys [base_type special_type]}]
   (and (isa? base_type :type/Integer)
-       (isa? special_type :type/DateTime)))
+       (isa? special_type :type/Temporal)))

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -54,12 +54,12 @@
        s/Keyword         s/Any}]
   (boolean
    (and (not (contains? #{:retired :sensitive :hidden :details-only} (keyword visibility-type)))
-        (not (isa? (keyword base-type) :type/DateTime))
+        (not (isa? (keyword base-type) :type/Temporal))
         (#{:list :auto-list} (keyword has-field-values)))))
 
 
 (defn- values-less-than-total-max-length?
-  "`true` if the combined length of all the values in DISTINCT-VALUES is below the threshold for what we'll allow in a
+  "`true` if the combined length of all the values in `distinct-values` is below the threshold for what we'll allow in a
   FieldValues entry. Does some logging as well."
   [distinct-values]
   (let [total-length (reduce + (map (comp count str)

--- a/src/metabase/pulse/render.clj
+++ b/src/metabase/pulse/render.clj
@@ -1,13 +1,13 @@
 (ns metabase.pulse.render
   (:require [clojure.tools.logging :as log]
             [hiccup.core :refer [h]]
-            [metabase.mbql.util :as mbql.u]
             [metabase.pulse.render
              [body :as body]
              [common :as common]
              [image-bundle :as image-bundle]
              [png :as png]
              [style :as style]]
+            [metabase.types :as types]
             [metabase.util
              [i18n :refer [trs tru]]
              [urls :as urls]]
@@ -75,7 +75,7 @@
 
       (and (= col-count 2)
            (> row-count 1)
-           (mbql.u/datetime-field? col-1)
+           (types/temporal-field? col-1)
            (number-field? col-2))
       :sparkline
 

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -1,6 +1,5 @@
 (ns metabase.pulse.render.body
   (:require [hiccup.core :refer [h]]
-            [metabase.mbql.util :as mbql.u]
             [metabase.pulse.render
              [color :as color]
              [common :as common]
@@ -9,6 +8,7 @@
              [sparkline :as sparkline]
              [style :as style]
              [table :as table]]
+            [metabase.types :as types]
             [metabase.util.i18n :refer [trs]]
             [schema.core :as s]))
 
@@ -43,9 +43,9 @@
 (defn- format-cell
   [timezone value col]
   (cond
-    (mbql.u/datetime-field? col)                             (datetime/format-timestamp timezone value col)
-    (and (number? value) (not (mbql.u/datetime-field? col))) (common/format-number value)
-    :else                                                    (str value)))
+    (types/temporal-field? col)                             (datetime/format-timestamp timezone value col)
+    (and (number? value) (not (types/temporal-field? col))) (common/format-number value)
+    :else                                                   (str value)))
 
 ;;; --------------------------------------------------- Rendering ----------------------------------------------------
 

--- a/src/metabase/pulse/render/sparkline.clj
+++ b/src/metabase/pulse/render/sparkline.clj
@@ -1,9 +1,9 @@
 (ns metabase.pulse.render.sparkline
-  (:require [metabase.mbql.util :as mbql.u]
-            [metabase.pulse.render
+  (:require [metabase.pulse.render
              [common :as common]
              [image-bundle :as image-bundle]
              [style :as style]]
+            [metabase.types :as types]
             [metabase.util
              [date :as du]
              [i18n :refer [tru]]])
@@ -58,8 +58,9 @@
         (throw (Exception. (tru "No appropriate image writer found!"))))
       (.toByteArray os))))
 
+;; TIMEZONE FIXME
 (defn- format-val-fn [timezone cols x-axis-rowfn]
-  (if (mbql.u/datetime-field? (x-axis-rowfn cols))
+  (if (types/temporal-field? (x-axis-rowfn cols))
     #(.getTime ^Date (du/->Timestamp % timezone))
     identity))
 

--- a/src/metabase/query_processor/middleware/add_implicit_clauses.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_clauses.clj
@@ -4,6 +4,7 @@
             [honeysql.core :as hsql]
             [metabase
              [db :as mdb]
+             [types :as types]
              [util :as u]]
             [metabase.mbql
              [schema :as mbql.s]
@@ -28,9 +29,9 @@
    [:position :asc]
    ;; or if that's the same, sort PKs first, followed by names, followed by everything else
    [(hsql/call :case
-      (mdb/isa :special_type :type/PK)   0
-      (mdb/isa :special_type :type/Name) 1
-      :else                              2)
+               (mdb/isa :special_type :type/PK)   0
+               (mdb/isa :special_type :type/Name) 1
+               :else                              2)
     :asc]
    ;; finally, sort by name (case-insensitive)
    [:%lower.name :asc]])
@@ -49,7 +50,7 @@
   in `metabase.query-processor.sort`, for all the Fields in a given Table."
   [table-id :- su/IntGreaterThanZero]
   (for [field (table->sorted-fields table-id)]
-    (if (mbql.u/datetime-field? field)
+    (if (types/temporal-field? field)
       ;; implicit datetime Fields get bucketing of `:default`. This is so other middleware doesn't try to give it
       ;; default bucketing of `:day`
       [:datetime-field [:field-id (u/get-id field)] :default]

--- a/src/metabase/query_processor/middleware/wrap_value_literals.clj
+++ b/src/metabase/query_processor/middleware/wrap_value_literals.clj
@@ -8,6 +8,7 @@
             [metabase.query-processor
              [store :as qp.store]
              [timezone :as qp.timezone]]
+            [metabase.types :as types]
             [metabase.util.date-2 :as u.date])
   (:import [java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime]))
 
@@ -28,7 +29,7 @@
      field-info
      ;; add in a default unit for this Field so we know to wrap datetime strings in `absolute-datetime` below based on
      ;; its presence. It will get replaced by `:datetime-field` unit if we're wrapped by one
-     (when (mbql.u/datetime-field? field-info)
+     (when (types/temporal-field? field-info)
        {:unit :default}))))
 
 (defmethod type-info :field-id [[_ field-id]]

--- a/src/metabase/sync/analyze/classifiers/category.clj
+++ b/src/metabase/sync/analyze/classifiers/category.clj
@@ -23,7 +23,7 @@
 
 (defn- cannot-be-category-or-list?
   [{:keys [base_type special_type]}]
-  (or (isa? base_type :type/DateTime)
+  (or (isa? base_type :type/Temporal)
       (isa? base_type :type/Collection)
       (isa? base_type :type/Float)
       ;; Don't let IDs become list Fields (they already can't become categories, because they already have a special

--- a/src/metabase/sync/analyze/classifiers/name.clj
+++ b/src/metabase/sync/analyze/classifiers/name.clj
@@ -2,9 +2,7 @@
   "Classifier that infers the special type of a Field based on its name and base type."
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [metabase
-             [config :as config]
-             [util :as u]]
+            [metabase.config :as config]
             [metabase.models.database :refer [Database]]
             [metabase.sync
              [interface :as i]
@@ -118,7 +116,7 @@
 (when-not config/is-prod?
   (doseq [[name-pattern base-types special-type] pattern+base-types+special-type]
     (assert (instance? java.util.regex.Pattern name-pattern))
-    (assert (every? (u/rpartial isa? :type/*) base-types))
+    (assert (every? #(isa? % :type/*) base-types))
     (assert (isa? special-type :type/*))))
 
 
@@ -140,7 +138,7 @@
    s/Any                          s/Any})
 
 (s/defn infer-special-type :- (s/maybe s/Keyword)
-  "Classifer that infers the special type of a FIELD based on its name and base type."
+  "Classifer that infers the special type of a `field` based on its name and base type."
   [field-or-column :- FieldOrColumn]
   ;; Don't overwrite keys, else we're ok with overwriting as a new more precise type might have
   ;; been added.

--- a/src/metabase/sync/analyze/classify.clj
+++ b/src/metabase/sync/analyze/classify.clj
@@ -75,7 +75,7 @@
    text-fingerprint/infer-special-type])
 
 (s/defn run-classifiers :- i/FieldInstance
-  "Run all the available `classifiers` against FIELD and FINGERPRINT, and return the resulting FIELD with changes
+  "Run all the available `classifiers` against `field` and `fingerprint`, and return the resulting `field` with changes
   decided upon by the classifiers."
   [field :- i/FieldInstance, fingerprint :- (s/maybe i/Fingerprint)]
   (loop [field field, [classifier & more] classifiers]
@@ -89,10 +89,11 @@
 
 
 (s/defn ^:private classify!
-  "Run various classifiers on FIELD and its FINGERPRINT, and save any detected changes."
+  "Run various classifiers on `field` and its `fingerprint`, and save any detected changes."
   ([field :- i/FieldInstance]
    (classify! field (or (:fingerprint field)
                         (db/select-one-field :fingerprint Field :id (u/get-id field)))))
+
   ([field :- i/FieldInstance, fingerprint :- (s/maybe i/Fingerprint)]
    (sync-util/with-error-handling (format "Error classifying %s" (sync-util/name-for-logging field))
      (let [updated-field (run-classifiers field fingerprint)]
@@ -105,8 +106,8 @@
 ;;; +------------------------------------------------------------------------------------------------------------------+
 
 (s/defn ^:private fields-to-classify :- (s/maybe [i/FieldInstance])
-  "Return a sequences of Fields belonging to TABLE for which we should attempt to determine special type. This should
-  include Fields that have the latest fingerprint, but have not yet *completed* analysis."
+  "Return a sequences of Fields belonging to `table` for which we should attempt to determine special type. This
+  should include Fields that have the latest fingerprint, but have not yet *completed* analysis."
   [table :- i/TableInstance]
   (seq (db/select Field
          :table_id            (u/get-id table)
@@ -127,8 +128,7 @@
                                                fields)}))
 
 (s/defn ^:always-validate classify-table!
-  "Run various classifiers on the TABLE. These do things like inferring (and
-   setting) entitiy type of TABLE."
+  "Run various classifiers on the `table`. These do things like inferring (and setting) entitiy type of `table`."
   [table :- i/TableInstance]
   (save-model-updates! table (name/infer-entity-type table)))
 

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -14,14 +14,16 @@
              [interface :as i]
              [util :as sync-util]]
             [metabase.sync.analyze.fingerprint.fingerprinters :as f]
-            [metabase.util.schema :as su]
+            [metabase.util
+             [i18n :refer [trs]]
+             [schema :as su]]
             [redux.core :as redux]
             [schema.core :as s]
             [toucan.db :as db]))
 
 (s/defn ^:private save-fingerprint!
   [field :- i/FieldInstance, fingerprint :- (s/maybe i/Fingerprint)]
-  (log/debug (format "Saving fingerprint for %s" (sync-util/name-for-logging field)))
+  (log/debug (trs "Saving fingerprint for {0}" (sync-util/name-for-logging field)))
   ;; All Fields who get new fingerprints should get marked as having the latest fingerprint version, but we'll
   ;; clear their values for `last_analyzed`. This way we know these fields haven't "completed" analysis for the
   ;; latest fingerprints.

--- a/src/metabase/sync/analyze/fingerprint/insights.clj
+++ b/src/metabase/sync/analyze/fingerprint/insights.clj
@@ -6,6 +6,7 @@
             [metabase.mbql.util :as mbql.u]
             [metabase.models.field :as field]
             [metabase.sync.analyze.fingerprint.fingerprinters :as f]
+            [metabase.util.date :as du]
             [redux.core :as redux]))
 
 (defn- last-n
@@ -214,13 +215,13 @@
                                          (assoc col :position idx)))
                           (group-by (fn [{:keys [base_type special_type unit] :as field}]
                                       (cond
-                                        (#{:type/FK :type/PK} special_type)          :others
-                                        (= unit :year)                               :datetimes
-                                        (metabase.util.date/date-extract-units unit) :numbers
-                                        (field/unix-timestamp? field)                :datetimes
-                                        (isa? base_type :type/Number)                :numbers
-                                        (isa? base_type :type/DateTime)              :datetimes
-                                        :else                                        :others))))]
+                                        (#{:type/FK :type/PK} special_type) :others
+                                        (= unit :year)                      :datetimes
+                                        (du/date-extract-units unit)        :numbers
+                                        (field/unix-timestamp? field)       :datetimes
+                                        (isa? base_type :type/Number)       :numbers
+                                        (isa? base_type :type/Temporal)     :datetimes
+                                        :else                               :others))))]
     (cond
       (timeseries? cols-by-type) (timeseries-insight cols-by-type)
       :else                      (f/constant-fingerprinter nil))))

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -114,8 +114,8 @@
    (s/optional-key :percent-email)  (s/maybe Percent)
    (s/optional-key :average-length) s/Num})
 
-(def DateTimeFingerprint
-  "Schema for fingerprint information for Fields deriving from `:type/DateTime`."
+(def TemporalFingerprint
+  "Schema for fingerprint information for Fields deriving from `:type/Temporal`."
   {(s/optional-key :earliest) (s/maybe s/Str)
    (s/optional-key :latest)   (s/maybe s/Str)})
 
@@ -124,7 +124,9 @@
   (s/constrained
    {(s/optional-key :type/Number)   NumberFingerprint
     (s/optional-key :type/Text)     TextFingerprint
-    (s/optional-key :type/DateTime) DateTimeFingerprint}
+    ;; temporal fingerprints are keyed by `:type/DateTime` for historical reasons. `DateTime` used to be the parent of
+    ;; all temporal MB types.
+    (s/optional-key :type/DateTime) TemporalFingerprint}
    (fn [m]
      (= 1 (count (keys m))))
    "Type-specific fingerprint with exactly one key"))

--- a/src/metabase/types.clj
+++ b/src/metabase/types.clj
@@ -80,19 +80,24 @@
 
 ;;; DateTime Types
 
-;; TODO - Consider renaming the parent of temporal types to `:type/Temporal`, and making `:type/DateTime` a sibling of
-;; `:type/Time` and `:type/Date` rather than its parent
-;; TIMEZONE FIXME
-(derive :type/DateTime :type/*)
-(derive :type/DateTimeWithTZ :type/DateTime)
-(derive :type/Time :type/DateTime)
-(derive :type/TimeWithTZ :type/Time)
-(derive :type/Date :type/DateTime)
-;; TODO - what about Date with timezone?
-;;
-;; TODO - should we differentiate between timezone offset vs ID, and what Oracle calls `TIMESTAMP WITH LOCAL TIME
-;; ZONE` (normalized to UTC when stored) vs columns that actually store offset?
+(derive :type/Temporal :type/*)
 
+(derive :type/Date :type/Temporal)
+;; You could have Dates with TZ info but it's not supported by JSR-310 so we'll not worry about that for now.
+
+(derive :type/Time :type/Temporal)
+(derive :type/TimeWithTZ :type/Time)
+(derive :type/TimeWithLocalTZ :type/TimeWithTZ)    ; a column that is timezone-aware, but normalized to UTC or another offset at rest.
+(derive :type/TimeWithZoneOffset :type/TimeWithTZ) ; a column that stores its timezone offset
+
+(derive :type/DateTime :type/Temporal)
+(derive :type/DateTimeWithTZ :type/DateTime)
+(derive :type/DateTimeWithLocalTZ :type/DateTimeWithTZ)    ; a column that is timezone-aware, but normalized to UTC or another offset at rest.
+(derive :type/DateTimeWithZoneOffset :type/DateTimeWithTZ) ; a column that stores its timezone offset, e.g. `-08:00`
+(derive :type/DateTimeWithZoneID :type/DateTimeWithTZ)     ; a column that stores its timezone ID, e.g. `US/Pacific`
+
+;; isn't this technically a :type/DateTimeWithLocalTZ? Since it's normalized to UTC
+;; TODO - consider whether it makes sense to have a separate `type/Instant` type
 (derive :type/UNIXTimestamp :type/DateTime)
 (derive :type/UNIXTimestamp :type/Integer)
 (derive :type/UNIXTimestampSeconds :type/UNIXTimestamp)
@@ -105,7 +110,7 @@
 (derive :type/CreationDate :type/CreationTimestamp)
 
 (derive :type/JoinTimestamp :type/DateTime)
-(derive :type/JoinTime :type/Date)
+(derive :type/JoinTime :type/Date) ; TODO - shouldn't this be derived from `:type/Time` ?
 (derive :type/JoinTime :type/JoinTimestamp)
 (derive :type/JoinDate :type/Date)
 (derive :type/JoinDate :type/JoinTimestamp)

--- a/src/metabase/util/date_2/parse.clj
+++ b/src/metabase/util/date_2/parse.clj
@@ -72,7 +72,7 @@
   "Parse a string into a `java.time` object."
   [^String s]
   {:pre [((some-fn string? nil?) s)]}
-  (when (seq s)
+  (when-not (str/blank? s)
     (let [s                 (normalize s)
           temporal-accessor (.parse formatter s)
           local-date        (query temporal-accessor :local-date)

--- a/src/metabase/util/ui_logic.clj
+++ b/src/metabase/util/ui_logic.clj
@@ -14,7 +14,7 @@
   (and (or (isa? base_type :type/Number)
            (isa? special_type :type/Number))
        (not (isa? special_type :type/Special))
-       (not (isa? special_type :type/DateTime))))
+       (not (isa? special_type :type/Temporal))))
 
 (defn- metric-column?
   "A metric column is any non-breakout column that is summable (numeric that isn't a special type like an FK/PK/Unix

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor.middleware.results-metadata-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
+            [expectations :refer [expect]]
             [metabase
              [query-processor :as qp]
              [util :as u]]
@@ -163,31 +164,31 @@
       round-to-2-decimals
       (->> (tu/round-fingerprint-cols [:columns]))))
 
-;; make sure that a Card where a DateTime column is broken out by year works the way we'd expect
-(expect
-  [{:base_type    "type/Date"
-    :display_name "Date"
-    :name         "DATE"
-    :unit         "year"
-    :special_type nil
-    :fingerprint  {:global {:distinct-count 618 :nil% 0.0}, :type {:type/DateTime {:earliest "2013-01-03T00:00:00.000Z"
-                                                                                   :latest   "2015-12-29T00:00:00.000Z"}}}}
-   {:base_type    "type/Integer"
-    :display_name "Count"
-    :name         "count"
-    :special_type "type/Quantity"
-    :fingerprint  {:global {:distinct-count 3
-                            :nil%           0.0},
-                   :type   {:type/Number {:min 235.0, :max 498.0, :avg 333.33 :q1 243.0, :q3 440.0 :sd 143.5}}}}]
-  (tt/with-temp Card [card]
-    (qp/process-query {:database (data/id)
-                       :type     :query
-                       :query    {:source-table (data/id :checkins)
-                                  :aggregation  [[:count]]
-                                  :breakout     [[:datetime-field [:field-id (data/id :checkins :date)] :year]]}
-                       :info     {:card-id    (u/get-id card)
-                                  :query-hash (qputil/query-hash {})}})
-    (-> card
-        card-metadata
-        round-to-2-decimals
-        tu/round-fingerprint-cols)))
+(deftest card-with-datetime-breakout-by-year-test
+  (testing "make sure that a Card where a DateTime column is broken out by year works the way we'd expect"
+    (is (= [{:base_type    "type/Date"
+             :display_name "Date"
+             :name         "DATE"
+             :unit         "year"
+             :special_type nil
+             :fingerprint  {:global {:distinct-count 618 :nil% 0.0}, :type {:type/DateTime {:earliest "2013-01-03T00:00:00.000Z"
+                                                                                            :latest   "2015-12-29T00:00:00.000Z"}}}}
+            {:base_type    "type/Integer"
+             :display_name "Count"
+             :name         "count"
+             :special_type "type/Quantity"
+             :fingerprint  {:global {:distinct-count 3
+                                     :nil%           0.0},
+                            :type   {:type/Number {:min 235.0, :max 498.0, :avg 333.33 :q1 243.0, :q3 440.0 :sd 143.5}}}}]
+           (tt/with-temp Card [card]
+             (qp/process-query {:database (data/id)
+                                :type     :query
+                                :query    {:source-table (data/id :checkins)
+                                           :aggregation  [[:count]]
+                                           :breakout     [[:datetime-field [:field-id (data/id :checkins :date)] :year]]}
+                                :info     {:card-id    (u/get-id card)
+                                           :query-hash (qputil/query-hash {})}})
+             (-> card
+                 card-metadata
+                 round-to-2-decimals
+                 tu/round-fingerprint-cols))))))

--- a/test/metabase/test/data/dataset_definitions.clj
+++ b/test/metabase/test/data/dataset_definitions.clj
@@ -1,6 +1,7 @@
 (ns metabase.test.data.dataset-definitions
   "Definitions of various datasets for use in tests with `data/dataset` and the like."
-  (:require [medley.core :as m]
+  (:require [java-time :as t]
+            [medley.core :as m]
             [metabase.test.data.interface :as tx])
   (:import java.sql.Time
            [java.util Calendar TimeZone]))
@@ -141,3 +142,47 @@
           [username last-login password-text (if (zero? idx)
                                                1
                                                idx)])))))
+
+(tx/defdataset ^:private attempted-murders
+  "A dataset for testing temporal values with and without timezones. Records of number of crow counts spoted and the
+  date/time when they spotting occured in several different column types."
+  [["attempts"
+    [{:field-name "num-crows",       :base-type :type/Integer}
+     {:field-name "date",            :base-type :type/Date}
+     {:field-name "time",            :base-type :type/Time}
+     {:field-name "time-ltz",        :base-type :type/TimeWithLocalTZ}
+     {:field-name "time-tz",         :base-type :type/TimeWithZoneOffset}
+     {:field-name "timestamp",       :base-type :type/DateTime}
+     {:field-name "timestamp-ltz",   :base-type :type/DateTimeWithLocalTZ}
+     {:field-name "timestamp-tz",    :base-type :type/DateTimeWithZoneOffset}
+     {:field-name "timestamp-tz-id", :base-type :type/DateTimeWithZoneID}]
+    (for [[cnt s] [[6 "2019-11-01T00:23:18.331-07:00[America/Los_Angeles]"]
+                   [8 "2019-11-02T00:14:14.246-07:00[America/Los_Angeles]"]
+                   [6 "2019-11-03T23:35:17.906-08:00[America/Los_Angeles]"]
+                   [7 "2019-11-04T01:04:09.593-08:00[America/Los_Angeles]"]
+                   [8 "2019-11-05T14:23:46.411-08:00[America/Los_Angeles]"]
+                   [4 "2019-11-06T18:51:16.270-08:00[America/Los_Angeles]"]
+                   [6 "2019-11-07T02:45:34.443-08:00[America/Los_Angeles]"]
+                   [4 "2019-11-08T19:51:39.753-08:00[America/Los_Angeles]"]
+                   [3 "2019-11-09T09:59:10.483-08:00[America/Los_Angeles]"]
+                   [1 "2019-11-10T08:41:35.860-08:00[America/Los_Angeles]"]
+                   [5 "2019-11-11T08:09:08.892-08:00[America/Los_Angeles]"]
+                   [3 "2019-11-12T07:36:16.088-08:00[America/Los_Angeles]"]
+                   [2 "2019-11-13T04:28:40.489-08:00[America/Los_Angeles]"]
+                   [9 "2019-11-14T09:52:17.242-08:00[America/Los_Angeles]"]
+                   [7 "2019-11-15T16:07:25.292-08:00[America/Los_Angeles]"]
+                   [7 "2019-11-16T13:32:16.936-08:00[America/Los_Angeles]"]
+                   [1 "2019-11-17T14:11:38.076-08:00[America/Los_Angeles]"]
+                   [3 "2019-11-18T20:47:27.902-08:00[America/Los_Angeles]"]
+                   [5 "2019-11-19T00:35:23.146-08:00[America/Los_Angeles]"]
+                   [1 "2019-11-20T20:09:55.752-08:00[America/Los_Angeles]"]]
+          :let    [t (t/zoned-date-time s)]]
+      [cnt                              ; num-crows
+       (t/local-date t)                 ; date
+       (t/local-time t)                 ; time
+       (t/offset-time t)                ; time-ltz
+       (t/offset-time t)                ; time-tz
+       (t/local-date-time t)            ; timestamp
+       (t/offset-date-time t)           ; timestamp-ltz
+       (t/offset-date-time t)           ; timestamp-tz
+       t])]])                           ; timestamp-tz-id

--- a/test/metabase/test/data/dataset_definitions.clj
+++ b/test/metabase/test/data/dataset_definitions.clj
@@ -152,10 +152,10 @@
      {:field-name "time",            :base-type :type/Time}
      {:field-name "time-ltz",        :base-type :type/TimeWithLocalTZ}
      {:field-name "time-tz",         :base-type :type/TimeWithZoneOffset}
-     {:field-name "timestamp",       :base-type :type/DateTime}
-     {:field-name "timestamp-ltz",   :base-type :type/DateTimeWithLocalTZ}
-     {:field-name "timestamp-tz",    :base-type :type/DateTimeWithZoneOffset}
-     {:field-name "timestamp-tz-id", :base-type :type/DateTimeWithZoneID}]
+     {:field-name "datetime",       :base-type :type/DateTime}
+     {:field-name "datetime-ltz",   :base-type :type/DateTimeWithLocalTZ}
+     {:field-name "datetime-tz",    :base-type :type/DateTimeWithZoneOffset}
+     {:field-name "datetime-tz-id", :base-type :type/DateTimeWithZoneID}]
     (for [[cnt s] [[6 "2019-11-01T00:23:18.331-07:00[America/Los_Angeles]"]
                    [8 "2019-11-02T00:14:14.246-07:00[America/Los_Angeles]"]
                    [6 "2019-11-03T23:35:17.906-08:00[America/Los_Angeles]"]
@@ -182,7 +182,7 @@
        (t/local-time t)                 ; time
        (t/offset-time t)                ; time-ltz
        (t/offset-time t)                ; time-tz
-       (t/local-date-time t)            ; timestamp
-       (t/offset-date-time t)           ; timestamp-ltz
-       (t/offset-date-time t)           ; timestamp-tz
-       t])]])                           ; timestamp-tz-id
+       (t/local-date-time t)            ; datetime
+       (t/offset-date-time t)           ; datetime-ltz
+       (t/offset-date-time t)           ; datetime-tz
+       t])]])                           ; datetime-tz-id

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -420,7 +420,22 @@
                           (dataset-table-definition table))})))
 
 (defmacro defdataset
-  "Define a new dataset to test against."
+  "Define a new dataset to test against. Definition should be of the format
+
+    [table-def+]
+
+  Where each table-def is of the format
+
+    [table-name [field-def+] [row+]]
+
+  e.g.
+
+  [[\"bird_species\"
+    [{:field-name \"name\", :base-type :type/Text}]
+    [[\"House Finch\"]
+     [\"Mourning Dove\"]]]]
+
+  Refer to the EDN definitions (e.g. `test-data.edn`) for more examples."
   ([dataset-name definition]
    `(defdataset ~dataset-name nil ~definition))
 

--- a/test/metabase/test/data/mysql.clj
+++ b/test/metabase/test/data/mysql.clj
@@ -13,13 +13,19 @@
 (doseq [[base-type database-type] {:type/BigInteger     "BIGINT"
                                    :type/Boolean        "BOOLEAN"
                                    :type/Date           "DATE"
-                                   :type/DateTime       "TIMESTAMP"
-                                   :type/DateTimeWithTZ "TIMESTAMP"
+                                   ;; (3) is fractional seconds precision, i.e. millisecond precision
+                                   :type/DateTime       "DATETIME(3)"
+                                   ;; MySQL is extra dumb and can't have two `TIMESTAMP` columns without default
+                                   ;; values — see
+                                   ;; https://stackoverflow.com/questions/11601034/unable-to-create-2-timestamp-columns-in-1-mysql-table.
+                                   ;; They also have to have non-zero values. See also
+                                   ;; https://dba.stackexchange.com/questions/6171/invalid-default-value-for-datetime-when-changing-to-utf8-general-ci
+                                   :type/DateTimeWithTZ "TIMESTAMP(3) DEFAULT '1970-01-01 00:00:01'"
                                    :type/Decimal        "DECIMAL"
                                    :type/Float          "DOUBLE"
                                    :type/Integer        "INTEGER"
                                    :type/Text           "TEXT"
-                                   :type/Time           "TIME"}]
+                                   :type/Time           "TIME(3)"}]
   (defmethod sql.tx/field-base-type->sql-type [:mysql base-type] [_ _] database-type))
 
 (defmethod tx/dbdef->connection-details :mysql
@@ -41,5 +47,10 @@
 (defmethod load-data/load-data! :mysql
   [& args]
   (apply load-data/load-data-all-at-once! args))
+
+#_(defmethod load-data/do-insert! :mysql
+  [driver spec table-identifier row-or-rows]
+  (jdbc/execute! spec "SET @@session.time_zone = 'UTC'");
+  ((get-method load-data/do-insert! :sql-jdbc/test-extensions) driver spec table-identifier row-or-rows))
 
 (defmethod sql.tx/pk-sql-type :mysql [_] "INTEGER NOT NULL AUTO_INCREMENT")

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -26,6 +26,7 @@
                              :type/IPAddress      "INET"
                              :type/Text           "TEXT"
                              :type/Time           "TIME"
+                             :type/TimeWithTZ     "TIME WITH TIME ZONE"
                              :type/UUID           "UUID"}]
   (defmethod sql.tx/field-base-type->sql-type [:postgres base-type] [_ _] db-type))
 

--- a/test/metabase/test/data/sql_jdbc/load_data.clj
+++ b/test/metabase/test/data/sql_jdbc/load_data.clj
@@ -6,7 +6,9 @@
             [metabase
              [driver :as driver]
              [util :as u]]
+            [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.driver.sql.query-processor :as sql.qp]
+            [metabase.query-processor.timezone :as qp.timezone]
             [metabase.test.data
              [interface :as tx]
              [sql :as sql.tx]]
@@ -180,14 +182,21 @@
 (defmethod do-insert! :sql-jdbc/test-extensions
   [driver spec table-identifier row-or-rows]
   (let [statements (ddl/insert-rows-ddl-statements driver table-identifier row-or-rows)]
-    (try
-      ;; TODO - why don't we use `execute/execute-sql!` here like we do below?
-      (doseq [sql+args statements]
-        (jdbc/execute! spec sql+args))
-      (catch SQLException e
-        (println (u/format-color 'red "INSERT FAILED: \n%s\n" statements))
-        (jdbc/print-sql-exception-chain e)
-        (throw e)))))
+    ;; `set-parameters` might try to look at DB timezone; we don't want to do that while loading the data because the
+    ;; DB hasn't been synced yet
+    (when-let [set-timezone-format-string (sql-jdbc.execute/set-timezone-sql driver)]
+      (let [set-timezone-sql (format set-timezone-format-string "'UTC'")]
+        (log/debugf "Setting timezone to UTC before inserting data with SQL \"%s\"" set-timezone-sql)
+        (jdbc/execute! spec [set-timezone-sql])))
+    (qp.timezone/with-database-timezone-id nil
+      (try
+        ;; TODO - why don't we use `execute/execute-sql!` here like we do below?
+        (doseq [sql+args statements]
+          (jdbc/execute! spec sql+args {:set-parameters (partial sql-jdbc.execute/set-parameters driver)}))
+        (catch SQLException e
+          (println (u/format-color 'red "INSERT FAILED: \n%s\n" statements))
+          (jdbc/print-sql-exception-chain e)
+          (throw e))))))
 
 (defn create-db!
   "Default implementation of `create-db!` for SQL drivers."

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -123,7 +123,12 @@
   (testing "nil"
     (is (= nil
            (u.date/parse nil))
-        "Passing `nil` should return `nil`")))
+        "Passing `nil` should return `nil`"))
+  (testing "blank strings"
+    (is (= nil
+           (u.date/parse ""))
+        (= nil
+           (u.date/parse "   ")))))
 
 ;; TODO - more tests!
 (deftest format-test

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -96,11 +96,20 @@
         (is-parsed? expected s "US/Pacific"))))
   (testing "Weird formats"
     (is (= (t/offset-date-time "2014-08-01T10:00-07:00")
-           (u.date/parse "2014-08-01 10:00:00.000 -0700")))
-    (is (= (t/zoned-date-time "2014-08-01T10:00Z[UTC]")
-           (u.date/parse "2014-08-01 10:00:00.000 UTC")))
-    (is (= (t/zoned-date-time "2014-08-02T00:00+08:00[Asia/Hong_Kong]")
-           (u.date/parse "2014-08-02 00:00:00.000 Asia/Hong_Kong")))))
+           (u.date/parse "2014-08-01 10:00:00.000 -0700"))
+        "Should be able to parse SQL-style literals where Zone offset is separated by a space, with no colons between hour and minute")
+    (testing "Should be able to parse SQL-style literals where Zone ID is separated by a space, without brackets"
+      (is (= (t/zoned-date-time "2014-08-01T10:00Z[UTC]")
+             (u.date/parse "2014-08-01 10:00:00.000 UTC")))
+      (is (= (t/zoned-date-time "2014-08-02T00:00+08:00[Asia/Hong_Kong]")
+             (u.date/parse "2014-08-02 00:00:00.000 Asia/Hong_Kong"))))
+    (is (= (t/offset-time "07:23:18.331Z")
+           (u.date/parse "07:23:18.331+00"))
+        "Should be able to parse strings with '+00' (hour-only) offsets"))
+  (testing "nil"
+    (is (= nil
+           (u.date/parse nil))
+        "Passing `nil` should return `nil`")))
 
 ;; TODO - more tests!
 (deftest format-test

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -95,17 +95,31 @@
         ;; OffsetDateTime
         (is-parsed? expected s "US/Pacific"))))
   (testing "Weird formats"
-    (is (= (t/offset-date-time "2014-08-01T10:00-07:00")
-           (u.date/parse "2014-08-01 10:00:00.000 -0700"))
-        "Should be able to parse SQL-style literals where Zone offset is separated by a space, with no colons between hour and minute")
+    (testing "Should be able to parse SQL-style literals where Zone offset is separated by a space, with no colons between hour and minute"
+      (is (= (t/offset-date-time "2014-08-01T10:00-07:00")
+             (u.date/parse "2014-08-01 10:00:00.000 -0700")))
+      (is (= (t/offset-date-time "2014-08-01T10:00-07:00")
+             (u.date/parse "2014-08-01 10:00:00 -0700")))
+      (is (= (t/offset-date-time "2014-08-01T10:00-07:00")
+             (u.date/parse "2014-08-01 10:00 -0700"))))
     (testing "Should be able to parse SQL-style literals where Zone ID is separated by a space, without brackets"
       (is (= (t/zoned-date-time "2014-08-01T10:00Z[UTC]")
              (u.date/parse "2014-08-01 10:00:00.000 UTC")))
       (is (= (t/zoned-date-time "2014-08-02T00:00+08:00[Asia/Hong_Kong]")
              (u.date/parse "2014-08-02 00:00:00.000 Asia/Hong_Kong"))))
-    (is (= (t/offset-time "07:23:18.331Z")
-           (u.date/parse "07:23:18.331+00"))
-        "Should be able to parse strings with '+00' (hour-only) offsets"))
+    (testing "Should be able to parse strings with hour-only offsets e.g. '+00'"
+      (is (= (t/offset-time "07:23:18.331Z")
+             (u.date/parse "07:23:18.331-00")))
+      (is (= (t/offset-time "07:23:18.000Z")
+             (u.date/parse "07:23:18-00")))
+      (is (= (t/offset-time "07:23:00.000Z")
+             (u.date/parse "07:23-00")))
+      (is (= (t/offset-time "07:23:18.331-08:00")
+             (u.date/parse "07:23:18.331-08")))
+      (is (= (t/offset-time "07:23:18.000-08:00")
+             (u.date/parse "07:23:18-08")))
+      (is (= (t/offset-time "07:23:00.000-08:00")
+             (u.date/parse "07:23-08")))))
   (testing "nil"
     (is (= nil
            (u.date/parse nil))
@@ -126,8 +140,7 @@
                                           :times     [(t/local-time  14 3 40 (* 555 1000000))
                                                       (t/offset-time 14 3 40 (* 555 1000000) (t/zone-offset -7))]
                                           :datetimes [(t/offset-date-time 2019 10 27 14 3 40 (* 555 1000000) (t/zone-offset -7))
-                                                      (t/zoned-date-time  2019 10 27 14 3 40 (* 555 1000000) (t/zone-id "America/Los_Angeles"))
-                                                      #_(t/instant (t/zoned-date-time  2019 10 27 14 3 40 (* 555 1000000) (t/zone-id "UTC")))]}]
+                                                      (t/zoned-date-time  2019 10 27 14 3 40 (* 555 1000000) (t/zone-id "America/Los_Angeles"))]}]
     (doseq [[categories unit->expected] {#{:times :datetimes} {:minute-of-hour 3
                                                                :hour-of-day    14}
                                          #{:dates :datetimes} {:day-of-week      1


### PR DESCRIPTION
*  Differentiate between columns that record timezone info vs ones that are normalized. (i.e., `TIMESTAMP WITH TIME ZONE` vs. `TIMESTAMP WITH LOCAL TIME ZONE` in Oracle and other DBs that have this distinction.) Also differentiate between recording offset from UTC and Zone ID.
*  New `:type/Temporal` base type for `:type/Date`, `:type/Time`, and `:type/DateTime`. Previously, `:type/Date` and `:type/Time` derived from `:type/DateTime` which didn't quite make sense.
*  Add new `attempted-murders` dataset to count number of crows spotted. Has same temporal instant in a variety of formats with and without timezone to facilitate writing new tests
*  New tests for `TIME WITH TIME ZONE` columns.
*  Fix MySQL behavior for `TIMESTAMP` columns, which are the equivalent of Oracle `TIMESTAMP WITH LOCAL TIME ZONE` (i.e., they are normalized to UTC when stored) vs `DATETIME` (which are Local non-timezone-aware columns).

Fixes #6273 
Fixes #7968
Fixes #8567