### PR TITLE
specify a resourceType for dashboard embeds

### DIFF
--- a/frontend/src/metabase/components/TextEditor.jsx
+++ b/frontend/src/metabase/components/TextEditor.jsx
@@ -74,6 +74,11 @@ export default class TextEditor extends Component {
   };
 
   componentDidMount() {
+    if (typeof ace === "undefined" || !ace || !ace.edit) {
+      // fail gracefully-ish if ace isn't available, e.x. in integration tests
+      return;
+    }
+
     const element = ReactDOM.findDOMNode(this);
     this._editor = ace.edit(element);
 

--- a/frontend/src/metabase/components/TextEditor.jsx
+++ b/frontend/src/metabase/components/TextEditor.jsx
@@ -40,6 +40,10 @@ export default class TextEditor extends Component {
   _update() {
     const element = ReactDOM.findDOMNode(this);
 
+    if (this._editor == null) {
+      return; // _editor is undefined when ace isn't loaded in tests
+    }
+
     this._updateValue();
 
     this._editor.getSession().setMode(this.props.mode);

--- a/frontend/src/metabase/dashboard/containers/DashboardEmbedWidget.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardEmbedWidget.jsx
@@ -71,6 +71,7 @@ export default class DashboardEmbedWidget extends Component {
           className={className}
           resource={dashboard}
           resourceParameters={dashboard && dashboard.parameters}
+          resourceType="dashboard"
           onCreatePublicLink={() => createPublicLink(dashboard)}
           onDisablePublicLink={() => deletePublicLink(dashboard)}
           onUpdateEnableEmbedding={enableEmbedding =>

--- a/frontend/test/metabase/dashboard/dashboard.e2e.spec.js
+++ b/frontend/test/metabase/dashboard/dashboard.e2e.spec.js
@@ -367,7 +367,7 @@ describe("Dashboard", () => {
       store.pushPath(dashboardUrl);
       const app = mount(store.getAppContainer());
       await store.waitForActions([FETCH_DASHBOARD]);
-      await delay(100);
+      await delay(1000);
       app.findByIcon("share").click();
       app.findByText("Embed this dashboard in an application").click();
       app.findByText("Code").click();

--- a/frontend/test/metabase/dashboard/dashboard.e2e.spec.js
+++ b/frontend/test/metabase/dashboard/dashboard.e2e.spec.js
@@ -29,6 +29,8 @@ import Question from "metabase/entities/questions";
 import Search from "metabase/entities/search";
 import Revisions from "metabase/entities/revisions";
 
+import { updateSetting } from "metabase/admin/settings/settings";
+
 import EditBar from "metabase/components/EditBar";
 
 import { delay } from "metabase/lib/promise";
@@ -363,11 +365,22 @@ describe("Dashboard", () => {
       checkDashboardWasCreated();
 
       const store = await createTestStore();
+      await store.dispatch(
+        updateSetting({ key: "enable-embedding", value: true }),
+      );
+
+      await store.dispatch(
+        updateSetting({
+          key: "embedding-secret-key",
+          value:
+            "2547733eb6a2fc0ff405f43ca94433b90b8f49aa2c667c39d3c7ce8750fcf1af",
+        }),
+      );
+
       const dashboardUrl = Urls.dashboard(dashboardId);
       store.pushPath(dashboardUrl);
       const app = mount(store.getAppContainer());
       await store.waitForActions([FETCH_DASHBOARD]);
-      await delay(1000);
       app.findByIcon("share").click();
       app.findByText("Embed this dashboard in an application").click();
       app.findByText("Code").click();
@@ -378,7 +391,7 @@ describe("Dashboard", () => {
 var jwt = require("jsonwebtoken");
 
 var METABASE_SITE_URL = "http://localhost:4000";
-var METABASE_SECRET_KEY = "35e56b52a8dd9e806c8007865f300c078e1bb5ed18d5f9d3731a7a01d80a86f4";
+var METABASE_SECRET_KEY = "2547733eb6a2fc0ff405f43ca94433b90b8f49aa2c667c39d3c7ce8750fcf1af";
 
 var payload = {
   resource: { dashboard: ${dashboardId} },
@@ -395,6 +408,10 @@ var iframeUrl = METABASE_SITE_URL + "/embed/dashboard/" + token + "#bordered=tru
     height="600"
     allowtransparency
 ></iframe>`);
+
+      await store.dispatch(
+        updateSetting({ key: "enable-embedding", value: false }),
+      );
     });
   });
 });

--- a/frontend/test/metabase/dashboard/dashboard.e2e.spec.js
+++ b/frontend/test/metabase/dashboard/dashboard.e2e.spec.js
@@ -358,5 +358,42 @@ describe("Dashboard", () => {
       await store.waitForActions([FETCH_DASHBOARD]);
       expect(app.find(".DashCard")).toHaveLength(1);
     });
+
+    it("displays the correct embed snippets", async () => {
+      checkDashboardWasCreated();
+
+      const store = await createTestStore();
+      const dashboardUrl = Urls.dashboard(dashboardId);
+      store.pushPath(dashboardUrl);
+      const app = mount(store.getAppContainer());
+      await store.waitForActions([FETCH_DASHBOARD]);
+      app.findByIcon("share").click();
+      app.findByText("Embed this dashboard in an application").click();
+      app.findByText("Code").click();
+      const [js, html] = app.find("TextEditor").map(n => n.prop("value"));
+      expect(js)
+        .toBe(`// you will need to install via 'npm install jsonwebtoken' or in your package.json
+
+var jwt = require("jsonwebtoken");
+
+var METABASE_SITE_URL = "http://localhost:4000";
+var METABASE_SECRET_KEY = "35e56b52a8dd9e806c8007865f300c078e1bb5ed18d5f9d3731a7a01d80a86f4";
+
+var payload = {
+  resource: { dashboard: ${dashboardId} },
+  params: {},
+  exp: Math.round(Date.now() / 1000) + (10 * 60) // 10 minute expiration
+};
+var token = jwt.sign(payload, METABASE_SECRET_KEY);
+
+var iframeUrl = METABASE_SITE_URL + "/embed/dashboard/" + token + "#bordered=true&titled=true";`);
+      expect(html).toBe(`<iframe
+    src="{{iframeUrl}}"
+    frameborder="0"
+    width="800"
+    height="600"
+    allowtransparency
+></iframe>`);
+    });
   });
 });

--- a/frontend/test/metabase/dashboard/dashboard.e2e.spec.js
+++ b/frontend/test/metabase/dashboard/dashboard.e2e.spec.js
@@ -367,6 +367,7 @@ describe("Dashboard", () => {
       store.pushPath(dashboardUrl);
       const app = mount(store.getAppContainer());
       await store.waitForActions([FETCH_DASHBOARD]);
+      await delay(100);
       app.findByIcon("share").click();
       app.findByText("Embed this dashboard in an application").click();
       app.findByText("Code").click();


### PR DESCRIPTION
Fixes #11315 

The Dashboard embed widget apparently wasn't specifying a `resourceType` which is required for constructing the URL for code snippets and actually previewing your dashboard embed. I'm not sure if this is the code path where things broke or not but specifying it here sets things right.

**Before**
<img width="848" alt="Screen Shot 2019-11-25 at 5 03 16 PM" src="https://user-images.githubusercontent.com/5248953/69582218-1b95a080-0fa6-11ea-80ca-9919dc4c9c2f.png">
**After**
<img width="844" alt="Screen Shot 2019-11-25 at 5 02 54 PM" src="https://user-images.githubusercontent.com/5248953/69582219-1b95a080-0fa6-11ea-979c-f365dc484a94.png">


ToDos
- [ ] Investigate further into how this broke and test the crap out of it.