### PR TITLE
Ignore application errors in Cypress tests

### DIFF
--- a/frontend/test/__support__/cypress.js
+++ b/frontend/test/__support__/cypress.js
@@ -9,3 +9,5 @@ export function signInAsNormalUser() {
 }
 
 export const plainDbHost = Cypress.env("PLAIN_DB_HOST");
+
+Cypress.on("uncaught:exception", (err, runnable) => false);

--- a/frontend/test/cypress.json
+++ b/frontend/test/cypress.json
@@ -2,5 +2,5 @@
 	"testFiles": "**/*.cy.spec.js",
 	"pluginsFile": "frontend/test/cypress-plugins.js",
 	"integrationFolder": "frontend/test",
-	"supportFile": false
+	"supportFile": "frontend/test/__support__/cypress.js"
 }

--- a/frontend/test/metabase/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/dashboard/dashboard.cy.spec.js
@@ -1,7 +1,6 @@
 import { signInAsAdmin } from "__support__/cypress";
 
 describe("dashboard", () => {
-  Cypress.on("uncaught:exception", (err, runnable) => false);
   beforeEach(signInAsAdmin);
 
   it("should have the correct embed snippet", () => {

--- a/frontend/test/metabase/query_builder/components/NativeQueryEditor.cy.spec.js
+++ b/frontend/test/metabase/query_builder/components/NativeQueryEditor.cy.spec.js
@@ -1,16 +1,6 @@
 import { signInAsNormalUser } from "__support__/cypress";
 describe("NativeQueryEditor", () => {
-  beforeEach(() => {
-    signInAsNormalUser();
-    cy.on("uncaught:exception", (err, runnable) => {
-      // ignore the error if it's a "script error"
-      if (err.message.match(/^Script error./)) {
-        return false;
-      }
-      // otherwise, let Cypress fail as usual
-      return true;
-    });
-  });
+  beforeEach(signInAsNormalUser);
 
   it("lets you create and run a SQL question", () => {
     cy.visit("/question/new");


### PR DESCRIPTION
By default, Cypress tests fail on any uncaught error. Now we ignore them instead.

Most of the flakes we were seeing in CI were due to third party code throwing benign errors (e.g. "ResizeObserver loop limit exceeded"). There's probably value in failing tests on any exception, but given how many third part deps we have, I think it's better to assume things work when the test's assertions pass.