### PR TITLE
Close editor in test to prevent timing bug

### DIFF
--- a/frontend/test/metabase/scenarios/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/public.cy.spec.js
@@ -77,6 +77,10 @@ describe("public and embeds", () => {
 
       cy.focused().blur();
 
+      // This is needed to work around a timing bug. Without closing the editor,
+      // part of the question name was getting entered into the ace editor.
+      cy.get(".Icon-contract").click();
+
       cy.contains("Save").click();
       modal()
         .find('input[name="name"]')


### PR DESCRIPTION
I was seeing some failures on master due to this test. Typing the name in the "Save question" modal would only type part of the name correctly. The rest would get typed in the SQL editor behind the modal. 

I'm not sure why this happened, but presumably it has something to do Ace's event handlers with how quickly all the steps are executed. Closing the editor before saving prevents this issue.

![image](https://user-images.githubusercontent.com/691495/72551540-0846d900-3863-11ea-87e3-e1a6585722c2.png)
