### PR TITLE
Shrink Docker image size

### DIFF
--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -4,11 +4,10 @@ ENV FC_LANG en-US
 ENV LC_CTYPE en_US.UTF-8
 
 # dependencies
-RUN apk add --update bash ttf-dejavu fontconfig
+RUN apk add --no-cache bash ttf-dejavu fontconfig
 
 # add Metabase jar
 COPY ./metabase.jar /app/
-RUN chmod o+r /app/metabase.jar
 
 # add our run script to the image
 COPY ./run_metabase.sh /app/

--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -119,6 +119,9 @@ if [ ! -z "$JAVA_TIMEZONE" ]; then
     JAVA_OPTS="${JAVA_OPTS} -Duser.timezone=${JAVA_TIMEZONE}"
 fi
 
+# Ensure JAR file is world readable
+chmod o+r /app/metabase.jar
+
 # Initialize the Metabase db from H2 dump, if available
 INITIAL_DB=$(ls /app/initial*.db 2> /dev/null | head -n 1)
 if [ -f "${INITIAL_DB}" ]; then


### PR DESCRIPTION
- Moves a `chmod` command from Dockerfile to `entrypoint` script, to avoid duplicate layer.
- Changes `apk --update` to `apk --no-cache`, since it both updates and avoids cache files.

Shrinks the image from 540MB to 350MB (mostly the extra layer of `metabase.jar`).
Fixes #10771