### PR TITLE
Show data values on charts

### DIFF
--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -71,7 +71,7 @@
 }
 
 .Dashboard.Dashboard--night .DashCard .Card svg text {
-  fill: color(var(--color-text-white) alpha(-14%)) !important;
+  fill: color(var(--color-text-white) alpha(-14%));
 }
 
 .Dashboard.Dashboard--night .DashCard .Card {

--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -71,7 +71,7 @@
 }
 
 .Dashboard.Dashboard--night .DashCard .Card svg text {
-  fill: color(var(--color-text-white) alpha(-14%));
+  fill: color(var(--color-text-white) alpha(-14%)) !important;
 }
 
 .Dashboard.Dashboard--night .DashCard .Card {

--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -674,3 +674,11 @@
 .ParameterValuePickerNoPopover input::-webkit-input-placeholder {
   color: var(--color-text-medium);
 }
+
+/* TEMP - spot for value labels */
+text.value-label {
+  font-weight: 900;
+  paint-order: stroke;
+  stroke-width: 4px;
+  stroke: white;
+}

--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -679,9 +679,13 @@
 text.value-label-outline {
   font-weight: 900;
   stroke-width: 4px;
-  stroke: white;
+  stroke: var(--color-text-white);
 }
 
 text.value-label {
   font-weight: 900;
+}
+
+.Dashboard--night text.value-label-outline {
+  stroke: var(--night-mode-card);
 }

--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -676,9 +676,12 @@
 }
 
 /* TEMP - spot for value labels */
-text.value-label {
+text.value-label-outline {
   font-weight: 900;
-  paint-order: stroke;
   stroke-width: 4px;
   stroke: white;
+}
+
+text.value-label {
+  font-weight: 900;
 }

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -245,16 +245,22 @@ function onRenderVoronoiHover(chart) {
     .order();
 }
 
-// TODO - this is a total hack just to get things rolling
+// NOTE- this is a total hack just to get things rolling, not sure if this is the right place
+// to do this or not
 function onRenderValueLabels(chart) {
+  // Do nothing if there is nothing to do
   if (!chart.settings["graph.show_values"]) {
     return false;
   }
-  const parent = chart.svg().select("svg > g");
 
-  const isNth = chart.settings["graph.label_value_frequency"] === "nth";
+  // use the chart body so things line up properly
+  const parent = chart.svg().select(".chart-body");
 
-  // grab all the bars
+  // Eventually use this to determine if we show all or some nth frequency
+  // const isNth = chart.settings["graph.label_value_frequency"] === "nth";
+
+  // So this is obviously a bad way to do this cause we're not working with the
+  // actual data values as a result, but I used the bars in the interim since it was an easy proxy
   const data = chart
     .svg()
     .selectAll(".bar")
@@ -264,25 +270,22 @@ function onRenderValueLabels(chart) {
       }),
     );
 
-  console.log("data length", data[0].length);
-
   parent
     .append("svg:g")
     .classed("value-labels", true)
     .selectAll("text.bar")
-    .data(data[0])
+    .data(data[0]) // TODO - make this less eww
     .enter()
     .append("text")
     .attr("class", "bar")
+    // TODO - I wonder if we should move as much of this as possible to CSS land to make it
+    // easier to
     .attr("text-anchor", "middle")
-    .attr("x", d => d.x.value)
-    .attr("y", d => d.y.value)
+    .attr("x", d => Number(d.x.value) + Number(d.width.value) / 2) // This is obviously gross and should be removed.
+    .attr("y", d => Number(d.y.value) - 8)
     .text(function(d) {
-      console.log(d);
-      return d.y.value;
+      return d.height.value; // The wrong value, but gives us something to work with
     });
-
-  //parent.append("svg:g").classed("value-labels").
 }
 
 function onRenderCleanupGoalAndTrend(chart, onGoalHover, isSplitAxis) {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -317,6 +317,7 @@ function onRenderValueLabels(chart, formatYValue, [data]) {
         .attr("class", klass)
         .attr("text-anchor", "middle")
         .attr("alignment-baseline", "middle")
+        .style("fill", "black")
         .text(({ y }) => formatYValue(y, { compact: true })),
     );
   };

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -330,26 +330,34 @@ function onRenderValueLabels(chart, formatYValue, [data]) {
     const sampleSize = Math.min(data.length, MAX_SAMPLE_SIZE);
     // $FlowFixMe
     addLabels(_.sample(data, sampleSize));
-    let totalWidth = 0;
-    for (const label of document.querySelectorAll(".value-label")) {
-      totalWidth += label.getBoundingClientRect().width;
-    }
+    const totalWidth = chart
+      .svg()
+      .selectAll(".value-label")
+      .flat()
+      .reduce((sum, label) => sum + label.getBoundingClientRect().width, 0);
     const labelWidth = totalWidth / sampleSize + LABEL_PADDING;
 
-    // $FlowFixMe
-    const { width: chartWidth } = document
-      .querySelector(".axis.x")
+    const { width: chartWidth } = chart
+      .svg()
+      .select(".axis.x")
+      .node()
       .getBoundingClientRect();
 
-    // $FlowFixMe
-    document.querySelector(".value-labels").remove();
+    chart
+      .svg()
+      .select(".value-labels")
+      .remove();
     nth = Math.ceil((labelWidth * data.length) / chartWidth);
   }
 
   addLabels(data.filter((d, i) => i % nth === 0));
 
-  // $FlowFixMe
-  moveToTop(document.querySelector(".value-labels").parentNode);
+  moveToTop(
+    chart
+      .svg()
+      .select(".value-labels")
+      .node().parentNode,
+  );
 }
 
 function onRenderCleanupGoalAndTrend(chart, onGoalHover, isSplitAxis) {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -265,11 +265,11 @@ function onRenderValueLabels(chart, formatYValue, [data]) {
   parent
     .append("svg:g")
     .classed("value-labels", true)
-    .selectAll("text.bar")
+    .selectAll("text.value-label")
     .data(data)
     .enter()
     .append("text")
-    .attr("class", "bar")
+    .attr("class", "value-label")
     // TODO - I wonder if we should move as much of this as possible to CSS land to make it
     // easier to
     .attr("text-anchor", "middle")

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -329,8 +329,8 @@ function onRenderValueLabels(chart, formatYValue, [data]) {
     // auto fit
     // Render a sample of rows to estimate average label size.
     // We use that estimate to compute the label interval.
-    const LABEL_PADDING = 4;
-    const MAX_SAMPLE_SIZE = 10;
+    const LABEL_PADDING = 6;
+    const MAX_SAMPLE_SIZE = 30;
     const sampleSize = Math.min(data.length, MAX_SAMPLE_SIZE);
     // $FlowFixMe
     addLabels(_.sample(data, sampleSize));

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -247,7 +247,7 @@ function onRenderVoronoiHover(chart) {
 
 // NOTE- this is a total hack just to get things rolling, not sure if this is the right place
 // to do this or not
-function onRenderValueLabels(chart, formatYValue) {
+function onRenderValueLabels(chart, formatYValue, [data]) {
   // Do nothing if there is nothing to do
   if (!chart.settings["graph.show_values"]) {
     return false;
@@ -258,11 +258,6 @@ function onRenderValueLabels(chart, formatYValue) {
 
   // Eventually use this to determine if we show all or some nth frequency
   // const isNth = chart.settings["graph.label_value_frequency"] === "nth";
-
-  const data = chart
-    .svg()
-    .selectAll(".bar")
-    .data();
 
   const xScale = chart.x();
   const yScale = chart.y();
@@ -278,9 +273,9 @@ function onRenderValueLabels(chart, formatYValue) {
     // TODO - I wonder if we should move as much of this as possible to CSS land to make it
     // easier to
     .attr("text-anchor", "middle")
-    .attr("x", d => xScale(d.x))
-    .attr("y", d => yScale(d.y) - 8)
-    .text(d => formatYValue(d.y, { compact: true }));
+    .attr("x", ([x]) => xScale(x))
+    .attr("y", ([, y]) => yScale(y) - 8)
+    .text(([, y]) => formatYValue(y, { compact: true }));
 }
 
 function onRenderCleanupGoalAndTrend(chart, onGoalHover, isSplitAxis) {
@@ -418,7 +413,7 @@ function onRenderAddExtraClickHandlers(chart) {
 // the various steps that get called
 function onRender(
   chart,
-  { onGoalHover, isSplitAxis, isStacked, formatYValue },
+  { onGoalHover, isSplitAxis, isStacked, formatYValue, datas },
 ) {
   onRenderRemoveClipPath(chart);
   onRenderMoveContentToTop(chart);
@@ -428,7 +423,7 @@ function onRender(
   onRenderEnableDots(chart);
   onRenderVoronoiHover(chart);
   onRenderCleanupGoalAndTrend(chart, onGoalHover, isSplitAxis); // do this before hiding x-axis
-  onRenderValueLabels(chart, formatYValue);
+  onRenderValueLabels(chart, formatYValue, datas);
   onRenderHideDisabledLabels(chart);
   onRenderHideDisabledAxis(chart);
   onRenderHideBadAxis(chart);
@@ -652,13 +647,8 @@ function beforeRender(chart) {
 // +-------------------------------------------------------------------------------------------------------------------+
 
 /// once chart has rendered and we can access the SVG, do customizations to axis labels / etc that you can't do through dc.js
-export default function lineAndBarOnRender(
-  chart,
-  { onGoalHover, isSplitAxis, isStacked, formatYValue },
-) {
+export default function lineAndBarOnRender(chart, args) {
   beforeRender(chart);
-  chart.on("renderlet.on-render", () =>
-    onRender(chart, { onGoalHover, isSplitAxis, isStacked, formatYValue }),
-  );
+  chart.on("renderlet.on-render", () => onRender(chart, args));
   chart.render();
 }

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -245,6 +245,46 @@ function onRenderVoronoiHover(chart) {
     .order();
 }
 
+// TODO - this is a total hack just to get things rolling
+function onRenderValueLabels(chart) {
+  if (!chart.settings["graph.show_values"]) {
+    return false;
+  }
+  const parent = chart.svg().select("svg > g");
+
+  const isNth = chart.settings["graph.label_value_frequency"] === "nth";
+
+  // grab all the bars
+  const data = chart
+    .svg()
+    .selectAll(".bar")
+    .map(d =>
+      d.map((data, index) => {
+        return data.attributes;
+      }),
+    );
+
+  console.log("data length", data[0].length);
+
+  parent
+    .append("svg:g")
+    .classed("value-labels", true)
+    .selectAll("text.bar")
+    .data(data[0])
+    .enter()
+    .append("text")
+    .attr("class", "bar")
+    .attr("text-anchor", "middle")
+    .attr("x", d => d.x.value)
+    .attr("y", d => d.y.value)
+    .text(function(d) {
+      console.log(d);
+      return d.y.value;
+    });
+
+  //parent.append("svg:g").classed("value-labels").
+}
+
 function onRenderCleanupGoalAndTrend(chart, onGoalHover, isSplitAxis) {
   // remove dots
   chart.selectAll(".goal .dot, .trend .dot").remove();
@@ -387,6 +427,7 @@ function onRender(chart, onGoalHover, isSplitAxis, isStacked) {
   onRenderEnableDots(chart);
   onRenderVoronoiHover(chart);
   onRenderCleanupGoalAndTrend(chart, onGoalHover, isSplitAxis); // do this before hiding x-axis
+  onRenderValueLabels(chart);
   onRenderHideDisabledLabels(chart);
   onRenderHideDisabledAxis(chart);
   onRenderHideBadAxis(chart);

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -247,10 +247,12 @@ function onRenderVoronoiHover(chart) {
 }
 
 function onRenderValueLabels(chart, formatYValue, [data]) {
+  const hasDuplicateX = new Set(data.map(([x]) => x)).size < data.length;
   if (
     !chart.settings["graph.show_values"] || // setting is off
     chart.settings["stackable.stack_type"] === "normalized" || // no normalized
-    chart.series.length > 1 // no multiseries
+    chart.series.length > 1 || // no multiseries
+    hasDuplicateX // need unique x values
   ) {
     return;
   }

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -317,7 +317,6 @@ function onRenderValueLabels(chart, formatYValue, [data]) {
         .attr("class", klass)
         .attr("text-anchor", "middle")
         .attr("alignment-baseline", "middle")
-        .style("fill", "black")
         .text(({ y }) => formatYValue(y, { compact: true })),
     );
   };

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -304,12 +304,16 @@ function onRenderValueLabels(chart, formatYValue, [data]) {
       .data(data)
       .enter()
       .append("g")
-      .attr(
-        "transform",
-        ({ x, y, showLabelBelow }) =>
-          `translate(${xShift + xScale(x)}, ${yScale(y) +
-            (showLabelBelow ? 14 : -10)})`,
-      );
+      .attr("transform", ({ x, y, showLabelBelow }) => {
+        const xPos = xShift + xScale(x);
+        let yPos = yScale(y) + (showLabelBelow ? 14 : -10);
+        // if the yPos is below the x axis, move it to be above the data point
+        const [yMax] = yScale.range();
+        if (yPos > yMax) {
+          yPos = yScale(y) - 10;
+        }
+        return `translate(${xPos}, ${yPos})`;
+      });
 
     ["value-label-outline", "value-label"].forEach(klass =>
       labelGroups

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -250,7 +250,17 @@ function onRenderVoronoiHover(chart) {
 function onRenderValueLabels(chart, formatYValue, [data]) {
   // Do nothing if there is nothing to do
   if (!chart.settings["graph.show_values"]) {
-    return false;
+    return;
+  }
+
+  const MIN_LABEL_WIDTH = 10;
+  const { width: chartWidth } = document
+    .querySelector(".chart-body")
+    .getBoundingClientRect();
+  // We check the acutal rendered labels for density later. Here we avoid
+  // rendering the labels at all if there's less than 10px per data point.
+  if (data.length * MIN_LABEL_WIDTH > chartWidth) {
+    return;
   }
 
   // use the chart body so things line up properly
@@ -276,6 +286,21 @@ function onRenderValueLabels(chart, formatYValue, [data]) {
     .attr("x", ([x]) => xScale(x))
     .attr("y", ([, y]) => yScale(y) - 8)
     .text(([, y]) => formatYValue(y, { compact: true }));
+
+  const totalWidth = [...document.querySelectorAll(".value-label")].reduce(
+    (sum, label) => sum + label.getBoundingClientRect().width,
+    0,
+  );
+
+  if (totalWidth > chartWidth) {
+    // This checks whether the labels are too crowded. It's an arbitrary cutoff
+    // that probably let's them get a bit too crowded before removing them.
+    document.querySelector(".value-labels").remove();
+  } else {
+    // If they're not too crowded and we're keeping them, move the containing
+    // '.chart-body' element to the top.
+    moveToTop(document.querySelector(".value-labels").parentNode);
+  }
 }
 
 function onRenderCleanupGoalAndTrend(chart, onGoalHover, isSplitAxis) {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -246,22 +246,15 @@ function onRenderVoronoiHover(chart) {
     .order();
 }
 
-// NOTE- this is a total hack just to get things rolling, not sure if this is the right place
-// to do this or not
 function onRenderValueLabels(chart, formatYValue, [data]) {
-  // Do nothing if there is nothing to do
   if (
-    !chart.settings["graph.show_values"] ||
-    chart.settings["stackable.stack_type"] === "normalized"
+    !chart.settings["graph.show_values"] || // setting is off
+    chart.settings["stackable.stack_type"] === "normalized" || // no normalized
+    chart.series.length > 1 // no multiseries
   ) {
     return;
   }
   const showAll = chart.settings["graph.label_value_frequency"] === "all";
-
-  // Only show lables on single series
-  if (chart.series.length > 1) {
-    return;
-  }
   const { display } = chart.settings.series(chart.series[0]);
 
   // Update `data` to use named x/y and include `showLabelBelow`.
@@ -291,7 +284,8 @@ function onRenderValueLabels(chart, formatYValue, [data]) {
     // this has to match the logic in `doHistogramBarStuff`
     const [x1, x2] = chart
       .svg()
-      .selectAll("rect")[0]
+      .selectAll("rect")
+      .flat()
       .map(r => parseFloat(r.getAttribute("x")));
     const barWidth = x2 - x1;
     xShift += barWidth / 2;
@@ -306,8 +300,6 @@ function onRenderValueLabels(chart, formatYValue, [data]) {
       .enter()
       .append("text")
       .attr("class", "value-label")
-      // TODO - I wonder if we should move as much of this as possible to CSS land to make it
-      // easier to
       .attr("text-anchor", "middle")
       .attr("alignment-baseline", "middle")
       .attr("x", ({ x }) => xShift + xScale(x))

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -250,7 +250,10 @@ function onRenderVoronoiHover(chart) {
 // to do this or not
 function onRenderValueLabels(chart, formatYValue, [data]) {
   // Do nothing if there is nothing to do
-  if (!chart.settings["graph.show_values"]) {
+  if (
+    !chart.settings["graph.show_values"] ||
+    chart.settings["stackable.stack_type"] === "normalized"
+  ) {
     return;
   }
   const showAll = chart.settings["graph.label_value_frequency"] === "all";

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -260,6 +260,7 @@ function onRenderValueLabels(chart, formatYValue, [data]) {
   const { display } = chart.settings.series(chart.series[0]);
 
   const MIN_LABEL_WIDTH = 10;
+  // $FlowFixMe
   const { width: chartWidth } = document
     .querySelector(".axis.x")
     .getBoundingClientRect();
@@ -297,24 +298,27 @@ function onRenderValueLabels(chart, formatYValue, [data]) {
         (i === 0 || data[i - 1][1] > y) &&
         // last point point or next is greater than y
         (i === data.length - 1 || data[i + 1][1] > y);
-      const shouldShowBelow = isLocalMin && display == "line";
+      const shouldShowBelow = isLocalMin && display === "line";
       return yScale(y) + (shouldShowBelow ? 14 : -10);
     })
     .text(([, y]) => formatYValue(y, { compact: true }));
 
-  const totalWidth = [...document.querySelectorAll(".value-label")].reduce(
-    (sum, label) => sum + label.getBoundingClientRect().width,
-    0,
-  );
+  let totalWidth = 0;
+  for (const label of document.querySelectorAll(".value-label")) {
+    totalWidth += label.getBoundingClientRect().width;
+  }
 
+  const valueLabels = document.querySelector(".value-labels");
   if (totalWidth > chartWidth) {
     // This checks whether the labels are too crowded. It's an arbitrary cutoff
     // that probably let's them get a bit too crowded before removing them.
-    document.querySelector(".value-labels").remove();
+    // $FlowFixMe
+    valueLabels.remove();
   } else {
     // If they're not too crowded and we're keeping them, move the containing
     // '.chart-body' element to the top.
-    moveToTop(document.querySelector(".value-labels").parentNode);
+    // $FlowFixMe
+    moveToTop(valueLabels.parentNode);
   }
 }
 

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -896,6 +896,7 @@ export default function lineAreaBar(
     isSplitAxis: yAxisProps.isSplit,
     isStacked: isStacked(parent.settings, datas),
     formatYValue: getYValueFormatter(parent, series, yAxisProps.yExtent),
+    datas,
   });
 
   // only ordinal axis can display "null" values

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -30,6 +30,7 @@ import {
   applyChartQuantitativeXAxis,
   applyChartOrdinalXAxis,
   applyChartYAxis,
+  getYValueFormatter,
 } from "./apply_axis";
 
 import { setupTooltips } from "./apply_tooltips";
@@ -890,12 +891,12 @@ export default function lineAreaBar(
   parent.render();
 
   // apply any on-rendering functions (this code lives in `LineAreaBarPostRenderer`)
-  lineAndBarOnRender(
-    parent,
+  lineAndBarOnRender(parent, {
     onGoalHover,
-    yAxisProps.isSplit,
-    isStacked(parent.settings, datas),
-  );
+    isSplitAxis: yAxisProps.isSplit,
+    isStacked: isStacked(parent.settings, datas),
+    formatYValue: getYValueFormatter(parent, series, yAxisProps.yExtent),
+  });
 
   // only ordinal axis can display "null" values
   if (isOrdinal(parent.settings)) {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -614,8 +614,6 @@ function addGoalChartAndGetOnGoalHover(
   const goalGroup = goalDimension
     .group()
     .reduce((p, d) => d[1], (p, d) => p, () => 0);
-
-  console.log("goalGroup", goalGroup);
   const goalIndex = charts.length;
 
   const goalChart = dc
@@ -865,8 +863,6 @@ export default function lineAreaBar(
   );
   addTrendlineChart(props, xAxisProps, yAxisProps, parent, charts);
 
-  addValueLabeledChart(props, xAxisProps, yAxisProps, parent, charts);
-
   parent.compose(charts);
 
   if (groups.length > 1 && !props.isScalarSeries) {
@@ -915,30 +911,6 @@ export default function lineAreaBar(
   return () => {
     dc.chartRegistry.deregister(parent);
   };
-}
-
-function addValueLabeledChart(
-  { settings },
-  xAxisProps,
-  yAxisProps,
-  parent,
-  charts,
-) {
-  if (!settings["graph.show_values"]) {
-    return () => {};
-  }
-
-  const frequency = settings["graph.label_value_frequency"];
-
-  console.log("xAxisPropsx", xAxisProps);
-  console.log("yAxisPropsx", yAxisProps);
-  console.log("label frequency", frequency);
-  console.log("parent", parent);
-  console.log("charts", charts);
-
-  //const valueLabeledChart = dc.lineChart(parent);
-
-  //charts.push(valueLabeledChart);
 }
 
 export const lineRenderer = (element, props) =>

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -613,6 +613,8 @@ function addGoalChartAndGetOnGoalHover(
   const goalGroup = goalDimension
     .group()
     .reduce((p, d) => d[1], (p, d) => p, () => 0);
+
+  console.log("goalGroup", goalGroup);
   const goalIndex = charts.length;
 
   const goalChart = dc
@@ -862,6 +864,8 @@ export default function lineAreaBar(
   );
   addTrendlineChart(props, xAxisProps, yAxisProps, parent, charts);
 
+  addValueLabeledChart(props, xAxisProps, yAxisProps, parent, charts);
+
   parent.compose(charts);
 
   if (groups.length > 1 && !props.isScalarSeries) {
@@ -909,6 +913,30 @@ export default function lineAreaBar(
   return () => {
     dc.chartRegistry.deregister(parent);
   };
+}
+
+function addValueLabeledChart(
+  { settings },
+  xAxisProps,
+  yAxisProps,
+  parent,
+  charts,
+) {
+  if (!settings["graph.show_values"]) {
+    return () => {};
+  }
+
+  const frequency = settings["graph.label_value_frequency"];
+
+  console.log("xAxisPropsx", xAxisProps);
+  console.log("yAxisPropsx", yAxisProps);
+  console.log("label frequency", frequency);
+  console.log("parent", parent);
+  console.log("charts", charts);
+
+  //const valueLabeledChart = dc.lineChart(parent);
+
+  //charts.push(valueLabeledChart);
 }
 
 export const lineRenderer = (element, props) =>

--- a/frontend/src/metabase/visualizations/lib/apply_axis.js
+++ b/frontend/src/metabase/visualizations/lib/apply_axis.js
@@ -356,18 +356,7 @@ export function applyChartYAxis(chart, series, yExtent, axisName) {
   }
 
   if (axis.setting("axis_enabled")) {
-    // special case for normalized stacked charts
-    // for normalized stacked charts the y-axis is a percentage number. In Javascript, 0.07 * 100.0 = 7.000000000000001 (try it) so we
-    // round that number to get something nice like "7". Then we append "%" to get a nice tick like "7%"
-    if (chart.settings["stackable.stack_type"] === "normalized") {
-      axis.axis().tickFormat(value => Math.round(value * 100) + "%");
-    } else {
-      const metricColumn = series[0].data.cols[1];
-      axis.axis().tickFormat(value => {
-        value = maybeRoundValueToZero(value, yExtent);
-        return formatValue(value, chart.settings.column(metricColumn));
-      });
-    }
+    axis.axis().tickFormat(getYValueFormatter(chart, series, yExtent));
     chart.renderHorizontalGridLines(true);
     adjustYAxisTicksIfNeeded(axis.axis(), chart.height());
   } else {
@@ -426,4 +415,19 @@ export function applyChartYAxis(chart, series, yExtent, axisName) {
     }
     axis.scale(scale.domain([min, max]));
   }
+}
+
+export function getYValueFormatter(chart, series, yExtent) {
+  // special case for normalized stacked charts
+  // for normalized stacked charts the y-axis is a percentage number. In Javascript, 0.07 * 100.0 = 7.000000000000001 (try it) so we
+  // round that number to get something nice like "7". Then we append "%" to get a nice tick like "7%"
+  if (chart.settings["stackable.stack_type"] === "normalized") {
+    return value => Math.round(value * 100) + "%";
+  }
+  const metricColumn = series[0].data.cols[1];
+  const columnSettings = chart.settings.column(metricColumn);
+  return (value, options) => {
+    const roundedValue = maybeRoundValueToZero(value, yExtent);
+    return formatValue(roundedValue, { ...columnSettings, ...options });
+  };
 }

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -326,10 +326,11 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS = {
       vizSettings["graph.show_values"] !== true,
     props: {
       options: [
-        { name: t`All ticks`, value: "all" },
-        { name: t`Every nth`, value: "nth" }, // TODO - this option needs to allow for the user to set a value and should have a default value based on the chart density, similar to how we handle x-axis ticks
+        { name: t`Auto fit`, value: "fit" },
+        { name: t`Show all`, value: "all" },
       ],
     },
+    default: "fit",
     readDependencies: ["graph.show_values"],
   },
 };

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -317,14 +317,17 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS = {
     title: t`Label values`,
     widget: "toggle",
     default: false,
-    getHidden: (series, vizSettings) => series.length > 1,
+    getHidden: (series, vizSettings) =>
+      series.length > 1 || vizSettings["stackable.stack_type"] === "normalized",
   },
   "graph.label_value_frequency": {
     section: t`Display`,
     title: t`Label frequency`, // TODO better copy here
     widget: "radio",
     getHidden: (series, vizSettings) =>
-      series.length > 1 || vizSettings["graph.show_values"] !== true,
+      series.length > 1 ||
+      vizSettings["graph.show_values"] !== true ||
+      vizSettings["stackable.stack_type"] === "normalized",
     props: {
       options: [
         { name: t`Auto fit`, value: "fit" },

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -311,14 +311,18 @@ export const GRAPH_GOAL_SETTINGS = {
   },
 };
 
+// with more than this many rows, don't display values on top of bars by default
+const AUTO_SHOW_VALUES_MAX_ROWS = 25;
+
 export const GRAPH_DISPLAY_VALUES_SETTINGS = {
   "graph.show_values": {
     section: t`Display`,
     title: t`Label values`,
     widget: "toggle",
-    default: false,
     getHidden: (series, vizSettings) =>
       series.length > 1 || vizSettings["stackable.stack_type"] === "normalized",
+    getDefault: ([{ card, data }]) =>
+      card.display === "bar" && data.rows.length < AUTO_SHOW_VALUES_MAX_ROWS,
   },
   "graph.label_value_frequency": {
     section: t`Display`,

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -317,13 +317,14 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS = {
     title: t`Label values`,
     widget: "toggle",
     default: false,
+    getHidden: (series, vizSettings) => series.length > 1,
   },
   "graph.label_value_frequency": {
     section: t`Display`,
     title: t`Label frequency`, // TODO better copy here
     widget: "radio",
     getHidden: (series, vizSettings) =>
-      vizSettings["graph.show_values"] !== true,
+      series.length > 1 || vizSettings["graph.show_values"] !== true,
     props: {
       options: [
         { name: t`Auto fit`, value: "fit" },

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -278,7 +278,7 @@ export const STACKABLE_SETTINGS = {
 export const GRAPH_GOAL_SETTINGS = {
   "graph.show_goal": {
     section: t`Display`,
-    title: t`Show goal`,
+    title: t`Goal line`,
     widget: "toggle",
     default: false,
   },
@@ -300,7 +300,7 @@ export const GRAPH_GOAL_SETTINGS = {
   },
   "graph.show_trendline": {
     section: t`Display`,
-    title: t`Show trend line`,
+    title: t`Trend line`,
     widget: "toggle",
     default: false,
     getHidden: (series, vizSettings) => {
@@ -317,7 +317,7 @@ const AUTO_SHOW_VALUES_MAX_ROWS = 25;
 export const GRAPH_DISPLAY_VALUES_SETTINGS = {
   "graph.show_values": {
     section: t`Display`,
-    title: t`Label values`,
+    title: t`Show values on data points`,
     widget: "toggle",
     getHidden: (series, vizSettings) =>
       series.length > 1 || vizSettings["stackable.stack_type"] === "normalized",
@@ -326,7 +326,7 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS = {
   },
   "graph.label_value_frequency": {
     section: t`Display`,
-    title: t`Label frequency`, // TODO better copy here
+    title: t`Values to show`,
     widget: "radio",
     getHidden: (series, vizSettings) =>
       series.length > 1 ||
@@ -334,8 +334,8 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS = {
       vizSettings["stackable.stack_type"] === "normalized",
     props: {
       options: [
-        { name: t`Auto fit`, value: "fit" },
-        { name: t`Show all`, value: "all" },
+        { name: t`As many as can fit nicely`, value: "fit" },
+        { name: t`All`, value: "all" },
       ],
     },
     default: "fit",

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -311,6 +311,29 @@ export const GRAPH_GOAL_SETTINGS = {
   },
 };
 
+export const GRAPH_DISPLAY_VALUES_SETTINGS = {
+  "graph.show_values": {
+    section: t`Display`,
+    title: t`Label values`,
+    widget: "toggle",
+    default: false,
+  },
+  "graph.label_value_frequency": {
+    section: t`Display`,
+    title: t`Label frequency`, // TODO better copy here
+    widget: "radio",
+    getHidden: (series, vizSettings) =>
+      vizSettings["graph.show_values"] !== true,
+    props: {
+      options: [
+        { name: t`All ticks`, value: "all" },
+        { name: t`Every nth`, value: "nth" }, // TODO - this option needs to allow for the user to set a value and should have a default value based on the chart density, similar to how we handle x-axis ticks
+      ],
+    },
+    readDependencies: ["graph.show_values"],
+  },
+};
+
 export const GRAPH_COLORS_SETTINGS = {
   // DEPRECATED: replaced with "color" series setting
   "graph.colors": {},

--- a/frontend/src/metabase/visualizations/visualizations/AreaChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/AreaChart.jsx
@@ -12,6 +12,7 @@ import {
   GRAPH_GOAL_SETTINGS,
   GRAPH_COLORS_SETTINGS,
   GRAPH_AXIS_SETTINGS,
+  GRAPH_DISPLAY_VALUES_SETTINGS,
 } from "../lib/settings/graph";
 
 export default class AreaChart extends LineAreaBarChart {
@@ -27,6 +28,7 @@ export default class AreaChart extends LineAreaBarChart {
     ...GRAPH_GOAL_SETTINGS,
     ...GRAPH_COLORS_SETTINGS,
     ...GRAPH_AXIS_SETTINGS,
+    ...GRAPH_DISPLAY_VALUES_SETTINGS,
   };
 
   static renderer = areaRenderer;

--- a/frontend/src/metabase/visualizations/visualizations/BarChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/BarChart.jsx
@@ -11,6 +11,7 @@ import {
   GRAPH_GOAL_SETTINGS,
   GRAPH_COLORS_SETTINGS,
   GRAPH_AXIS_SETTINGS,
+  GRAPH_DISPLAY_VALUES_SETTINGS,
 } from "../lib/settings/graph";
 
 export default class BarChart extends LineAreaBarChart {
@@ -25,6 +26,7 @@ export default class BarChart extends LineAreaBarChart {
     ...GRAPH_GOAL_SETTINGS,
     ...GRAPH_COLORS_SETTINGS,
     ...GRAPH_AXIS_SETTINGS,
+    ...GRAPH_DISPLAY_VALUES_SETTINGS,
   };
 
   static renderer = barRenderer;

--- a/frontend/src/metabase/visualizations/visualizations/LineChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/LineChart.jsx
@@ -10,6 +10,7 @@ import {
   GRAPH_GOAL_SETTINGS,
   GRAPH_COLORS_SETTINGS,
   GRAPH_AXIS_SETTINGS,
+  GRAPH_DISPLAY_VALUES_SETTINGS,
 } from "../lib/settings/graph";
 
 export default class LineChart extends LineAreaBarChart {
@@ -24,6 +25,7 @@ export default class LineChart extends LineAreaBarChart {
     ...GRAPH_GOAL_SETTINGS,
     ...GRAPH_COLORS_SETTINGS,
     ...GRAPH_AXIS_SETTINGS,
+    ...GRAPH_DISPLAY_VALUES_SETTINGS,
   };
 
   static renderer = lineRenderer;


### PR DESCRIPTION
Will eventually resolve #4788

Wanted to try something a little different and try opening a PR to be able to use as a tool to refine aspects of the design because for this particular issue designing outside of the real environment seems like the way to a bunch of dumb assumptions. It'll also let me ask some questions about the code so hopefully features like this will get easier to work on by more folks less familiar with the visualization code. 

I basically did a dumb busted version that only works on bar charts and links up the major themes, a setting and then resulting text so I could start using it, see it both on dashboards and in questions and go from there.
 
## What
Make it easier to understand values (especially helpful in non interactive environments like a dashboard on a TV) by adding a viz setting to supported chart types that shows the value.

![Screen Shot 2019-11-20 at 3 21 51 PM](https://user-images.githubusercontent.com/5248953/69287641-cd4e5f00-0bab-11ea-9fd4-f4b39ddd4cf1.png)

Supported visualizations
- **v1 (this pr) Line, bar, area, row, scatterplot**
- v2. (a later release) Pie 

## Why
Cause a ton of folks have asked for it and it improves the accessibility of our visualizations.

## Where / how
- Add a new section to "Display" for the supported visualization types that allows the user to configure whether or not to show values on the viz.

![Screen Shot 2019-11-20 at 3 32 07 PM](https://user-images.githubusercontent.com/5248953/69287849-8a40bb80-0bac-11ea-8e17-084ca0dbb7d7.png)

- Once the toggle is on,  the user should be able to pick between whether or not to show value labels for 
all the x axis ticks or to show the value text above the point for every Nth tick which they can specify via an input box. The idea behind using Nth here is that it'll help avoid possible confusing magic settings like "auto" or "sparse" and give users finer control in cases where "all" is far too dense.

We should default the value in the input based on the cardinality of the x-axis similar to how we handle x-axis labels. This means that for a relatively sparse viz we would default to "all" but for something more intense (say the total sales per month for 8 years) we would add labels in a more spread out way so that people reading the chart have context and aren't distracted by crazy overlapping labels. If we guess wrong the user can make the labeling more or less dense by changing this number until it looks right.

## Scoping
I want to make sure we do this well for the base case first so we can get this to folks sooner, so for now I'm proposing that we implement this initially *only for single series visualizations in the supported list* above as opposed to trying to get everything right for all cases including multiple breakouts, stacks, etc. If we're able to make quick progress on this I'm happy to handle multiple series and stacks and I have done a bit of thinking about how we'd deal with that.

## Todos for somebody smarter than me
- [x] Allow for this on more than just bar charts (see supported charts above)
- [x] Actually show the right values above the ticks
- [x] Default the viz label frequency based on the x-axis cardinality
- [ ] Allow the user to change the default nth (this seems like it might require a more complex widget for the radio buttons)

## Todos for me (there will be more)
- [ ] Text styling and work on edge cases around density