### PR TITLE
Fix col_count typo

### DIFF
--- a/frontend/src/metabase/pulse/components/PulseEditCards.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditCards.jsx
@@ -22,7 +22,7 @@ function isAutoAttached(cardPreview) {
     cardPreview &&
     cardPreview.pulse_card_type === "table" &&
     (cardPreview.row_count > TABLE_MAX_ROWS ||
-      cardPreview.col_cound > TABLE_MAX_COLS)
+      cardPreview.col_count > TABLE_MAX_COLS)
   );
 }
 


### PR DESCRIPTION
Someone on Gitter pointed this typo out. I'm not sure what this might fix/do, but it looks like `src/metabase/api/pulse.clj` returns `col_count`, not `col_cound`. :)