### PR TITLE
add env var config to enable tracing

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -50,6 +50,7 @@
    [org.clojure/math.numeric-tower "0.0.4"]                           ; math functions like `ceil`
    [org.clojure/tools.logging "0.4.1"]                                ; logging framework
    [org.clojure/tools.namespace "0.2.11"]
+   [org.clojure/tools.trace "0.7.10"]                                 ; function tracing
    [amalloy/ring-buffer "1.2.2"
     :exclusions [org.clojure/clojure
                  org.clojure/clojurescript]]                          ; fixed length queue implementation, used in log buffering
@@ -218,8 +219,8 @@
 
      :repl-options
      {:init (do
-             (require 'metabase.core)
-             (metabase.core/-main))
+              (require 'metabase.core)
+              (metabase.core/-main))
       :timeout 60000}}]
 
    ;; start the dev HTTP server with 'lein ring server'

--- a/project.clj
+++ b/project.clj
@@ -218,9 +218,8 @@
      {:mb-jetty-join "false"}
 
      :repl-options
-     {:init (do
-              (require 'metabase.core)
-              (metabase.core/-main))
+     {:init (do (require 'metabase.core)
+                (metabase.core/-main))
       :timeout 60000}}]
 
    ;; start the dev HTTP server with 'lein ring server'

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -26,6 +26,7 @@
    ;; other application settings
    :mb-password-complexity "normal"
    :mb-version-info-url    "http://static.metabase.com/version-info.json"
+   :mb-ns-trace            ""                                             ; comma-separated namespaces to trace
    :max-session-age        "20160"                                        ; session length in minutes (14 days)
    :mb-colorize-logs       (str (not is-windows?))                        ; since PowerShell and cmd.exe don't support ANSI color escape codes or emoji,
    :mb-emoji-in-logs       (str (not is-windows?))                        ; disable them by default when running on Windows. Otherwise they're enabled

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -138,9 +138,7 @@
 
 (defn- maybe-enable-tracing
   []
-  (log/warn (trs (str "WARNING: You have enabled namespace tracing. This can result in sensitive information "
-                      "like database passwords getting logged. It should only be used temporarily to provide "
-                      "debugging information.")))
+  (log/warn (trs "WARNING: You have enabled namespace tracing, which could log sensitive information like db passwords."))
   (let [mb-trace-str (config/config-str :mb-ns-trace)]
     (when (not-empty mb-trace-str)
       (doseq [namespace (map symbol (str/split mb-trace-str #",\s*"))]

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -137,7 +137,7 @@
 
 (defn maybe-enable-tracing
   []
-  (log/info (trs "You have enabled namespace tracing. This should only be used temporarily to provide debugging information."))
+  (log/warn (trs "WARNING: You have enabled namespace tracing. This can result in sensitive information like database passwords getting logged. It should only be used temporarily to provide debugging information."))
   (let [mb-trace-str (config/config-str :mb-ns-trace)]
     (when (not-empty mb-trace-str)
       (doseq [namespace (map symbol (str/split mb-trace-str #","))]

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -138,7 +138,9 @@
 
 (defn- maybe-enable-tracing
   []
-  (log/warn (trs "WARNING: You have enabled namespace tracing. This can result in sensitive information like database passwords getting logged. It should only be used temporarily to provide debugging information."))
+  (log/warn (trs (str "WARNING: You have enabled namespace tracing. This can result in sensitive information "
+                      "like database passwords getting logged. It should only be used temporarily to provide "
+                      "debugging information.")))
   (let [mb-trace-str (config/config-str :mb-ns-trace)]
     (when (not-empty mb-trace-str)
       (doseq [namespace (map symbol (str/split mb-trace-str #",\s*"))]

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -320,8 +320,10 @@
   ([db-details direction]
    (jdbc/with-db-transaction [conn (jdbc-details db-details)]
      ;; Tell transaction to automatically `.rollback` instead of `.commit` when the transaction finishes
+     (log/debug (trs "Set transaction to automatically roll back..."))
      (jdbc/db-set-rollback-only! conn)
      ;; Disable auto-commit. This should already be off but set it just to be safe
+     (log/debug (trs "Disable auto-commit..."))
      (.setAutoCommit (jdbc/get-connection conn) false)
      ;; Set up liquibase and let it do its thing
      (log/info (trs "Setting up Liquibase..."))
@@ -366,6 +368,7 @@
                                    :postgres :ansi
                                    :h2       :h2
                                    :mysql    :mysql))
+  (log/debug (trs "Set default db connection with connection pool..."))
   (db/set-default-db-connection! (connection-pool/connection-pool-spec spec))
   (db/set-default-jdbc-options! {:read-columns db.jdbc-protocols/read-columns}))
 


### PR DESCRIPTION
also adds extra `log/debug` statements around database migrations.

if you set the the env var `MB_NS_TRACE="metabase.db"` then _all_ function calls in the `metabase.db` namespace will be logged, including arguments and return values. If you set the env var `MB_NS_TRACE="metabase.db,metabase.server"` then both `metabase.db` and `metabase.server` will get traced.

closes #11749, which was created in response to #10709 .