### PR TITLE
Druid: fix HLL aggregation queries 

### DIFF
--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -578,6 +578,10 @@
   [filtr aggregator]
   {:type :filtered, :filter filtr, :aggregator aggregator})
 
+(defn- hyper-unique?
+  [[_ field-id]]
+  (-> field-id qp.store/field :base_type (isa? :type/DruidHyperUnique)))
+
 (defn- ag:distinct
   [field output-name]
   (cond
@@ -587,7 +591,7 @@
      :fieldNames (mapv ->rvalue (rest field))
      :byRow      true
      :round      true}
-    (isa? (:base-type field) :type/DruidHyperUnique)
+    (hyper-unique? field)
     {:type      :hyperUnique
      :name      output-name
      :fieldName (->rvalue field)}
@@ -602,7 +606,7 @@
   ([output-name]
    {:type :count, :name output-name})
   ([field output-name]
-   (if (isa? (:base-type field) :type/DruidHyperUnique)
+   (if (hyper-unique? field)
      {:type      :hyperUnique
       :name      output-name
       :fieldName (->rvalue field)}

--- a/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/query_processor.clj
@@ -606,7 +606,8 @@
   ([output-name]
    {:type :count, :name output-name})
   ([field output-name]
-   (if (hyper-unique? field)
+   (if (and (mbql.u/is-clause? #{:field-id} field)
+            (hyper-unique? field))
      {:type      :hyperUnique
       :name      output-name
       :fieldName (->rvalue field)}

--- a/modules/drivers/druid/test/metabase/driver/druid_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid_test.clj
@@ -456,7 +456,7 @@
    ["Bar" "Felipinho Asklepios" 10]
    ["Bar" "Kaneonuskatew Eiran" 10]]
   (druid-query-returning-rows
-    {:aggregation [[:aggregation-options [:count $checkins.user_name] {:name "__count_0"}]]
+    {:aggregation [[:aggregation-options [:count $checkins.user_name] {:name "unique_users"}]]
      :breakout   [$venue_category_name $user_name]
      :order-by   [[:desc [:aggregation 0]] [:asc $checkins.venue_category_name]]
      :limit      5}))

--- a/modules/drivers/druid/test/metabase/test/data/druid.clj
+++ b/modules/drivers/druid/test/metabase/test/data/druid.clj
@@ -70,9 +70,7 @@
                                                                       :format :auto}
                                                      :dimensionsSpec {:dimensions ["id"
                                                                                    "user_last_login"
-                                                                                   {:name "user_name"
-                                                                                    :type "string"
-                                                                                    :isInputHyperUnique true}
+                                                                                   "user_name"
                                                                                    "user_password"
                                                                                    "venue_category_name"
                                                                                    {:name "venue_latitude"
@@ -83,7 +81,11 @@
                                                                                    {:name "venue_price"
                                                                                     :type "float"}]}}}
                        :metricsSpec     [{:type :count
-                                          :name :count}]
+                                          :name :count}
+                                         {:name               :unique_users
+                                          :type               :hyperUnique
+                                          :field_name         "user_name"
+                                          :isInputHyperUnique false}]
                        :granularitySpec {:type               :uniform
                                          :segmentGranularity :DAY
                                          :queryGranularity   :NONE


### PR DESCRIPTION
Continuation of #11039 which rather embarrassingly didn't test what it should so it passed even though it didn't fix the issue. This is another stab at it that also fixes the other point (`[:distinct]`) where we generate HLL queries. 

I'm still not sure this is the right approach as far as manually generating the test query is concerned. 