### PR TITLE
Don't center pie charts on dashboards

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartWithLegend.jsx
@@ -34,6 +34,7 @@ export default class ChartWithLegend extends Component {
       height,
       width,
       showLegend,
+      isDashboard,
     } = this.props;
 
     // padding
@@ -129,7 +130,15 @@ export default class ChartWithLegend extends Component {
           {children}
         </div>
         {/* spacer div to balance legend */}
-        {legend && <div className={cx(styles.LegendSpacer)}>{legend}</div>}
+        {legend && (
+          <div
+            className={cx(styles.LegendSpacer)}
+            // don't center the chart on dashboards
+            style={isDashboard ? { flexBasis: 0 } : {}}
+          >
+            {legend}
+          </div>
+        )}
       </div>
     );
   }

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -317,6 +317,7 @@ export default class ChoroplethMap extends Component {
         gridSize={gridSize}
         hovered={hovered}
         onHoverChange={onHoverChange}
+        isDashboard={this.props.isDashboard}
       >
         {projection ? (
           <LegacyChoropleth

--- a/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart.jsx
@@ -402,6 +402,7 @@ export default class PieChart extends Component {
           onHoverChange(d && { ...d, ...hoverForIndex(d.index) })
         }
         showLegend={settings["pie.show_legend"]}
+        isDashboard={this.props.isDashboard}
       >
         <div className={styles.ChartAndDetail}>
           <div ref="detail" className={styles.Detail}>

--- a/modules/drivers/oracle/project.clj
+++ b/modules/drivers/oracle/project.clj
@@ -1,6 +1,8 @@
 (defproject metabase/oracle-driver "1.0.0"
   :min-lein-version "2.5.0"
 
+  :include-drivers-dependencies [#"^ojdbc\d+\.jar$"]
+
   :profiles
   {:provided
    {:dependencies

--- a/project.clj
+++ b/project.clj
@@ -260,13 +260,12 @@
    :eastwood
    [:include-all-drivers
     {:plugins
-     [[jonase/eastwood "0.3.1" :exclusions [org.clojure/clojure]]]
+     [[jonase/eastwood "0.3.6" :exclusions [org.clojure/clojure]]]
 
      :eastwood
-     {:exclude-namespaces [:test-paths dev]
+     {:exclude-namespaces [:test-paths dev dev.test]
       :config-files       ["./test_resources/eastwood-config.clj"]
       :add-linters        [:unused-private-vars
-                           :unused-namespaces
                            ;; These linters are pretty useful but give a few false positives and can't be selectively
                            ;; disabled (yet)
                            ;;
@@ -277,8 +276,12 @@
                            ;; get them to work
                            #_:unused-fn-args
                            #_:unused-locals]
-      ;; Turn this off temporarily until we finish removing self-deprecated functions & macros
-      :exclude-linters    [:deprecations]}}]
+      :exclude-linters    [; Turn this off temporarily until we finish removing self-deprecated functions & macros
+                           :deprecations
+                           ;; this has a fit in libs that use Potemin `import-vars` such as `java-time`
+                           :implicit-dependencies
+                           ;; too many false positives for now
+                           :unused-ret-vals]}}]
 
    ;; run ./bin/reflection-linter to check for reflection warnings
    :reflection-warnings

--- a/project.clj
+++ b/project.clj
@@ -116,7 +116,7 @@
    [org.flatland/ordered "1.5.7"]                                     ; ordered maps & sets
    [org.liquibase/liquibase-core "3.6.3"                              ; migration management (Java lib)
     :exclusions [ch.qos.logback/logback-classic]]
-   [org.mariadb.jdbc/mariadb-java-client "2.5.1"]                     ; MySQL/MariaDB driver 
+   [org.mariadb.jdbc/mariadb-java-client "2.5.1"]                     ; MySQL/MariaDB driver
    [org.postgresql/postgresql "42.2.5"]                               ; Postgres driver
    [org.slf4j/slf4j-log4j12 "1.7.25"]                                 ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
    [org.tcrawley/dynapath "1.0.0"]                                    ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath
@@ -243,7 +243,10 @@
 
    :include-all-drivers
    [:with-include-drivers-middleware
-    {:include-drivers :all}]
+   {:include-drivers :all
+    :injections
+    [(require 'metabase.plugins)
+     (metabase.plugins/load-plugins!)]}]
 
    :repl
    [:include-all-drivers


### PR DESCRIPTION
This isn't quite a full revert to previous functionality, but it does prevent aggressive centering on dashboards.

# Before
## Question
![image](https://user-images.githubusercontent.com/691495/68796126-4edc4500-0620-11ea-9f1c-5d6ffa085388.png)
## Dashboard
![image](https://user-images.githubusercontent.com/691495/68796339-b1cddc00-0620-11ea-99a9-cb27d681b1fb.png)
![image](https://user-images.githubusercontent.com/691495/68796154-5b609d80-0620-11ea-8f8c-d8574868d7fe.png)


# After
## Question (unchanged)
![image](https://user-images.githubusercontent.com/691495/68795854-c78ed180-061f-11ea-9784-0151e661d80d.png)
## Dashboard
![image](https://user-images.githubusercontent.com/691495/68795875-d2496680-061f-11ea-9aa9-ca43535e3ea9.png)
![image](https://user-images.githubusercontent.com/691495/68795927-e4c3a000-061f-11ea-8680-265d8aa2d931.png)
