### PR TITLE
Fix issues where dates in Pulses could be formatted with wrong year (year of the start of the week instead of actual year)

### DIFF
--- a/src/metabase/pulse/render/datetime.clj
+++ b/src/metabase/pulse/render/datetime.clj
@@ -19,10 +19,10 @@
   [timezone-id s col]
   (case (:unit col)
     ;; these types have special formatting
-    :hour    (reformat-temporal-str timezone-id s "h a - MMM YYYY")
+    :hour    (reformat-temporal-str timezone-id s "h a - MMM yyyy")
     :week    (str "Week " (reformat-temporal-str timezone-id s "w - YYYY"))
-    :month   (reformat-temporal-str timezone-id s "MMMM YYYY")
-    :quarter (reformat-temporal-str timezone-id s "QQQ - YYYY")
+    :month   (reformat-temporal-str timezone-id s "MMMM yyyy")
+    :quarter (reformat-temporal-str timezone-id s "QQQ - yyyy")
 
     ;; no special formatting here : return as ISO-8601
     ;; TODO: probably shouldn't even be showing sparkline for x-of-y groupings?
@@ -30,7 +30,7 @@
     s
 
     ;; for everything else return in this format
-    (reformat-temporal-str timezone-id s "MMM d, YYYY")))
+    (reformat-temporal-str timezone-id s "MMM d, yyyy")))
 
 (def ^:private RenderableInterval
   {:interval-start     Temporal


### PR DESCRIPTION
This is PR #11613 rebased against `release-0.34.x`