### PR TITLE
fix mongo field value scan bug

### DIFF
--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -68,6 +68,7 @@
    (field-distinct-values field absolute-max-distinct-values-limit))
   ([field, max-results :- su/IntGreaterThanZero]
    (mapv first (field-query field {:breakout [[:field-id (u/get-id field)]]
+                                   :filter [:not-null [:field-id (u/get-id field)]]
                                    :limit    max-results}))))
 
 (defn field-distinct-count


### PR DESCRIPTION
When I manual sync mongo field-values in the admin panel, data in mysql does't be updated properly. values colum always keep null, like `[null, null, null, null, null]`.

After lot's of  debug (since I am not familiar with clojure), I find it is because that in mongodb, not all row contains the target field, and this caused some chained problem. Thus, I made this fix.

![image](https://user-images.githubusercontent.com/13233969/70501402-f0d84a00-1b58-11ea-9f8f-895473726e3f.png)
