### PR TITLE
Improve Google auth token error message

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx
@@ -130,6 +130,9 @@ export default class SettingsSingleSignOnForm extends Component {
               </a>
             )}.`}
           </p>
+          <p className="text-medium">
+            {t`Be sure to include the full client ID, including the apps.googleusercontent.com suffix.`}
+          </p>
           <InputBlurChange
             className="SettingsInput AdminInput bordered rounded h3"
             type="text"

--- a/frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSingleSignOnForm.jsx
@@ -126,9 +126,9 @@ export default class SettingsSingleSignOnForm extends Component {
                 href="https://developers.google.com/identity/sign-in/web/devconsole-project"
                 target="_blank"
               >
-                here.
+                here
               </a>
-            )}`}
+            )}.`}
           </p>
           <InputBlurChange
             className="SettingsInput AdminInput bordered rounded h3"

--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -271,7 +271,9 @@
        (let [audience (:aud <>)
              audience (if (string? audience) [audience] audience)]
          (when-not (contains? (set audience) client-id)
-           (throw (ex-info (tru "Google Auth token meant for a different site.") {:status-code 400}))))
+           (throw (ex-info (str (deferred-tru "Google Auth token appears to be incorrect. ")
+                                (deferred-tru "Double check that it matches in Google and Metabase."))
+                           {:status-code 400}))))
        (when-not (= (:email_verified <>) "true")
          (throw (ex-info (tru "Email is not verified.") {:status-code 400})))))))
 

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -370,7 +370,7 @@
                  [(-> e ex-data :status-code) (.getMessage e)])))))
 
     (testing "for invalid data."
-      (is (= [400 "Google Auth token meant for a different site."]
+      (is (= [400 "Google Auth token appears to be incorrect. Double check that it matches in Google and Metabase."]
              (try
                (#'session-api/google-auth-token-info
                  {:status 200


### PR DESCRIPTION
The original error message caused some confusion about what was going wrong (see e.g. #11516). These changes are based on (but not exactly) @kdoh's suggestions.

Additionally, I [moved](https://github.com/metabase/metabase/commit/f3a3e60fe927de460093265bcdf45755d5b0563c) a sentence ending period out of the link text at the end of a sentence. Please confirm that this is correct, or if we deliberately include trailing punctuation in such situations.