### PR TITLE
Update GA driver's Google dependency version

### DIFF
--- a/modules/drivers/googleanalytics/project.clj
+++ b/modules/drivers/googleanalytics/project.clj
@@ -9,7 +9,7 @@
    {:dependencies
     [[org.clojure/clojure "1.10.1"]
      [metabase-core "1.0.0-SNAPSHOT"]
-     [metabase/google-driver "1.0.0-SNAPSHOT-1.27.0"]]}
+     [metabase/google-driver "1.0.0-SNAPSHOT-1.30.7"]]}
 
    :uberjar
    {:auto-clean    true


### PR DESCRIPTION
I confirmed that the `bigquery` driver's dependency is already updated, and that building the `googleanalytics` driver jar works.