### PR TITLE
Fix snowflake date filters

### DIFF
--- a/modules/drivers/snowflake/project.clj
+++ b/modules/drivers/snowflake/project.clj
@@ -1,8 +1,8 @@
-(defproject metabase/snowflake-driver "1.0.0-SNAPSHOT-3.10.2"
+(defproject metabase/snowflake-driver "1.0.0-SNAPSHOT-3.11.0"
   :min-lein-version "2.5.0"
 
   :dependencies
-  [[net.snowflake/snowflake-jdbc "3.10.2"]]
+  [[net.snowflake/snowflake-jdbc "3.11.0"]]
 
   :profiles
   {:provided

--- a/modules/drivers/snowflake/resources/metabase-plugin.yaml
+++ b/modules/drivers/snowflake/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase Snowflake Driver
-  version: 1.0.0-SNAPSHOT-3.10.2
+  version: 1.0.0-SNAPSHOT-3.11.0
   description: Allows Metabase to connect to Snowflake databases.
 driver:
   name: snowflake

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -101,16 +101,18 @@
 (defmethod sql.qp/unix-timestamp->timestamp [:snowflake :seconds]      [_ _ expr] (hsql/call :to_timestamp expr))
 (defmethod sql.qp/unix-timestamp->timestamp [:snowflake :milliseconds] [_ _ expr] (hsql/call :to_timestamp expr 3))
 
-(defmethod sql.qp/current-datetime-fn :snowflake [_]
+(defmethod sql.qp/current-datetime-fn :snowflake
+  [_]
   :%current_timestamp)
 
-(defmethod driver/date-add :snowflake [_ dt amount unit]
+(defmethod driver/date-add :snowflake
+  [_ dt amount unit]
   (hsql/call :dateadd
     (hsql/raw (name unit))
     (hsql/raw (int amount))
     (hx/->timestamp dt)))
 
-(defn- extract [unit expr] (hsql/call :date_part unit (hx/->timestamp expr)))
+(defn- extract    [unit expr] (hsql/call :date_part unit (hx/->timestamp expr)))
 (defn- date-trunc [unit expr] (hsql/call :date_trunc unit (hx/->timestamp expr)))
 
 (defmethod sql.qp/date [:snowflake :default]         [_ _ expr] expr)
@@ -283,3 +285,19 @@
         t (u.date/parse s)]
     (log/tracef "(.getString rs %d) [TIME_WITH_TIMEZONE] -> %s -> %s" i s t)
     t))
+
+;; TODO ­ would it make more sense to use functions like `timestamp_tz_from_parts` directly instead of JDBC parameters?
+
+;; Snowflake seems to ignore the calendar parameter of `.setTime` and `.setTimestamp` and instead uses the session
+;; timezone; normalize temporal values to UTC so we end up with the right values
+(defmethod sql-jdbc.execute/set-parameter [::use-legacy-classes-for-read-and-set java.time.OffsetTime]
+  [driver ps i t]
+  (sql-jdbc.execute/set-parameter driver ps i (t/sql-time (t/with-offset-same-instant t (t/zone-offset 0)))))
+
+(defmethod sql-jdbc.execute/set-parameter [::use-legacy-classes-for-read-and-set java.time.OffsetDateTime]
+  [driver ps i t]
+  (sql-jdbc.execute/set-parameter driver ps i (t/sql-timestamp (t/with-offset-same-instant t (t/zone-offset 0)))))
+
+(defmethod sql-jdbc.execute/set-parameter [:snowflake java.time.ZonedDateTime]
+  [driver ps i t]
+  (sql-jdbc.execute/set-parameter driver ps i (t/sql-timestamp (t/with-zone-same-instant t (t/zone-id "UTC")))))

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -3,23 +3,19 @@
              [set :as set]
              [string :as str]
              [test :refer :all]]
-            [metabase.driver :as driver]
-            [metabase.models.table :refer [Table]]
-            [metabase.test
-             [data :as data]
-             [util :as tu]]
+            [metabase
+             [driver :as driver]
+             [models :refer [Table]]
+             [test :as mt]]
             [metabase.test.data
              [dataset-definitions :as dataset-defs]
-             [datasets :as datasets :refer [expect-with-driver]]
-             [interface :as tx]
              [sql :as sql.tx]]
-            [metabase.test.data.sql.ddl :as ddl]
-            [metabase.test.util.log :as tu.log]))
+            [metabase.test.data.sql.ddl :as ddl]))
 
 ;; make sure we didn't break the code that is used to generate DDL statements when we add new test datasets
 (deftest ddl-statements-test
   (is (= "DROP DATABASE IF EXISTS \"test-data\"; CREATE DATABASE \"test-data\";"
-         (sql.tx/create-db-sql :snowflake (tx/get-dataset-definition dataset-defs/test-data))))
+         (sql.tx/create-db-sql :snowflake (mt/get-dataset-definition dataset-defs/test-data))))
   (is (= (map
           #(str/replace % #"\s+" " ")
           ["DROP TABLE IF EXISTS \"test-data\".\"PUBLIC\".\"users\";"
@@ -40,63 +36,57 @@
            FOREIGN KEY (\"user_id\") REFERENCES \"test-data\".\"PUBLIC\".\"users\" (\"id\");"
            "ALTER TABLE \"test-data\".\"PUBLIC\".\"checkins\" ADD CONSTRAINT \"ns_venue_id_venues_-1854903846\"
            FOREIGN KEY (\"venue_id\") REFERENCES \"test-data\".\"PUBLIC\".\"venues\" (\"id\");"])
-         (ddl/create-db-ddl-statements :snowflake (tx/get-dataset-definition dataset-defs/test-data)))))
+         (ddl/create-db-ddl-statements :snowflake (mt/get-dataset-definition dataset-defs/test-data)))))
 
-(expect-with-driver :snowflake
-  "UTC"
-  (tu/db-timezone-id))
+(deftest describe-database-test
+  (mt/test-driver :snowflake
+    (testing (str "describe-database (etc) should accept either `:db` or `:dbname` in the details, working around a "
+                  "bug with the original Snowflake impl")
+      (is (= {:tables
+              #{{:name "users", :schema "PUBLIC", :description nil}
+                {:name "venues", :schema "PUBLIC", :description nil}
+                {:name "checkins", :schema "PUBLIC", :description nil}
+                {:name "categories", :schema "PUBLIC", :description nil}}}
+             (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :dbname})))))
+    (testing "if details have neither `:db` nor `:dbname`, they should throw an Exception"
+      (is (thrown? Exception
+                   (driver/describe-database :snowflake (update (mt/db) :details set/rename-keys {:db :xyz})))))
+    (testing (str "does describe-database (etc) use the NAME FROM DETAILS instead of the DB DISPLAY NAME to fetch "
+                  "metadata? (#8864)")
+      (is (= {:tables
+              #{{:name "users",      :schema "PUBLIC", :description nil}
+                {:name "venues",     :schema "PUBLIC", :description nil}
+                {:name "checkins",   :schema "PUBLIC", :description nil}
+                {:name "categories", :schema "PUBLIC", :description nil}}}
+             (driver/describe-database :snowflake (assoc (mt/db) :name "ABC")))))))
 
-;; does describe-database (etc) use the NAME FROM DETAILS instead of the DB DISPLAY NAME to fetch metadata? (#8864)
-(expect-with-driver :snowflake
-  {:tables
-   #{{:name "users",      :schema "PUBLIC", :description nil}
-     {:name "venues",     :schema "PUBLIC", :description nil}
-     {:name "checkins",   :schema "PUBLIC", :description nil}
-     {:name "categories", :schema "PUBLIC", :description nil}}}
-  (driver/describe-database :snowflake (assoc (data/db) :name "ABC")))
+(deftest describe-table-test
+  (mt/test-driver :snowflake
+    (testing "make sure describe-table uses the NAME FROM DETAILS too"
+      (is (= {:name   "categories"
+              :schema "PUBLIC"
+              :fields #{{:name          "id"
+                         :database-type "NUMBER"
+                         :base-type     :type/Number
+                         :pk?           true}
+                        {:name "name", :database-type "VARCHAR", :base-type :type/Text}}}
+             (driver/describe-table :snowflake (assoc (mt/db) :name "ABC") (Table (mt/id :categories))))))))
 
-;; make sure describe-table uses the NAME FROM DETAILS too
-(expect-with-driver :snowflake
-  {:name   "categories"
-   :schema "PUBLIC"
-   :fields #{{:name          "id"
-              :database-type "NUMBER"
-              :base-type     :type/Number
-              :pk?           true}
-             {:name "name", :database-type "VARCHAR", :base-type :type/Text}}}
-  (driver/describe-table :snowflake (assoc (data/db) :name "ABC") (Table (data/id :categories))))
-
-;; make sure describe-table-fks uses the NAME FROM DETAILS too
-(expect-with-driver :snowflake
-  #{{:fk-column-name   "category_id"
-     :dest-table       {:name "categories", :schema "PUBLIC"}
-     :dest-column-name "id"}}
-  (driver/describe-table-fks :snowflake (assoc (data/db) :name "ABC") (Table (data/id :venues))))
-
-;; describe-database (etc) should accept either `:db` or `:dbname` in the details, working around a bug with the
-;; original Snowflake impl
-(expect-with-driver :snowflake
-  {:tables
-   #{{:name "users",      :schema "PUBLIC", :description nil}
-     {:name "venues",     :schema "PUBLIC", :description nil}
-     {:name "checkins",   :schema "PUBLIC", :description nil}
-     {:name "categories", :schema "PUBLIC", :description nil}}}
-  (driver/describe-database :snowflake (update (data/db) :details set/rename-keys {:db :dbname})))
-
-;; if details have neither `:db` nor `:dbname`, they should throw an Exception
-
-(expect-with-driver :snowflake
-  Exception
-  (driver/describe-database :snowflake (update (data/db) :details set/rename-keys {:db :xyz})))
+(deftest describe-table-fks-test
+  (testing "make sure describe-table-fks uses the NAME FROM DETAILS too"
+    (is (= #{{:fk-column-name   "category_id"
+              :dest-table       {:name "categories", :schema "PUBLIC"}
+              :dest-column-name "id"}}
+           (driver/describe-table-fks :snowflake (assoc (mt/db) :name "ABC") (Table (mt/id :venues)))))))
 
 (deftest can-connect-test
-  (datasets/test-driver :snowflake
+  (mt/test-driver :snowflake
     (letfn [(can-connect? [details]
               (driver/can-connect? :snowflake details))]
       (is (= true
-             (can-connect? (:details (data/db))))
+             (can-connect? (:details (mt/db))))
           "can-connect? should return true for normal Snowflake DB details")
       (is (= false
-             (tu.log/suppress-output
-               (can-connect? (assoc (:details (data/db)) :db (tu/random-name)))))
+             (mt/suppress-output
+               (can-connect? (assoc (:details (mt/db)) :db (mt/random-name)))))
           "can-connect? should return false for Snowflake databases that don't exist (#9041)"))))

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -297,9 +297,8 @@
 ;; TIMEZONE FIXME — does it make sense to convert this to UTC? Shouldn't we convert it to the report timezone? Figure
 ;; this mystery out
 (defmethod sql-jdbc.execute/set-parameter [:sqlserver OffsetTime]
-  [driver prepared-statement index t]
-  (sql-jdbc.execute/set-parameter driver prepared-statement index
-                                  (t/local-time (t/with-offset-same-instant t (t/zone-offset 0)))))
+  [driver ps i t]
+  (sql-jdbc.execute/set-parameter driver ps i (t/local-time (t/with-offset-same-instant t (t/zone-offset 0)))))
 
 ;; instead of default `microsoft.sql.DateTimeOffset`
 (defmethod sql-jdbc.execute/read-column [:sqlserver microsoft.sql.Types/DATETIMEOFFSET]

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -533,7 +533,7 @@
               "2018-04-18"
 
               ;; TIMEZONE FIXME — Busted
-              (#{:snowflake :vertica} driver/*driver*)
+              (= driver/*driver* :vertica)
               "2018-04-17T00:00:00-07:00"
 
               (qp.test/supports-report-timezone? driver/*driver*)


### PR DESCRIPTION
Looks like the Snowflake JDBC driver is broken – it's ignoring the `calendar` param of methods like [`setTimestamp(int index, Timestamp timestamp, Calendar calendar)`](https://docs.oracle.com/javase/8/docs/api/java/sql/PreparedStatement.html#setTimestamp-int-java.sql.Timestamp-java.util.Calendar-). We can work around this by normalizing zoned temporal values to UTC and relying on the session timezone to convert them to the correct values.

Fixes #11036