### PR TITLE
Update auto-viz selection

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -276,7 +276,30 @@ export default class Question {
     return this.setCard(assoc(this.card(), "display", display));
   }
 
+  setSensibleDisplays(displays) {
+    return this.setCard(assoc(this.card(), "sensibleDisplays", displays));
+  }
+
+  shouldNotSetDisplay(): boolean {
+    const { selectedDisplay, sensibleDisplays } = this._card;
+    console.log("shouldSetDisplay", { selectedDisplay, sensibleDisplays });
+    return (
+      sensibleDisplays &&
+      selectedDisplay &&
+      sensibleDisplays.includes(selectedDisplay)
+    );
+  }
+
+  setSelectedDisplay(display) {
+    return this.setCard(
+      assoc(this.card(), "selectedDisplay", display),
+    ).setDisplay(display);
+  }
+
   setDefaultDisplay(): Question {
+    if (this.shouldNotSetDisplay()) {
+      return this;
+    }
     const query = this.query();
     if (query instanceof StructuredQuery) {
       // TODO: move to StructuredQuery?

--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -307,6 +307,26 @@ export default class Question {
     return this.sensibleDisplays().includes(this.selectedDisplay());
   }
 
+  // Switches display based on data shape. For 1x1 data, we show a scalar. If
+  // our display was a 1x1 type, but the data isn't 1x1, we show a table.
+  switchTableScalar({ rows = [], cols }): Question {
+    const display = this.display();
+    const isScalar = ["scalar", "progress", "gauge"].includes(display);
+    const isOneByOne = rows.length === 1 && cols.length === 1;
+
+    const newDisplay =
+      !isScalar && isOneByOne
+        ? // if we have a 1x1 data result then this should always be viewed as a scalar
+          "scalar"
+        : isScalar && !isOneByOne
+        ? // any time we were a scalar and now have more than 1x1 data switch to table view
+          "table"
+        : // otherwise leave the display unchanged
+          display;
+
+    return this.setDisplay(newDisplay);
+  }
+
   setDefaultDisplay(): Question {
     if (this.shouldNotSetDisplay()) {
       return this;

--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -276,24 +276,30 @@ export default class Question {
     return this.setCard(assoc(this.card(), "display", display));
   }
 
-  setSensibleDisplays(displays) {
-    return this.setCard(assoc(this.card(), "sensibleDisplays", displays));
-  }
-
-  shouldNotSetDisplay(): boolean {
-    const { selectedDisplay, sensibleDisplays } = this._card;
-    console.log("shouldSetDisplay", { selectedDisplay, sensibleDisplays });
-    return (
-      sensibleDisplays &&
-      selectedDisplay &&
-      sensibleDisplays.includes(selectedDisplay)
-    );
-  }
-
-  setSelectedDisplay(display) {
+  // The selected display is set when the user explicitly chooses a
+  // visualization type. Having it set prevents auto selecting a new type,
+  // unless the selected type isn't sensible.
+  setSelectedDisplay(display): Question {
     return this.setCard(
       assoc(this.card(), "selectedDisplay", display),
     ).setDisplay(display);
+  }
+
+  // This feels a bit hacky because it stores result-dependent info on card. We
+  // use the list of sensible displays to override a user-selected display if it
+  // no longer makes sense for the data.
+  setSensibleDisplays(displays): Question {
+    return this.setCard(assoc(this.card(), "sensibleDisplays", displays));
+  }
+
+  // This determines whether `setDefaultDisplay` should replace the current
+  // display. If we have a list of sensibleDisplays and the user-selected
+  // display is one of them, we won't overwrite it in `setDefaultDisplay`. If
+  // the user hasn't selected a display or `sensibleDisplays` hasn't been set,
+  // we can let `setDefaultDisplay` choose a display type.
+  shouldNotSetDisplay(): boolean {
+    const { selectedDisplay, sensibleDisplays = [] } = this._card;
+    return sensibleDisplays.includes(selectedDisplay);
   }
 
   setDefaultDisplay(): Question {

--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -284,12 +284,18 @@ export default class Question {
       assoc(this.card(), "selectedDisplay", display),
     ).setDisplay(display);
   }
+  selectedDisplay(): string {
+    return this._card && this._card.selectedDisplay;
+  }
 
   // This feels a bit hacky because it stores result-dependent info on card. We
   // use the list of sensible displays to override a user-selected display if it
   // no longer makes sense for the data.
   setSensibleDisplays(displays): Question {
     return this.setCard(assoc(this.card(), "sensibleDisplays", displays));
+  }
+  sensibleDisplays(): string[] {
+    return (this._card && this._card.sensibleDisplays) || [];
   }
 
   // This determines whether `setDefaultDisplay` should replace the current
@@ -298,8 +304,7 @@ export default class Question {
   // the user hasn't selected a display or `sensibleDisplays` hasn't been set,
   // we can let `setDefaultDisplay` choose a display type.
   shouldNotSetDisplay(): boolean {
-    const { selectedDisplay, sensibleDisplays = [] } = this._card;
-    return sensibleDisplays.includes(selectedDisplay);
+    return this.sensibleDisplays().includes(this.selectedDisplay());
   }
 
   setDefaultDisplay(): Question {

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -989,16 +989,21 @@ export const QUERY_COMPLETED = "metabase/qb/QUERY_COMPLETED";
 export const queryCompleted = (question, queryResults, initialRun) => {
   return async (dispatch, getState) => {
     const sensibleDisplays = getSensibleDisplays(queryResults[0].data);
-    if (!initialRun) {
+    if (initialRun) {
       question = question
-        .setDisplay(getDisplayTypeForCard(question.card(), queryResults))
-        .setSensibleDisplays(sensibleDisplays)
-        .setDefaultDisplay();
-    }
+        // .setDisplay(getDisplayTypeForCard(question.card(), queryResults))
+        // .setSensibleDisplays(sensibleDisplays)
+        .setSelectedDisplay(question.display());
+    } //else {
+    question = question
+      .setDisplay(getDisplayTypeForCard(question.card(), queryResults))
+      .setSensibleDisplays(sensibleDisplays)
+      .setDefaultDisplay();
+    // }
     dispatch.action(QUERY_COMPLETED, {
       card: question.card(),
-      sensibleDisplays,
-      cardDisplay: question.display(),
+      // sensibleDisplays,
+      // cardDisplay: question.display(),
       queryResults,
     });
   };
@@ -1030,7 +1035,6 @@ export const QUERY_ERRORED = "metabase/qb/QUERY_ERRORED";
 export const queryErrored = createThunkAction(
   QUERY_ERRORED,
   (startTime, error) => {
-    console.log("queryErrored", error);
     return async (dispatch, getState) => {
       if (error && error.isCancelled) {
         // cancelled, do nothing

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -958,49 +958,34 @@ export const runQuestionQuery = ({
 export const CLEAR_QUERY_RESULT = "metabase/query_builder/CLEAR_QUERY_RESULT";
 export const clearQueryResult = createAction(CLEAR_QUERY_RESULT);
 
-const getDisplayTypeForCard = (card, queryResults) => {
-  // TODO Atte Keinänen 6/1/17: Make a holistic decision based on all queryResults, not just one
-  // This method seems to has been a candidate for a rewrite anyway
-  const queryResult = queryResults[0];
-
-  let cardDisplay = card.display;
-
-  // try a little logic to pick a smart display for the data
-  // TODO: less hard-coded rules for picking chart type
+// Most of display-type auto-selection lives in Question. This takes place
+// *after* that, uses the column/row count, and also affects SQL questions. It's
+// used to switch between table and scalar.
+const getDisplayTypeForCard = (display, { cols, rows = [] }) => {
   const isScalarVisualization =
-    card.display === "scalar" ||
-    card.display === "progress" ||
-    card.display === "gauge";
-  if (
-    !isScalarVisualization &&
-    queryResult.data.rows &&
-    queryResult.data.rows.length === 1 &&
-    queryResult.data.cols.length === 1
-  ) {
+    display === "scalar" || display === "progress" || display === "gauge";
+  if (!isScalarVisualization && rows.length === 1 && cols.length === 1) {
     // if we have a 1x1 data result then this should always be viewed as a scalar
-    cardDisplay = "scalar";
-  } else if (
-    isScalarVisualization &&
-    queryResult.data.rows &&
-    (queryResult.data.rows.length > 1 || queryResult.data.cols.length > 1)
-  ) {
+    return "scalar";
+  } else if (isScalarVisualization && (rows.length > 1 || cols.length > 1)) {
     // any time we were a scalar and now have more than 1x1 data switch to table view
-    cardDisplay = "table";
-  } else if (!card.display) {
+    return "table";
+  } else if (display == null) {
     // if our query aggregation is "rows" then ALWAYS set the display to "table"
-    cardDisplay = "table";
+    return "table";
   }
-
-  return cardDisplay;
+  return display;
 };
 
 export const QUERY_COMPLETED = "metabase/qb/QUERY_COMPLETED";
 export const queryCompleted = (question, queryResults) => {
   return async (dispatch, getState) => {
+    const [{ data }] = queryResults;
+    question = question
+      .setSensibleDisplays(getSensibleDisplays(data))
+      .setDefaultDisplay();
     const card = question
-      .setDisplay(getDisplayTypeForCard(question.card(), queryResults))
-      .setSensibleDisplays(getSensibleDisplays(queryResults[0].data))
-      .setDefaultDisplay()
+      .setDisplay(getDisplayTypeForCard(question.display(), data))
       .card();
     dispatch.action(QUERY_COMPLETED, { card, queryResults });
   };

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -958,34 +958,14 @@ export const runQuestionQuery = ({
 export const CLEAR_QUERY_RESULT = "metabase/query_builder/CLEAR_QUERY_RESULT";
 export const clearQueryResult = createAction(CLEAR_QUERY_RESULT);
 
-// Most of display-type auto-selection lives in Question. This takes place
-// *after* that, uses the column/row count, and also affects SQL questions. It's
-// used to switch between table and scalar.
-const getDisplayTypeForCard = (display, { cols, rows = [] }) => {
-  const isScalarVisualization =
-    display === "scalar" || display === "progress" || display === "gauge";
-  if (!isScalarVisualization && rows.length === 1 && cols.length === 1) {
-    // if we have a 1x1 data result then this should always be viewed as a scalar
-    return "scalar";
-  } else if (isScalarVisualization && (rows.length > 1 || cols.length > 1)) {
-    // any time we were a scalar and now have more than 1x1 data switch to table view
-    return "table";
-  } else if (display == null) {
-    // if our query aggregation is "rows" then ALWAYS set the display to "table"
-    return "table";
-  }
-  return display;
-};
-
 export const QUERY_COMPLETED = "metabase/qb/QUERY_COMPLETED";
 export const queryCompleted = (question, queryResults) => {
   return async (dispatch, getState) => {
     const [{ data }] = queryResults;
-    question = question
-      .setSensibleDisplays(getSensibleDisplays(data))
-      .setDefaultDisplay();
     const card = question
-      .setDisplay(getDisplayTypeForCard(question.display(), data))
+      .setSensibleDisplays(getSensibleDisplays(data))
+      .setDefaultDisplay()
+      .switchTableScalar(data)
       .card();
     dispatch.action(QUERY_COMPLETED, { card, queryResults });
   };

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -454,10 +454,10 @@ export const initializeQB = (location, params) => {
     let question = card && new Question(card, getMetadata(getState()));
     if (params.cardId) {
       // loading a saved question prevents auto-viz selection
-      question = question.setSelectedDisplay(question.display());
+      question = question && question.setSelectedDisplay(question.display());
     }
 
-    card = question.card();
+    card = question && question.card();
 
     // Update the question to Redux state together with the initial state of UI controls
     dispatch.action(INITIALIZE_QB, {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
@@ -60,7 +60,9 @@ const ChartTypeSidebar = ({
                     visualization.isSensible(result.data)
                   }
                   onClick={() => {
-                    question.setDisplay(type).update(null, { reload: false });
+                    question
+                      .setSelectedDisplay(type)
+                      .update(null, { reload: false });
                     onOpenChartSettings({ section: t`Data` });
                     setUIControls({ isShowingRawTable: false });
                   }}

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -199,8 +199,9 @@ export const card = handleActions(
     [QUERY_COMPLETED]: {
       next: (state, { payload }) => ({
         ...state,
-        sensibleDisplays: payload.sensibleDisplays,
-        display: payload.cardDisplay,
+        sensibleDisplays: payload.card.sensibleDisplays,
+        selectedDisplay: payload.card.selectedDisplay,
+        display: payload.card.display,
       }),
     },
 

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -199,6 +199,7 @@ export const card = handleActions(
     [QUERY_COMPLETED]: {
       next: (state, { payload }) => ({
         ...state,
+        sensibleDisplays: payload.sensibleDisplays,
         display: payload.cardDisplay,
       }),
     },

--- a/frontend/src/metabase/visualizations/index.js
+++ b/frontend/src/metabase/visualizations/index.js
@@ -28,6 +28,12 @@ visualizations.get = function(key) {
   return Map.prototype.get.call(this, key) || aliases.get(key) || Table;
 };
 
+export function getSensibleDisplays(data) {
+  return Array.from(visualizations)
+    .filter(([, viz]) => viz.isSensible && viz.isSensible(data))
+    .map(([display]) => display);
+}
+
 export function registerVisualization(visualization) {
   if (visualization == null) {
     throw new Error(t`Visualization is null`);

--- a/frontend/src/metabase/visualizations/visualizations/Map.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map.jsx
@@ -45,7 +45,10 @@ export default class Map extends Component {
   static minSize = { width: 4, height: 4 };
 
   static isSensible({ cols, rows }) {
-    return true;
+    return (
+      PinMap.isSensible({ cols, rows }) ||
+      ChoroplethMap.isSensible({ cols, rows })
+    );
   }
 
   static placeholderSeries = [

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -267,6 +267,25 @@ describe("Question", () => {
         expect(scalarQuestion.display()).toBe("scalar");
       });
     });
+    describe("setDefaultDisplay", () => {
+      it("sets display to 'scalar' for order count", () => {
+        const question = new Question(
+          orders_count_card,
+          metadata,
+        ).setDefaultDisplay();
+
+        expect(question.display()).toBe("scalar");
+      });
+
+      it("should not set the display to scalar table was selected", () => {
+        const question = new Question(orders_count_card, metadata)
+          .setSelectedDisplay("table")
+          .setSensibleDisplays(["table", "scalar"])
+          .setDefaultDisplay();
+
+        expect(question.display()).toBe("table");
+      });
+    });
   });
 
   // TODO: These are mode-dependent and should probably be tied to modes

--- a/frontend/test/metabase/scenarios/query_builder.e2e.spec.js
+++ b/frontend/test/metabase/scenarios/query_builder.e2e.spec.js
@@ -31,9 +31,7 @@ describe("query builder", () => {
       await app.async.findByText("Simple question").click();
 
       await waitForAllRequestsToComplete(); // race condition in DataSelector with loading metadata
-      try {
-        await app.async.findByText("Sample Dataset").click(); // not needed if there's only one database
-      } catch (e) {}
+      await maybeClickSampleDataset(app);
       await app.async.findByText("Orders").click();
       await app.async.findByText("37.65");
     });
@@ -47,9 +45,7 @@ describe("query builder", () => {
       await app.async.findByText("Custom question").click();
 
       await waitForAllRequestsToComplete(); // race condition in DataSelector with loading metadata
-      try {
-        await app.async.findByText("Sample Dataset").click(); // not needed if there's only one database
-      } catch (e) {}
+      await maybeClickSampleDataset(app);
       await app.async.findByText("Orders").click();
       await app.async.findByText("Visualize").click();
       await app.async.findByText("37.65");
@@ -62,9 +58,7 @@ describe("query builder", () => {
       await app.async.findByText("Custom question").click();
 
       await waitForAllRequestsToComplete(); // race condition in DataSelector with loading metadata
-      try {
-        await app.async.findByText("Sample Dataset").click(); // not needed if there's only one database
-      } catch (e) {}
+      await maybeClickSampleDataset(app);
       await app.async.findByText("Orders").click();
       await app.async.findByText("Pick the metric you want to see").click();
       await app.async.findByText("Count of rows").click();
@@ -103,3 +97,14 @@ describe("query builder", () => {
     });
   });
 });
+
+// This isn't needed if there's only one db. In that case, clicking "Sample
+// Dataset" will actually take you back to select a db again.
+async function maybeClickSampleDataset(app) {
+  try {
+    const sampleDataset = await app.async.findByText("Sample Dataset");
+    if (sampleDataset.hasClass("List-section-title")) {
+      sampleDataset.click();
+    }
+  } catch (e) {}
+}


### PR DESCRIPTION
Resolves #10957

### New Logic

When a user chooses a visualization type or saves a question we lock in that choice unless the display type isn't sensible any more. 

### More Details

A card in the QB now has information on a selected display and a list of sensible displays.

Explicitly choosing a visualization sets the _selected_ display (alongside the current display). Saving a question or loading a saved question both set the current display as the selected display. Effectively, `selectedDisplay` acts as a boolean flag that disables auto-selection when the question updates.


Whenever a query completes we update the list of sensible displays given the new data.
This list of sensible displays is used to override the selected display. If the selected display isn't sensible, auto-selection picks a new one.
