### PR TITLE
Use time format settings for hour-of-day

### DIFF
--- a/frontend/src/metabase/lib/formatting/date.js
+++ b/frontend/src/metabase/lib/formatting/date.js
@@ -25,7 +25,6 @@ const DEFAULT_DATE_FORMATS: { [unit: DatetimeUnit]: MomentFormat } = {
   year: "YYYY",
   quarter: "[Q]Q - YYYY",
   "minute-of-hour": "m",
-  "hour-of-day": "h A",
   "day-of-week": "dddd",
   "day-of-month": "D",
   "day-of-year": "DDD",
@@ -86,7 +85,12 @@ export function getDateFormatFromStyle(
   return replaceSeparators(style);
 }
 
-const UNITS_WITH_HOUR: DatetimeUnit[] = ["default", "minute", "hour"];
+const UNITS_WITH_HOUR: DatetimeUnit[] = [
+  "default",
+  "minute",
+  "hour",
+  "hour-of-day",
+];
 const UNITS_WITH_DAY: DatetimeUnit[] = [
   "default",
   "minute",

--- a/frontend/src/metabase/lib/formatting/date.js
+++ b/frontend/src/metabase/lib/formatting/date.js
@@ -13,7 +13,7 @@ export type DateStyle =
   | "D MMMM, YYYY"
   | "dddd, MMMM D, YYYY";
 
-export type TimeStyle = "h:mm A" | "k:mm";
+export type TimeStyle = "h:mm A" | "k:mm" | "h A";
 
 export type MomentFormat = string; // moment.js format strings
 export type DateFormat = MomentFormat;

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -26,7 +26,6 @@ import {
   numberFormatterForOptions,
 } from "metabase/lib/formatting";
 import {
-  DEFAULT_DATE_STYLE,
   getDateFormatFromStyle,
   hasDay,
   hasHour,
@@ -184,7 +183,7 @@ export const DATE_COLUMN_SETTINGS = {
   date_style: {
     title: t`Date style`,
     widget: "select",
-    getDefault: ({ unit }) => {
+    getDefault: ({ unit }: Column) => {
       // Grab the first option's value. If there were no options (for
       // hour-of-day probably), use an empty format string instead.
       const [{ value = "" } = {}] = getDateStyleOptionsForUnit(unit);

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -200,6 +200,32 @@ describe("formatting", () => {
         }),
       ).toEqual("foobar@example.com");
     });
+    it("should display hour-of-day with 12 hour clock", () => {
+      expect(
+        formatValue(24, {
+          date_style: null,
+          time_enabled: "minutes",
+          time_style: "h:mm A",
+          column: {
+            base_type: "type/DateTime",
+            unit: "hour-of-day",
+          },
+        }),
+      ).toEqual("12:00 AM");
+    });
+    it("should display hour-of-day with 24 hour clock", () => {
+      expect(
+        formatValue(24, {
+          date_style: null,
+          time_enabled: "minutes",
+          time_style: "k:mm",
+          column: {
+            base_type: "type/DateTime",
+            unit: "hour-of-day",
+          },
+        }),
+      ).toEqual("24:00");
+    });
   });
 
   describe("formatUrl", () => {

--- a/frontend/test/metabase/visualizations/lib/settings/column.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/settings/column.unit.spec.js
@@ -96,4 +96,19 @@ describe("column settings", () => {
     const computed = getComputedSettings(defs, series, stored);
     expect(computed.column(series[0].data.cols[0]).currency).toEqual("BTC");
   });
+  it("should set a time style but no date style for hour-of-day", () => {
+    const series = seriesWithColumn({
+      unit: "hour-of-day",
+      base_type: "type/DateTime",
+      special_type: undefined,
+    });
+    const defs = { ...columnSettings() };
+    const computed = getComputedSettings(defs, series, {});
+    const { time_enabled, time_style, date_style } = computed.column(
+      series[0].data.cols[0],
+    );
+    expect(time_enabled).toEqual("minutes");
+    expect(time_style).toEqual("h:mm A");
+    expect(date_style).toEqual("");
+  });
 });


### PR DESCRIPTION
Resolves #11337

Date part formatting was handled after settings with a custom mapping from `unit` to format string. This prevented time formatting setting from affecting the format for hour-of-day.

I removed hour-of-day from this mapping and instead have it use the `time_style` setting. I also suppress `date_style`, so that we only have a time format.

Previously, the custom mapping had `"h A"` as its format string which nicely prints just the hour with AM/PM. Using our standard time formatting, this option was lost. I added it to the column settings _only_ for hour-of-day.

Hour of day:
![image](https://user-images.githubusercontent.com/691495/71215979-254db380-2287-11ea-8e87-12e694571609.png)
Hour:
![image](https://user-images.githubusercontent.com/691495/71216008-3c8ca100-2287-11ea-82ef-37d2b3cb891a.png)
