### PR TITLE
Embed metabase.util/metabase-namespace-symbols as ^:const var in code

### DIFF
--- a/src/metabase/cmd/endpoint_dox.clj
+++ b/src/metabase/cmd/endpoint_dox.clj
@@ -13,7 +13,7 @@
   (str "# API Documentation for Metabase "
        (config/mb-version-info :tag)
        "\n\n"
-       (str/join "\n\n\n" (for [ns-symb     @u/metabase-namespace-symbols
+       (str/join "\n\n\n" (for [ns-symb     u/metabase-namespace-symbols
                                 :when       (.startsWith (name ns-symb) "metabase.api.")
                                 [symb varr] (do (classloader/require ns-symb)
                                                 (sort (ns-interns ns-symb)))

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -80,7 +80,7 @@
   This really only needs to be done by the public settings API endpoint to populate the list of available drivers.
   Please avoid using this function elsewhere, as loading all of these namespaces can be quite expensive!"
   []
-  (doseq [ns-symb @u/metabase-namespace-symbols
+  (doseq [ns-symb u/metabase-namespace-symbols
           :when   (re-matches #"^metabase\.driver\.[a-z0-9_]+$" (name ns-symb))
           :let    [driver (keyword (-> (last (str/split (name ns-symb) #"\."))
                                        (str/replace #"_" "-")))]

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -28,7 +28,7 @@
   exists."
   []
   (when-not config/is-test?
-    (doseq [ns-symb @u/metabase-namespace-symbols
+    (doseq [ns-symb u/metabase-namespace-symbols
             :when   (.startsWith (name ns-symb) "metabase.events.")]
       (classloader/require ns-symb)
       ;; look for `events-init` function in the namespace and call it if it exists

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -61,7 +61,7 @@
 (defn- find-and-load-task-namespaces!
   "Search Classpath for namespaces that start with `metabase.tasks.`, then `require` them so initialization can happen."
   []
-  (doseq [ns-symb @u/metabase-namespace-symbols
+  (doseq [ns-symb u/metabase-namespace-symbols
           :when   (.startsWith (name ns-symb) "metabase.task.")]
     (try
       (log/debug (trs "Loading tasks namespace:") (u/format-color 'blue ns-symb))

--- a/test/metabase/cmd/load_from_h2_test.clj
+++ b/test/metabase/cmd/load_from_h2_test.clj
@@ -38,7 +38,7 @@
     "QueryExecution"})
 
 (defn- all-model-names []
-  (set (for [ns       @u/metabase-namespace-symbols
+  (set (for [ns       u/metabase-namespace-symbols
              :when    (or (re-find #"^metabase\.models\." (name ns))
                           (= (name ns) "metabase.db.migrations"))
              :when    (not (re-find #"test" (name ns)))


### PR DESCRIPTION
As part of Metabase initialization we do things like load all task (`metabase.task.*`) namespaces. To find these sorts of namespaces, we need to have a way to find all Metabase (`metabase.*`) namespaces.

Before 0.33.7.x, that was accomplished by using `(ns-find/find-namespaces (classpath/system-classpath))`, which enumerated all the files in the Metabase JAR (or in the classpath when running locally) and determined which were Clojure source files; we then filtered out the corresponding namespaces by seeing which ones matched `metabase.*`. This process could take a second or two.

In 0.33.7.x I cached the output of this step in a `namespaces.edn` file. This was mainly done because `ns-find` doesn't work if the Clojure source files are omitted. However, even if source files are included, caching this output at compile time is still a good idea because it speeds up launch time.

This PR includes the namespace symbols inline as a `^:const` var rather than writing and reading them from an EDN file, so it simplifies the steps a bit and speeds up launch by a few more milliseconds. Doing this this way didn't occur to me at first but it is a simpler way of accomplishing the same thing.