### PR TITLE
Fix using BigQuery driver when running with Leiningen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 /local/src
 /local/src
 /locales/metabase-*.pot
+/modules/drivers/*/resources/namespaces.edn
 /modules/drivers/*/target
 /node_modules/
 /osx-artifacts

--- a/modules/drivers/bigquery/project.clj
+++ b/modules/drivers/bigquery/project.clj
@@ -1,15 +1,15 @@
-(defproject metabase/bigquery-driver "1.0.0-SNAPSHOT-1.27.0"
+(defproject metabase/bigquery-driver "1.0.0-SNAPSHOT-1.30.3"
   :min-lein-version "2.5.0"
 
   :dependencies
-  [[com.google.apis/google-api-services-bigquery "v2-rev20181202-1.27.0"]]
+  [[com.google.apis/google-api-services-bigquery "v2-rev20190917-1.30.3"]]
 
   :profiles
   {:provided
    {:dependencies
     [[org.clojure/clojure "1.10.1"]
      [metabase-core "1.0.0-SNAPSHOT"]
-     [metabase/google-driver "1.0.0-SNAPSHOT-1.27.0"]]}
+     [metabase/google-driver "1.0.0-SNAPSHOT-1.30.7"]]}
 
    :uberjar
    {:auto-clean    true

--- a/modules/drivers/bigquery/resources/metabase-plugin.yaml
+++ b/modules/drivers/bigquery/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase BigQuery Driver
-  version: 1.0.0-SNAPSHOT-1.27.0
+  version: 1.0.0-SNAPSHOT-1.30.3
   description: Allows Metabase to connect to Google BigQuery databases.
 dependencies:
   - plugin: Metabase Google Drivers Shared Dependencies

--- a/modules/drivers/google/project.clj
+++ b/modules/drivers/google/project.clj
@@ -1,11 +1,11 @@
-(defproject metabase/google-driver "1.0.0-SNAPSHOT-1.27.0"
+(defproject metabase/google-driver "1.0.0-SNAPSHOT-1.30.7"
   :min-lein-version "2.5.0"
 
   :aliases
   {"install-for-building-drivers" ["with-profile" "+install-for-building-drivers" "install"]}
 
   :dependencies
-  [[com.google.api-client/google-api-client "1.27.0"]]
+  [[com.google.api-client/google-api-client "1.30.7"]]
 
   :profiles
   {:provided

--- a/modules/drivers/google/resources/metabase-plugin.yaml
+++ b/modules/drivers/google/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase Google Drivers Shared Dependencies
-  version: 1.0.0-SNAPSHOT-1.27.0
+  version: 1.0.0-SNAPSHOT-1.30.7
   description: Shared dependencies for BigQuery, Google Analytics, and other Google drivers.
 driver:
   name: google

--- a/modules/drivers/google/src/metabase/driver/google.clj
+++ b/modules/drivers/google/src/metabase/driver/google.clj
@@ -41,7 +41,7 @@
                            (into {} error)))))))
 
 (defn execute
-  "`execute` REQUEST, and catch any `GoogleJsonResponseException` is throws, converting them to `ExceptionInfo` and
+  "Execute `request`, and catch any `GoogleJsonResponseException` is throws, converting them to `ExceptionInfo` and
   rethrowing them.
 
   This automatically retries any failed requests up to 2 times."

--- a/modules/drivers/sparksql/project.clj
+++ b/modules/drivers/sparksql/project.clj
@@ -7,7 +7,7 @@
    ;; implementations of things like log4j <-> slf4j, or are part of both hadoop-common and hive-jdbc;
    [org.apache.hadoop/hadoop-common "3.1.1"
     :exclusions [com.fasterxml.jackson.core/jackson-core
-                 #_com.google.guava/guava
+                 com.google.guava/guava
                  commons-logging
                  org.apache.httpcomponents/httpcore
                  org.codehaus.jackson/jackson-core-asl

--- a/project.clj
+++ b/project.clj
@@ -77,6 +77,7 @@
                  it.unimi.dsi/fastutil]]
    [com.draines/postal "2.0.3"]                                       ; SMTP library
    [com.jcraft/jsch "0.1.55"]                                         ; SSH client for tunnels
+   [com.google.guava/guava "28.2-jre"]                                ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
    [com.h2database/h2 "1.4.197"]                                      ; embedded SQL database
    [com.mattbertolini/liquibase-slf4j "2.0.0"]                        ; Java Migrations lib logging. We don't actually use this AFAIK (?)
    [com.taoensso/nippy "2.14.0"]                                      ; Fast serialization (i.e., GZIP) library for Clojure


### PR DESCRIPTION
When running Metabase from the REPL, custom Leiningen middleware merges the dependencies for various drivers into the core project, so you can access all drivers from the REPL without having to build them first. However, the dep for Guava 11 (required by Hadoop, which is required by the Spark SQL JDBC driver) conflicted with the the dep for Guava 18 (required by the Google API client lib, which is required by the BigQuery client); this could lead to situations where the BigQuery driver failed to load from the REPL. 

My efforts to debug this issue are documented in comments on issue #9697, which was for a similar issue that affected Metabase when running from the uberjar (itself fixed in 0.33.2). 

This fix only applies to running via Leiningen; the issue doesn't exist in production.