### PR TITLE
GeoJSON proxy response perf improvements & improved resource cleanup

### DIFF
--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -2,7 +2,7 @@
   (:require [cheshire.core :as json]
             [clojure.java.io :as io]
             [compojure.core :refer [GET]]
-            [metabase.api.common :refer [defendpoint define-routes]]
+            [metabase.api.common :as api]
             [metabase.models.setting :as setting :refer [defsetting]]
             [metabase.util :as u]
             [metabase.util
@@ -22,13 +22,13 @@
   (int (* 60 1000)))
 
 (defn- valid-json?
-  "Does this URL-OR-RESOURCE point to valid JSON?
-  URL-OR-RESOURCE should be something that can be passed to `slurp`, like an HTTP URL or a `java.net.URL` (which is
-  what `io/resource` returns below)."
+  "Does this `url-or-resource` point to valid JSON? `url-or-resource` should be something that can be passed to `slurp`,
+  like an HTTP URL or a `java.net.URL` (which is what `io/resource` returns below)."
   [url-or-resource]
   (try
     (u/with-timeout geojson-fetch-timeout-ms
-      (dorun (json/parse-stream (io/reader url-or-resource))))
+      (with-open [reader (io/reader url-or-resource)]
+        (dorun (json/parse-stream reader))))
     ;; `with-timeout` executes the body in a future. If an exception occurs, it will throw an ExcecutionException
     ;; which isn't very useful. The cause of the ExcutionException is what we want to propagate as that is something
     ;; that will be actionable by the user to fix
@@ -36,16 +36,10 @@
       (throw (.getCause e))))
   true)
 
-(defn- rethrow-with-message
-  "Throws an exception using `exception` as the cause (so we don't lose the related stacktrace) but includes a new,
-  hopefully more user friendly error message `msg`."
-  [msg exception]
-  (throw (Exception. (str msg) exception)))
-
-(defn- valid-json-resource?
-  "Does this RELATIVE-PATH point to a valid local JSON resource? (RELATIVE-PATH is something like
+(defn- valid-json-resource-path-string?
+  "Does this `relative-path` point to a valid local JSON resource? (`relative-path` is something like
   \"app/assets/geojson/us-states.json\".)"
-  [relative-path]
+  [^String relative-path]
   (when-let [^java.net.URI uri (u/ignore-exceptions (java.net.URI. relative-path))]
     (when-not (.isAbsolute uri)
       (let [relative-path-with-prefix (str "frontend_client/" uri)]
@@ -53,12 +47,12 @@
           (try
             (valid-json? resource)
             (catch JsonParseException e
-              (rethrow-with-message (tru "Unable to parse resource `{0}` as JSON" relative-path-with-prefix) e)))
+              (throw (Exception. (tru "Unable to parse resource `{0}` as JSON" relative-path-with-prefix) e))))
           (throw (FileNotFoundException. (tru "Unable to find JSON via relative path `{0}`" relative-path-with-prefix))))))))
 
-(defn- valid-json-url?
-  "Is URL a valid HTTP URL and does it point to valid JSON?"
-  [url]
+(defn- valid-json-url-string?
+  "Is `url` a valid HTTP URL string and does it point to valid JSON?"
+  [^String url]
   (when (u/url? url)
     (try
       (valid-json? url)
@@ -66,25 +60,25 @@
       ;; below attempt to provide the user with more info around the failure so they can correct the issue and try
       ;; again.
       (catch TimeoutException e
-        (rethrow-with-message (tru "Connection to host timed out for URL `{0}`" url) e))
+        (throw (Exception. (tru "Connection to host timed out for URL `{0}`" url) e)))
       (catch UnknownHostException e
-        (rethrow-with-message (tru "Unable to connect to unknown host at URL `{0}`" url) e))
+        (throw (Exception. (tru "Unable to connect to unknown host at URL `{0}`" url) e)))
       (catch NoRouteToHostException e
-        (rethrow-with-message (tru "Unable to connect to host at URL `{0}`" url) e))
+        (throw (Exception. (tru "Unable to connect to host at URL `{0}`" url) e)))
       (catch ConnectException e
-        (rethrow-with-message (tru "Connection refused by host for URL `{0}`" url) e))
+        (throw (Exception. (tru "Connection refused by host for URL `{0}`" url) e)))
       (catch FileNotFoundException e
-        (rethrow-with-message (tru "Unable to retrieve resource at URL `{0}`" url) e))
+        (throw (Exception. (tru "Unable to retrieve resource at URL `{0}`" url) e)))
       (catch JsonParseException e
-        (rethrow-with-message (tru "Unable to parse resource at URL `{0}` as JSON" url) e)))))
+        (throw (Exception. (tru "Unable to parse resource at URL `{0}` as JSON" url) e))))))
 
-(def ^:private valid-json-url-or-resource?
-  "Check that remote URL points to a valid JSON file, or throw an exception.
-   Since the remote file isn't likely to change, this check isn't repeated for URLs that have already succeded;
-   if the check fails, an exception is thrown (thereby preventing memoization)."
+(def ^:private ^{:arglists '([url-or-resource])} valid-json-url-or-resource?
+  "Check that remote URL points to a valid JSON file, or throw an exception. Since the remote file isn't likely to
+  change, this check isn't repeated for URLs that have already succeded; if the check fails, an exception is
+  thrown (thereby preventing memoization)."
   (memoize (fn [url-or-resource-path]
-             (or (valid-json-url? url-or-resource-path)
-                 (valid-json-resource? url-or-resource-path)
+             (or (valid-json-url-string? url-or-resource-path)
+                 (valid-json-resource-path-string? url-or-resource-path)
                  (throw (Exception. (tru "Invalid JSON URL or resource: {0}" url-or-resource-path)))))))
 
 (def ^:private CustomGeoJSON
@@ -122,17 +116,17 @@
              (setting/set-json! :custom-geojson new-value)))
 
 
-(defendpoint GET "/:key"
+(api/defendpoint-async GET "/:key"
   "Fetch a custom GeoJSON file as defined in the `custom-geojson` setting. (This just acts as a simple proxy for the
-  file specified for KEY)."
-  [key]
+  file specified for `key`)."
+  [{{:keys [key]} :params} respond raise]
   {key su/NonBlankString}
-  (let [url (or (get-in (custom-geojson) [(keyword key) :url])
-                (throw (ex-info (tru "Invalid custom GeoJSON key: {0}" key)
-                         {:status-code 400})))]
-    ;; TODO - it would be nice if we could also avoid returning our usual cache-busting headers with the response here
-    (-> (rr/response (ReaderInputStream. (io/reader url)))
-        (rr/content-type "application/json"))))
+  (if-let [url (get-in (custom-geojson) [(keyword key) :url])]
+    (with-open [reader (io/reader url)
+                is     (ReaderInputStream. reader)]
+      (respond (-> (rr/response is)
+                   (rr/content-type "application/json"))))
+    (raise (ex-info (tru "Invalid custom GeoJSON key: {0}" key)
+             {:status-code 400}))))
 
-
-(define-routes)
+(api/define-routes)

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -24,16 +24,16 @@
   []
   (boolean (seq (slack-token))))
 
-
 (defn- handle-response [{:keys [status body]}]
-  (let [body (-> body io/reader (json/parse-stream keyword))]
-    (if (and (= 200 status) (:ok body))
-      body
-      (let [error (if (= (:error body) "invalid_auth")
-                    {:errors {:slack-token "Invalid token"}}
-                    {:message (str "Slack API error: " (:error body)), :response body})]
-        (log/warn (u/pprint-to-str 'red error))
-        (throw (ex-info (:message error) error))))))
+  (with-open [reader (io/reader body)]
+    (let [body (json/parse-stream reader keyword)]
+      (if (and (= 200 status) (:ok body))
+        body
+        (let [error (if (= (:error body) "invalid_auth")
+                      {:errors {:slack-token "Invalid token"}}
+                      {:message (str "Slack API error: " (:error body)), :response body})]
+          (log/warn (u/pprint-to-str 'red error))
+          (throw (ex-info (:message error) error)))))))
 
 (defn- do-slack-request [request-fn params-key endpoint & {:keys [token], :as params, :or {token (slack-token)}}]
   (when token

--- a/src/metabase/metabot/command.clj
+++ b/src/metabase/metabot/command.clj
@@ -204,9 +204,9 @@
 
 (def ^:private kanye-quotes
   (delay
-   (log/debug (trs "Loading Kanye quotes..."))
-   (when-let [data (slurp (io/reader (io/resource "kanye-quotes.edn")))]
-     (edn/read-string data))))
+    (log/debug (trs "Loading Kanye quotes..."))
+    (when-let [url (io/resource "kanye-quotes.edn")]
+      (edn/read-string (slurp url)))))
 
 (defmethod command :kanye [& _]
   (str ":kanye:\n> " (rand-nth @kanye-quotes)))

--- a/src/metabase/middleware/util.clj
+++ b/src/metabase/middleware/util.clj
@@ -22,6 +22,11 @@
 
 (defn cacheable?
   "Can the ring request be permanently cached?"
-  [{:keys [uri query-string]}]
-  ;; match requests that are js/css and have a cache-busting query string
-  (and query-string (re-matches #"^/app/dist/.*\.(js|css)$" uri)))
+  [{:keys [request-method uri query-string], :as request}]
+  (and (= request-method :get)
+       (or
+        ;; match requests that are js/css and have a cache-busting query string
+        (and query-string
+             (re-matches #"^/app/dist/.*\.(js|css)$" uri))
+        ;; GeoJSON proxy requests should also be cached
+        (re-matches #"^/api/geojson/.*" uri))))

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -1,12 +1,11 @@
 (ns metabase.api.geojson-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
             [metabase
              [http-client :as client]
+             [test :as mt]
              [util :as u]]
             [metabase.api.geojson :as geojson-api]
-            [metabase.test.data.users :refer [user->client]]
-            [metabase.test.util :as tu]
-            [metabase.test.util.log :as tu.log]
+            [metabase.middleware.security :as mw.security]
             [schema.core :as s]))
 
 (def ^:private ^String test-geojson-url
@@ -21,100 +20,80 @@
                   :region_name nil}})
 
 
-;;; test valid-json-url?
-(expect
-  (#'geojson-api/valid-json-url? test-geojson-url))
+(deftest valid-url-test
+  (is (= true
+         (#'geojson-api/valid-json-url-string? test-geojson-url))))
 
 
-;;; test valid-json-resource?
-(expect
-  (#'geojson-api/valid-json-resource? "app/assets/geojson/us-states.json"))
+(deftest valid-resource-test
+  (is (= true
+         (#'geojson-api/valid-json-resource-path-string? "app/assets/geojson/us-states.json"))))
 
+(deftest geojson-schema-test
+  (is (= true
+         (boolean (s/validate @#'geojson-api/CustomGeoJSON test-custom-geojson)))))
 
-;;; test the CustomGeoJSON schema
-(expect
-  (boolean (s/validate @#'geojson-api/CustomGeoJSON test-custom-geojson)))
+(deftest invalid-url-test
+  (testing "test that you're not allowed to set invalid URLs"
+    (is (thrown? Exception
+                 (geojson-api/custom-geojson {:name        "Middle Earth"
+                                              :url         "ABC"
+                                              :region_key  nil
+                                              :region_name nil})))
 
-;; test that you're not allowed to set invalid URLs
-(expect
-  Exception
-  (geojson-api/custom-geojson {:name        "Middle Earth"
-                               :url         "ABC"
-                               :region_key  nil
-                               :region_name nil}))
+    (is (thrown? Exception
+                 (geojson-api/custom-geojson {:name        "Middle Earth"
+                                              :url         "http://google.com"
+                                              :region_key  nil
+                                              :region_name nil})))))
 
-(expect
-  Exception
-  (geojson-api/custom-geojson {:name        "Middle Earth"
-                               :url         "http://google.com"
-                               :region_key  nil
-                               :region_name nil}))
+(deftest update-endpoint-test
+  (testing "PUT /api/setting/custom-geojson"
+    (testing "test that we can set the value of geojson-api/custom-geojson via the normal routes"
+      (is (= (merge @#'geojson-api/builtin-geojson test-custom-geojson)
+             ;; try this up to 3 times since Circle's outbound connections likes to randomly stop working
+             (u/auto-retry 3
+               ;; bind a temporary value so it will get set back to its old value here after the API calls are done
+               ;; stomping all over it
+               (mt/with-temporary-setting-values [custom-geojson nil]
+                 ((mt/user->client :crowberto) :put 200 "setting/custom-geojson" {:value test-custom-geojson})
+                 ((mt/user->client :crowberto) :get 200 "setting/custom-geojson"))))))
+    (testing "error conditions"
+      (letfn [(put-bad-url [url]
+                (mt/suppress-output
+                  ;; try this up to 3 times since Circle's outbound connections likes to randomly stop working
+                  (u/auto-retry 3
+                    ;; bind a temporary value so it will get set back to its old value here after the API calls are done
+                    ;; stomping all over it
+                    (mt/with-temporary-setting-values [custom-geojson nil]
+                      (let [url (assoc-in test-custom-geojson [:middle-earth :url] url)]
+                        (:message ((mt/user->client :crowberto) :put 500 "setting/custom-geojson" {:value url})))))))]
+        (testing "Test that a bad url will return a descriptive error message"
+          (is (re= #"^Unable to retrieve resource.*"
+                   (put-bad-url "https://raw.githubusercontent.com/metabase/metabase/master/test_resources/something-random"))))
+        (testing "Test that a bad host will return a connection refused error"
+          (is (re= #"^Unable to connect.*"
+                   (put-bad-url "https://somethingrandom.metabase.com"))))
+        (testing "Test out the error message for a relative path file we can't find"
+          (is (re= #"^Unable to find JSON via relative path.*"
+                   (put-bad-url "some/relative/path"))))))))
 
-
-;;; test that we can set the value of geojson-api/custom-geojson via the normal routes
-(expect
-  (merge @#'geojson-api/builtin-geojson test-custom-geojson)
-  ;; try this up to 3 times since Circle's outbound connections likes to randomly stop working
-  (u/auto-retry 3
-    ;; bind a temporary value so it will get set back to its old value here after the API calls are done
-    ;; stomping all over it
-    (tu/with-temporary-setting-values [custom-geojson nil]
-      ((user->client :crowberto) :put 200 "setting/custom-geojson" {:value test-custom-geojson})
-      ((user->client :crowberto) :get 200 "setting/custom-geojson"))))
-
-;; Test that a bad url will return a descriptive error message
-(expect
-  #"Unable to retrieve resource"
-  (tu.log/suppress-output
-    ;; try this up to 3 times since Circle's outbound connections likes to randomly stop working
-    (u/auto-retry 3
-      ;; bind a temporary value so it will get set back to its old value here after the API calls are done
-      ;; stomping all over it
-      (tu/with-temporary-setting-values [custom-geojson nil]
-        (let [bad-url-custom-geojson (update-in test-custom-geojson [:middle-earth :url] str "something-random")]
-          (:message ((user->client :crowberto) :put 500 "setting/custom-geojson" {:value bad-url-custom-geojson})))))))
-
-;; Test that a bad host will return a connection refused error
-(expect
-  #"Unable to connect"
-  (tu.log/suppress-output
-    ;; try this up to 3 times since Circle's outbound connections likes to randomly stop working
-    (u/auto-retry 3
-      ;; bind a temporary value so it will get set back to its old value here after the API calls are done
-      ;; stomping all over it
-      (tu/with-temporary-setting-values [custom-geojson nil]
-        (let [bad-url-custom-geojson (assoc-in test-custom-geojson [:middle-earth :url] "https://somethingrandom.metabase.com")]
-          (:message ((user->client :crowberto) :put 500 "setting/custom-geojson" {:value bad-url-custom-geojson})))))))
-
-;; Test out the error message for a relative path file we can't find
-(expect
-  #"Unable to find JSON via relative path"
-  (tu.log/suppress-output
-    ;; try this up to 3 times since Circle's outbound connections likes to randomly stop working
-    (u/auto-retry 3
-      ;; bind a temporary value so it will get set back to its old value here after the API calls are done
-      ;; stomping all over it
-      (tu/with-temporary-setting-values [custom-geojson nil]
-        (let [bad-url-custom-geojson (assoc-in test-custom-geojson [:middle-earth :url] "some/relative/path")]
-          (:message ((user->client :crowberto) :put 500 "setting/custom-geojson" {:value bad-url-custom-geojson})))))))
-
-
-;;; test the endpoint that acts as a proxy for JSON files
-(expect
-  {:type        "Point"
-   :coordinates [37.77986 -122.429]}
-  (tu/with-temporary-setting-values [custom-geojson test-custom-geojson]
-    ((user->client :rasta) :get 200 "geojson/middle-earth")))
-
-;; should be able to fetch the GeoJSON even if you aren't logged in
-(expect
-  {:type        "Point"
-   :coordinates [37.77986 -122.429]}
-  (tu/with-temporary-setting-values [custom-geojson test-custom-geojson]
-    (client/client :get 200 "geojson/middle-earth")))
-
-;; try fetching an invalid key; should fail
-(expect
-  "Invalid custom GeoJSON key: invalid-key"
-  (tu/with-temporary-setting-values [custom-geojson test-custom-geojson]
-    ((user->client :rasta) :get 400 "geojson/invalid-key")))
+(deftest proxy-endpoint-test
+  (testing "GET /api/geojson/:key"
+    (mt/with-temporary-setting-values [custom-geojson test-custom-geojson]
+      (testing "test the endpoint that acts as a proxy for JSON files"
+        (is (= {:type        "Point"
+                :coordinates [37.77986 -122.429]}
+               ((mt/user->client :rasta) :get 200 "geojson/middle-earth"))))
+      (testing "response should not include the usual cache-busting headers"
+        (is (= (#'mw.security/cache-far-future-headers)
+               (select-keys (:headers (client/client-full-response :get 200 "geojson/middle-earth"))
+                            (keys (#'mw.security/cache-prevention-headers))))))
+      (testing "should be able to fetch the GeoJSON even if you aren't logged in"
+        (is (= {:type        "Point"
+                :coordinates [37.77986 -122.429]}
+               (client/client :get 200 "geojson/middle-earth"))))
+      (testing "error conditions"
+        (testing "try fetching an invalid key; should fail"
+          (is (= "Invalid custom GeoJSON key: invalid-key"
+                 ((mt/user->client :rasta) :get 400 "geojson/invalid-key"))))))))

--- a/test/metabase/integrations/slack_test.clj
+++ b/test/metabase/integrations/slack_test.clj
@@ -58,7 +58,9 @@
        (channels-list)))))
 
 (def ^:private default-users-response
-  (delay (slurp (io/resource "slack_users_response.json"))))
+  (delay (slurp (or (io/resource "slack_users_response.json")
+                    ;; when running from the REPL
+                    (slurp "./test_resources/slack_users_response.json")))))
 
 (def ^:private default-users
   (delay (:members (json/parse-string @default-users-response keyword))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -268,7 +268,7 @@
                          (setting/get setting-k))]
     (try
       (setting/set! setting-k value)
-      (testing (colorize/blue (format "Setting %s = %s" (keyword setting-k) value))
+      (testing (colorize/blue (format "\nSetting %s = %s\n" (keyword setting-k) (pr-str value)))
         (f))
       (finally
         (setting/set! setting-k original-value)))))


### PR DESCRIPTION
* There were a few places we weren't using `with-open` in conjunction with a `Reader`, which could lead to memory being retained longer than needed.
* I tweaked the `GET /api/geojson/:key` endpoint (GeoJSON proxy endpoint) to return headers suggesting the response can be cached, which should be a nice perf improvement