### PR TITLE
Fix LDAP groups sync regression (#11654)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,6 +455,8 @@ jobs:
               then ./bin/build version frontend uberjar;
             fi
           no_output_timeout: 5m
+      - store_artifacts:
+          path: /home/circleci/metabase/metabase/target/uberjar/metabase.jar
       - save_cache:
           key: uberjar-{{ checksum "./backend-checksums.txt" }}-{{ checksum "./frontend-checksums.txt" }}
           paths:

--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -197,9 +197,9 @@
           :last-name  lname
           :email      email
           :groups     (when (ldap-group-sync)
-                        ;; ActiveDirectory (and others?) will supply a `memberOf` overlay attribute for groups
-                        ;; Otherwise we have to make the inverse query to get them
-                        (or (:memberOf result) (get-user-groups dn) []))})))))
+                        ;; Active Directory and others (like FreeIPA) will supply a `memberOf` overlay attribute for
+                        ;; groups. Otherwise we have to make the inverse query to get them.
+                        (or (:memberof result) (get-user-groups dn) []))})))))
 
 (defn verify-password
   "Verifies if the supplied password is valid for the `user-info` (from `find-user`) or DN."


### PR DESCRIPTION
Already merged into `master` in #11617.

* Fix LDAP groups sync

This is bug to LDAP servers that communicates group membership via the
`memberOf` overlay, introduced by #11412, where attribute keys were all
lower cased to support case insensitive matching. The hard-coded lookup
of the `:memberOf` key was not similarly lower cased.

* Save CircleCI-built uberjar as build artifact

* Update comment to mention FreeIPA also uses `memberOf`