### PR TITLE
MongoDB: add nippy serialization for BSON.ObjectId

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -18,14 +18,24 @@
              [command :as cmd]
              [conversion :as conv]
              [db :as mdb]]
-            [schema.core :as s])
+            [schema.core :as s]
+            [taoensso.nippy :as nippy])
   (:import com.mongodb.DB
-           org.bson.BsonUndefined))
+           org.bson.BsonUndefined
+           org.bson.types.ObjectId))
 
 ;; JSON Encoding (etc.)
 
 ;; Encode BSON undefined like `nil`
 (json.generate/add-encoder org.bson.BsonUndefined json.generate/encode-nil)
+
+(nippy/extend-freeze ObjectId :mongodb/ObjectId
+  [^ObjectId oid data-output]
+  (.writeUTF data-output (.toHexString oid)))
+
+(nippy/extend-thaw :mongodb/ObjectId
+  [data-input]
+  (ObjectId. (.readUTF data-input)))
 
 (driver/register! :mongo)
 

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -21,6 +21,7 @@
             [metabase.test.data
              [datasets :as datasets]
              [interface :as tx]]
+            [taoensso.nippy :as nippy]
             [toucan.db :as db]
             [toucan.util.test :as tt])
   (:import org.bson.types.ObjectId))
@@ -293,3 +294,9 @@
         :limit    3})
      qp.t/data
      (select-keys [:columns :rows]))))
+
+
+;; Make sure we correctly (un-)freeze BSON IDs
+(deftest ObjectId-serialization
+  (let [oid (ObjectId. "012345678901234567890123")]
+    (is (= oid (nippy/thaw (nippy/freeze oid))))))


### PR DESCRIPTION
Adds nippy (de)serializers for Mongo's BSON/ObjectIds

Fixes #11121