### PR TITLE
Tweak Cypress config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,6 +187,15 @@ jobs:
               do echo `md5sum $file` >> backend-checksums.txt;
             done;
             echo `md5sum project.clj` >> backend-checksums.txt
+      # Do the same for the frontend
+      - run:
+          name: Generate checksums of all frontend source files to use as Uberjar cache key
+          command: >
+            for file in `find ./frontend -type f | sort`;
+              do echo `md5sum $file` >> frontend-checksums.txt;
+            done;
+            echo `md5sum yarn.lock` >> frontend-checksums.txt
+            echo `md5sum webpack.config.js` >> frontend-checksums.txt
       - persist_to_workspace:
           root: /home/circleci/
           paths:
@@ -438,7 +447,7 @@ jobs:
       - restore-be-deps-cache
       - restore_cache:
           keys:
-            - uberjar-{{ checksum "./backend-checksums.txt" }}-{{ checksum "yarn.lock" }}
+            - uberjar-{{ checksum "./backend-checksums.txt" }}-{{ checksum "./frontend-checksums.txt" }}
       - run:
           name: Build uberjar if needed
           command: >
@@ -447,7 +456,7 @@ jobs:
             fi
           no_output_timeout: 5m
       - save_cache:
-          key: uberjar-{{ checksum "./backend-checksums.txt" }}-{{ checksum "yarn.lock" }}
+          key: uberjar-{{ checksum "./backend-checksums.txt" }}-{{ checksum "./frontend-checksums.txt" }}
           paths:
             - /home/circleci/metabase/metabase/target/uberjar/metabase.jar
 

--- a/package.json
+++ b/package.json
@@ -210,8 +210,8 @@
     "ci": "yarn ci-frontend && yarn ci-backend",
     "ci-frontend": "yarn lint && yarn flow && yarn test",
     "ci-backend": "lein docstring-checker && lein bikeshed && lein eastwood && lein test",
-    "test-cypress": "./bin/build-for-test && yarn test-cypress-no-build",
-    "test-cypress-open": "yarn test-cypress --open",
+    "test-cypress-headless": "yarn build && ./bin/build-for-test && yarn test-cypress-no-build",
+    "test-cypress-open": "./bin/build-for-test && yarn test-cypress-no-build --open",
     "test-cypress-no-build": "yarn && babel-node ./frontend/test/__runner__/run_cypress_tests.js"
   },
   "lint-staged": {


### PR DESCRIPTION
Resolves #11453

Two separate things:

1. Cypress yarn commands
@kdoh pointed out that running `yarn test-cypress` on its own would fail unless the frontend had been build separately. That's weird, so now there are these two commands:
* `test-cypress-headless` - This builds the frontend and runs headless Cypress. 
* `test-cypress-open` - This expects the user is doing active development and has the frontend built already. It runs Cypress open.
2. Use right checksum in Circle cache
I previously updated the `build-uberjar` job to build the frontend before the uberjar. Previously the cache key included `backend-checksums.txt`, and I had appended a checksum of `yarn.lock` without really thinking about it. Most of our frontend updates don't touch `yarn.lock`, so we need to checksum all the source files too. I created `frontend-checksums.txt` for that.