### PR TITLE
Fix date ranges generated for MongoDB params

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
@@ -35,7 +35,7 @@
   (pr-str (mongo.qp/field->name field ".")))
 
 (defn- substitute-one-field-filter-date-range [{field :field, {param-type :type, value :value} :value}]
-  (let [{:keys [start end]} (date-params/date-string->range value)
+  (let [{:keys [start end]} (date-params/date-string->range value {:inclusive-end? false})
         start-condition     (when start
                               (format "{%s: {$gte: %s}}" (field->name field) (param-value->str (u.date/parse start))))
         end-condition       (when end

--- a/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
@@ -174,7 +174,7 @@
                                                          :dimension    $date}}}
                     :parameters [{:type   :date/range
                                   :target [:dimension [:template-tag "date"]]
-                                  :value  "2014-03-01~2014-03-03"}]}))))))
+                                  :value  "2014-03-01~2014-03-02"}]}))))))
     (testing "multiple values"
       (is (= [[1 "African"]
               [2 "American"]

--- a/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
@@ -2,7 +2,9 @@
   (:require [cheshire
              [core :as json]
              [generate :as json.generate]]
-            [clojure.test :refer :all]
+            [clojure
+             [string :as str]
+             [test :refer :all]]
             [metabase
              [query-processor :as qp]
              [test :as mt]]
@@ -78,25 +80,71 @@
            (substitute {:id (comma-separated-numbers [1 2 3])}
                        [(param :id)])))))
 
+(defprotocol ^:private ToBSON
+  (^:private to-bson [this]
+   "Utility method for converting normal Clojure objects to string-serialized 'BSON'."))
+
+(extend-protocol ToBSON
+  nil
+  (to-bson [_] "null")
+
+  Object
+  (to-bson [this] (pr-str this))
+
+  clojure.lang.Keyword
+  (to-bson [this] (name this))
+
+  clojure.lang.Sequential
+  (to-bson [this]
+    (str "["
+         (str/join ", " (map to-bson this))
+         "]"))
+
+  clojure.lang.IPersistentMap
+  (to-bson [this]
+    (str "{"
+         (str/join ", " (for [[k v] this]
+                          (str (to-bson k) ": " (to-bson v))))
+         "}")))
+
+(defn- bson-fn-call [f & args]
+  (reify ToBSON
+    (to-bson [_]
+      (format "%s(%s)" (name f) (str/join "," (map pr-str args))))))
+
+(defn- ISODate [s]
+  (bson-fn-call :ISODate s))
+
 (deftest field-filter-test
   (testing "Date ranges"
     (mt/with-clock #t "2019-12-13T12:00:00.000Z[UTC]"
-      (is (= "[{$match: {$and: [{\"date\": {$gte: ISODate(\"2019-12-08\")}}, {\"date\": {$lt: ISODate(\"2019-12-12\")}}]}}]"
-             (substitute {:date (field-filter "date" :date/range "past5days")}
-                         ["[{$match: " (param :date) "}]"])))))
+      (letfn [(substitute-date-range [s]
+                (substitute {:date (field-filter "date" :date/range s)}
+                            ["[{$match: " (param :date) "}]"]))]
+        (is (= (to-bson [{:$match {:$and [{"date" {:$gte (ISODate "2019-12-08")}}
+                                          {"date" {:$lt  (ISODate "2019-12-13")}}]}}])
+               (substitute-date-range "past5days")))
+        (testing "Make sure ranges like last[x]/this[x] include the full range (#11715)"
+          (is (= (to-bson [{:$match {:$and [{"date" {:$gte (ISODate "2019-12-01")}}
+                                            {"date" {:$lt  (ISODate "2020-01-01")}}]}}])
+                 (substitute-date-range "thismonth")))
+          (is (= (to-bson [{:$match {:$and [{"date" {:$gte (ISODate "2019-11-01")}}
+                                            {"date" {:$lt  (ISODate "2019-12-01")}}]}}])
+                 (substitute-date-range "lastmonth")))))))
   (testing "multiple values"
     (doseq [[message v] {"values are a vector of numbers" [1 2 3]
                          "comma-separated numbers"        (comma-separated-numbers [1 2 3])}]
       (testing message
-        (is (= "[{$match: {\"id\": {$in: [1, 2, 3]}}}]"
+        (is (= (to-bson [{:$match {"id" {:$in [1 2 3]}}}])
                (substitute {:id (field-filter "id" :number v)}
                            ["[{$match: " (param :id) "}]"]))))))
   (testing "single date"
-    (is (= "[{$match: {$and: [{\"date\": {$gte: ISODate(\"2019-12-08\")}}, {\"date\": {$lt: ISODate(\"2019-12-09\")}}]}}]"
+    (is (= (to-bson [{:$match {:$and [{"date" {:$gte (ISODate "2019-12-08")}}
+                                      {"date" {:$lt  (ISODate "2019-12-09")}}]}}])
            (substitute {:date (field-filter "date" :date/single "2019-12-08")}
                        ["[{$match: " (param :date) "}]"]))))
   (testing "parameter not supplied"
-    (is (= "[{$match: {}}]"
+    (is (= (to-bson [{:$match {}}])
            (substitute {:date (common.params/->FieldFilter {:name "date"} common.params/no-value)} ["[{$match: " (param :date) "}]"])))))
 
 (defn- json-raw

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -197,7 +197,7 @@
 ;; for relative dates convert the param to a `DateRange` record type and call `->replacement-snippet-info` on it
 (s/defn ^:private date-range-field-filter->replacement-snippet-info :- ParamSnippetInfo
   [driver value]
-  (->> (date-params/date-string->range value (qp.timezone/results-timezone-id))
+  (->> (date-params/date-string->range value)
        i/map->DateRange
        (->replacement-snippet-info driver)))
 

--- a/src/metabase/util/date_2.clj
+++ b/src/metabase/util/date_2.clj
@@ -64,7 +64,8 @@
 (defn format
   "Format temporal value `t` as a ISO-8601 date/time/datetime string."
   ^String [t]
-  (format* (temporal->iso-8601-formatter t) t))
+  (when t
+    (format* (temporal->iso-8601-formatter t) t)))
 
 (defn format-sql
   "Format a temporal value `t` as a SQL-style literal string (for most SQL databases). This is the same as ISO-8601 but

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -142,7 +142,11 @@
         "should get formatted as the same way as an OffsetDateTime"))
   (testing "Instant"
     (is (= "1970-01-01T00:00:00Z"
-           (u.date/format (t/instant "1970-01-01T00:00:00Z"))))))
+           (u.date/format (t/instant "1970-01-01T00:00:00Z")))))
+  (testing "nil"
+    (is (= nil
+           (u.date/format nil))
+        "Passing `nil` should return `nil`")))
 
 (deftest format-sql-test
   (testing "LocalDateTime"


### PR DESCRIPTION
The logic used to translate Field filter date params such as `thismonth` generated *inclusive* ranges, e.g. 

```clj
(date-string->range \"past2days\") ; -> {:start \"2020-01-20\", :end \"2020-01-21\"}
```

Originally this was only used for SQL, e.g.

```sql
WHERE date(some_column) BETWEEN date '2020-01-20' AND date '2020-01-21'
```

which works as expected (`BETWEEN` is inclusive).

With MongoDB we're generating a`$match` with an exclusive end date, meaning the range needs to be adjusted to be correct.

Fixes #11690 by adding support for either inclusive or exclusive ranges to `date-string->range`. Once that was in place the Mongo stuff started working as expected.