### PR TITLE
Document the hide_parameters URL option in the embedding doc

### DIFF
--- a/docs/administration-guide/12-public-links.md
+++ b/docs/administration-guide/12-public-links.md
@@ -1,18 +1,57 @@
 ## Sharing and embedding dashboards or questions
+
 Sometimes you'll want to share a dashboard or question you've saved with someone that isn't a part of your organization or company, or someone who doesn't need access to your full Metabase instance. Metabase lets administrators create public links and simple embeds to let you do just that.
 
 ### Turning public links on
+
 ![Enable public sharing](images/public-links/enable-public-sharing.png)
 First things first, you'll need to go to the Admin Panel and enable public sharing. In the future, you'll see dashboards and questions you've shared listed here, and you'll be able to revoke any public links that you no longer want to be used.
 
 ### Enable sharing on your dashboard or saved question
+
 ![Enable sharing](images/public-links/enable-links.png)
 Next, exit the Admin Panel and go to the dashboard or question that you want to share, then click on the `Sharing and Embedding` icon in the top-right of the screen (it looks like a box with an arrow pointing up). Then click on the toggle to enable public sharing for this dashboard or question.
 
 ### Copy, paste, and share!
+
 Now just copy and share the public link URL with whomever you please. If you want to embed your dashboard or question in a simple web page or blog post, then copy and paste the iframe snippet to your destination of choice.
+
+### Assigning values to filters or hiding them via the URL
+
+This is a bit more advanced, but if you're embedding a dashboard or question in an iframe and it has one or more filter widgets on it, you can give those filters values and even hide one or more filters by adding some options to the end of the URL. (You could also do this when just sharing a link, but note that if you do that, the person you're sharing the link with could of course directly edit the URL to change the filters' values, or to change which filters are hidden or not.)
+
+Here's an example where we have a dashboard that has a couple filters on it, one of which is called "ID." We can give this filter a value of 7 and simultaneously prevent the filter widget from showing up by constructing our URL like this:
+
+```
+/dashboard/42?id=7#hide_parameters=id
+```
+
+You don't _have_ to assign a filter a value, though — if you only want to hide it, so that it isn't usable in this context, you can do this:
+
+```
+/dashboard/42#hide_parameters=id
+```
+
+Note that the name of the filter in the URL should be specified in lower case, and with underscores instead of spaces. So if your filter was called "Filter for User ZIP Code," you'd write:
+
+```
+/dashboard/42#hide_parameters=filter_for_user_zip_code
+```
+
+You can specify multiple filters to hide by separating them with commas, like this:
+
+```
+/dashboard/42#hide_parameters=id,customer_name
+```
+
+To specify multiple values for filters, though, you'll need to separate them with ampersands (&), like this:
+
+```
+/dashboard/42?id=7&customer_name=janet
+```
 
 ---
 
 ## Next: embedding dashboards and charts in other applications
+
 If you're trying to do more complex, integrated embedding in your own web application, then you can check out the [documentation for that feature](13-embedding.md).

--- a/docs/administration-guide/13-embedding.md
+++ b/docs/administration-guide/13-embedding.md
@@ -65,7 +65,7 @@ If you wish to have a parameter locked down to prevent your embedding applicatio
 
 ### Hiding parameters
 
-If you have parameters that aren't required, but that you'd like to be hidden, instead of marking them as Locked you can use the `hide_parameters` URL option to hide one or more parameter (i.e., prevent it from showing up as a filter widget on screen). You'll want to add this option to the Metabase URL specified in your embedding iframe.
+If you have parameters that aren't required, but that you'd like to be hidden, instead of marking them as Locked you can use the `hide_parameters` URL option to hide one or more parameters (i.e., prevent it from showing up as a filter widget on screen). You'll want to add this option to the Metabase URL specified in your embedding iframe.
 
 For example, if you have a parameter called "ID," in this example the ID filter widget would be hidden:
 

--- a/docs/administration-guide/13-embedding.md
+++ b/docs/administration-guide/13-embedding.md
@@ -1,28 +1,35 @@
 ## Embedding Metabase in other applications
 
 Metabase includes a powerful application embedding feature that allows you to embed your saved questions or dashboards in your own web applications. You can even pass parameters to these embeds to customize them for different users.
+
 ### Key Concepts
 
 #### Applications
+
 An important distinction to keep in mind is the difference between Metabase and the embedding application. The charts and dashboards you will be embedding live in the Metabase application, and will be embedded in your application (i.e. the embedding application).
 
 #### Parameters
+
 Some dashboards and questions have the ability to accept parameters. In dashboards, these are synonymous with dashboard filters. For example, if you have a dashboard with a filter on Publisher ID, this can be specified as a parameter when embedding, so that you could insert the dashboard filtered down to a specific Publisher ID.
 
 SQL based questions with template variables can also accept parameters for each variable. So for a query like
+
 ```
 SELECT count(*)
 FROM orders
 WHERE product_id = {% raw %}{{productID}}{% endraw %}
 ```
+
 you could specify a specific productID when embedding the question.
 
 #### Signed parameters
+
 In general, when embedding a chart or dashboard, the server of your embedding application will need to sign a request for that resource.
 
 If you choose to sign a specific parameter value, that means the user can't modify that, nor is a filter widget displayed for that parameter. For example, if the "Publisher ID" is assigned a value and the request signed, that means the front-end client that renders that dashboard on behalf of a given logged-in user can only see information for that publisher ID.
 
 ### Enabling embedding
+
 To enable embedding, go to the Admin Panel and under Settings, go to the "Embedding in other applications" tab. From there, click "Enable." Here you will see a secret signing key you can use later to sign requests. If you ever need to invalidate that key and generate a new one, just click on "Regenerate Key".
 ![Enabling Embedding](images/embedding/01-enabling.png)
 
@@ -44,28 +51,59 @@ Here you will see a preview of the question or dashboard as it will appear in yo
 
 ![Preview](images/embedding/04-preview.png)
 
-Importantly, you will need to hit "Publish" when you first set up a  chart or dashboard for embedding and each time you change your embedding settings. Also, any changes you make to the resource might require you to update the code in your own application to the latest code sample in the "Code Pane".
+Importantly, you will need to hit "Publish" when you first set up a chart or dashboard for embedding and each time you change your embedding settings. Also, any changes you make to the resource might require you to update the code in your own application to the latest code sample in the "Code Pane".
 
 ![Code samples for embedding](images/embedding/05-code.png)
 
 We provide code samples for common front end template languages as well as some common back-end web frameworks and languages. You may also use these as starting points for writing your own versions in other platforms.
 
-
 ### Embedding charts and dashboards with locked parameters
-If you wish to have a parameter locked down to prevent your embedding application's end users from seeing other users' data, you can mark parameters as "Locked."Once a parameter is marked as Locked, it is not displayed as a filter widget, and must be set by the embedding application's server code.
+
+If you wish to have a parameter locked down to prevent your embedding application's end users from seeing other users' data, you can mark parameters as "Locked." This will prevent that parameter from being displayed as a filter widget, so its value must instead be set by the embedding application's server code.
 
 ![Locked parameters](images/embedding/06-locked.png)
 
+### Hiding parameters
+
+If you have parameters that aren't required, but that you'd like to be hidden, instead of marking them as Locked you can use the `hide_parameters` URL option to hide one or more parameter (i.e., prevent it from showing up as a filter widget on screen). You'll want to add this option to the Metabase URL specified in your embedding iframe.
+
+For example, if you have a parameter called "ID," in this example the ID filter widget would be hidden:
+
+```
+/dashboard/42#hide_parameters=id
+```
+
+If you want, you can also simultaneously assign a parameter a value and hide the widget like this:
+
+```
+/dashboard/42?id=7#hide_parameters=id
+```
+
+Note that the name of the parameter in the URL should be specified in lower case, and with underscores instead of spaces. So if your parameter was called "Filter for User ZIP Code," you'd write:
+
+```
+/dashboard/42#hide_parameters=filter_for_user_zip_code
+```
+
+You can specify multiple parameters to hide by separating them with commas, like this:
+
+```
+/dashboard/42#hide_parameters=id,customer_name
+```
+
 ### Resizing dashboards to fit their content
+
 Dashboards are a fixed aspect ratio, so if you'd like to ensure they're automatically sized vertically to fit their contents you can use the [iFrame Resizer](https://github.com/davidjbradshaw/iframe-resizer) script. Metabase serves a copy for convenience:
+
 ```
 <script src="http://metabase.example.com/app/iframeResizer.js"></script>
 <iframe src="http://metabase.example.com/embed/dashboard/TOKEN" onload="iFrameResize({}, this)"></iframe>
 ```
 
 ### Reference applications
+
 To see concrete examples of how to embed Metabase in applications under a number of common frameworks, check out our [reference implementations](https://github.com/metabase/embedding-reference-apps) on Github.
 
-
 ## Premium embedding
+
 If you'd like to embed Metabase dashboards or charts in your application without the "Powered by Metabase" attribution, you can purchase premium embedding from the Metabase store. [Find out more here](https://store.metabase.com/product/embedding).

--- a/docs/administration-guide/13-embedding.md
+++ b/docs/administration-guide/13-embedding.md
@@ -91,6 +91,12 @@ You can specify multiple parameters to hide by separating them with commas, like
 /dashboard/42#hide_parameters=id,customer_name
 ```
 
+To specify multiple values for filters, though, you'll need to separate them with ampersands (&), like this:
+
+```
+/dashboard/42?id=7&customer_name=janet
+```
+
 ### Resizing dashboards to fit their content
 
 Dashboards are a fixed aspect ratio, so if you'd like to ensure they're automatically sized vertically to fit their contents you can use the [iFrame Resizer](https://github.com/davidjbradshaw/iframe-resizer) script. Metabase serves a copy for convenience:


### PR DESCRIPTION
It doesn't seem to me we've documented anywhere the [ability to hide parameter filter widgets via the URL](https://github.com/metabase/metabase/pull/9395). 

This PR adds some explanatory text about this option to the Admin > Embedding doc page (i.e., the JWT embedding doc).

Do we also want to add something about this to the full-app embedding doc?