### PR TITLE
Make LDAP attribute discovery case-insensitive

### DIFF
--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -50,15 +50,18 @@
 
 (defsetting ldap-attribute-email
   (deferred-tru "Attribute to use for the user's email. (usually ''mail'', ''email'' or ''userPrincipalName'')")
-  :default "mail")
+  :default "mail"
+  :getter (fn [] (u/lower-case-en (setting/get-string :ldap-attribute-email))))
 
 (defsetting ldap-attribute-firstname
   (deferred-tru "Attribute to use for the user''s first name. (usually ''givenName'')")
-  :default "givenName")
+  :default "givenName"
+  :getter (fn [] (u/lower-case-en (setting/get-string :ldap-attribute-firstname))))
 
 (defsetting ldap-attribute-lastname
   (deferred-tru "Attribute to use for the user''s last name. (usually ''sn'')")
-  :default "sn")
+  :default "sn"
+  :getter (fn [] (u/lower-case-en (setting/get-string :ldap-attribute-lastname))))
 
 (defsetting ldap-group-sync
   (deferred-tru "Enable group membership synchronization with LDAP.")
@@ -183,7 +186,7 @@
    (with-connection find-user username))
 
   ([conn username]
-   (when-let [{:keys [dn], :as result} (search conn username)]
+   (when-let [{:keys [dn], :as result} (u/lower-case-map-keys (search conn username))]
      (let [{fname (keyword (ldap-attribute-firstname))
             lname (keyword (ldap-attribute-lastname))
             email (keyword (ldap-attribute-email))}    result]

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -786,3 +786,9 @@
   `Locale/US` locale."
   [^CharSequence s]
   (.. s toString (toLowerCase (Locale/US))))
+
+(defn lower-case-map-keys
+  "Changes the keys of a given map to lower case."
+  [m]
+  (into {} (for [[k v] m]
+             [(-> k name lower-case-en keyword) v])))

--- a/test/metabase/integrations/ldap_test.clj
+++ b/test/metabase/integrations/ldap_test.clj
@@ -105,6 +105,16 @@
   (ldap.test/with-ldap-server
     (ldap/find-user "John.Smith@metabase.com")))
 
+;; Find by email should also work (also given our default settings and fixtures)
+(expect
+  {:dn         "cn=Fred Taylor,ou=People,dc=metabase,dc=com"
+   :first-name "Fred"
+   :last-name  "Taylor"
+   :email      "fred.taylor@metabase.com"
+   :groups     []}
+  (ldap.test/with-ldap-server
+    (ldap/find-user "fred.taylor@metabase.com")))
+
 ;; LDAP group matching should identify Metabase groups using DN equality rules
 (expect
   #{1 2 3}

--- a/test_resources/ldap.ldif
+++ b/test_resources/ldap.ldif
@@ -34,6 +34,18 @@ uid: sbrown20
 mail: sally.brown@metabase.com
 userPassword: 1234
 
+dn: cn=Fred Taylor,ou=People,dc=metabase,dc=com
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: Fred Taylor
+sN: Taylor
+givenname: Fred
+uid: ftaylor300
+mAiL: fred.taylor@metabase.com
+userpassword: unh4ck4bl3
+
 dn: ou=Birds,dc=metabase,dc=com
 objectClass: top
 objectClass: organizationalUnit


### PR DESCRIPTION
Fixes #11411 

- transforms all the keys of the retrieved LDAP record to lower case
- fetch the values from the LDAP record using the lower cased attribute names