### PR TITLE
Resize Ace if the NativeQueryEditor's width changes

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -33,6 +33,7 @@ import { SQLBehaviour } from "metabase/lib/ace/sql_behaviour";
 import _ from "underscore";
 
 import Icon from "metabase/components/Icon";
+import ExplicitSize from "metabase/components/ExplicitSize";
 
 import Parameters from "metabase/parameters/components/Parameters";
 
@@ -98,6 +99,7 @@ type State = {
   hasTextSelected: boolean,
 };
 
+@ExplicitSize()
 export default class NativeQueryEditor extends Component {
   props: Props;
   state: State;
@@ -151,7 +153,7 @@ export default class NativeQueryEditor extends Component {
     document.addEventListener("keydown", this.handleKeyDown);
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     const { query } = this.props;
     if (!query || !this._editor) {
       return;
@@ -182,6 +184,10 @@ export default class NativeQueryEditor extends Component {
       if (aceMode.indexOf("sql") >= 0) {
         this._editor.getSession().$mode.$behaviour = new SQLBehaviour();
       }
+    }
+
+    if (this.props.width !== prevProps.width && this._editor) {
+      this._editor.resize();
     }
   }
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -93,6 +93,7 @@ type Props = {
   isNativeEditorOpen: boolean,
 
   viewHeight: number,
+  width: number,
 };
 type State = {
   initialHeight: number,
@@ -153,7 +154,7 @@ export default class NativeQueryEditor extends Component {
     document.addEventListener("keydown", this.handleKeyDown);
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Props) {
     const { query } = this.props;
     if (!query || !this._editor) {
       return;


### PR DESCRIPTION
This fixes a bug that @mazameli found:

![sql-horizontal-scroll](https://user-images.githubusercontent.com/691495/70578441-c055d780-1b7b-11ea-98d6-1f3149a1d3e9.gif)
