### PR TITLE
[WIP] Add sorting to native queries in QB

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.js
@@ -310,4 +310,8 @@ export default class NativeQuery extends AtomicQuery {
     }
     return {};
   }
+
+  fieldReferenceForColumn(column) {
+    return column.field_ref;
+  }
 }

--- a/frontend/src/metabase/meta/types/Visualization.js
+++ b/frontend/src/metabase/meta/types/Visualization.js
@@ -53,6 +53,7 @@ export type ClickAction = {
 export type ClickActionProps = {
   question: Question,
   clicked?: ClickObject,
+  settings: VisualizationSettings,
 };
 
 export type OnChangeCardAndRun = ({

--- a/frontend/src/metabase/modes/components/modes/NativeMode.jsx
+++ b/frontend/src/metabase/modes/components/modes/NativeMode.jsx
@@ -2,11 +2,12 @@
 
 import type { QueryMode } from "metabase/meta/types/Visualization";
 import CompoundQueryAction from "../actions/CompoundQueryAction";
+import SortAction from "../drill/SortAction";
 
 const NativeMode: QueryMode = {
   name: "native",
   actions: [CompoundQueryAction],
-  drills: [],
+  drills: [SortAction],
 };
 
 export default NativeMode;

--- a/frontend/src/metabase/visualizations/components/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive.jsx
@@ -45,7 +45,7 @@ import type {
   ClickObject,
 } from "metabase/meta/types/Visualization";
 import type { VisualizationSettings } from "metabase/meta/types/Card";
-import type { DatasetData } from "metabase/meta/types/Dataset";
+import type { DatasetData, Row } from "metabase/meta/types/Dataset";
 
 function pickRowsToMeasure(rows, columnIndex, count = 10) {
   const rowIndexes = [];
@@ -83,6 +83,7 @@ type State = {
     center: number,
     width: number,
   }[]),
+  sortedRows: ?(Row[]),
 };
 
 type CellRendererProps = {
@@ -117,6 +118,7 @@ export default class TableInteractive extends Component {
     this.state = {
       columnWidths: [],
       contentWidths: null,
+      sortedRows: null,
     };
     this.columnHasResized = {};
     this.headerRefs = [];
@@ -195,7 +197,7 @@ export default class TableInteractive extends Component {
     this.setState({ sortedRows: this.getSortedRows() });
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Props) {
     if (!this.state.contentWidths) {
       this._measure();
     } else if (this.props.onContentWidthChange) {

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -271,7 +271,8 @@ export default class Visualization extends React.PureComponent {
     const card = rawSeries[seriesIndex].card;
     const question = this._getQuestionForCardCached(metadata, card);
     const mode = question && question.mode();
-    return mode ? mode.actionsForClick(clicked, {}) : [];
+    const settings = this.state.computedSettings || {};
+    return mode ? mode.actionsForClick(clicked, settings) : [];
   }
 
   visualizationIsClickable = (clicked: ClickObject) => {

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -226,6 +226,12 @@ export default class Table extends Component {
       },
       readDependencies: ["table.column_formatting", "table.pivot"],
     },
+    // This is really just a placeholder. table.sort is set in a drill and used
+    // in TableInteractive for client-side sorting.
+    "table.sort": {
+      default: null,
+      getHidden: () => true,
+    },
   };
 
   static columnSettings = column => {
@@ -382,7 +388,10 @@ export default class Table extends Component {
       settings,
     } = this.props;
     const { data } = this.state;
-    const sort = getIn(card, ["dataset_query", "query", "order-by"]) || null;
+    const sort =
+      getIn(card, ["dataset_query", "query", "order-by"]) ||
+      settings["table.sort"] ||
+      null;
     const isPivoted = settings["table.pivot"];
     const isColumnsDisabled =
       (settings["table.columns"] || []).filter(f => f.enabled).length < 1;

--- a/frontend/test/metabase/scenarios/table_sorting.cy.spec.js
+++ b/frontend/test/metabase/scenarios/table_sorting.cy.spec.js
@@ -1,0 +1,87 @@
+import { signInAsAdmin } from "__support__/cypress";
+
+describe("table sorting", () => {
+  beforeEach(signInAsAdmin);
+
+  it("should sort structured queries", () => {
+    // List orders for user #4
+    cy.visit("/");
+    cy.contains("Ask a question").click();
+    cy.contains("Simple question").click();
+    cy.contains("Sample Dataset").click();
+    cy.contains("Orders").click();
+    cy.contains("Filter").click();
+    cy.contains("Filter by")
+      .parent()
+      .parent()
+      .as("sidebar");
+    cy.get("@sidebar")
+      .contains("User ID")
+      .click();
+    cy.get("@sidebar")
+      .get(`input[placeholder="Enter an ID"]`)
+      .type("4");
+    cy.contains("Add filter").click();
+    cy.get(".TableInteractive-header").contains("ID");
+
+    verifySortingBySubtotal();
+  });
+
+  it("should sort native queries", () => {
+    // List orders for user #4
+    cy.visit("/");
+    cy.contains("Ask a question").click();
+    cy.contains("Native query").click();
+    cy.contains("Sample Dataset").click();
+    cy.get(".ace_content").type("SELECT * FROM ORDERS WHERE USER_ID = 4");
+    cy.get(".NativeQueryEditor .Icon-play").click();
+
+    verifySortingBySubtotal();
+  });
+});
+
+function verifySortingBySubtotal() {
+  // sort by subtotal ascending
+  cy.contains(/Subtotal/i).click(); // case-insensitive match to catch both Subtotal and SUBTOTAL
+  cy.contains("Ascending").click();
+
+  // should indicate the sort direction
+  cy.contains(/Subtotal/i)
+    .get(".Icon-chevronup")
+    .should("exist");
+  cy.contains(/Subtotal/i)
+    .closest(".TableInteractive-headerCellData--sorted")
+    .should("exist");
+
+  // This row should be first
+  cy.contains("September 20, 2019")
+    .parent()
+    .should("have.css", "top", "0px");
+  // This row should be last
+  cy.contains("December 21, 2019")
+    .parent()
+    .should("have.css", "top", "108px");
+
+  // sort by subtotal descending
+  cy.contains(/Subtotal/i).click();
+  cy.contains("Descending");
+  cy.contains("Ascending").should("not.exist");
+  cy.contains("Descending").click();
+
+  // should indicate the sort direction
+  cy.contains(/Subtotal/i)
+    .get(".Icon-chevrondown")
+    .should("exist");
+  cy.contains(/Subtotal/i)
+    .closest(".TableInteractive-headerCellData--sorted")
+    .should("exist");
+
+  // Now, this row should be last
+  cy.contains("September 20, 2019")
+    .parent()
+    .should("have.css", "top", "108px");
+  // Now, this row should be first
+  cy.contains("December 21, 2019")
+    .parent()
+    .should("have.css", "top", "0px");
+}


### PR DESCRIPTION
Resolves #11329

This PR reuses the existing UI built into `TableInteractive`.  Client-side sort columns are stored in a setting.

![image](https://user-images.githubusercontent.com/691495/71701068-5f45ac00-2d95-11ea-9c24-854ef75b70de.png)

Still needed:
- [ ] tests