### PR TITLE
Add probot/stale config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,24 @@
+# For now we want to only check for stale pull requests
+only: pulls
+
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+   This issue was automatically marked as stale due to a lack of recent activity.
+
+   This isn't a criticism of the PR, just an attempt to keep the PR queue in a happier state.
+   If you'd like to bring this PR back to the attention of the folks on the Metabase team, just comment
+   to prevent it from being closed.
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Help us do a better job of managing our PRs by getting the robots involved. If
no activity occurs on a pull request in a 60 day period (that includes any comments, labels, etc)
then the bot will comment that the issue has been marked as stale and then close it if no
further activity occurs within a week.

As we're introducing this for the first time and we have an extensive backlog the
initial copy is meant to let folks know we're still willing to consider things that might
have slipped through the cracks of this very busy repository if they let us know about it.