### PR TITLE
Don't automatically display chart values on saved questions

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -324,7 +324,7 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS = {
     getDefault: ([{ card, data }]) =>
       // small bar graphs should have this turned on by default,
       // but bar graphs that were saved without this feature shouldn't
-      card.id == null &&
+      card.original_card_id == null &&
       card.display === "bar" &&
       data.rows.length < AUTO_SHOW_VALUES_MAX_ROWS,
     persistDefault: true,

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -322,7 +322,12 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS = {
     getHidden: (series, vizSettings) =>
       series.length > 1 || vizSettings["stackable.stack_type"] === "normalized",
     getDefault: ([{ card, data }]) =>
-      card.display === "bar" && data.rows.length < AUTO_SHOW_VALUES_MAX_ROWS,
+      // small bar graphs should have this turned on by default,
+      // but bar graphs that were saved without this feature shouldn't
+      card.id == null &&
+      card.display === "bar" &&
+      data.rows.length < AUTO_SHOW_VALUES_MAX_ROWS,
+    persistDefault: true,
   },
   "graph.label_value_frequency": {
     section: t`Display`,

--- a/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
@@ -123,6 +123,36 @@ describe("visualization_settings", () => {
         expect(settings["graph.y_axis.title_text"]).toBe(null);
       });
     });
+    describe("graph.show_values", () => {
+      it("should show values on a bar chart with ten bars", () => {
+        const card = { visualization_settings: {}, display: "bar" };
+        const data = { rows: new Array(10).fill([1]) };
+        const settings = getComputedSettingsForSeries([{ card, data }]);
+        expect(settings["graph.show_values"]).toBe(true);
+      });
+      it("should not show values on a line chart with ten value", () => {
+        const card = { visualization_settings: {}, display: "line" };
+        const data = { rows: new Array(10).fill([1]) };
+        const settings = getComputedSettingsForSeries([{ card, data }]);
+        expect(settings["graph.show_values"]).toBe(false);
+      });
+      it("should not show values on a bar chart with thirty bars", () => {
+        const card = { visualization_settings: {}, display: "bar" };
+        const data = { rows: new Array(30).fill([1]) };
+        const settings = getComputedSettingsForSeries([{ card, data }]);
+        expect(settings["graph.show_values"]).toBe(false);
+      });
+      it("should not show values on a previously saved bar chart", () => {
+        const card = {
+          visualization_settings: {},
+          display: "bar",
+          original_card_id: 1,
+        };
+        const data = { rows: new Array(10).fill([1]) };
+        const settings = getComputedSettingsForSeries([{ card, data }]);
+        expect(settings["graph.show_values"]).toBe(false);
+      });
+    });
   });
 
   describe("getStoredSettingsForSeries", () => {


### PR DESCRIPTION
@mazameli pointed out that new chart values feature was displaying on already saved questions.

Now, chart values will appear by default on new bar charts, but questions that were saved before this feature existed will need it explicitly turned on.