### PR TITLE
Cast PG 'money' columns to ::numeric so they can be used in numeric fns

### DIFF
--- a/src/metabase/query_processor/middleware/normalize_query.clj
+++ b/src/metabase/query_processor/middleware/normalize_query.clj
@@ -1,11 +1,20 @@
 (ns metabase.query-processor.middleware.normalize-query
   "Middleware that converts a query into a normalized, canonical form."
-  (:require [metabase.mbql.normalize :as normalize]))
+  (:require [metabase.mbql.normalize :as normalize]
+            [metabase.query-processor.error-type :as error-type]))
 
 (defn normalize
   "Middleware that converts a query into a normalized, canonical form, including things like converting all identifiers
   into standard `lisp-case` ones, removing/rewriting legacy clauses, removing empty ones, etc. This is done to
   simplifiy the logic in the QP steps following this."
   [qp]
-  (fn [query respond raise canceled-chan]
-    (qp (normalize/normalize query) respond raise canceled-chan)))
+  (letfn [(normalize [query]
+            (try
+              (normalize/normalize query)
+              (catch Throwable e
+                (throw (ex-info (.getMessage e)
+                         {:type  error-type/invalid-query
+                          :query query}
+                         e)))))]
+    (fn [query respond raise canceled-chan]
+      (qp (normalize query) respond raise canceled-chan))))


### PR DESCRIPTION
Works around a limitation in PostgreSQL itself.

Fixes #11498