### PR TITLE
Fix Mac App Title Bar [ci skip]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-# don't use private/SSH remotes (e.x. git@github.com) because they break Heroku deploys
-[submodule "OSX/Vendor/INAppStoreWindow"]
-	path = OSX/Vendor/INAppStoreWindow
-	url = https://github.com/indragiek/INAppStoreWindow.git

--- a/OSX/Metabase.xcodeproj/project.pbxproj
+++ b/OSX/Metabase.xcodeproj/project.pbxproj
@@ -7,11 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		D105B2241BB378C100A5D850 /* INAppStoreWindowSwizzling.c in Sources */ = {isa = PBXBuildFile; fileRef = D105B1F21BB378C100A5D850 /* INAppStoreWindowSwizzling.c */; };
-		D105B2251BB378C100A5D850 /* INWindowBackgroundView+CoreUIRendering.m in Sources */ = {isa = PBXBuildFile; fileRef = D105B1F51BB378C100A5D850 /* INWindowBackgroundView+CoreUIRendering.m */; };
-		D105B2261BB378C100A5D850 /* NSDocument+INAppStoreWindowFixes.m in Sources */ = {isa = PBXBuildFile; fileRef = D105B1F71BB378C100A5D850 /* NSDocument+INAppStoreWindowFixes.m */; };
-		D105B2271BB378C100A5D850 /* INAppStoreWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = D105B1F91BB378C100A5D850 /* INAppStoreWindow.m */; };
-		D105B2281BB378C100A5D850 /* INWindowButton.m in Sources */ = {isa = PBXBuildFile; fileRef = D105B1FC1BB378C100A5D850 /* INWindowButton.m */; };
 		D105B23C1BB5BE4A00A5D850 /* back_icon@1x.png in Resources */ = {isa = PBXBuildFile; fileRef = D105B2331BB5BE4A00A5D850 /* back_icon@1x.png */; };
 		D105B23D1BB5BE4A00A5D850 /* back_icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D105B2341BB5BE4A00A5D850 /* back_icon@2x.png */; };
 		D105B23E1BB5BE4A00A5D850 /* forward_icon@1x.png in Resources */ = {isa = PBXBuildFile; fileRef = D105B2351BB5BE4A00A5D850 /* forward_icon@1x.png */; };
@@ -75,17 +70,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		D105B1F21BB378C100A5D850 /* INAppStoreWindowSwizzling.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = INAppStoreWindowSwizzling.c; sourceTree = "<group>"; };
-		D105B1F31BB378C100A5D850 /* INAppStoreWindowSwizzling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = INAppStoreWindowSwizzling.h; sourceTree = "<group>"; };
-		D105B1F41BB378C100A5D850 /* INWindowBackgroundView+CoreUIRendering.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "INWindowBackgroundView+CoreUIRendering.h"; sourceTree = "<group>"; };
-		D105B1F51BB378C100A5D850 /* INWindowBackgroundView+CoreUIRendering.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "INWindowBackgroundView+CoreUIRendering.m"; sourceTree = "<group>"; };
-		D105B1F61BB378C100A5D850 /* NSDocument+INAppStoreWindowFixes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDocument+INAppStoreWindowFixes.h"; sourceTree = "<group>"; };
-		D105B1F71BB378C100A5D850 /* NSDocument+INAppStoreWindowFixes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDocument+INAppStoreWindowFixes.m"; sourceTree = "<group>"; };
-		D105B1F81BB378C100A5D850 /* INAppStoreWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = INAppStoreWindow.h; sourceTree = "<group>"; };
-		D105B1F91BB378C100A5D850 /* INAppStoreWindow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = INAppStoreWindow.m; sourceTree = "<group>"; };
-		D105B1FA1BB378C100A5D850 /* INAppStoreWindowCompatibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = INAppStoreWindowCompatibility.h; sourceTree = "<group>"; };
-		D105B1FB1BB378C100A5D850 /* INWindowButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = INWindowButton.h; sourceTree = "<group>"; };
-		D105B1FC1BB378C100A5D850 /* INWindowButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = INWindowButton.m; sourceTree = "<group>"; };
+		329A3BAF23C54C6700D0949B /* Metabase.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Metabase.entitlements; sourceTree = "<group>"; };
 		D105B2331BB5BE4A00A5D850 /* back_icon@1x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "back_icon@1x.png"; sourceTree = "<group>"; };
 		D105B2341BB5BE4A00A5D850 /* back_icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "back_icon@2x.png"; sourceTree = "<group>"; };
 		D105B2351BB5BE4A00A5D850 /* forward_icon@1x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "forward_icon@1x.png"; sourceTree = "<group>"; };
@@ -166,43 +151,8 @@
 			isa = PBXGroup;
 			children = (
 				D121FD631BC5B2AF002101B0 /* Sparkle-1.11.0 */,
-				D105B1BE1BB378C100A5D850 /* INAppStoreWindow */,
 			);
 			path = Vendor;
-			sourceTree = "<group>";
-		};
-		D105B1BE1BB378C100A5D850 /* INAppStoreWindow */ = {
-			isa = PBXGroup;
-			children = (
-				D105B1F01BB378C100A5D850 /* INAppStoreWindow */,
-			);
-			path = INAppStoreWindow;
-			sourceTree = "<group>";
-		};
-		D105B1F01BB378C100A5D850 /* INAppStoreWindow */ = {
-			isa = PBXGroup;
-			children = (
-				D105B1F11BB378C100A5D850 /* Extensions */,
-				D105B1F81BB378C100A5D850 /* INAppStoreWindow.h */,
-				D105B1F91BB378C100A5D850 /* INAppStoreWindow.m */,
-				D105B1FA1BB378C100A5D850 /* INAppStoreWindowCompatibility.h */,
-				D105B1FB1BB378C100A5D850 /* INWindowButton.h */,
-				D105B1FC1BB378C100A5D850 /* INWindowButton.m */,
-			);
-			path = INAppStoreWindow;
-			sourceTree = "<group>";
-		};
-		D105B1F11BB378C100A5D850 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				D105B1F21BB378C100A5D850 /* INAppStoreWindowSwizzling.c */,
-				D105B1F31BB378C100A5D850 /* INAppStoreWindowSwizzling.h */,
-				D105B1F41BB378C100A5D850 /* INWindowBackgroundView+CoreUIRendering.h */,
-				D105B1F51BB378C100A5D850 /* INWindowBackgroundView+CoreUIRendering.m */,
-				D105B1F61BB378C100A5D850 /* NSDocument+INAppStoreWindowFixes.h */,
-				D105B1F71BB378C100A5D850 /* NSDocument+INAppStoreWindowFixes.m */,
-			);
-			path = Extensions;
 			sourceTree = "<group>";
 		};
 		D105B2321BB5BE4A00A5D850 /* Images */ = {
@@ -312,6 +262,7 @@
 		D18853C41BB0CEC600D89803 /* Metabase */ = {
 			isa = PBXGroup;
 			children = (
+				329A3BAF23C54C6700D0949B /* Metabase.entitlements */,
 				D162C4981BC87D2B009F678F /* Backend */,
 				D162C4A11BC87D2B009F678F /* UI */,
 				D18853C51BB0CEC600D89803 /* Supporting Files */,
@@ -480,14 +431,9 @@
 			files = (
 				D162C4AB1BC87D2B009F678F /* TaskHealthChecker.m in Sources */,
 				D1CB9FE81BCEDE9A009A61FB /* LoadingView.m in Sources */,
-				D105B2261BB378C100A5D850 /* NSDocument+INAppStoreWindowFixes.m in Sources */,
 				D162C4AA1BC87D2B009F678F /* SettingsManager.m in Sources */,
-				D105B2251BB378C100A5D850 /* INWindowBackgroundView+CoreUIRendering.m in Sources */,
-				D105B2241BB378C100A5D850 /* INAppStoreWindowSwizzling.c in Sources */,
 				D18853CB1BB0CEC600D89803 /* main.m in Sources */,
 				D162C4AF1BC87D2B009F678F /* MainViewController.m in Sources */,
-				D105B2281BB378C100A5D850 /* INWindowButton.m in Sources */,
-				D105B2271BB378C100A5D850 /* INAppStoreWindow.m in Sources */,
 				D1BDAC6D1C0565640075D3AC /* JavaTask.m in Sources */,
 				D1BDAC721C05695B0075D3AC /* ResetPasswordTask.m in Sources */,
 				D162C4A91BC87D2B009F678F /* MetabaseTask.m in Sources */,
@@ -641,8 +587,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Metabase/Metabase.entitlements;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Vendor/Sparkle-1.11.0",
@@ -660,9 +608,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Metabase/Metabase.entitlements;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Vendor/Sparkle-1.11.0",

--- a/OSX/Metabase/Metabase.entitlements
+++ b/OSX/Metabase/Metabase.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/OSX/Metabase/UI/MainMenu.xib
+++ b/OSX/Metabase/UI/MainMenu.xib
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9532" systemVersion="14F27" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9532"/>
-        <plugIn identifier="com.apple.WebKitIBPlugin" version="9532"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
+        <plugIn identifier="com.apple.WebKitIBPlugin" version="15702"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -24,9 +25,10 @@
             <connections>
                 <outlet property="backButtonCell" destination="lEo-fP-VyB" id="Liq-b8-nP9"/>
                 <outlet property="forwardButtonCell" destination="uF3-qn-F0a" id="eR7-ml-w4X"/>
+                <outlet property="leftTitleBarView" destination="V9v-oH-CLo" id="TdT-j4-Ooc"/>
                 <outlet property="linkButtonCell" destination="D9P-hg-lf8" id="G2L-cA-69g"/>
                 <outlet property="refreshButtonCell" destination="SSf-hM-lhY" id="xJE-83-OZr"/>
-                <outlet property="titleBarView" destination="Pem-Bq-pDs" id="nGc-wz-YES"/>
+                <outlet property="rightTitleBarView" destination="Iss-xM-4Ib" id="US0-BJ-PTe"/>
                 <outlet property="view" destination="EiT-Mj-1SZ" id="hOv-v9-VQo"/>
                 <outlet property="webView" destination="mhE-X5-FF6" id="MTz-Fg-4Di"/>
             </connections>
@@ -172,8 +174,9 @@
                     </menu>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="140" y="154"/>
         </menu>
-        <window allowsToolTipsWhenApplicationIsInactive="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g" customClass="INAppStoreWindow">
+        <window title="Metabase" allowsToolTipsWhenApplicationIsInactive="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <rect key="contentRect" x="335" y="390" width="1000" height="700"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="2537"/>
@@ -203,75 +206,69 @@
             <userDefinedRuntimeAttributes>
                 <userDefinedRuntimeAttribute type="boolean" keyPath="showsTitle" value="NO"/>
             </userDefinedRuntimeAttributes>
+            <point key="canvasLocation" x="-203" y="602"/>
         </window>
-        <customView id="Pem-Bq-pDs" userLabel="titleBarView">
-            <rect key="frame" x="0.0" y="0.0" width="651" height="32"/>
+        <customView id="V9v-oH-CLo">
+            <rect key="frame" x="0.0" y="0.0" width="72" height="32"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <customView translatesAutoresizingMaskIntoConstraints="NO" id="V9v-oH-CLo">
-                    <rect key="frame" x="64" y="0.0" width="523" height="32"/>
-                    <subviews>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BVV-jo-b9C">
-                            <rect key="frame" x="229" y="8" width="65" height="17"/>
-                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" title="Metabase" id="Vvp-PZ-SY5">
-                                <font key="font" metaFont="system"/>
-                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                            </textFieldCell>
-                        </textField>
-                        <button translatesAutoresizingMaskIntoConstraints="NO" id="dZP-Ul-oSB">
-                            <rect key="frame" x="0.0" y="0.0" width="24" height="32"/>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="24" id="6zn-IR-p7a"/>
-                            </constraints>
-                            <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="back_icon" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="lEo-fP-VyB">
-                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="system" size="23"/>
-                            </buttonCell>
-                            <connections>
-                                <action selector="back:" target="8au-ff-PAw" id="MfY-gk-scw"/>
-                            </connections>
-                        </button>
-                        <button translatesAutoresizingMaskIntoConstraints="NO" id="5Bt-VB-Dba">
-                            <rect key="frame" x="24" y="0.0" width="24" height="32"/>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="24" id="cZI-NR-ghh"/>
-                            </constraints>
-                            <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="forward_icon" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="uF3-qn-F0a">
-                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="system" size="23"/>
-                            </buttonCell>
-                            <connections>
-                                <action selector="forward:" target="8au-ff-PAw" id="Hwj-Yo-Qtt"/>
-                            </connections>
-                        </button>
-                        <button translatesAutoresizingMaskIntoConstraints="NO" id="HAI-2S-GZQ">
-                            <rect key="frame" x="48" y="0.0" width="24" height="32"/>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="24" id="Bk3-9A-EeN"/>
-                            </constraints>
-                            <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="refresh_icon" imagePosition="overlaps" alignment="center" imageScaling="proportionallyDown" inset="2" id="SSf-hM-lhY">
-                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="system" size="23"/>
-                            </buttonCell>
-                            <connections>
-                                <action selector="reload:" target="8au-ff-PAw" id="y95-m6-iZ1"/>
-                            </connections>
-                        </button>
-                    </subviews>
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="dZP-Ul-oSB">
+                    <rect key="frame" x="0.0" y="9" width="24" height="15"/>
                     <constraints>
-                        <constraint firstAttribute="centerY" secondItem="5Bt-VB-Dba" secondAttribute="centerY" id="2iz-ND-ODT"/>
-                        <constraint firstAttribute="centerY" secondItem="HAI-2S-GZQ" secondAttribute="centerY" id="Efu-ly-nfn"/>
-                        <constraint firstAttribute="centerY" secondItem="dZP-Ul-oSB" secondAttribute="centerY" id="FYl-6N-5zd"/>
-                        <constraint firstAttribute="centerX" secondItem="BVV-jo-b9C" secondAttribute="centerX" id="LIX-0H-Hcn"/>
-                        <constraint firstAttribute="centerY" secondItem="BVV-jo-b9C" secondAttribute="centerY" id="NaO-8y-1rD"/>
-                        <constraint firstItem="dZP-Ul-oSB" firstAttribute="leading" secondItem="V9v-oH-CLo" secondAttribute="leading" id="P36-OS-GAI"/>
-                        <constraint firstItem="HAI-2S-GZQ" firstAttribute="leading" secondItem="5Bt-VB-Dba" secondAttribute="trailing" id="cAU-bJ-DfV"/>
-                        <constraint firstItem="5Bt-VB-Dba" firstAttribute="leading" secondItem="dZP-Ul-oSB" secondAttribute="trailing" id="pHA-7b-NC5"/>
+                        <constraint firstAttribute="width" constant="24" id="6zn-IR-p7a"/>
                     </constraints>
-                </customView>
+                    <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="back_icon" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="lEo-fP-VyB">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="system" size="23"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="back:" target="8au-ff-PAw" id="MfY-gk-scw"/>
+                    </connections>
+                </button>
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="5Bt-VB-Dba">
+                    <rect key="frame" x="24" y="9" width="24" height="15"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="24" id="cZI-NR-ghh"/>
+                    </constraints>
+                    <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="forward_icon" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="uF3-qn-F0a">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="system" size="23"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="forward:" target="8au-ff-PAw" id="Hwj-Yo-Qtt"/>
+                    </connections>
+                </button>
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="HAI-2S-GZQ">
+                    <rect key="frame" x="48" y="9" width="24" height="15"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="24" id="Bk3-9A-EeN"/>
+                    </constraints>
+                    <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="refresh_icon" imagePosition="overlaps" alignment="center" imageScaling="proportionallyDown" inset="2" id="SSf-hM-lhY">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="system" size="23"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="reload:" target="8au-ff-PAw" id="y95-m6-iZ1"/>
+                    </connections>
+                </button>
+            </subviews>
+            <constraints>
+                <constraint firstAttribute="centerY" secondItem="5Bt-VB-Dba" secondAttribute="centerY" id="2iz-ND-ODT"/>
+                <constraint firstAttribute="centerY" secondItem="HAI-2S-GZQ" secondAttribute="centerY" id="Efu-ly-nfn"/>
+                <constraint firstAttribute="centerY" secondItem="dZP-Ul-oSB" secondAttribute="centerY" id="FYl-6N-5zd"/>
+                <constraint firstItem="dZP-Ul-oSB" firstAttribute="leading" secondItem="V9v-oH-CLo" secondAttribute="leading" id="P36-OS-GAI"/>
+                <constraint firstItem="HAI-2S-GZQ" firstAttribute="leading" secondItem="5Bt-VB-Dba" secondAttribute="trailing" id="cAU-bJ-DfV"/>
+                <constraint firstItem="5Bt-VB-Dba" firstAttribute="leading" secondItem="dZP-Ul-oSB" secondAttribute="trailing" id="pHA-7b-NC5"/>
+                <constraint firstAttribute="trailing" secondItem="HAI-2S-GZQ" secondAttribute="trailing" id="soW-Yt-FUQ"/>
+            </constraints>
+            <point key="canvasLocation" x="-426" y="1199"/>
+        </customView>
+        <customView id="Iss-xM-4Ib">
+            <rect key="frame" x="0.0" y="0.0" width="24" height="32"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <subviews>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="XfF-w9-qlO">
-                    <rect key="frame" x="627" y="0.0" width="24" height="32"/>
+                    <rect key="frame" x="0.0" y="9" width="24" height="15"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="24" id="O1n-dk-WFr"/>
                     </constraints>
@@ -285,14 +282,11 @@
                 </button>
             </subviews>
             <constraints>
-                <constraint firstAttribute="trailing" secondItem="XfF-w9-qlO" secondAttribute="trailing" id="ScP-H6-pcc"/>
-                <constraint firstAttribute="bottom" secondItem="V9v-oH-CLo" secondAttribute="bottom" id="TY7-Sy-rWe"/>
-                <constraint firstItem="V9v-oH-CLo" firstAttribute="top" secondItem="Pem-Bq-pDs" secondAttribute="top" id="YVh-iR-cBq"/>
-                <constraint firstItem="V9v-oH-CLo" firstAttribute="leading" secondItem="Pem-Bq-pDs" secondAttribute="leading" constant="64" id="cEB-9C-Fnb"/>
-                <constraint firstAttribute="trailing" secondItem="V9v-oH-CLo" secondAttribute="trailing" constant="64" id="pcy-tI-xwH"/>
-                <constraint firstItem="XfF-w9-qlO" firstAttribute="top" secondItem="Pem-Bq-pDs" secondAttribute="top" id="rTc-5I-7Vt"/>
-                <constraint firstAttribute="bottom" secondItem="XfF-w9-qlO" secondAttribute="bottom" id="zqj-GW-B55"/>
+                <constraint firstItem="XfF-w9-qlO" firstAttribute="leading" secondItem="Iss-xM-4Ib" secondAttribute="leading" id="0V6-XG-Ewc"/>
+                <constraint firstAttribute="trailing" secondItem="XfF-w9-qlO" secondAttribute="trailing" id="jGa-xG-jnk"/>
+                <constraint firstItem="XfF-w9-qlO" firstAttribute="centerY" secondItem="Iss-xM-4Ib" secondAttribute="centerY" id="sOf-6o-oSa"/>
             </constraints>
+            <point key="canvasLocation" x="-190" y="1087"/>
         </customView>
     </objects>
     <resources>

--- a/OSX/Metabase/UI/MainViewController.m
+++ b/OSX/Metabase/UI/MainViewController.m
@@ -9,8 +9,6 @@
 @import JavaScriptCore;
 @import WebKit;
 
-#import "INAppStoreWindow.h"
-
 #import "LoadingView.h"
 #import "MainViewController.h"
 #import "ResetPasswordWindowController.h"
@@ -18,15 +16,16 @@
 #import "TaskHealthChecker.h"
 
 
-
 NSString *BaseURL() {
-	return SettingsManager.instance.baseURL.length ? SettingsManager.instance.baseURL : LocalHostBaseURL();
+    return SettingsManager.instance.baseURL.length ? SettingsManager.instance.baseURL : LocalHostBaseURL();
 }
 
 
 @interface MainViewController () <ResetPasswordWindowControllerDelegate>
 @property (weak) IBOutlet WebView *webView;
-@property (strong) IBOutlet NSView *titleBarView;
+
+@property (strong) IBOutlet NSView *leftTitleBarView;
+@property (strong) IBOutlet NSView *rightTitleBarView;
 
 @property (weak) IBOutlet NSButtonCell *backButtonCell;
 @property (weak) IBOutlet NSButtonCell *forwardButtonCell;
@@ -47,70 +46,73 @@ NSString *BaseURL() {
 #pragma mark - Lifecycle
 
 - (void)awakeFromNib {
-	// configure window / title bar
-	{
-		INAppStoreWindow *window = (INAppStoreWindow *)self.view.window;
-		window.titleBarHeight = self.titleBarView.bounds.size.height;
-		
-		self.view.wantsLayer = YES;
-		self.view.layer.backgroundColor = [NSColor whiteColor].CGColor;
-		
-		self.titleBarView.frame = window.titleBarView.bounds;
-		self.titleBarView.autoresizingMask = NSViewWidthSizable|NSViewHeightSizable;
-		[window.titleBarView addSubview:self.titleBarView];
-	}
-	
-	// programatically add loading view to container
-	{
-		LoadingView *loadingView = [[LoadingView alloc] init];
-		[self.view addSubview:loadingView];
-		
-		[self.view addConstraints:@[[NSLayoutConstraint constraintWithItem:loadingView attribute:NSLayoutAttributeWidth   relatedBy:NSLayoutRelationEqual toItem:nil       attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0f constant:200.0f],
-									[NSLayoutConstraint constraintWithItem:loadingView attribute:NSLayoutAttributeHeight  relatedBy:NSLayoutRelationEqual toItem:nil       attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0f constant:200.0f],
-									[NSLayoutConstraint constraintWithItem:loadingView attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeCenterX        multiplier:1.0f constant:0],
-									[NSLayoutConstraint constraintWithItem:loadingView attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeCenterY        multiplier:1.0f constant:0]]];
-		
-		self.loadingView = loadingView;
-	}
-	
-	self.webView.wantsLayer = YES;
-	self.webView.animator.alphaValue = 0.0f;
+    // configure window / title bar accessory views
+    {
+        self.view.wantsLayer = YES;
+        self.view.layer.backgroundColor = [NSColor whiteColor].CGColor;
 
-	dispatch_async(dispatch_get_main_queue(), ^{
-		self.loading = YES;
-	});
-	
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(taskBecameHealthy:) name:MetabaseTaskBecameHealthyNotification object:nil];
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(taskBecameUnhealthy:) name:MetabaseTaskBecameUnhealthyNotification object:nil];
+        NSTitlebarAccessoryViewController* leftTitleBarAccessoryViewController = [[NSTitlebarAccessoryViewController alloc] init];
+        leftTitleBarAccessoryViewController.layoutAttribute = NSLayoutAttributeLeft;
+        leftTitleBarAccessoryViewController.view = self.leftTitleBarView;
+        [self.view.window addTitlebarAccessoryViewController:leftTitleBarAccessoryViewController];
+
+        NSTitlebarAccessoryViewController* rightTitleBarAccessoryViewController = [[NSTitlebarAccessoryViewController alloc] init];
+        rightTitleBarAccessoryViewController.layoutAttribute = NSLayoutAttributeRight;
+        rightTitleBarAccessoryViewController.view = self.rightTitleBarView;
+        [self.view.window addTitlebarAccessoryViewController:rightTitleBarAccessoryViewController];
+    }
+
+    // programatically add loading view to container
+    {
+        LoadingView *loadingView = [[LoadingView alloc] init];
+        [self.view addSubview:loadingView];
+
+        [self.view addConstraints:@[[NSLayoutConstraint constraintWithItem:loadingView attribute:NSLayoutAttributeWidth   relatedBy:NSLayoutRelationEqual toItem:nil       attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0f constant:200.0f],
+                                    [NSLayoutConstraint constraintWithItem:loadingView attribute:NSLayoutAttributeHeight  relatedBy:NSLayoutRelationEqual toItem:nil       attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0f constant:200.0f],
+                                    [NSLayoutConstraint constraintWithItem:loadingView attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeCenterX        multiplier:1.0f constant:0],
+                                    [NSLayoutConstraint constraintWithItem:loadingView attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeCenterY        multiplier:1.0f constant:0]]];
+
+        self.loadingView = loadingView;
+    }
+
+    self.webView.wantsLayer = YES;
+    self.webView.animator.alphaValue = 0.0f;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.loading = YES;
+    });
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(taskBecameHealthy:) name:MetabaseTaskBecameHealthyNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(taskBecameUnhealthy:) name:MetabaseTaskBecameUnhealthyNotification object:nil];
 }
 
 - (void)dealloc {
-	[[NSNotificationCenter defaultCenter] removeObserver:self];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 
 #pragma mark - Notifications
 
 - (void)taskBecameHealthy:(NSNotification *)notification {
-	dispatch_async(dispatch_get_main_queue(), ^{
-        
+    dispatch_async(dispatch_get_main_queue(), ^{
+
         if (self.launchRoute) {
             [self navigateToRoute:self.launchRoute];
             self.launchRoute = nil;
         } else {
             [self loadMainPage];
         }
-		
-		dispatch_async(dispatch_get_main_queue(), ^{
-			self.loading = NO;
-		});
-	});
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self.loading = NO;
+        });
+    });
 }
 
 - (void)taskBecameUnhealthy:(NSNotification *)notification {
-	dispatch_async(dispatch_get_main_queue(), ^{
-		self.loading = YES;
-	});
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.loading = YES;
+    });
 }
 
 
@@ -130,41 +132,41 @@ NSString *BaseURL() {
 }
 
 - (void)downloadWithMethod:(NSString *)methodString url:(NSString *)urlString params:(NSDictionary *)paramsDict extensions:(NSArray *)extensions {
-	NSSavePanel *savePanel			= [NSSavePanel savePanel];
-	savePanel.extensionHidden		= NO;
-	savePanel.showsTagField			= NO;
+    NSSavePanel *savePanel            = [NSSavePanel savePanel];
+    savePanel.extensionHidden        = NO;
+    savePanel.showsTagField            = NO;
     if ([extensions count] > 0) {
         savePanel.allowedFileTypes = extensions;
         savePanel.allowsOtherFileTypes = NO;
     }
-	
-	NSString *downloadsDirectory	=  NSSearchPathForDirectoriesInDomains(NSDownloadsDirectory, NSUserDomainMask, YES)[0];
-	savePanel.directoryURL			= [NSURL URLWithString:downloadsDirectory];
-    
+
+    NSString *downloadsDirectory    =  NSSearchPathForDirectoriesInDomains(NSDownloadsDirectory, NSUserDomainMask, YES)[0];
+    savePanel.directoryURL            = [NSURL URLWithString:downloadsDirectory];
+
     // TODO: either figure out how to pull default filename from the Content-Disposition header or pass it in from JS land.
-	NSDateFormatter *dateFormatter	= [[NSDateFormatter alloc] init];
-	dateFormatter.locale			= [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
-	dateFormatter.dateFormat		= @"yyyy-MM-dd'T'HH_mm_ss";
-	savePanel.nameFieldStringValue	= [NSString stringWithFormat:@"query_result_%@", [dateFormatter stringFromDate:[NSDate date]]];
-	
-	if ([savePanel runModal] == NSFileHandlingPanelOKButton) {
-		NSLog(@"Will save file at: %@", savePanel.URL);
-		
+    NSDateFormatter *dateFormatter    = [[NSDateFormatter alloc] init];
+    dateFormatter.locale            = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+    dateFormatter.dateFormat        = @"yyyy-MM-dd'T'HH_mm_ss";
+    savePanel.nameFieldStringValue    = [NSString stringWithFormat:@"query_result_%@", [dateFormatter stringFromDate:[NSDate date]]];
+
+    if ([savePanel runModal] == NSFileHandlingPanelOKButton) {
+        NSLog(@"Will save file at: %@", savePanel.URL);
+
         NSString *method = [methodString uppercaseString];
-        
-		NSURL *url = [NSURL URLWithString:urlString relativeToURL:[NSURL URLWithString:BaseURL()]];
+
+        NSURL *url = [NSURL URLWithString:urlString relativeToURL:[NSURL URLWithString:BaseURL()]];
 
         NSMutableString *query = [NSMutableString string];
         for (NSString* key in paramsDict) {
             NSString* value = [paramsDict objectForKey:key];
             [query appendFormat:@"%@=%@",
-                                [key stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]],
-                                [value stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+             [key stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]],
+             [value stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
         }
-        
+
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:10.0f];
         request.HTTPMethod = [method uppercaseString];
-        
+
         if ([query length] > 0) {
             if ([request.HTTPMethod isEqualToString:@"POST"] || [request.HTTPMethod isEqualToString:@"PUT"]) {
                 NSData *data = [query dataUsingEncoding:NSUTF8StringEncoding];
@@ -176,34 +178,34 @@ NSString *BaseURL() {
             }
         }
 
-		[NSURLConnection sendAsynchronousRequest:request queue:[[NSOperationQueue alloc] init] completionHandler:^(NSURLResponse *response, NSData *data, NSError *connectionError) {
-			NSError *writeError = nil;
-			[data writeToURL:savePanel.URL options:NSDataWritingAtomic error:&writeError];
-			
-			dispatch_async(dispatch_get_main_queue(), ^{
-				if (writeError) {
-					[[NSAlert alertWithError:writeError] runModal];
-				} else {
-					[[NSAlert alertWithMessageText:@"Saved" defaultButton:@"Done" alternateButton:nil otherButton:nil informativeTextWithFormat:@"Your data has been saved."] runModal];
-				}
-			});
-		}];
-	}
+        [NSURLConnection sendAsynchronousRequest:request queue:[[NSOperationQueue alloc] init] completionHandler:^(NSURLResponse *response, NSData *data, NSError *connectionError) {
+            NSError *writeError = nil;
+            [data writeToURL:savePanel.URL options:NSDataWritingAtomic error:&writeError];
+
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (writeError) {
+                    [[NSAlert alertWithError:writeError] runModal];
+                } else {
+                    [[NSAlert alertWithMessageText:@"Saved" defaultButton:@"Done" alternateButton:nil otherButton:nil informativeTextWithFormat:@"Your data has been saved."] runModal];
+                }
+            });
+        }];
+    }
 }
 
 - (void)injectJS {
-	JSContext *context = self.webView.mainFrame.javaScriptContext;
-	
-	// replace console.log with a function that calls NSLog so we can see the output
-	context[@"console"][@"log"] = ^(JSValue *message) {
-		NSLog(@"console.log: %@", message);
-	};
-	
-	// custom functions for OS X integration are available to the frontend as properties of window.OSX
+    JSContext *context = self.webView.mainFrame.javaScriptContext;
+
+    // replace console.log with a function that calls NSLog so we can see the output
+    context[@"console"][@"log"] = ^(JSValue *message) {
+        NSLog(@"console.log: %@", message);
+    };
+
+    // custom functions for OS X integration are available to the frontend as properties of window.OSX
     context[@"OSX"] = @{@"download": ^(JSValue *method, JSValue *url, JSValue *params, JSValue *extensions) {
         [self downloadWithMethod:[method toString] url:[url toString] params:[params toDictionary] extensions:[extensions toArray]];
     }, @"resetPassword": ^(){
-		[self resetPassword:nil];
+        [self resetPassword:nil];
     }};
 }
 
@@ -211,61 +213,61 @@ NSString *BaseURL() {
 #pragma mark - Getters / Setters
 
 - (void)setLoading:(BOOL)loading {
-	_loading = loading;
+    _loading = loading;
 
-	if (loading) {
-		self.webView.animator.alphaValue = 0;
-		self.loadingView.animator.alphaValue = 1;
-	} else {
-		self.webView.animator.alphaValue = 1;
-		self.loadingView.animator.alphaValue = 0;
-		
-		self.backButtonCell.enabled = self.forwardButtonCell.enabled = self.linkButtonCell.enabled = NO;
-	}
-	self.loadingView.animate = loading;
+    if (loading) {
+        self.webView.animator.alphaValue = 0;
+        self.loadingView.animator.alphaValue = 1;
+    } else {
+        self.webView.animator.alphaValue = 1;
+        self.loadingView.animator.alphaValue = 0;
+
+        self.backButtonCell.enabled = self.forwardButtonCell.enabled = self.linkButtonCell.enabled = NO;
+    }
+    self.loadingView.animate = loading;
 }
 
 - (void)setResetPasswordWindowController:(ResetPasswordWindowController *)resetPasswordWindowController {
-	[_resetPasswordWindowController.window close];
-	
-	_resetPasswordWindowController = resetPasswordWindowController;
-	
-	resetPasswordWindowController.delegate = self;
-	[resetPasswordWindowController.window makeKeyWindow];
+    [_resetPasswordWindowController.window close];
+
+    _resetPasswordWindowController = resetPasswordWindowController;
+
+    resetPasswordWindowController.delegate = self;
+    [resetPasswordWindowController.window makeKeyWindow];
 }
 
 
 #pragma mark - Actions
 
 - (IBAction)back:(id)sender {
-	[self.webView goBack];
+    [self.webView goBack];
 }
 
 - (IBAction)forward:(id)sender {
-	[self.webView goForward];
+    [self.webView goForward];
 }
 
 - (IBAction)reload:(id)sender {
-	[self.webView.mainFrame reload];
+    [self.webView.mainFrame reload];
 }
 
 - (IBAction)copyURLToClipboard:(id)sender {
-	[NSPasteboard.generalPasteboard declareTypes:@[NSStringPboardType] owner:nil];
-	[NSPasteboard.generalPasteboard setString:self.webView.mainFrameURL forType:NSStringPboardType];
-	
-	[[NSAlert alertWithMessageText:@"Link Copied" defaultButton:@"Ok" alternateButton:nil otherButton:nil informativeTextWithFormat:@"A link to this page has been copied to your clipboard."] runModal];
+    [NSPasteboard.generalPasteboard declareTypes:@[NSStringPboardType] owner:nil];
+    [NSPasteboard.generalPasteboard setString:self.webView.mainFrameURL forType:NSStringPboardType];
+
+    [[NSAlert alertWithMessageText:@"Link Copied" defaultButton:@"Ok" alternateButton:nil otherButton:nil informativeTextWithFormat:@"A link to this page has been copied to your clipboard."] runModal];
 }
 
 - (IBAction)resetPassword:(id)sender {
-	self.resetPasswordWindowController = [[ResetPasswordWindowController alloc] init];
+    self.resetPasswordWindowController = [[ResetPasswordWindowController alloc] init];
 }
 
 
 #pragma mark - ResetPasswordWindowControllerDelegate
 
 - (void)resetPasswordWindowController:(ResetPasswordWindowController *)resetPasswordWindowController didFinishWithResetToken:(NSString *)resetToken {
-	self.resetPasswordWindowController = nil;
-    
+    self.resetPasswordWindowController = nil;
+
     // now tell the app to reroute to the reset password page once Metabase relauches
     self.launchRoute = [@"/auth/reset_password/" stringByAppendingString:resetToken];
 }
@@ -274,21 +276,22 @@ NSString *BaseURL() {
 #pragma mark - WebResourceLoadDelegate
 
 - (void)webView:(WebView *)sender resource:(id)identifier didFinishLoadingFromDataSource:(WebDataSource *)dataSource {
-	[self injectJS];
-	
-	self.linkButtonCell.enabled = YES;
-	self.backButtonCell.enabled = self.webView.canGoBack;
-	self.forwardButtonCell.enabled = self.webView.canGoForward;
+    [self injectJS];
+
+    self.linkButtonCell.enabled = YES;
+    self.backButtonCell.enabled = self.webView.canGoBack;
+    self.forwardButtonCell.enabled = self.webView.canGoForward;
 }
 
 
 #pragma mark - WebPolicyDelegate
 
 - (void)webView:(WebView *)webView decidePolicyForNewWindowAction:(NSDictionary *)actionInformation request:(NSURLRequest *)request newFrameName:(NSString *)frameName decisionListener:(id<WebPolicyDecisionListener>)listener {
-	// Tell webkit window to open new links in browser
-	NSURL *url = actionInformation[WebActionOriginalURLKey];
-	[[NSWorkspace sharedWorkspace] openURL:url];
-	[listener ignore];
+    // Tell webkit window to open new links in browser
+    NSURL *url = actionInformation[WebActionOriginalURLKey];
+    [[NSWorkspace sharedWorkspace] openURL:url];
+    [listener ignore];
 }
 
 @end
+


### PR DESCRIPTION
In the past we were using a lib called [`INAppStoreWindow`](https://github.com/indragiek/INAppStoreWindow) to add our custom buttons to the title bar. It doesn't look like this is working correctly in Catalina. However it looks like there's a way to do the same thing now natively in Cocoa: [`NSTitlebarAccessoryViewController`](https://developer.apple.com/documentation/appkit/nstitlebaraccessoryviewcontroller). This PR reworks `MainViewController` and the associated NIB file to use `NSTitlebarAccessoryViewController`.