### PR TITLE
Stream export

### DIFF
--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -127,7 +127,12 @@
   {parameters    (s/maybe su/JSONString)
    export-format dataset-api/ExportFormat}
   (dataset-api/as-format-async export-format respond raise
-    (run-query-for-card-with-public-uuid-async uuid (json/parse-string parameters keyword), :constraints nil)))
+    (fn [f]
+      (run-query-for-card-with-public-uuid-async
+        uuid
+        (json/parse-string parameters keyword)
+        :constraints nil
+        :data-fn f))))
 
 
 
@@ -250,7 +255,7 @@
   `dashboard-id`. Throws a 404 immediately if the Card isn't part of the Dashboard. Otherwise returns channel for
   fetching results."
   {:style/indent 3}
-  [dashboard-id card-id parameters & {:keys [context constraints]
+  [dashboard-id card-id parameters & {:keys [context constraints data-fn]
                                       :or   {context :public-dashboard
                                              constraints constraints/default-query-constraints}}]
   (check-card-is-in-dashboard card-id dashboard-id)
@@ -260,7 +265,8 @@
     (run-query-for-card-with-id-async card-id params
       :dashboard-id dashboard-id
       :context      context
-      :constraints  constraints)))
+      :constraints  constraints
+      :data-fn      data-fn)))
 
 (api/defendpoint GET "/dashboard/:uuid/card/:card-id"
   "Fetch the results for a Card in a publicly-accessible Dashboard. Does not require auth credentials. Public

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -331,6 +331,14 @@
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
+(defmulti execute-query-callback
+  "Like execute-query, but pass the result to a callback rather than returning it."
+  {:arglists '([driver query callback]), :style/indent 1}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
+(defmethod execute-query-callback :default [driver query callback]
+  (callback (execute-query driver query)))
 
 (def driver-features
   "Set of all features a driver can support."

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -48,6 +48,10 @@
   [driver query]
   (sql-jdbc.execute/execute-query driver query))
 
+(defmethod driver/execute-query-callback :sql-jdbc
+  [driver query callback]
+  (sql-jdbc.execute/execute-query driver (assoc query :data-fn callback)))
+
 (defmethod driver/notify-database-updated :sql-jdbc
   [driver database]
   (sql-jdbc.conn/notify-database-updated driver database))


### PR DESCRIPTION
This adds streaming support to exports, improving response time and greatly reducing memory usage. All 3 formats are supported, but note that XLSX still creates the entire spreadsheet in memory under the hood, so the gains there will be more limited. Addresses #5187, #9533, and #11463.

This started as an attempt to resolve conflicts on #9614, but after fixing bugs, cleaning up some design issues, and extending it to JSON and XLSX, I don't think much of the original PR remains. [A comment on that issue](https://github.com/metabase/metabase/pull/9614#pullrequestreview-281171595) stated changes of this nature wouldn't necessarily require tests; crossing my fingers that it still holds.

###### Before submitting the PR, please make sure you do the following
- [N/A] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
