### PR TITLE
Add id to "try it" sql examples

### DIFF
--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { t, jt } from "ttag";
 import Code from "metabase/components/Code";
 import MetabaseSettings from "metabase/lib/settings";
+import Utils from "metabase/lib/utils";
 
 const EXAMPLES = {
   variable: {
@@ -11,6 +12,7 @@ const EXAMPLES = {
       query: "SELECT count(*)\nFROM products\nWHERE category = {{category}}",
       "template-tags": {
         category: {
+          id: Utils.uuid(),
           name: "category",
           display_name: "Category",
           type: "text",
@@ -27,6 +29,7 @@ const EXAMPLES = {
       query: "SELECT count(*)\nFROM products\nWHERE {{created_at}}",
       "template-tags": {
         created_at: {
+          id: Utils.uuid(),
           name: "created_at",
           display_name: "Created At",
           type: "dimension",
@@ -44,6 +47,7 @@ const EXAMPLES = {
         "SELECT count(*)\nFROM products\n[[WHERE category = {{category}}]]",
       "template-tags": {
         category: {
+          id: Utils.uuid(),
           name: "category",
           display_name: "Category",
           type: "text",
@@ -60,12 +64,14 @@ const EXAMPLES = {
         "SELECT count(*)\nFROM products\nWHERE 1=1\n  [[AND id = {{id}}]]\n  [[AND category = {{category}}]]",
       "template-tags": {
         id: {
+          id: Utils.uuid(),
           name: "id",
           display_name: "ID",
           type: "number",
           required: false,
         },
         category: {
+          id: Utils.uuid(),
           name: "category",
           display_name: "Category",
           type: "text",
@@ -82,6 +88,7 @@ const EXAMPLES = {
         "SELECT count(*)\nFROM products\nWHERE 1=1\n  [[AND {{category}}]]",
       "template-tags": {
         category: {
+          id: Utils.uuid(),
           name: "category",
           display_name: "Category",
           type: "dimension",


### PR DESCRIPTION
Resolves #11484

The examples were missing ids in the template tag code. It feels specific and low-impact enough that I don't think it's worth guarding against this in `NativeQuery` or even testing it. 