### PR TITLE
remove remaining references to generate-sample-dataset

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -42,15 +42,6 @@ translations() {
     fi
 }
 
-sample-dataset() {
-    if [ -f resources/sample-dataset.db.mv.db ]; then
-        echo "Sample Dataset already generated."
-    else
-        echo "Running 'lein generate-sample-dataset' to generate the sample dataset..."
-        lein generate-sample-dataset
-    fi
-}
-
 drivers() {
     echo "Building Metabase drivers..."
     ./bin/build-drivers.sh
@@ -62,11 +53,11 @@ uberjar() {
 }
 
 all() {
-    version && translations && frontend && sample-dataset && drivers && uberjar
+    version && translations && frontend && drivers && uberjar
 }
 
 no-translations() {
-    version && frontend && sample-dataset && drivers && uberjar
+    version && frontend && drivers && uberjar
 }
 
 # Default to running all but let someone specify one or more sub-tasks to run instead if desired

--- a/project.clj
+++ b/project.clj
@@ -7,8 +7,7 @@
   :min-lein-version "2.5.0"
 
   :aliases
-  {"generate-sample-dataset"           ["with-profile" "+generate-sample-dataset" "run"]
-   "profile"                           ["with-profile" "+profile" "run" "profile"]
+  {"profile"                           ["with-profile" "+profile" "run" "profile"]
    "h2"                                ["with-profile" "+h2-shell" "run" "-url" "jdbc:h2:./metabase.db"
                                         "-user" "" "-password" "" "-driver" "org.h2.Driver"]
    "generate-automagic-dashboards-pot" ["with-profile" "+generate-automagic-dashboards-pot" "run"]
@@ -142,10 +141,10 @@
   :manifest
   {"Liquibase-Package"
    #= (eval
-        (str "liquibase.change,liquibase.changelog,liquibase.database,liquibase.parser,liquibase.precondition,"
-             "liquibase.datatype,liquibase.serializer,liquibase.sqlgenerator,liquibase.executor,"
-             "liquibase.snapshot,liquibase.logging,liquibase.diff,liquibase.structure,"
-             "liquibase.structurecompare,liquibase.lockservice,liquibase.sdk,liquibase.ext"))}
+       (str "liquibase.change,liquibase.changelog,liquibase.database,liquibase.parser,liquibase.precondition,"
+            "liquibase.datatype,liquibase.serializer,liquibase.sqlgenerator,liquibase.executor,"
+            "liquibase.snapshot,liquibase.logging,liquibase.diff,liquibase.structure,"
+            "liquibase.structurecompare,liquibase.lockservice,liquibase.sdk,liquibase.ext"))}
 
   :jvm-opts
   ["-XX:+IgnoreUnrecognizedVMOptions"                                 ; ignore things not recognized for our Java version instead of refusing to start


### PR DESCRIPTION
The `generate-sample-dataset` lein command was [removed](https://github.com/metabase/metabase/commit/0becaab728cf8d863bf75c4a773ffca6da8e26e1). This PR removes some references to `generate-sample-dataset` that we missed.