### PR TITLE
SQL editor fixes

### DIFF
--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -491,17 +491,19 @@
 
 .NativeQueryEditorDragHandleWrapper {
   position: absolute;
-  height: 5px;
+  height: 8px;
   width: 100%;
-  bottom: -2.5px;
+  bottom: -4px;
   cursor: row-resize;
   display: flex;
   justify-content: center;
+  align-items: center;
 }
 
 .NativeQueryEditorDragHandle {
   background: color(var(--color-border) blackness(+ 3%));
   width: 100px;
+  height: 5px;
   border-radius: 4px;
 }
 

--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -489,17 +489,20 @@
   border-right: none;
 }
 
+.NativeQueryEditorDragHandleWrapper {
+  position: absolute;
+  height: 5px;
+  width: 100%;
+  bottom: -2.5px;
+  cursor: row-resize;
+  display: flex;
+  justify-content: center;
+}
+
 .NativeQueryEditorDragHandle {
   background: color(var(--color-border) blackness(+ 3%));
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-  height: 5px;
   width: 100px;
   border-radius: 4px;
-  cursor: row-resize;
-  margin-left: -50px;
-  margin-bottom: -2.5px;
 }
 
 /* VISUALIZATION SETTINGS */

--- a/frontend/src/metabase/lib/browser.js
+++ b/frontend/src/metabase/lib/browser.js
@@ -26,3 +26,8 @@ export function updateQueryString(location, optionsUpdater) {
     search: queryString ? `?${queryString}` : null,
   };
 }
+
+export function isMac() {
+  const { platform = "" } = navigator;
+  return Boolean(platform.match(/^Mac/));
+}

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -206,24 +206,28 @@ export default class NativeQueryEditor extends Component {
   };
 
   handleKeyDown = (e: KeyboardEvent) => {
-    const { query, runQuestionQuery } = this.props;
-
     const ENTER_KEY = 13;
     if (e.keyCode === ENTER_KEY && (e.metaKey || e.ctrlKey)) {
-      // if any text is selected, just run that
-      const selectedText = this._editor.getSelectedText();
-      if (selectedText) {
-        const temporaryCard = query
-          .setQueryText(selectedText)
-          .question()
-          .card();
-        runQuestionQuery({
-          overrideWithCard: temporaryCard,
-          shouldUpdateUrl: false,
-        });
-      } else if (query.canRun()) {
-        runQuestionQuery();
-      }
+      this.runQuery();
+    }
+  };
+
+  runQuery = () => {
+    const { query, runQuestionQuery } = this.props;
+
+    // if any text is selected, just run that
+    const selectedText = this._editor.getSelectedText();
+    if (selectedText) {
+      const temporaryCard = query
+        .setQueryText(selectedText)
+        .question()
+        .card();
+      runQuestionQuery({
+        overrideWithCard: temporaryCard,
+        shouldUpdateUrl: false,
+      });
+    } else if (query.canRun()) {
+      runQuestionQuery();
     }
   };
 
@@ -357,7 +361,6 @@ export default class NativeQueryEditor extends Component {
       isRunning,
       isResultDirty,
       isPreviewing,
-      runQuestionQuery,
     } = this.props;
 
     const database = query.database();
@@ -482,7 +485,7 @@ export default class NativeQueryEditor extends Component {
               isRunning={isRunning}
               isDirty={isResultDirty}
               isPreviewing={isPreviewing}
-              onRun={runQuestionQuery}
+              onRun={this.runQuery}
               compact
               className="mx2 mb2 mt-auto p2"
               getTooltip={() =>

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -95,7 +95,6 @@ type Props = {
 type State = {
   initialHeight: number,
   hasTextSelected: boolean,
-  firstRun: boolean,
 };
 
 export default class NativeQueryEditor extends Component {
@@ -118,7 +117,6 @@ export default class NativeQueryEditor extends Component {
 
     this.state = {
       initialHeight: getEditorLineHeight(lines),
-      firstRun: true,
       hasTextSelected: false,
     };
 
@@ -183,13 +181,6 @@ export default class NativeQueryEditor extends Component {
       if (aceMode.indexOf("sql") >= 0) {
         this._editor.getSession().$mode.$behaviour = new SQLBehaviour();
       }
-    }
-  }
-
-  componentWillReceiveProps(nextProps: Props) {
-    if (this.state.firstRun && nextProps.isRunning && !this.props.isRunning) {
-      this.setState({ firstRun: false });
-      this._updateSize(true);
     }
   }
 
@@ -295,7 +286,7 @@ export default class NativeQueryEditor extends Component {
     });
   }
 
-  _updateSize(allowShrink: boolean = false) {
+  _updateSize() {
     const doc = this._editor.getSession().getDocument();
     const element = ReactDOM.findDOMNode(this.refs.resizeBox);
     // set the newHeight based on the line count, but ensure it's within
@@ -306,7 +297,7 @@ export default class NativeQueryEditor extends Component {
         MIN_HEIGHT_LINES,
       ),
     );
-    if (allowShrink || newHeight > element.offsetHeight) {
+    if (newHeight > element.offsetHeight) {
       element.style.height = newHeight + "px";
       this._editor.resize();
     }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -219,7 +219,7 @@ export default class NativeQueryEditor extends Component {
     const { query, runQuestionQuery } = this.props;
 
     // if any text is selected, just run that
-    const selectedText = this._editor.getSelectedText();
+    const selectedText = this._editor && this._editor.getSelectedText();
     if (selectedText) {
       const temporaryCard = query
         .setQueryText(selectedText)

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -148,7 +148,6 @@ export default class NativeQueryEditor extends Component {
 
   componentDidMount() {
     this.loadAceEditor();
-    document.addEventListener("selectionchange", this.handleSelectionChange);
     document.addEventListener("keydown", this.handleKeyDown);
   }
 
@@ -194,7 +193,6 @@ export default class NativeQueryEditor extends Component {
   }
 
   componentWillUnmount() {
-    document.removeEventListener("selectionchange", this.handleSelectionChange);
     document.removeEventListener("keydown", this.handleKeyDown);
   }
 
@@ -246,6 +244,7 @@ export default class NativeQueryEditor extends Component {
 
     // listen to onChange events
     this._editor.getSession().on("change", this.onChange);
+    this._editor.on("changeSelection", this.handleSelectionChange);
 
     // initialize the content
     this._editor.setValue(query ? query.queryText() : "");

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -412,6 +412,11 @@ export default class NativeQueryEditor extends Component {
         : t`Show Query`;
       toggleEditorIcon = "expand";
     }
+    const dragHandle = (
+      <div className="NativeQueryEditorDragHandleWrapper">
+        <div className="NativeQueryEditorDragHandle" />
+      </div>
+    );
 
     return (
       <div className="NativeQueryEditor bg-light full">
@@ -445,7 +450,7 @@ export default class NativeQueryEditor extends Component {
           height={this.state.initialHeight}
           minConstraints={[Infinity, getEditorLineHeight(MIN_HEIGHT_LINES)]}
           axis="y"
-          handle={<div className="NativeQueryEditorDragHandle" />}
+          handle={dragHandle}
           onResizeStop={(e, data) => {
             this.props.handleResize();
             this._editor.resize();

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 
 import cx from "classnames";
 
+import ExplicitSize from "metabase/components/ExplicitSize";
 import Popover from "metabase/components/Popover";
 import DebouncedFrame from "metabase/components/DebouncedFrame";
 import Subhead from "metabase/components/Subhead";
@@ -42,6 +43,7 @@ const DEFAULT_POPOVER_STATE = {
   breakoutPopoverTarget: null,
 };
 
+@ExplicitSize()
 export default class View extends React.Component {
   state = {
     ...DEFAULT_POPOVER_STATE,
@@ -97,6 +99,7 @@ export default class View extends React.Component {
       queryBuilderMode,
       mode,
       fitClassNames,
+      height,
     } = this.props;
     const {
       aggregationIndex,
@@ -253,6 +256,7 @@ export default class View extends React.Component {
                 <div className="z2 hide sm-show border-bottom mb2">
                   <NativeQueryEditor
                     {...this.props}
+                    viewHeight={height}
                     isOpen={!card.dataset_query.native.query || isDirty}
                     datasetQuery={card && card.dataset_query}
                   />


### PR DESCRIPTION
Fix #11451 

* Expand the resize drag handle to the full width
* Increase the default height of the editor and have it grow with page height
* Run selected portion of query when clicking the run button
* Fix some jankiness with updating the run button tooltip when text is selected
* Switch between "⌘ + enter" and "Ctrl + enter" depending on OS
