### PR TITLE
Show error when running selected SQL

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -246,15 +246,17 @@ export default class DataSelector extends Component {
   };
 
   componentWillMount() {
+    this.hydrateActiveStep();
+  }
+
+  componentDidMount() {
     const useOnlyAvailableDatabase =
       !this.props.selectedDatabaseId &&
       this.props.databases.length === 1 &&
       !this.props.segments;
     if (useOnlyAvailableDatabase) {
-      setTimeout(() => this.onChangeDatabase(0, true));
+      this.onChangeDatabase(0, true);
     }
-
-    this.hydrateActiveStep();
   }
 
   componentWillReceiveProps(nextProps) {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -19,6 +19,7 @@ import "ace/mode-pgsql";
 import "ace/mode-sqlserver";
 import "ace/mode-json";
 
+import "ace/snippets/text";
 import "ace/snippets/sql";
 import "ace/snippets/mysql";
 import "ace/snippets/pgsql";
@@ -472,9 +473,16 @@ export default class NativeQueryEditor extends Component {
         >
           <div className="flex-full" id="id_sql" ref="editor" />
           <div className="flex flex-column align-center border-left">
-            {[DataReferenceButton, NativeVariablesButton].map(Button => (
-              <Button {...this.props} size={ICON_SIZE} className="mt3" />
-            ))}
+            <DataReferenceButton
+              {...this.props}
+              size={ICON_SIZE}
+              className="mt3"
+            />
+            <NativeVariablesButton
+              {...this.props}
+              size={ICON_SIZE}
+              className="mt3"
+            />
             <RunButtonWithTooltip
               disabled={!isRunnable}
               isRunning={isRunning}

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -121,9 +121,7 @@ export default class QueryVisualization extends Component {
             "Visualization--loading": isRunning,
           })}
         >
-          {result && result.error && isResultDirty ? null : result &&
-            result.error &&
-            !isResultDirty ? (
+          {result && result.error ? (
             <VisualizationError
               className="spread"
               error={result.error}

--- a/frontend/test/__support__/mocks.js
+++ b/frontend/test/__support__/mocks.js
@@ -23,6 +23,7 @@ jest.mock("ace/mode-sql", () => {}, { virtual: true });
 jest.mock("ace/mode-mysql", () => {}, { virtual: true });
 jest.mock("ace/mode-pgsql", () => {}, { virtual: true });
 jest.mock("ace/mode-sqlserver", () => {}, { virtual: true });
+jest.mock("ace/snippets/text", () => {}, { virtual: true });
 jest.mock("ace/snippets/sql", () => {}, { virtual: true });
 jest.mock("ace/snippets/mysql", () => {}, { virtual: true });
 jest.mock("ace/snippets/pgsql", () => {}, { virtual: true });

--- a/frontend/test/metabase/query_builder/components/NativeQueryEditor.cy.spec.js
+++ b/frontend/test/metabase/query_builder/components/NativeQueryEditor.cy.spec.js
@@ -1,0 +1,42 @@
+import { signInAsNormalUser } from "__support__/cypress";
+describe("NativeQueryEditor", () => {
+  beforeEach(() => {
+    signInAsNormalUser();
+    cy.on("uncaught:exception", (err, runnable) => {
+      // ignore the error if it's a "script error"
+      if (err.message.match(/^Script error./)) {
+        return false;
+      }
+      // otherwise, let Cypress fail as usual
+      return true;
+    });
+  });
+
+  it("lets you create and run a SQL question", () => {
+    cy.visit("/question/new");
+    cy.contains("Native query").click();
+    cy.get(".ace_content").type("select count(*) from orders");
+    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.contains("18,760");
+  });
+
+  it("displays an error", () => {
+    cy.visit("/question/new");
+    cy.contains("Native query").click();
+    cy.get(".ace_content").type("select * from not_a_table");
+    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.contains('Table "NOT_A_TABLE" not found');
+  });
+
+  it("displays an error when running selected text", () => {
+    cy.visit("/question/new");
+    cy.contains("Native query").click();
+    cy.get(".ace_content").type(
+      "select * from orders" +
+      "{leftarrow}".repeat(3) + // move left three
+        "{shift}{leftarrow}".repeat(19), // highlight back to the front
+    );
+    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.contains('Table "ORD" not found');
+  });
+});


### PR DESCRIPTION
Resolves #11471

This problem was that we only displayed errors if the query wasn't dirty. My hack/fix was to change that behavior. We now show the error as long as the last run query was an error.

@mazameli what do you think about that change? Should errors disappear as soon as the query is edited?

If we do want want to keep the previous behavior, I think the right fix is to correct our definition of dirty for selections. That's a bit more complicated, but doable.