### PR TITLE
Minor cleanup to sql-jdbc.execute

### DIFF
--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -49,8 +49,8 @@
   (sql-jdbc.execute/execute-query driver query))
 
 (defmethod driver/notify-database-updated :sql-jdbc
-  [driver database]
-  (sql-jdbc.conn/notify-database-updated driver database))
+  [_ database]
+  (sql-jdbc.conn/notify-database-updated database))
 
 (defmethod driver/describe-database :sql-jdbc
   [driver database]

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -115,7 +115,7 @@
   "Default implementation of `driver/notify-database-updated` for JDBC SQL drivers. We are being informed that a
   `database` has been updated, so lets shut down the connection pool (if it exists) under the assumption that the
   connection details have changed."
-  [_ database]
+  [database]
   (set-pool! (u/get-id database) nil))
 
 (defn db->pooled-connection-spec


### PR DESCRIPTION
Remove the internal `do-with-ensured-connection` macro from `metabase.driver.sql-jdbc.connection` since it doesn't do anything (it's already passed a `Connection`, and it thus effectively a no-op). It also had incorrect parameter names

Rename some ambiguous `connection` parameters to clarify whether they're `clojure.java.jdbc` connection specs or `java.sql.Connection` objects.