### PR TITLE
site url detection

### DIFF
--- a/src/metabase/handler.clj
+++ b/src/metabase/handler.clj
@@ -40,11 +40,11 @@
    mw.json/wrap-streamed-json-response     ; middleware to automatically serialize suitable objects as JSON in responses
    wrap-keyword-params                     ; converts string keys in :params to keyword keys
    wrap-params                             ; parses GET and POST params as :query-params/:form-params and both as :params
+   mw.misc/maybe-set-site-url              ; set the value of `site-url` if it hasn't been set yet
    mw.session/bind-current-user            ; Binds *current-user* and *current-user-id* if :metabase-user-id is non-nil
    mw.session/wrap-current-user-id         ; looks for :metabase-session-id and sets :metabase-user-id if Session ID is valid
    mw.session/wrap-session-id              ; looks for a Metabase Session ID and assoc as :metabase-session-id
    mw.auth/wrap-api-key                    ; looks for a Metabase API Key on the request and assocs as :metabase-api-key
-   mw.misc/maybe-set-site-url              ; set the value of `site-url` if it hasn't been set yet
    mw.misc/bind-user-locale                ; Binds *locale* for i18n
    wrap-cookies                            ; Parses cookies in the request map and assocs as :cookies
    mw.misc/add-content-type                ; Adds a Content-Type header for any response that doesn't already have one


### PR DESCRIPTION
Only auto-set site url when the request has a current user associated. This is necessary because sometimes another processor like a load balancer will make requests, and we don't want the site url to be associated with the origin or host of the load balancer.

closes #4617