### PR TITLE
Fix bug with timeseries spacing of a single month

### DIFF
--- a/frontend/src/metabase/visualizations/lib/timeseriesScale.js
+++ b/frontend/src/metabase/visualizations/lib/timeseriesScale.js
@@ -41,10 +41,12 @@ const timeseriesScale = (
 };
 
 function domainForEvenlySpacedMonths(domain, { timezone, interval }) {
-  return wrapValues(
-    ticksForRange(domain, { count: 1, timezone, interval }),
-    domain,
-  );
+  const ticks = ticksForRange(domain, { count: 1, timezone, interval });
+  // if the domain only contains one month, return the domain untouched
+  if (ticks.length < 2) {
+    return domain;
+  }
+  return wrapValues(ticks, domain);
 }
 
 function rangeForEvenlySpacedMonths(range, domain, { timezone, interval }) {

--- a/frontend/src/metabase/visualizations/lib/timeseriesScale.js
+++ b/frontend/src/metabase/visualizations/lib/timeseriesScale.js
@@ -53,6 +53,10 @@ function rangeForEvenlySpacedMonths(range, domain, { timezone, interval }) {
     .domain(domain.map(toInt))
     .range(range);
   const ticks = ticksForRange(domain, { count: 1, timezone, interval });
+  // if the domain only contains one month, return the range untouched
+  if (ticks.length < 2) {
+    return range;
+  }
   const [start, end] = firstAndLast(ticks).map(t => plainScale(toInt(t)));
   const step = (end - start) / (ticks.length - 1);
   const monthPoints = d3.range(ticks.length).map(i => start + i * step);

--- a/frontend/test/metabase/visualizations/lib/timeseriesScale.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/timeseriesScale.unit.spec.js
@@ -257,6 +257,25 @@ describe("timeseriesScale", () => {
     ).toEqual([0, 10, 20, 30]);
   });
 
+  it("should work for one 'evenly spaced' month", () => {
+    const scale = timeseriesScale({
+      interval: "month",
+      count: 1,
+      timezone: "Etc/UTC",
+    })
+      .domain([
+        moment("2018-11-15T00:00:00.000Z"),
+        moment("2018-12-15T00:00:00.000Z"),
+      ])
+      .range([0, 30]);
+
+    expect(
+      ["2018-11-15", "2018-12-15"].map(d =>
+        scale(moment(`${d}T00:00:00.000Z`)),
+      ),
+    ).toEqual([0, 30]);
+  });
+
   it("should not evenly space years", () => {
     // 2020 is a leap year and 2019 is not. With the total width set to the
     // total number of days, each year should have one pixel per day.


### PR DESCRIPTION
Resolves #11619

This broke in #11497. The new logic to space month evenly, didn't handle narrower axes that only contained a single month tick. This issue was especially bad because our tick spacing logic drops ticks a bit too aggressively.