### PR TITLE
Run api embed tests for all response formats

### DIFF
--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -185,6 +185,7 @@
          `(let [~response-format-binding         ~response-format
                 ~(or request-options-binding '_) {:request-options ~request-options}]
             (expect
+              ~(symbol (format "expect-for-response-formats-%s-%d" (str/join (rest response-format)) (hash [expected actual])))
               ~expected
               ~actual)))))
 
@@ -198,7 +199,9 @@
 ;; but if the card has an invalid query we should just get a generic "query failed" exception (rather than leaking
 ;; query info)
 (expect-for-response-formats [response-format]
-  "An error occurred while running the query."
+  (if (= response-format "")
+    {:status "failed" :error "An error occurred while running the query."}
+    "An error occurred while running the query.")
   (tu.log/suppress-output
     (with-embedding-enabled-and-new-secret-key
       (with-temp-card [card {:enable_embedding true, :dataset_query {:database (data/id)


### PR DESCRIPTION
`expect` picks a function name based on a hash of the form, which means
that all four functions defined by `expect-for-response-formats` share
the same name and only the last actually runs.  This change gives each
function a unique name.

Discovered in the process of creating #11554.

###### Before submitting the PR, please make sure you do the following
- [N/A] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [N/A] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
