### PR TITLE
Log handle nil status

### DIFF
--- a/src/metabase/middleware/log.clj
+++ b/src/metabase/middleware/log.clj
@@ -29,13 +29,19 @@
 
 ;; These functions take parts of the info map and convert it into formatted strings.
 
-(defn- format-status-info [{:keys [async-status], {:keys [request-method uri]} :request, {:keys [status]} :response}]
+(defn- format-status-info
+  [{:keys [async-status]
+    {:keys [request-method uri] :or {request-method :XXX}} :request
+    {:keys [status]} :response}]
   (str
    (format "%s %s %d" (str/upper-case (name request-method)) uri status)
    (when async-status
      (format " [ASYNC: %s]" async-status))))
 
-(defn- format-performance-info [{:keys [start-time call-count-fn]}]
+(defn- format-performance-info
+  [{:keys [start-time call-count-fn]
+    :or {start-time    (System/nanoTime)
+         call-count-fn (constantly -1)}}]
   (let [elapsed-time (du/format-nanoseconds (- (System/nanoTime) start-time))
         db-calls     (call-count-fn)]
     (format "%s (%d DB calls)" elapsed-time db-calls)))
@@ -99,12 +105,15 @@
     :log-fn         #(log/debug %)
     :include-stats? true}])
 
-(defn- log-info [{{:keys [status]} :response, :as info}]
+(defn- log-info
+  [{{:keys [status] :or {status -1}} :response, :as info}]
   (try
-    (let [{:keys [color log-fn], :as opts} (some #(when (and (some? status)
-                                                             ((:status-pred %) status))
-                                                    %)
-                                                 log-options)]
+    (let [{:keys [color log-fn]
+           :or {color  :default-color
+                log-fn identity}
+           :as opts}
+          (some #(when ((:status-pred %) status) %)
+                log-options)]
       (log-fn (u/format-color color (format-info info opts))))
     (catch Throwable e
       (log/error e (trs "Error logging API request")))))

--- a/src/metabase/middleware/log.clj
+++ b/src/metabase/middleware/log.clj
@@ -101,7 +101,8 @@
 
 (defn- log-info [{{:keys [status]} :response, :as info}]
   (try
-    (let [{:keys [color log-fn], :as opts} (some #(when ((:status-pred %) status)
+    (let [{:keys [color log-fn], :as opts} (some #(when (and (some? status)
+                                                             ((:status-pred %) status))
                                                     %)
                                                  log-options)]
       (log-fn (u/format-color color (format-info info opts))))

--- a/test/metabase/middleware/log_test.clj
+++ b/test/metabase/middleware/log_test.clj
@@ -1,0 +1,12 @@
+(ns metabase.middleware.log-test
+  (:require [clojure.test :refer :all]
+            [metabase.middleware.log :as log]))
+
+(deftest log-info-input-tests
+  (testing "log-info handles nil status input"
+    (is (true?
+          (try
+            (#'log/log-info nil)
+            true
+            (catch Throwable _
+              false)))))) ; Make sure it didn't throw NPE


### PR DESCRIPTION
I've noticed this error in EE logs a few times, and found CE to be affected too:

```
11-28 00:10:18 ERROR middleware.log :: Error logging API request
java.lang.NullPointerException
        at clojure.lang.Numbers.ops(Numbers.java:1068)
        at clojure.lang.Numbers.gte(Numbers.java:263)
        at clojure.lang.Numbers.gte(Numbers.java:3981)
        at metabase.middleware.log$fn__76687.invokeStatic(log.clj:81)
        at metabase.middleware.log$fn__76687.invoke(log.clj:80)
        at metabase.middleware.log$log_info$fn__76710.invoke(log.clj:104)
        at clojure.core$some.invokeStatic(core.clj:2701)
        at clojure.core$some.invoke(core.clj:2692)
        at metabase.middleware.log$log_info.invokeStatic(log.clj:104)
        at metabase.middleware.log$log_info.invoke(log.clj:102)
        at metabase.middleware.log$logged_response.invokeStatic(log.clj:139)
        at metabase.middleware.log$logged_response.invoke(log.clj:133)
        at clojure.core$comp$fn__5807.invoke(core.clj:2569)
        at clojure.core$comp$fn__5807.invoke(core.clj:2569)
        at clojure.core$comp$fn__5807.invoke(core.clj:2569)
        at metabase.middleware.exceptions$catch_uncaught_exceptions$fn__75917.invoke(exceptions.clj:114)
        at metabase.middleware.exceptions$catch_api_exceptions$fn__75914.invoke(exceptions.clj:92)
        at metabase.middleware.log$log_api_call$fn__76804$fn__76805.invoke(log.clj:170)
        at toucan.db$_do_with_call_counting.invokeStatic(db.clj:213)
        at toucan.db$_do_with_call_counting.invoke(db.clj:206)
        at metabase.middleware.log$log_api_call$fn__76804.invoke(log.clj:164)
        at metabase.middleware.security$add_security_headers$fn__75872.invoke(security.clj:132)
        at metabase.middleware.json$wrap_json_body$fn__76405.invoke(json.clj:61)
        at metabase.middleware.json$wrap_streamed_json_response$fn__76423.invoke(json.clj:97)
        at ring.middleware.keyword_params$wrap_keyword_params$fn__77027.invoke(keyword_params.clj:55)
        at ring.middleware.params$wrap_params$fn__77101.invoke(params.clj:69)
        at metabase.middleware.session$bind_current_user$fn__71878$fn__71879.invoke(session.clj:282)
        at metabase.middleware.session$do_with_current_user.invokeStatic(session.clj:257)
        at metabase.middleware.session$do_with_current_user.invoke(session.clj:250)
        at metabase.middleware.session$bind_current_user$fn__71878.invoke(session.clj:281)
        at metabase.middleware.session$wrap_current_user_id$fn__71855.invoke(session.clj:230)
        at metabase.middleware.session$wrap_session_id$fn__71834.invoke(session.clj:160)
        at metabase.middleware.auth$wrap_api_key$fn__75797.invoke(auth.clj:27)
        at metabase.middleware.misc$maybe_set_site_url$fn__71642.invoke(misc.clj:56)
        at metabase.middleware.misc$bind_user_locale$fn__71645.invoke(misc.clj:72)
        at ring.middleware.cookies$wrap_cookies$fn__76931.invoke(cookies.clj:177)
        at metabase.middleware.misc$add_content_type$fn__71630.invoke(misc.clj:28)
        at metabase.middleware.misc$disable_streaming_buffering$fn__71653.invoke(misc.clj:87)
        at ring.middleware.gzip$wrap_gzip$fn__76981.invoke(gzip.clj:86)
        at metabase.middleware.misc$bind_request$fn__71656.invoke(misc.clj:104)
        at clojure.lang.Var.invoke(Var.java:393)
        at ring.adapter.jetty$async_proxy_handler$fn__76601.invoke(jetty.clj:35)
        at ring.adapter.jetty.proxy$org.eclipse.jetty.server.handler.AbstractHandler$ff19274a.handle(Unknown Sour
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
        at org.eclipse.jetty.server.Server.handle(Server.java:502)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:370)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:267)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:305)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
        at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:117)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:333)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:310)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:168)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:126)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:36
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:765)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:683)
        at java.lang.Thread.run(Thread.java:748)
```

I'm not sure how `status` gets to be `nil` (I can't reliably reproduce it), but it clearly happens. Through the test in this PR, I discovered a few more related NPEs. Hence the other changes.