### PR TITLE
Fix SQL editor typing interruption and click positioning

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.css
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.css
@@ -40,15 +40,11 @@
   font-weight: 700;
   color: var(--color-text-light);
   padding-left: 0;
-  padding-right: 0;
+  padding-right: 7px;
   display: block;
   text-align: center;
 }
 
 .NativeQueryEditor .ace_editor .ace_gutter {
   background-color: var(--color-bg-light);
-}
-
-.NativeQueryEditor .ace_editor .ace_content {
-  padding-left: 7px;
 }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -161,7 +161,10 @@ export default class NativeQueryEditor extends Component {
       return;
     }
 
-    if (this._editor.getValue() !== query.queryText()) {
+    // Check that the query prop changed before updating the editor. Otherwise,
+    // we might overwrite just typed characters before onChange is called.
+    const queryPropUpdated = this.props.query !== prevProps.query;
+    if (queryPropUpdated && this._editor.getValue() !== query.queryText()) {
       // This is a weird hack, but the purpose is to avoid an infinite loop caused by the fact that calling editor.setValue()
       // will trigger the editor 'change' event, update the query, and cause another rendering loop which we don't want, so
       // we need a way to update the editor without causing the onChange event to go through as well


### PR DESCRIPTION
Resolves #11581, Resolves #11584

The fix for #11584 was to move the padding from the content to the gutter so Ace's click handling code reads the correct offset.

#11581 broke with the recent change to wrap NativeQueryEditor in ExplicitSize. As the sidebar animated open, the component would get continually updated with new widths. The unexpected side effect of this was that `componentDidUpdate` would overwrite any newly typed characters if it ran before `onChange`.

To fix that, we now check that the `query` prop was updated before using it to overwrite the contents of the editor.
