### PR TITLE
Allow admins to hide `Our data` and `X-rays` on the homepage

### DIFF
--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -148,7 +148,7 @@ class Overworld extends React.Component {
                                   }
                                 >
                                   <Box>
-                                    {t`These won’t show up on the homepage for any of your users anymore, but you can always get to x-rays by clicking on Browse Data in the main navigation, then clicking on the lightning bolt :zap: icon on one of your tables.`}
+                                    {t`These won’t show up on the homepage for any of your users anymore, but you can always get to x-rays by clicking on Browse Data in the main navigation, then clicking on the lightning bolt icon on one of your tables.`}
                                   </Box>
                                 </ModalWithTrigger>
                               )}
@@ -295,7 +295,7 @@ class Overworld extends React.Component {
                           }
                         >
                           <Box>
-                            {t`Our Data” won’t show up on the homepage for any of your users anymore, but you can always browse through your databases and tables by clicking Browse Data in the main navigation.`}
+                            {t`"Our Data" won’t show up on the homepage for any of your users anymore, but you can always browse through your databases and tables by clicking Browse Data in the main navigation.`}
                           </Box>
                         </ModalWithTrigger>
                       )}

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -113,47 +113,47 @@ class Overworld extends React.Component {
                       <Box mx={PAGE_PADDING} mt={[1, 3]}>
                         {user.is_superuser && <AdminPinMessage />}
                         <Box mt={[1, 3]}>
-                          <Flex
-                            align="center"
-                            className="hover-parent hover--visibility"
-                          >
-                            <SectionHeading>
+                          <SectionHeading>
+                            <Flex
+                              align="center"
+                              className="hover-parent hover--visibility"
+                            >
                               {t`Try these x-rays based on your data.`}
-                            </SectionHeading>
-                            {user.is_superuser && (
-                              <ModalWithTrigger
-                                triggerElement={
-                                  <Tooltip
-                                    tooltip={t`Remove these suggestions`}
-                                  >
-                                    <Icon
-                                      ml="1"
-                                      name="close"
-                                      className="hover-child text-brand-hover"
-                                    />
-                                  </Tooltip>
-                                }
-                                title={t`Remove these suggestions?`}
-                                footer={
-                                  <Button
-                                    danger
-                                    onClick={onClose => {
-                                      updateSetting({
-                                        key: "show-homepage-xrays",
-                                        value: false,
-                                      });
-                                    }}
-                                  >
-                                    {t`Remove`}
-                                  </Button>
-                                }
-                              >
-                                <Box>
-                                  {t`These won’t show up on the homepage for any of your users anymore, but you can always get to x-rays by clicking on Browse Data in the main navigation, then clicking on the lightning bolt :zap: icon on one of your tables.`}
-                                </Box>
-                              </ModalWithTrigger>
-                            )}
-                          </Flex>
+                              {user.is_superuser && (
+                                <ModalWithTrigger
+                                  triggerElement={
+                                    <Tooltip
+                                      tooltip={t`Remove these suggestions`}
+                                    >
+                                      <Icon
+                                        ml="2"
+                                        name="close"
+                                        className="hover-child text-brand-hover"
+                                      />
+                                    </Tooltip>
+                                  }
+                                  title={t`Remove these suggestions?`}
+                                  footer={
+                                    <Button
+                                      danger
+                                      onClick={onClose => {
+                                        updateSetting({
+                                          key: "show-homepage-xrays",
+                                          value: false,
+                                        });
+                                      }}
+                                    >
+                                      {t`Remove`}
+                                    </Button>
+                                  }
+                                >
+                                  <Box>
+                                    {t`These won’t show up on the homepage for any of your users anymore, but you can always get to x-rays by clicking on Browse Data in the main navigation, then clicking on the lightning bolt :zap: icon on one of your tables.`}
+                                  </Box>
+                                </ModalWithTrigger>
+                              )}
+                            </Flex>
+                          </SectionHeading>
                           <Box>
                             <ExplorePane
                               candidates={candidates}
@@ -263,43 +263,45 @@ class Overworld extends React.Component {
               }
               return (
                 <Box pt={2} px={PAGE_PADDING}>
-                  <Flex
-                    align="center"
-                    className="hover-parent hover--visibility"
-                  >
-                    <SectionHeading>{t`Our data`}</SectionHeading>
-                    {user.is_superuser && (
-                      <ModalWithTrigger
-                        triggerElement={
-                          <Tooltip tooltip={t`Hide this section`}>
-                            <Icon
-                              ml="1"
-                              name="close"
-                              className="hover-child text-brand-hover"
-                            />
-                          </Tooltip>
-                        }
-                        title={t`Remove this section?`}
-                        footer={
-                          <Button
-                            danger
-                            onClick={onClose => {
-                              updateSetting({
-                                key: "show-homepage-data",
-                                value: false,
-                              });
-                            }}
-                          >
-                            {t`Remove`}
-                          </Button>
-                        }
-                      >
-                        <Box>
-                          {t`Our Data” won’t show up on the homepage for any of your users anymore, but you can always browse through your databases and tables by clicking Browse Data in the main navigation.`}
-                        </Box>
-                      </ModalWithTrigger>
-                    )}
-                  </Flex>
+                  <SectionHeading>
+                    <Flex
+                      align="center"
+                      className="hover-parent hover--visibility"
+                    >
+                      {t`Our data`}
+                      {user.is_superuser && (
+                        <ModalWithTrigger
+                          triggerElement={
+                            <Tooltip tooltip={t`Hide this section`}>
+                              <Icon
+                                ml="4"
+                                name="close"
+                                className="block hover-child text-brand-hover"
+                              />
+                            </Tooltip>
+                          }
+                          title={t`Remove this section?`}
+                          footer={
+                            <Button
+                              danger
+                              onClick={onClose => {
+                                updateSetting({
+                                  key: "show-homepage-data",
+                                  value: false,
+                                });
+                              }}
+                            >
+                              {t`Remove`}
+                            </Button>
+                          }
+                        >
+                          <Box>
+                            {t`Our Data” won’t show up on the homepage for any of your users anymore, but you can always browse through your databases and tables by clicking Browse Data in the main navigation.`}
+                          </Box>
+                        </ModalWithTrigger>
+                      )}
+                    </Flex>
+                  </SectionHeading>
                   <Box mb={4}>
                     <Grid>
                       {databases.map(database => (

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -112,12 +112,12 @@ class Overworld extends React.Component {
                     return (
                       <Box mx={PAGE_PADDING} mt={[1, 3]}>
                         {user.is_superuser && <AdminPinMessage />}
-                        <Box mt={[1, 3]}>
+                        <Box
+                          mt={[1, 3]}
+                          className="hover-parent hover--visibility"
+                        >
                           <SectionHeading>
-                            <Flex
-                              align="center"
-                              className="hover-parent hover--visibility"
-                            >
+                            <Flex align="center">
                               {t`Try these x-rays based on your data.`}
                               {user.is_superuser && (
                                 <ModalWithTrigger
@@ -210,7 +210,6 @@ class Overworld extends React.Component {
             );
           }}
         </CollectionItemsLoader>
-
         <Box px={PAGE_PADDING} my={3}>
           <SectionHeading>{ROOT_COLLECTION.name}</SectionHeading>
           <Box p={[1, 2]} mt={2} bg={color("bg-medium")}>
@@ -254,7 +253,6 @@ class Overworld extends React.Component {
             </Link>
           </Box>
         </Box>
-
         {showHomepageData && (
           <Database.ListLoader>
             {({ databases }) => {
@@ -262,12 +260,13 @@ class Overworld extends React.Component {
                 return null;
               }
               return (
-                <Box pt={2} px={PAGE_PADDING}>
+                <Box
+                  pt={2}
+                  px={PAGE_PADDING}
+                  className="hover-parent hover--visibility"
+                >
                   <SectionHeading>
-                    <Flex
-                      align="center"
-                      className="hover-parent hover--visibility"
-                    >
+                    <Flex align="center">
                       {t`Our data`}
                       {user.is_superuser && (
                         <ModalWithTrigger

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -203,63 +203,66 @@ class Overworld extends React.Component {
           </Box>
         </Box>
 
-        <Database.ListLoader>
-          {({ databases }) => {
-            if (databases.length === 0) {
-              return null;
-            }
-            return (
-              <Box pt={2} px={PAGE_PADDING}>
-                <SectionHeading>{t`Our data`}</SectionHeading>
-                <Box mb={4}>
-                  <Grid>
-                    {databases.map(database => (
-                      <GridItem w={[1, 1 / 3]} key={database.id}>
-                        <Link
-                          to={`browse/${database.id}`}
-                          hover={{ color: color("brand") }}
-                          data-metabase-event={`Homepage;Browse DB Clicked; DB Type ${database.engine}`}
-                        >
-                          <Box
-                            p={3}
-                            bg={color("bg-medium")}
-                            className="hover-parent hover--visibility"
+        {// this.props.collections represents the collections inside of the root collection. if there are any then we should hide the our data section
+        this.props.collections.length === 0 && (
+          <Database.ListLoader>
+            {({ databases }) => {
+              if (databases.length === 0) {
+                return null;
+              }
+              return (
+                <Box pt={2} px={PAGE_PADDING}>
+                  <SectionHeading>{t`Our data`}</SectionHeading>
+                  <Box mb={4}>
+                    <Grid>
+                      {databases.map(database => (
+                        <GridItem w={[1, 1 / 3]} key={database.id}>
+                          <Link
+                            to={`browse/${database.id}`}
+                            hover={{ color: color("brand") }}
+                            data-metabase-event={`Homepage;Browse DB Clicked; DB Type ${database.engine}`}
                           >
-                            <Icon
-                              name="database"
-                              color={color("database")}
-                              mb={3}
-                              size={28}
-                            />
-                            <Flex align="center">
-                              <h3 className="text-wrap">{database.name}</h3>
-                              <Box ml="auto" mr={1} className="hover-child">
-                                <Flex align="center">
-                                  <Tooltip
-                                    tooltip={t`Learn about this database`}
-                                  >
-                                    <Link
-                                      to={`reference/databases/${database.id}`}
+                            <Box
+                              p={3}
+                              bg={color("bg-medium")}
+                              className="hover-parent hover--visibility"
+                            >
+                              <Icon
+                                name="database"
+                                color={color("database")}
+                                mb={3}
+                                size={28}
+                              />
+                              <Flex align="center">
+                                <h3 className="text-wrap">{database.name}</h3>
+                                <Box ml="auto" mr={1} className="hover-child">
+                                  <Flex align="center">
+                                    <Tooltip
+                                      tooltip={t`Learn about this database`}
                                     >
-                                      <Icon
-                                        name="reference"
-                                        color={color("text-light")}
-                                      />
-                                    </Link>
-                                  </Tooltip>
-                                </Flex>
-                              </Box>
-                            </Flex>
-                          </Box>
-                        </Link>
-                      </GridItem>
-                    ))}
-                  </Grid>
+                                      <Link
+                                        to={`reference/databases/${database.id}`}
+                                      >
+                                        <Icon
+                                          name="reference"
+                                          color={color("text-light")}
+                                        />
+                                      </Link>
+                                    </Tooltip>
+                                  </Flex>
+                                </Box>
+                              </Flex>
+                            </Box>
+                          </Link>
+                        </GridItem>
+                      ))}
+                    </Grid>
+                  </Box>
                 </Box>
-              </Box>
-            );
-          }}
-        </Database.ListLoader>
+              );
+            }}
+          </Database.ListLoader>
+        )}
       </Box>
     );
   }

--- a/frontend/src/metabase/containers/Overworld.jsx
+++ b/frontend/src/metabase/containers/Overworld.jsx
@@ -11,6 +11,8 @@ import ExplorePane from "metabase/components/ExplorePane";
 import Tooltip from "metabase/components/Tooltip";
 import MetabotLogo from "metabase/components/MetabotLogo";
 import CollectionList from "metabase/components/CollectionList";
+import ModalWithTrigger from "metabase/components/ModalWithTrigger";
+import Button from "metabase/components/Button";
 
 import Card from "metabase/components/Card";
 import { Grid, GridItem } from "metabase/components/Grid";
@@ -223,19 +225,35 @@ class Overworld extends React.Component {
                   <Flex align="center" className="hover-parent">
                     <SectionHeading>{t`Our data`}</SectionHeading>
                     {user.is_superuser && (
-                      <Tooltip tooltip={t`Hide this section`}>
-                        <Icon
-                          ml="1"
-                          name="close"
-                          className="hover-child text-brand-hover"
-                          onClick={() =>
-                            updateSetting({
-                              key: "show-homepage-data",
-                              value: false,
-                            })
-                          }
-                        />
-                      </Tooltip>
+                      <ModalWithTrigger
+                        triggerElement={
+                          <Tooltip tooltip={t`Hide this section`}>
+                            <Icon
+                              ml="1"
+                              name="close"
+                              className="hover-child text-brand-hover"
+                            />
+                          </Tooltip>
+                        }
+                        title={t`Remove this section?`}
+                        footer={
+                          <Button
+                            danger
+                            onClick={onClose => {
+                              updateSetting({
+                                key: "show-homepage-data",
+                                value: false,
+                              });
+                            }}
+                          >
+                            {t`Remove`}
+                          </Button>
+                        }
+                      >
+                        <Box>
+                          {t`Our Data” won’t show up on the homepage for any of your users anymore, but you can always browse through your databases and tables by clicking Browse Data in the main navigation.`}
+                        </Box>
+                      </ModalWithTrigger>
                     )}
                   </Flex>
                   <Box mb={4}>

--- a/frontend/src/metabase/selectors/settings.js
+++ b/frontend/src/metabase/selectors/settings.js
@@ -1,3 +1,5 @@
+import { createSelector } from "reselect";
+
 // NOTE: these are "public" settings
 export const getIsPublicSharingEnabled = state =>
   state.settings.values["public_sharing"];
@@ -8,6 +10,11 @@ export const getXraysEnabled = state => state.settings.values["enable_xrays"];
 
 export const getShowHomepageData = state =>
   state.settings.values["show-homepage-data"];
+
+export const getShowHomepageXrays = createSelector(
+  [getXraysEnabled, state => state.settings.values["show-homepage-xrays"]],
+  (enabled, show) => enabled && show,
+);
 
 // NOTE: these are admin-only settings
 export const getSiteUrl = state => state.settings.values["site-url"];

--- a/frontend/src/metabase/selectors/settings.js
+++ b/frontend/src/metabase/selectors/settings.js
@@ -6,6 +6,9 @@ export const getIsApplicationEmbeddingEnabled = state =>
 // Whether or not xrays are enabled on the instance
 export const getXraysEnabled = state => state.settings.values["enable_xrays"];
 
+export const getShowHomepageData = state =>
+  state.settings.values["show-homepage-data"];
+
 // NOTE: these are admin-only settings
 export const getSiteUrl = state => state.settings.values["site-url"];
 export const getEmbeddingSecretKey = state =>

--- a/frontend/src/metabase/selectors/settings.js
+++ b/frontend/src/metabase/selectors/settings.js
@@ -9,10 +9,10 @@ export const getIsApplicationEmbeddingEnabled = state =>
 export const getXraysEnabled = state => state.settings.values["enable_xrays"];
 
 export const getShowHomepageData = state =>
-  state.settings.values["show-homepage-data"];
+  state.settings.values["show_homepage_data"];
 
 export const getShowHomepageXrays = createSelector(
-  [getXraysEnabled, state => state.settings.values["show-homepage-xrays"]],
+  [getXraysEnabled, state => state.settings.values["show_homepage_xrays"]],
   (enabled, show) => enabled && show,
 );
 

--- a/frontend/test/metabase/home/Overworld.cy.spec.js
+++ b/frontend/test/metabase/home/Overworld.cy.spec.js
@@ -1,0 +1,24 @@
+import { signInAsAdmin, signInAsNormalUser } from "__support__/cypress";
+
+describe("homepage", () => {
+  describe("content management", () => {
+    beforeEach(() => {
+      signInAsAdmin();
+      // Be sure that the relevant app settings are in the right state to start
+      cy.request("PUT", "api/setting/show-homepage-data", { value: true });
+    });
+    it('should be possible for an admin to hide the "Our data" section', () => {
+      cy.server();
+      cy.route("PUT", "**/show-homepage-data").as("hideData");
+      cy.visit("/");
+      cy.contains("Sample Dataset");
+      cy.contains("Our data")
+        .parent()
+        .get(".Icon-close")
+        .click();
+      cy.get(".Button").click();
+      cy.wait("@hideData");
+      cy.contains("Sample Dataset").should("have.length", 0);
+    });
+  });
+});

--- a/frontend/test/metabase/home/Overworld.cy.spec.js
+++ b/frontend/test/metabase/home/Overworld.cy.spec.js
@@ -12,7 +12,7 @@ describe("homepage", () => {
         cy.request("PUT", "api/setting/show-homepage-data", { value: true });
         cy.request("PUT", "api/setting/show-homepage-xrays", { value: true });
       });
-      it('should be possible for an admin to hide the "Our data" section', () => {
+      xit('should be possible for an admin to hide the "Our data" section', () => {
         cy.server();
         cy.route("PUT", "**/show-homepage-data").as("hideData");
         cy.visit("/");
@@ -25,7 +25,7 @@ describe("homepage", () => {
         cy.contains("Sample Dataset").should("have.length", 0);
         // cleanup
       });
-      it('should be possible for an admin to hide the "xrays" section', () => {
+      xit('should be possible for an admin to hide the "xrays" section', () => {
         cy.server();
         cy.route("PUT", "**/show-homepage-xrays").as("hideXrays");
         cy.visit("/");
@@ -38,7 +38,7 @@ describe("homepage", () => {
     });
     describe("as regular folk", () => {
       beforeEach(signInAsNormalUser);
-      it("should not be possible for them to see the controls", () => {
+      xit("should not be possible for them to see the controls", () => {
         cy.visit("/");
         cy.contains("Our data")
           .find(".Icon-close")

--- a/frontend/test/metabase/home/Overworld.cy.spec.js
+++ b/frontend/test/metabase/home/Overworld.cy.spec.js
@@ -8,35 +8,32 @@ describe("homepage", () => {
         cy.request("PUT", "api/setting/show-homepage-data", { value: true });
         cy.request("PUT", "api/setting/show-homepage-xrays", { value: true });
       });
+      afterEach(() => {
+        cy.request("PUT", "api/setting/show-homepage-data", { value: true });
+        cy.request("PUT", "api/setting/show-homepage-xrays", { value: true });
+      });
       it('should be possible for an admin to hide the "Our data" section', () => {
         cy.server();
         cy.route("PUT", "**/show-homepage-data").as("hideData");
         cy.visit("/");
         cy.contains("Sample Dataset");
         cy.contains("Our data")
-          .parent()
-          .trigger("mouseover")
-          .get(".Icon-close")
-          .click();
+          .find(".Icon-close")
+          .click({ force: true });
         cy.get(".Button--danger").click();
         cy.wait("@hideData");
         cy.contains("Sample Dataset").should("have.length", 0);
         // cleanup
-        cy.request("PUT", "api/setting/show-homepage-data", { value: true });
       });
       it('should be possible for an admin to hide the "xrays" section', () => {
         cy.server();
         cy.route("PUT", "**/show-homepage-xrays").as("hideXrays");
         cy.visit("/");
         cy.contains("based on")
-          .parent()
-          .trigger("mouseover")
-          .get(".Icon-close")
-          .click();
+          .find(".Icon-close")
+          .click({ force: true });
         cy.get(".Button--danger").click();
         cy.wait("@hideXrays");
-        // clean up
-        cy.request("PUT", "api/setting/show-homepage-xrays", { value: true });
       });
     });
     describe("as regular folk", () => {
@@ -44,12 +41,10 @@ describe("homepage", () => {
       it("should not be possible for them to see the controls", () => {
         cy.visit("/");
         cy.contains("Our data")
-          .parent()
-          .get(".Icon-close")
+          .find(".Icon-close")
           .should("have.length", 0);
         cy.contains("x-ray")
-          .parent()
-          .get(".Icon-close")
+          .find(".Icon-close")
           .should("have.length", 0);
       });
     });

--- a/frontend/test/metabase/reference/databases.cy.spec.js
+++ b/frontend/test/metabase/reference/databases.cy.spec.js
@@ -48,5 +48,12 @@ describe("sample database reference", () => {
       .type("My definitely profitable business");
     cy.contains("Save").click();
     cy.contains("My definitely profitable business");
+
+    // reset
+    cy.contains("Edit").click();
+    cy.get(".wrapper input")
+      .clear()
+      .type("Sample Dataset");
+    cy.contains("Save").click();
   });
 });

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -172,6 +172,12 @@
   :type    :boolean
   :default true)
 
+(defsetting show-homepage-data
+  (deferred-tru "Whether or not to display data on the homepage. Admins might turn this off in order to direct users to
+                better content than raw data")
+  :type    :boolean
+  :default true)
+
 (defsetting source-address-header
   (deferred-tru "Identify the source of HTTP requests by this header's value, instead of its remote address.")
   :getter (fn [] (some-> (setting/get-string :source-address-header)
@@ -233,6 +239,7 @@
    :public_sharing        (enable-public-sharing)
    :report_timezone       (resolve-setting 'metabase.driver 'report-timezone)
    :setup_token           (resolve-setting 'metabase.setup 'token-value)
+   :show_homepage_data    (show-homepage-data)
    :site_name             (site-name)
    :site_url              (site-url)
    :timezone_short        (short-timezone-name (setting/get :report-timezone))

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -173,8 +173,12 @@
   :default true)
 
 (defsetting show-homepage-data
-  (deferred-tru "Whether or not to display data on the homepage. Admins might turn this off in order to direct users to
-                better content than raw data")
+  (deferred-tru "Whether or not to display data on the homepage. Admins might turn this off in order to direct users to better content than raw data")
+  :type    :boolean
+  :default true)
+
+(defsetting show-homepage-xrays
+  (deferred-tru "Whether or not to display x-ray suggestions on the homepage. They will also be hidden if any dashboards are pinned. Admins might hide this to direct users to better content than raw data")
   :type    :boolean
   :default true)
 
@@ -240,6 +244,7 @@
    :report_timezone       (resolve-setting 'metabase.driver 'report-timezone)
    :setup_token           (resolve-setting 'metabase.setup 'token-value)
    :show_homepage_data    (show-homepage-data)
+   :show_homepage_xrays   (show-homepage-xrays)
    :site_name             (site-name)
    :site_url              (site-url)
    :timezone_short        (short-timezone-name (setting/get :report-timezone))


### PR DESCRIPTION
When first setting up and using Metabase it can be handy to have quick access to underlying data right on the homepage. However as things mature and people create useful questions or better views of the data, having access to the raw tables right there can actually be a drawback that moves users away from curated work and gives the raw data more prominence than it might warrant.

This allows admins to hide that section from the homepage if it suits their needs.

ToDos
- [x] Add setting to the BE
- [x] Add hiding action to the homepage and display based on the setting
- [x] Improve icon placement and add more context
- [x] Test as admin
- [x] Test as normal user