### PR TITLE
Release 0.33.x into master

### DIFF
--- a/bin/version
+++ b/bin/version
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="v0.33.7.2"
+VERSION="v0.33.7.3"
 
 # dynamically pull more interesting stuff from latest git commit
 HASH=$(git show-ref --head --hash=7 head)            # first 7 letters of hash should be enough; that's what GitHub uses

--- a/bin/version
+++ b/bin/version
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="v0.33.6"
+VERSION="v0.33.7.2"
 
 # dynamically pull more interesting stuff from latest git commit
 HASH=$(git show-ref --head --hash=7 head)            # first 7 letters of hash should be enough; that's what GitHub uses

--- a/project.clj
+++ b/project.clj
@@ -140,10 +140,10 @@
   :manifest
   {"Liquibase-Package"
    #= (eval
-       (str "liquibase.change,liquibase.changelog,liquibase.database,liquibase.parser,liquibase.precondition,"
-            "liquibase.datatype,liquibase.serializer,liquibase.sqlgenerator,liquibase.executor,"
-            "liquibase.snapshot,liquibase.logging,liquibase.diff,liquibase.structure,"
-            "liquibase.structurecompare,liquibase.lockservice,liquibase.sdk,liquibase.ext"))}
+        (str "liquibase.change,liquibase.changelog,liquibase.database,liquibase.parser,liquibase.precondition,"
+             "liquibase.datatype,liquibase.serializer,liquibase.sqlgenerator,liquibase.executor,"
+             "liquibase.snapshot,liquibase.logging,liquibase.diff,liquibase.structure,"
+             "liquibase.structurecompare,liquibase.lockservice,liquibase.sdk,liquibase.ext"))}
 
   :jvm-opts
   ["-XX:+IgnoreUnrecognizedVMOptions"                                 ; ignore things not recognized for our Java version instead of refusing to start
@@ -243,10 +243,10 @@
 
    :include-all-drivers
    [:with-include-drivers-middleware
-   {:include-drivers :all
-    :injections
-    [(require 'metabase.plugins)
-     (metabase.plugins/load-plugins!)]}]
+    {:include-drivers :all
+     :injections
+     [(require 'metabase.plugins)
+      (metabase.plugins/load-plugins!)]}]
 
    :repl
    [:include-all-drivers
@@ -308,8 +308,7 @@
    ;; build the uberjar with `lein uberjar`
    :uberjar
    {:auto-clean true
-    :aot        :all
-    :omit-source true}
+    :aot        :all}
 
    ;; generate sample dataset with `lein generate-sample-dataset`
    :generate-sample-dataset

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -252,13 +252,22 @@
 (defsetting google-auth-auto-create-accounts-domain
   (deferred-tru "When set, allow users to sign up on their own if their Google account email address is from this domain."))
 
-(defn- google-auth-token-info [^String token]
-  (let [{:keys [status body]} (http/post (str "https://www.googleapis.com/oauth2/v3/tokeninfo?id_token=" token))]
-    (when-not (= status 200)
-      (throw (ex-info (tru "Invalid Google Auth token.") {:status-code 400})))
-    (u/prog1 (json/parse-string body keyword)
-      (when-not (= (:email_verified <>) "true")
-        (throw (ex-info (tru "Email is not verified.") {:status-code 400}))))))
+(def ^:private google-auth-token-info-url "https://www.googleapis.com/oauth2/v3/tokeninfo?id_token=%s")
+
+(defn- google-auth-token-info
+  ([token-info-response]
+   (google-auth-token-info token-info-response (google-auth-client-id)))
+  ([token-info-response client-id]
+   (let [{:keys [status body]} token-info-response]
+     (when-not (= status 200)
+       (throw (ex-info (tru "Invalid Google Auth token.") {:status-code 400})))
+     (u/prog1 (json/parse-string body keyword)
+       (let [audience (:aud <>)
+             audience (if (string? audience) [audience] audience)]
+         (when-not (contains? (set audience) client-id)
+           (throw (ex-info (tru "Google Auth token meant for a different site.") {:status-code 400}))))
+       (when-not (= (:email_verified <>) "true")
+         (throw (ex-info (tru "Email is not verified.") {:status-code 400})))))))
 
 ;; TODO - are these general enough to move to `metabase.util`?
 (defn- email->domain ^String [email]
@@ -298,8 +307,9 @@
                                                      :email      email}))]
     (create-session! :sso user)))
 
-(defn- do-google-auth [{{:keys [token]} :body, :as request}]
-  (let [{:keys [given_name family_name email]} (google-auth-token-info token)]
+(defn- do-google-auth [{{:keys [token]} :body :as request}]
+  (let [token-info-response                    (http/post (format google-auth-token-info-url token))
+        {:keys [given_name family_name email]} (google-auth-token-info token-info-response)]
     (log/info (trs "Successfully authenticated Google Auth token for: {0} {1}" given_name family_name))
     (let [session-id (api/check-500 (google-auth-fetch-or-create-user! given_name family_name email))
           response   {:id session-id}]
@@ -309,6 +319,8 @@
   "Login with Google Auth."
   [:as {{:keys [token]} :body, :as request}]
   {token su/NonBlankString}
+  (when-not (google-auth-client-id)
+    (throw (ex-info "Google Auth is disabled." {:status-code 400})))
   ;; Verify the token is valid with Google
   (if throttling-disabled?
     (do-google-auth token)

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -6,7 +6,9 @@
              [set :as set]
              [string :as str]
              [walk :as walk]]
-            [clojure.java.classpath :as classpath]
+            [clojure.java
+             [classpath :as classpath]
+             [io :as io]]
             [clojure.math.numeric-tower :as math]
             [clojure.tools.logging :as log]
             [clojure.tools.namespace.find :as ns-find]
@@ -495,11 +497,12 @@
                                 (not (.contains (name ns-symb) "test")))]
                ns-symb))))
 
-(def ^:private namespace-symbs-filename "resources/namespaces.edn")
+(def ^:private namespace-symbs-filename "namespaces.edn")
 
 (when *compile-files*
-  (printf "Saving list of Metabase namespaces to %s...\n" namespace-symbs-filename)
-  (spit namespace-symbs-filename (with-out-str (pprint (metabase-namespace-symbs*)))))
+  (let [filename (str "resources/" namespace-symbs-filename)]
+    (printf "Saving list of Metabase namespaces to %s...\n" filename)
+    (spit filename (with-out-str (pprint (metabase-namespace-symbs*))))))
 
 (def metabase-namespace-symbols
   "Delay to a vector of symbols of all Metabase namespaces, excluding test namespaces. This is intended for use by
@@ -513,7 +516,7 @@
     (delay
       (try
         (log/info (trs "Reading Metabase namespaces from {0}" namespace-symbs-filename))
-        (edn/read-string (slurp namespace-symbs-filename))
+        (edn/read-string (slurp (io/resource namespace-symbs-filename)))
         (catch Throwable e
           (log/error e (trs "Failed to read Metabase namespaces from {0}" namespace-symbs-filename))
           (metabase-namespace-symbs*))))


### PR DESCRIPTION
This is a different branch than release-0.33.x 
since that branch was corrupted with a merge commit the merge conflicts editor produced (https://github.com/metabase/metabase/pull/11567/commits/44bb913abb1564b69e4c549fc5f1200339fe4662)

Since release-0.33.x is a protected branch, and to avoid doing anything especially stupid, I've created a new branch for this and am merging this back into `master`. 

NOTE: Release-0.33.x will need to be fixed prior to shipping any further 0.33 patch releases.