### PR TITLE
Ensure Question.isDirtyComparedTo works for native queries

### DIFF
--- a/frontend/src/metabase-lib/lib/Question.js
+++ b/frontend/src/metabase-lib/lib/Question.js
@@ -26,7 +26,7 @@ import {
 } from "metabase-lib/lib/Dimension";
 import Mode from "metabase-lib/lib/Mode";
 
-import { memoize } from "metabase-lib/lib/utils";
+import { memoize, sortObject } from "metabase-lib/lib/utils";
 
 // TODO: remove these dependencies
 import * as Card_DEPRECATED from "metabase/lib/card";
@@ -928,7 +928,7 @@ export default class Question {
         : {}),
     };
 
-    return Card_DEPRECATED.utf8_to_b64url(JSON.stringify(cardCopy));
+    return Card_DEPRECATED.utf8_to_b64url(JSON.stringify(sortObject(cardCopy)));
   }
 }
 

--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.js
@@ -80,6 +80,16 @@ export default class NativeQuery extends AtomicQuery {
       .filter(database => database.native_permissions === "write");
   }
 
+  clean() {
+    return this.setDatasetQuery(
+      updateIn(
+        this.datasetQuery(),
+        ["native", "template-tags"],
+        tt => tt || {},
+      ),
+    );
+  }
+
   /* AtomicQuery superclass methods */
 
   tables(): ?(Table[]) {

--- a/frontend/src/metabase-lib/lib/utils.js
+++ b/frontend/src/metabase-lib/lib/utils.js
@@ -34,3 +34,25 @@ export function memoize(target, name, descriptor) {
 }
 
 const createMap = () => new Map();
+
+// `sortObject`` copies objects for deterministic serialization.
+// Objects that have equal keys and values don't necessarily serialize to the
+// same string. JSON.strinify prints properties in inserted order. This function
+// sorts keys before adding them to the duplicated object to ensure consistent
+// serialization.
+export function sortObject(obj) {
+  if (obj === null || typeof obj !== "object") {
+    return obj;
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(sortObject);
+  }
+  const sortedKeyValues = Object.entries(obj).sort(([keyA], [keyB]) =>
+    keyA.localeCompare(keyB),
+  );
+  const o = {};
+  for (const [k, v] of sortedKeyValues) {
+    o[k] = sortObject(v);
+  }
+  return o;
+}

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -2,7 +2,7 @@
 
 import { createSelector } from "reselect";
 import _ from "underscore";
-import { getIn, updateIn } from "icepick";
+import { getIn, assocIn, updateIn } from "icepick";
 
 // Needed due to wrong dependency resolution order
 // eslint-disable-next-line no-unused-vars
@@ -162,7 +162,7 @@ function normalizeQuery(query, tableMetadata) {
     });
   }
   if (query.native && query.native["template-tags"] == null) {
-    query.native["template-tags"] = {};
+    query = assocIn(query, ["native", "template-tags"], {});
   }
   return query;
 }

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -625,7 +625,7 @@ describe("Question", () => {
       it("returns a URL with hash for an unsaved question", () => {
         const question = new Question(dissoc(orders_raw_card, "id"), metadata);
         expect(question.getUrl()).toBe(
-          "/question#eyJuYW1lIjoiUmF3IG9yZGVycyBkYXRhIiwiZGF0YXNldF9xdWVyeSI6eyJ0eXBlIjoicXVlcnkiLCJkYXRhYmFzZSI6MSwicXVlcnkiOnsic291cmNlLXRhYmxlIjoxfX0sImRpc3BsYXkiOiJ0YWJsZSIsInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==",
+          "/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjF9LCJ0eXBlIjoicXVlcnkifSwiZGlzcGxheSI6InRhYmxlIiwibmFtZSI6IlJhdyBvcmRlcnMgZGF0YSIsInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==",
         );
       });
     });

--- a/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
@@ -126,6 +126,21 @@ describe("NativeQuery", () => {
       });
     });
   });
+  describe("clean", () => {
+    it("should add template-tags: {} if there are none", () => {
+      const cleanedQuery = native =>
+        new NativeQuery(SAMPLE_DATASET.question(), {
+          type: "native",
+          database: SAMPLE_DATASET.id,
+          native,
+        })
+          .clean()
+          .datasetQuery();
+      const q1 = cleanedQuery({ query: "select 1" });
+      const q2 = cleanedQuery({ query: "select 1", "template-tags": {} });
+      expect(q1).toEqual(q2);
+    });
+  });
   describe("Acessing the underlying native query", () => {
     describe("You can access the actual native query via queryText()", () => {
       expect(makeQuery("SELECT * FROM ORDERS").queryText()).toEqual(

--- a/frontend/test/metabase-lib/lib/utils.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/utils.unit.spec.js
@@ -1,0 +1,33 @@
+import { sortObject } from "metabase-lib/lib/utils";
+
+describe("sortObject", () => {
+  it("should serialize identically regardless of property creation order", () => {
+    const o1 = {};
+    o1.a = 1;
+    o1.b = 2;
+    const o2 = {};
+    o2.b = 2;
+    o2.a = 1;
+
+    expect(JSON.stringify(sortObject(o1))).toEqual(
+      JSON.stringify(sortObject(o2)),
+    );
+  });
+
+  it("should not sort arrays", () => {
+    expect(sortObject(["a", "c", "b"])).toEqual(["a", "c", "b"]);
+  });
+
+  it("should sort keys recursively", () => {
+    const o1 = { o: {} };
+    o1.o.a = 1;
+    o1.o.b = 2;
+    const o2 = { o: {} };
+    o2.o.b = 2;
+    o2.o.a = 1;
+
+    expect(JSON.stringify(sortObject(o1))).toEqual(
+      JSON.stringify(sortObject(o2)),
+    );
+  });
+});


### PR DESCRIPTION
Resolves #11572

It looks like this as caused by #11368. Similar to the bug fixed by #11517, the question updates in #11368 created a discrepancy in how we represented empty template tags.

This PR uses a similar solution to normalize empty template tags. Cleaning a native query adds `"template-tags": {}` if that key is missing.

That normalization tacked on at the end wasn't enough to fix the bug entirely. Questions are considered dirty if they have a different serialization string. Serialization with `JSON.stringify` depends on property insertion order, so I added a util to "sort" objects before serializing them.