### PR TITLE
update older-than test to not use hard coded date

### DIFF
--- a/src/metabase/util/date_2.clj
+++ b/src/metabase/util/date_2.clj
@@ -379,8 +379,8 @@
       ZonedDateTime  (t/zoned-date-time))))
 
 (defn older-than?
-  "True if temporal value `t` happened before some period/duration ago. Prefer this over using `t/before?`
-  because it is incredibly fussy about the classes of arguments it is passed.
+  "True if temporal value `t` happened before some period/duration ago, compared to now. Prefer this over using
+  `t/before?` to compare times to now because it is incredibly fussy about the classes of arguments it is passed.
 
     ;; did `t` happen more than 2 months ago?
     (older-than? t (t/months 2))"

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -380,12 +380,15 @@
            (u.date/period-duration (t/instant "2019-12-03T02:30:27Z") (t/offset-date-time "2019-12-03T02:31:26Z"))))))
 
 (deftest older-than-test
-  (t/with-clock (t/mock-clock  (t/zone-id "America/Los_Angeles"))
-    (testing "older-than works with differen date formats"
-      (doseq [t ((juxt t/instant t/local-date t/local-date-time t/offset-date-time identity)
-                 (t/minus (t/zoned-date-time) (t/days 20)))]
-        (testing (format "t = %s" (pr-str t))
-          (is (u.date/older-than? t (t/weeks 2))
-              (format "%s happened before 2019-11-19" (pr-str t)))
-          (is (not (u.date/older-than? t (t/months 2)))
-              (format "%s did not happen before 2019-10-03" (pr-str t))))))))
+  (let [now (t/instant "2019-12-04T00:45:00Z")]
+    (t/with-clock (t/mock-clock now (t/zone-id "America/Los_Angeles"))
+      (testing (str "now = " now)
+        (doseq [t ((juxt t/instant t/local-date t/local-date-time t/offset-date-time identity)
+                   (t/zoned-date-time "2019-11-01T00:00-08:00[US/Pacific]"))]
+          (testing (format "t = %s" (pr-str t))
+            (is (= true
+                   (u.date/older-than? t (t/weeks 2)))
+                (format "%s happened before 2019-11-19" (pr-str t)))
+            (is (= false
+                   (u.date/older-than? t (t/months 2)))
+                (format "%s did not happen before 2019-10-03" (pr-str t)))))))))

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -380,15 +380,12 @@
            (u.date/period-duration (t/instant "2019-12-03T02:30:27Z") (t/offset-date-time "2019-12-03T02:31:26Z"))))))
 
 (deftest older-than-test
-  (let [now (t/instant "2019-12-04T00:45:00Z")]
-    (t/with-clock (t/mock-clock  (t/zone-id "America/Los_Angeles"))
-      (testing (str "now = " now)
-        (doseq [t ((juxt t/instant t/local-date t/local-date-time t/offset-date-time identity)
-                   (t/zoned-date-time "2019-11-01T00:00-08:00[US/Pacific]"))]
-          (testing (format "t = %s" (pr-str t))
-            (is (= true
-                   (u.date/older-than? t (t/weeks 2)))
-                (format "%s happened before 2019-11-19" (pr-str t)))
-            (is (= false
-                   (u.date/older-than? t (t/months 2)))
-                (format "%s did not happen before 2019-10-03" (pr-str t)))))))))
+  (t/with-clock (t/mock-clock  (t/zone-id "America/Los_Angeles"))
+    (testing "older-than works with differen date formats"
+      (doseq [t ((juxt t/instant t/local-date t/local-date-time t/offset-date-time identity)
+                 (t/minus (t/zoned-date-time) (t/days 20)))]
+        (testing (format "t = %s" (pr-str t))
+          (is (u.date/older-than? t (t/weeks 2))
+              (format "%s happened before 2019-11-19" (pr-str t)))
+          (is (not (u.date/older-than? t (t/months 2)))
+              (format "%s did not happen before 2019-10-03" (pr-str t))))))))


### PR DESCRIPTION
With this change the `older-than` test will no longer fail, but I'm not sure what the actual behavior should be?

The test was failing because `older-than` always compares time `t` to now, so the test was checking, "is 11/01/2019 older than 2 weeks? older than 2 months?" Eventually, the duration between `now` and 11/01/2019 changed from being less than 2 months to more than 2 months, so the test started failing.

I'm confused about whether or not `older-than` should always be comparing time `t` to `now`. This is because the docstring for `older-than` reads:

```
"True if temporal value `t` happened before some period/duration ago. Prefer this over using `t/before?`
```

However, `t/before?` compares two arbitrary times, whereas `older-than?` always compares the given time to now, and it seemed like the tests may have been intended to support the use case of comparing two arbitrary times.