### PR TITLE
Fix issues with chart values

### DIFF
--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -688,7 +688,6 @@
   color: var(--color-text-medium);
 }
 
-/* TEMP - spot for value labels */
 text.value-label-outline {
   font-weight: 900;
   stroke-width: 4px;
@@ -696,7 +695,13 @@ text.value-label-outline {
 }
 
 text.value-label {
+  fill: var(--color-text-dark);
   font-weight: 900;
+}
+
+text.value-label-outline,
+text.value-label {
+  pointer-events: none;
 }
 
 .Dashboard--night text.value-label-outline {


### PR DESCRIPTION
This PR fixes issues with chart values that @flamber [mentioned](https://github.com/metabase/metabase/pull/11363#issuecomment-562391374). Specifically:

* Change the text color from black to `--color-text-dark`
* Make sampling deterministic
To compute the right density, we render a few labels and average their rendered widths. That was previously done with `_.sample`. This mostly worked, but for chart widths that were "between" two spacings, different samples would randomly return different spacing. Now, we just take an evenly spaced sample starting with the first item.
* Ensure labels are removed before adding more
This fixes the issue where clicking on the whitespace would add more labels.
* Fix Firefox issue
Firefox was following the spec and not applying `alignment-baseline` to `<text>`. I removed that property and tweaked the y shifts.
* Allow clicking for drill-through through the label
The Firefox issue revealed that the label wasn't clickable for drill through since it was rendered above the click target. I turned off pointer events on them to avoid this. The downside is that you can't highlight the value, but I doubt that's a common operation anyways.