### PR TITLE
Fix race condition when copying newer versions of MB plugins

### DIFF
--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -48,8 +48,10 @@
 
 
 ;; These are convenience functions for accessing config values that ensures a specific return type
-;; TODO - These names are bad. They should be something like  `int`, `boolean`, and `keyword`, respectively.
-;; See https://github.com/metabase/metabase/wiki/Metabase-Clojure-Style-Guide#dont-repeat-namespace-alias-in-function-names for discussion
+;;
+;; TODO - These names are bad. They should be something like `int`, `boolean`, and `keyword`, respectively. See
+;; https://github.com/metabase/metabase/wiki/Metabase-Clojure-Style-Guide#dont-repeat-namespace-alias-in-function-names
+;; for discussion
 (defn ^Integer config-int  "Fetch a configuration key and parse it as an integer." [k] (some-> k config-str Integer/parseInt))
 (defn ^Boolean config-bool "Fetch a configuration key and parse it as a boolean."  [k] (some-> k config-str Boolean/parseBoolean))
 (defn ^Keyword config-kw   "Fetch a configuration key and parse it as a keyword."  [k] (some-> k config-str keyword))
@@ -81,9 +83,11 @@
         (into {} (for [[k v] props]
                    [(keyword k) v]))))))
 
+;; TODO - Can we make this `^:const`, so we don't have to read the file at launch when running from the uberjar?
 (def mb-version-info
   "Information about the current version of Metabase.
-   This comes from `resources/version.properties` for prod builds and is fetched from `git` via the `./bin/version` script for dev.
+   This comes from `resources/version.properties` for prod builds and is fetched from `git` via the `./bin/version`
+  script for dev.
 
      mb-version-info -> {:tag: \"v0.11.1\", :hash: \"afdf863\", :branch: \"about_metabase\", :date: \"2015-10-05\"}"
   (or (if is-prod?

--- a/src/metabase/util/files.clj
+++ b/src/metabase/util/files.clj
@@ -13,7 +13,7 @@
   (:import java.io.FileNotFoundException
            java.net.URL
            [java.nio.file CopyOption Files FileSystem FileSystems LinkOption OpenOption Path StandardCopyOption]
-           [java.nio.file.attribute FileAttribute FileTime]
+           java.nio.file.attribute.FileAttribute
            java.util.Collections))
 
 ;;; --------------------------------------------------- Path Utils ---------------------------------------------------
@@ -68,19 +68,20 @@
 
 ;;; ------------------------------------------------- Copying Stuff --------------------------------------------------
 
-(defn- last-modified-time ^FileTime [^Path path]
-  (Files/getLastModifiedTime path (u/varargs LinkOption)))
+(defn- last-modified-timestamp ^java.time.Instant [^Path path]
+  (when (exists? path)
+    (.toInstant (Files/getLastModifiedTime path (u/varargs LinkOption)))))
 
 (defn- copy-file! [^Path source, ^Path dest]
   (when (or (not (exists? dest))
-            (pos? (.compareTo (last-modified-time source) (last-modified-time dest))))
+            (not= (last-modified-timestamp source) (last-modified-timestamp dest)))
     (u/profile (trs "Extract file {0} -> {1}" source dest)
       (Files/copy source dest (u/varargs CopyOption [StandardCopyOption/REPLACE_EXISTING
                                                      StandardCopyOption/COPY_ATTRIBUTES])))))
 
 (defn copy-files!
-  "Copy all files in `source-dir` to `dest-dir`. Overwrites existing files if last modified date is older than that of
-  the source file."
+  "Copy all files in `source-dir` to `dest-dir`. Overwrites existing files if last modified timestamp is not the same as
+  that of the source file — see #11699 for more context."
   [^Path source-dir, ^Path dest-dir]
   (doseq [^Path source (files-seq source-dir)
           :let [target (append-to-path dest-dir (str (.getFileName source)))]]
@@ -111,11 +112,14 @@
       (f (get-path (.getPath url))))))
 
 (defmacro with-open-path-to-resource
-  "Execute `body` with an Path to a resource file (i.e. a file in the project `resources/` directory), cleaning up when
-  finished.
+  "Execute `body` with an Path to a resource file or directory (i.e. a file in the project `resources/` directory, or
+  inside the uberjar), cleaning up when finished.
 
   Throws a FileNotFoundException if the resource does not exist; be sure to check with `io/resource` or similar before
-  calling this."
+  calling this.
+
+    (with-open-path-to-resouce [path \"modules\"]
+       ...)"
   [[path-binding resource-filename-str] & body]
   `(do-with-open-path-to-resource
     ~resource-filename-str

--- a/src/metabase/util/files.clj
+++ b/src/metabase/util/files.clj
@@ -75,7 +75,8 @@
   (when (or (not (exists? dest))
             (pos? (.compareTo (last-modified-time source) (last-modified-time dest))))
     (u/profile (trs "Extract file {0} -> {1}" source dest)
-      (Files/copy source dest (u/varargs CopyOption [StandardCopyOption/REPLACE_EXISTING])))))
+      (Files/copy source dest (u/varargs CopyOption [StandardCopyOption/REPLACE_EXISTING
+                                                     StandardCopyOption/COPY_ATTRIBUTES])))))
 
 (defn copy-files!
   "Copy all files in `source-dir` to `dest-dir`. Overwrites existing files if last modified date is older than that of


### PR DESCRIPTION
Extract new versions of Metabase plugins whenever last modified timestamp of the source file is different from the dest file, and make sure we copy the original last modified timestamp to the dest file. Fixes #11699, and also ensures we're using the correct version of a plugin if someone downgrades to an older version of Metabase.