### PR TITLE
Convert MySQL report_card table to utf8mb4 to fix 'Incorrect string value'

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -5304,3 +5304,16 @@ databaseChangeLog:
             tableName: metabase_field
             columnName: database_type
             newDataType: text
+
+#
+# Convert report_cart to utf8mb4 if it isn't alredy there. See #10691
+#
+
+  - changeSet:
+      id: 107
+      author: camsaul
+      comment: 'Added 0.34.2'
+      changes:
+        - sql:
+            dbms: mysql,mariadb
+            sql: 'ALTER TABLE report_card CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -206,8 +206,10 @@
    :zeroDateTimeBehavior "convertToNull"
    ;; Force UTF-8 encoding of results
    :useUnicode           true
-   :characterEncoding    "UTF8"
-   :characterSetResults  "UTF8"
+   :characterEncoding    "UTF-8"
+   :characterSetResults  "UTF-8"
+   :character_set_server "utf8mb4"
+   :connectionCollation  "utf8mb4_unicode_ci"
    ;; GZIP compress packets sent between Metabase server and MySQL/MariaDB database
    :useCompression       true})
 

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -169,15 +169,17 @@
 
 (def ^:private sample-jdbc-spec
   {:password             "bad-password"
-   :characterSetResults  "UTF8"
-   :characterEncoding    "UTF8"
+   :useUnicode           true
+   :characterEncoding    "UTF-8"
+   :characterSetResults  "UTF-8"
+   :character_set_server "utf8mb4"
+   :connectionCollation  "utf8mb4_unicode_ci"
    :classname            "org.mariadb.jdbc.Driver"
    :subprotocol          "mysql"
    :zeroDateTimeBehavior "convertToNull"
    :user                 "cam"
    :subname              "//localhost:3306/my_db"
-   :useCompression       true
-   :useUnicode           true})
+   :useCompression       true})
 
 ;; Do `:ssl` connection details give us the connection spec we'd expect?
 (expect


### PR DESCRIPTION
Fixes #10691 for people with existing setups. Alternative PR to #11573. Which one gets merged depends on how comfortable I am #11573 will not make peoples' DBs explode