### PR TITLE
Scope down URLs where a 403 triggers a error page

### DIFF
--- a/frontend/src/metabase/app-main.js
+++ b/frontend/src/metabase/app-main.js
@@ -13,6 +13,8 @@ import { clearCurrentUser } from "metabase/redux/user";
 const NOT_AUTHORIZED_TRIGGERS = [
   /\/api\/dashboard\/\d+$/,
   /\/api\/collection\/\d+$/,
+  /\/api\/card\/\d+$/,
+  /\/api\/pulse\/\d+$/,
   /\/api\/dataset$/,
 ];
 

--- a/frontend/src/metabase/app-main.js
+++ b/frontend/src/metabase/app-main.js
@@ -9,18 +9,11 @@ import api from "metabase/lib/api";
 import { setErrorPage } from "metabase/redux/app";
 import { clearCurrentUser } from "metabase/redux/user";
 
-// we shouldn't redirect these URLs because we want to handle them differently
-const WHITELIST_FORBIDDEN_URLS = [
-  // on dashboards, we show permission errors for individual cards we don't have access to
-  /api\/card\/\d+\/query$/,
-  // metadata endpoints should not cause redirects
-  // we should gracefully handle cases where we don't have access to metadata
-  /api\/database\/\d+\/metadata$/,
-  /api\/database\/\d+\/fields/,
-  /api\/field\/\d+/,
-  /api\/field\/\d+\/values/,
-  /api\/table\/\d+\/query_metadata$/,
-  /api\/table\/\d+\/fks$/,
+// If any of these receives a 403, we should display the "not authorized" page.
+const NOT_AUTHORIZED_TRIGGERS = [
+  /\/api\/dashboard\/\d+$/,
+  /\/api\/collection\/\d+$/,
+  /\/api\/dataset$/,
 ];
 
 init(reducers, getRoutes, store => {
@@ -35,13 +28,8 @@ init(reducers, getRoutes, store => {
 
   // received a 403 response
   api.on("403", url => {
-    if (url) {
-      for (const regex of WHITELIST_FORBIDDEN_URLS) {
-        if (regex.test(url)) {
-          return;
-        }
-      }
+    if (NOT_AUTHORIZED_TRIGGERS.some(regex => regex.test(url))) {
+      return store.dispatch(setErrorPage({ status: 403 }));
     }
-    store.dispatch(setErrorPage({ status: 403 }));
   });
 });

--- a/frontend/test/metabase/scenarios/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions.cy.spec.js
@@ -40,4 +40,15 @@ describe("custom question", () => {
       cy.contains("Sorry, you don’t have permission to see that.");
     });
   }
+
+  // There's no pulse in the fixture data, so we stub out the api call to
+  // replace the 404 with a 403.
+  it("should display the permissions screen for pulses", () => {
+    signInAsNormalUser();
+    cy.server();
+    cy.route({ url: /\/api\/pulse\/1/, status: 403, response: {} });
+    cy.visit("/pulse/1");
+    cy.get(".Icon-key");
+    cy.contains("Sorry, you don’t have permission to see that.");
+  });
 });

--- a/frontend/test/metabase/scenarios/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions.cy.spec.js
@@ -1,0 +1,43 @@
+import {
+  signInAsAdmin,
+  signInAsNormalUser,
+  restore,
+} from "__support__/cypress";
+
+describe("custom question", () => {
+  before(() => {
+    restore();
+    signInAsAdmin();
+    cy.request("PUT", "/api/permissions/graph", {
+      revision: 0,
+      groups: {
+        "1": { "1": { native: "none", schemas: "none" } },
+        "2": { "1": { native: "write", schemas: "all" } },
+      },
+    });
+    cy.request("PUT", "/api/collection/graph", {
+      revision: 0,
+      groups: {
+        "1": { root: "none" },
+        "2": { root: "write" },
+      },
+    });
+  });
+  const PATHS = [
+    "/dashboard/1",
+    "/question/1",
+    "/collection/1",
+    "/admin",
+    // this url is a native query pointing at the sample db
+    "/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJzZWxlY3QgMSIsInRlbXBsYXRlLXRhZ3MiOnt9fSwiZGF0YWJhc2UiOjF9LCJkaXNwbGF5IjoidGFibGUiLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=",
+  ];
+
+  for (const path of PATHS) {
+    it(`should display the permissions screen on ${path}`, () => {
+      signInAsNormalUser();
+      cy.visit(path);
+      cy.get(".Icon-key");
+      cy.contains("Sorry, you don’t have permission to see that.");
+    });
+  }
+});

--- a/frontend/test/metabase/scenarios/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions.cy.spec.js
@@ -1,12 +1,7 @@
-import {
-  signInAsAdmin,
-  signInAsNormalUser,
-  restore,
-} from "__support__/cypress";
+import { signInAsAdmin, signInAsNormalUser } from "__support__/cypress";
 
-describe("custom question", () => {
+describe("permissions", () => {
   before(() => {
-    restore();
     signInAsAdmin();
     cy.request("PUT", "/api/permissions/graph", {
       revision: 0,


### PR DESCRIPTION
Resolves #10816

Previously our default behavior displayed an error page when any API call returned a 403. We had a list of excepted URLs.

This PR flips that logic. Now, we ignore 403s by default and have a list of api calls that should trigger the error page. That should prevent errors where a stray API call broke an otherwise functional page by blocking it with the error page. However, it increases the likelihood of failing to display the error page when it would be useful.

I added some tests to ensure we still show the error page on blocked pages: question, dashboard, collection, etc. 