### PR TITLE
Fix LDAP groups sync regression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,6 +455,8 @@ jobs:
               then ./bin/build version frontend uberjar;
             fi
           no_output_timeout: 5m
+      - store_artifacts:
+          path: /home/circleci/metabase/metabase/target/uberjar/metabase.jar
       - save_cache:
           key: uberjar-{{ checksum "./backend-checksums.txt" }}-{{ checksum "./frontend-checksums.txt" }}
           paths:

--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -199,7 +199,7 @@
           :groups     (when (ldap-group-sync)
                         ;; ActiveDirectory (and others?) will supply a `memberOf` overlay attribute for groups
                         ;; Otherwise we have to make the inverse query to get them
-                        (or (:memberOf result) (get-user-groups dn) []))})))))
+                        (or (:memberof result) (get-user-groups dn) []))})))))
 
 (defn verify-password
   "Verifies if the supplied password is valid for the `user-info` (from `find-user`) or DN."

--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -197,8 +197,8 @@
           :last-name  lname
           :email      email
           :groups     (when (ldap-group-sync)
-                        ;; ActiveDirectory (and others?) will supply a `memberOf` overlay attribute for groups
-                        ;; Otherwise we have to make the inverse query to get them
+                        ;; Active Directory and others (like FreeIPA) will supply a `memberOf` overlay attribute for
+                        ;; groups. Otherwise we have to make the inverse query to get them.
                         (or (:memberof result) (get-user-groups dn) []))})))))
 
 (defn verify-password


### PR DESCRIPTION
This is bug to LDAP servers that communicates group membership via the `memberOf` overlay, introduced by #11412, where attribute keys were all lower cased to support case insensitive matching. The hard-coded lookup of the `:memberOf` key was not similarly lower cased.

Fixes #11617.