### PR TITLE
Fix DockerHub automated build

### DIFF
--- a/modules/drivers/bigquery/project.clj
+++ b/modules/drivers/bigquery/project.clj
@@ -7,7 +7,8 @@
   :profiles
   {:provided
    {:dependencies
-    [[metabase-core "1.0.0-SNAPSHOT"]
+    [[org.clojure/clojure "1.10.1"]
+     [metabase-core "1.0.0-SNAPSHOT"]
      [metabase/google-driver "1.0.0-SNAPSHOT-1.27.0"]]}
 
    :uberjar

--- a/modules/drivers/druid/project.clj
+++ b/modules/drivers/druid/project.clj
@@ -3,7 +3,8 @@
 
   :profiles
   {:provided
-   {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}
+   {:dependencies [[org.clojure/clojure "1.10.1"]
+                   [metabase-core "1.0.0-SNAPSHOT"]]}
 
    :uberjar
    {:auto-clean    true

--- a/modules/drivers/google/project.clj
+++ b/modules/drivers/google/project.clj
@@ -10,7 +10,8 @@
   :profiles
   {:provided
    {:dependencies
-    [[metabase-core "1.0.0-SNAPSHOT"]]}
+    [[org.clojure/clojure "1.10.1"]
+     [metabase-core "1.0.0-SNAPSHOT"]]}
 
    :install-for-building-drivers
    {:auto-clean true

--- a/modules/drivers/googleanalytics/project.clj
+++ b/modules/drivers/googleanalytics/project.clj
@@ -7,7 +7,8 @@
   :profiles
   {:provided
    {:dependencies
-    [[metabase-core "1.0.0-SNAPSHOT"]
+    [[org.clojure/clojure "1.10.1"]
+     [metabase-core "1.0.0-SNAPSHOT"]
      [metabase/google-driver "1.0.0-SNAPSHOT-1.27.0"]]}
 
    :uberjar

--- a/modules/drivers/mongo/project.clj
+++ b/modules/drivers/mongo/project.clj
@@ -6,7 +6,8 @@
 
   :profiles
   {:provided
-   {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}
+   {:dependencies [[org.clojure/clojure "1.10.1"]
+                   [metabase-core "1.0.0-SNAPSHOT"]]}
 
    :uberjar
    {:auto-clean    true

--- a/modules/drivers/oracle/project.clj
+++ b/modules/drivers/oracle/project.clj
@@ -7,7 +7,8 @@
   {:provided
    {:dependencies
     ;; can't ship it as part of MB!
-    [[com.oracle.ojdbc/ojdbc8 "19.3.0.0"]
+    [[org.clojure/clojure "1.10.1"]
+     [com.oracle.ojdbc/ojdbc8 "19.3.0.0"]
      [metabase-core "1.0.0-SNAPSHOT"]]}
 
    :uberjar

--- a/modules/drivers/presto/project.clj
+++ b/modules/drivers/presto/project.clj
@@ -3,7 +3,9 @@
 
   :profiles
   {:provided
-   {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}
+   {:dependencies
+    [[org.clojure/clojure "1.10.1"]
+     [metabase-core "1.0.0-SNAPSHOT"]]}
 
    :uberjar
    {:auto-clean    true

--- a/modules/drivers/redshift/project.clj
+++ b/modules/drivers/redshift/project.clj
@@ -10,7 +10,9 @@
 
   :profiles
   {:provided
-   {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}
+   {:dependencies
+    [[org.clojure/clojure "1.10.1"]
+     [metabase-core "1.0.0-SNAPSHOT"]]}
 
    :uberjar
    {:auto-clean    true

--- a/modules/drivers/snowflake/project.clj
+++ b/modules/drivers/snowflake/project.clj
@@ -6,7 +6,9 @@
 
   :profiles
   {:provided
-   {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}
+   {:dependencies
+    [[org.clojure/clojure "1.10.1"]
+     [metabase-core "1.0.0-SNAPSHOT"]]}
 
    :uberjar
    {:auto-clean    true

--- a/modules/drivers/sparksql/project.clj
+++ b/modules/drivers/sparksql/project.clj
@@ -37,7 +37,8 @@
   :profiles
   {:provided
    {:dependencies
-    [[metabase-core "1.0.0-SNAPSHOT"]]}
+    [[org.clojure/clojure "1.10.1"]
+     [metabase-core "1.0.0-SNAPSHOT"]]}
 
    :uberjar
    {:auto-clean    true

--- a/modules/drivers/sqlite/project.clj
+++ b/modules/drivers/sqlite/project.clj
@@ -6,7 +6,9 @@
 
   :profiles
   {:provided
-   {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}
+   {:dependencies
+    [[org.clojure/clojure "1.10.1"]
+     [metabase-core "1.0.0-SNAPSHOT"]]}
 
    :uberjar
    {:auto-clean    true

--- a/modules/drivers/sqlserver/project.clj
+++ b/modules/drivers/sqlserver/project.clj
@@ -6,7 +6,9 @@
 
   :profiles
   {:provided
-   {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}
+   {:dependencies
+    [[org.clojure/clojure "1.10.1"]
+     [metabase-core "1.0.0-SNAPSHOT"]]}
 
    :uberjar
    {:auto-clean    true

--- a/modules/drivers/vertica/project.clj
+++ b/modules/drivers/vertica/project.clj
@@ -5,7 +5,9 @@
 
   :profiles
   {:provided
-   {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}
+   {:dependencies
+    [[org.clojure/clojure "1.10.1"]
+     [metabase-core "1.0.0-SNAPSHOT"]]}
 
    :uberjar
    {:auto-clean    true


### PR DESCRIPTION
Make sure driver projects all have an provided dependency on the latest version of Clojure so they don't end up getting built with an older version