### PR TITLE
Don't attempt to load card metadata if the card's table wasn't fetched

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -40,6 +40,7 @@ import {
   getResultsMetadata,
   getFirstQueryResult,
   getIsPreviewing,
+  getTables,
   getTableForeignKeys,
   getQueryBuilderMode,
   getIsShowingTemplateTagsEditor,
@@ -447,7 +448,13 @@ export const initializeQB = (location, params) => {
     }
     // Fetch the question metadata (blocking)
     if (card) {
-      await dispatch(loadMetadataForCard(card));
+      const { tables } = getMetadata(getState());
+      // Only fetch the table metadata if the table was returned in the earlier
+      // call to fetch databases and tables. Otherwise, this user doesn't have
+      // permissions and the call will fail.
+      if (tables[card.table_id] != null) {
+        await dispatch(loadMetadataForCard(card));
+      }
     }
 
     // Update the question to Redux state together with the initial state of UI controls

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -40,7 +40,6 @@ import {
   getResultsMetadata,
   getFirstQueryResult,
   getIsPreviewing,
-  getTables,
   getTableForeignKeys,
   getQueryBuilderMode,
   getIsShowingTemplateTagsEditor,

--- a/frontend/test/__support__/e2e.js
+++ b/frontend/test/__support__/e2e.js
@@ -52,7 +52,7 @@ let hasFinishedCreatingStore = false;
 let loginSession = null; // Stores the current login session
 let previousLoginSession = null;
 let simulateOfflineMode = false;
-const apiRequestCompletedCallbacks = [];
+let apiRequestCompletedCallbacks = [];
 let skippedApiRequests = [];
 
 // load files that are loaded at the top if app.js
@@ -462,7 +462,7 @@ export const waitForRequestToComplete = (
       );
       removeCallback();
     }, timeout);
-    const cb = (requestMethod, requestUrl) => {
+    const callback = (requestMethod, requestUrl) => {
       if (requestMethod === method && urlRegex.test(requestUrl)) {
         clearTimeout(completionTimeoutId);
         removeCallback();
@@ -472,10 +472,11 @@ export const waitForRequestToComplete = (
       }
     };
     const removeCallback = () => {
-      const index = apiRequestCompletedCallbacks.findIndex(f => f === cb);
-      apiRequestCompletedCallbacks.splice(index, 1);
+      apiRequestCompletedCallbacks = apiRequestCompletedCallbacks.filter(
+        f => f !== callback,
+      );
     };
-    apiRequestCompletedCallbacks.push(cb);
+    apiRequestCompletedCallbacks.push(callback);
   });
 };
 

--- a/frontend/test/__support__/e2e.js
+++ b/frontend/test/__support__/e2e.js
@@ -52,7 +52,7 @@ let hasFinishedCreatingStore = false;
 let loginSession = null; // Stores the current login session
 let previousLoginSession = null;
 let simulateOfflineMode = false;
-let apiRequestCompletedCallback = null;
+const apiRequestCompletedCallbacks = [];
 let skippedApiRequests = [];
 
 // load files that are loaded at the top if app.js
@@ -460,16 +460,22 @@ export const waitForRequestToComplete = (
             ) || "No requests"}`,
         ),
       );
+      removeCallback();
     }, timeout);
-
-    apiRequestCompletedCallback = (requestMethod, requestUrl) => {
+    const cb = (requestMethod, requestUrl) => {
       if (requestMethod === method && urlRegex.test(requestUrl)) {
         clearTimeout(completionTimeoutId);
+        removeCallback();
         resolve();
       } else {
         skippedApiRequests.push(`${requestMethod} ${requestUrl}`);
       }
     };
+    const removeCallback = () => {
+      const index = apiRequestCompletedCallbacks.findIndex(f => f === cb);
+      apiRequestCompletedCallbacks.splice(index, 1);
+    };
+    apiRequestCompletedCallbacks.push(cb);
   });
 };
 
@@ -664,8 +670,9 @@ api._makeRequest = async (method, url, headers, requestBody, data, options) => {
       resultBody = JSON.parse(resultBody);
     } catch (e) {}
 
-    apiRequestCompletedCallback &&
-      setTimeout(() => apiRequestCompletedCallback(method, url), 0);
+    apiRequestCompletedCallbacks.forEach(f =>
+      setTimeout(() => f(method, url), 0),
+    );
 
     events.emit("request", { method, url });
 

--- a/frontend/test/metabase/parameters/parameters.e2e.spec.js
+++ b/frontend/test/metabase/parameters/parameters.e2e.spec.js
@@ -224,7 +224,10 @@ describe("parameters", () => {
       store.pushPath(Urls.question(question.id()) + "?id=1");
       app = mount(store.getAppContainer());
 
-      await waitForRequestToComplete("GET", /^\/api\/card\/\d+/);
+      await Promise.all([
+        waitForRequestToComplete("GET", /^\/api\/database.*include_tables/),
+        waitForRequestToComplete("GET", /^\/api\/card\/\d+/),
+      ]);
       expect(app.find("ViewHeading").text()).toEqual("Test Question");
 
       // wait for the query to load

--- a/frontend/test/metabase/scenarios/query_builder.e2e.spec.js
+++ b/frontend/test/metabase/scenarios/query_builder.e2e.spec.js
@@ -31,9 +31,7 @@ describe("query builder", () => {
       await app.async.findByText("Simple question").click();
 
       await waitForAllRequestsToComplete(); // race condition in DataSelector with loading metadata
-      try {
-        await app.async.findByText("Sample Dataset").click(); // not needed if there's only one database
-      } catch (e) {}
+      await maybeClickSampleDataset(app);
       await app.async.findByText("Orders").click();
       await app.async.findByText("37.65");
     });
@@ -47,9 +45,7 @@ describe("query builder", () => {
       await app.async.findByText("Custom question").click();
 
       await waitForAllRequestsToComplete(); // race condition in DataSelector with loading metadata
-      try {
-        await app.async.findByText("Sample Dataset").click(); // not needed if there's only one database
-      } catch (e) {}
+      await maybeClickSampleDataset(app);
       await app.async.findByText("Orders").click();
       await app.async.findByText("Visualize").click();
       await app.async.findByText("37.65");
@@ -62,9 +58,7 @@ describe("query builder", () => {
       await app.async.findByText("Custom question").click();
 
       await waitForAllRequestsToComplete(); // race condition in DataSelector with loading metadata
-      try {
-        await app.async.findByText("Sample Dataset").click(); // not needed if there's only one database
-      } catch (e) {}
+      await maybeClickSampleDataset(app);
       await app.async.findByText("Orders").click();
       await app.async.findByText("Pick the metric you want to see").click();
       await app.async.findByText("Count of rows").click();
@@ -103,3 +97,14 @@ describe("query builder", () => {
     });
   });
 });
+
+// This isn't needed if there's only one db. In that case, clicking "Sample
+// Dataset" will actually take you back to select a db again.
+async function maybeClickSampleDataset(app) {
+  try {
+    const sampleDataset = await app.async.findByText("Sample Dataset");
+    if (sampleDataset.hasClass("List-section-title")) {
+      sampleDataset.click();
+    }
+  } catch (e) {}
+}


### PR DESCRIPTION
Resolves #11297

This PR fixes the immediate cause of the bug but doesn't address the larger issues:

## 1. What's the right way to display the QB UI in this state?

* Should we hide the bottom bar that contains Visualzation and Settings?
* Should we allow tables headers to be filtered or reordered?
* Should we allow drill through? What about custom drill through in EE?

In v0.33.3, without data permissions we didn't show the "clicky chevrons" in table headers. That feels like the right behavior. However, as far as I can tell this was by accident. When getting the click actions an error occurred, which resulted in [visualizationIsClickable](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/visualizations/components/Visualization.jsx#L282-L287) returning false.

## 2. How should we handle failed API calls

We should avoid making calls to endpoints that will 403. If we do get a 403, we probably shouldn't blow up the page. Even if we avoid all situations like that, these API calls still might fail. @camsaul suggested that we shouldn't break the question if auxiliary endpoints fail. 

I'm hesitant to just silence all API errors on secondary endpoints. If fetching table metadata fails, we can no longer display some essential UI for editing a question. Can we come up with a good, general way to gracefully degrade when we have most of the data? e.g. maybe we display an error to the user but never let the exception bubble up and break things.

## 3. We need some better tests

@camsaul pointed out that this looks very much like #10656. While the root cause was different, a few good e2e tests would have caught either situation.

I started implementing those in [this file](https://github.com/metabase/metabase/blob/master/frontend/test/metabase/scenarios/query_builder.e2e.spec.js), but it seemed like it was going to be a mess. Instead, I'm going to add them to #11302. That will be a good opportunity to to test out Cypress some more, but if we end up abandoning it, I'll need to port the tests.