### PR TITLE
Fix webpack config for file-loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,7 +85,7 @@ const config = (module.exports = {
       },
       {
         test: /\.(eot|woff2?|ttf|svg|png)$/,
-        use: [{ loader: "file-loader", options: { publicPath: "./" } }],
+        use: [{ loader: "file-loader" }],
       },
       {
         test: /\.css$/,
@@ -95,6 +95,7 @@ const config = (module.exports = {
             { loader: "css-loader", options: CSS_CONFIG },
             { loader: "postcss-loader" },
           ],
+          publicPath: "./",
         }),
       },
     ],


### PR DESCRIPTION
Resolves #11282

This really should have been fixed in #11206, but there were still some bugs. In an attempt to avoid more missed cases, here's a list of things I'm testing with the most recent changes.

Assets to test:
- [x] fonts (only imported from css)
Note: a 200 does not mean it loaded correctly. Chrome dev tools has a "Rendered Fonts" section in computed styles.
- [x] images imported in js
The icon on our [not found page](http://localhost:3000/not-a-page) is an example of this.
- [x] images imported in css
The icon displayed when a [query is empty](http://localhost:3000/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InF1ZXJ5Ijp7InNvdXJjZS10YWJsZSI6MiwiZmlsdGVyIjpbImFuZCIsWyI9IixbImZpZWxkLWlkIiwxMl0sMjMzMjQ4OV1dfSwidHlwZSI6InF1ZXJ5IiwiZGF0YWJhc2UiOjF9LCJkaXNwbGF5IjoidGFibGUiLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=) is an example of this.

All the above assets should work in these situations:
- [x] when hosting Metabase on subpath
- [x] local dev with `yarn build-hot`

Before testing I'm cleaning out dist with: `rm resources/frontend_client/app/dist/*`
