### PR TITLE
convert streaming endpoints

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -144,8 +144,8 @@
   `all`, but other options include `mine`, `fav`, `database`, `table`, `recent`, `popular`, and `archived`. See
   corresponding implementation functions above for the specific behavior of each filter option. :card_index:"
   [f model_id]
-  {f          (s/maybe CardFilterOption)
-   model_id   (s/maybe su/IntGreaterThanZero)}
+  {f        (s/maybe CardFilterOption)
+   model_id (s/maybe su/IntGreaterThanZero)}
   (let [f (keyword f)]
     (when (contains? #{:database :table} f)
       (api/checkp (integer? model_id) "model_id" (format "model_id is a required parameter when filter mode is '%s'"
@@ -157,7 +157,6 @@
          ;; filterv because we want make sure all the filtering is done while current user perms set is still bound
          (filterv mi/can-read?))))
 
-
 (api/defendpoint GET "/:id"
   "Get `Card` with ID."
   [id]
@@ -166,7 +165,6 @@
                api/read-check)
     (events/publish-event! :card-read (assoc <> :actor_id api/*current-user-id*))))
 
-
 ;;; -------------------------------------------------- Saving Cards --------------------------------------------------
 
 ;; When a new Card is saved, we wouldn't normally have the results metadata for it until the first time its query is
@@ -174,8 +172,6 @@
 ;; frontend pass it back to us when saving or updating a Card.  As a basic step to make sure the Metadata is valid
 ;; we'll also pass a simple checksum and have the frontend pass it back to us.  See the QP `results-metadata`
 ;; middleware namespace for more details
-
-
 
 (s/defn ^:private result-metadata-async :- ManyToManyChannel
   "Get the right results metadata for this `card`, and return them in a channel. We'll check to see whether the

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -34,8 +34,8 @@
   [form]
   (cond
     (map? form) (args-form-flatten (mapcat (fn [[k v]]
-                                          [(args-form-flatten k) (args-form-flatten v)])
-                                        form))
+                                             [(args-form-flatten k) (args-form-flatten v)])
+                                           form))
     (sequential? form) (mapcat args-form-flatten form)
     :else       [form]))
 
@@ -60,7 +60,7 @@
           (log/warn
            (u/format-color 'red (str "We don't have a nice error message for schema: %s\n"
                                      "Consider wrapping it in `su/with-api-error-message`.")
-             (u/pprint-to-str schema)))))))
+                           (u/pprint-to-str schema)))))))
 
 (defn- param-name
   "Return the appropriate name for this PARAM-SYMB based on its SCHEMA. Usually this is just the name of the

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -10,7 +10,8 @@
             [metabase.util
              [i18n :as ui18n :refer [tru]]
              [schema :as su]]
-            [schema.core :as s]))
+            [schema.core :as s])
+  (:import clojure.core.async.impl.channels.ManyToManyChannel))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              DOCSTRING GENERATION                                              |
@@ -259,5 +260,7 @@
            (contains? response :status)
            (contains? response :body))
     response
-    {:status 200
+    {:status (if (instance? ManyToManyChannel response)
+               202
+               200)
      :body   response}))

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -108,7 +108,7 @@
   (api/let-404 [export-conf (ex/export-formats export-format)]
     (if (= status :completed)
       ;; successful query, send file
-      {:status  200
+      {:status  202
        :body    ((:export-fn export-conf)
                  (map #(some % [:display_name :name]) cols)
                  (maybe-modify-date-values cols rows))

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -40,7 +40,7 @@
     (api/read-check Card source-card-id)
     source-card-id))
 
-(api/defendpoint POST "/"
+(api/defendpoint ^:returns-chan POST "/"
   "Execute a query and retrieve the results in the usual format."
   [:as {{:keys [database], :as query} :body}]
   {database s/Int}
@@ -146,7 +146,7 @@
      (api/defendpoint POST [\"/:export-format\", :export-format export-format-regex]"
   (re-pattern (str "(" (str/join "|" (keys ex/export-formats)) ")")))
 
-(api/defendpoint-async POST ["/:export-format", :export-format export-format-regex]
+(api/defendpoint-async ^:returns-chan POST ["/:export-format", :export-format export-format-regex]
   "Execute a query and download the result data as a file in the specified format."
   [{{:keys [export-format query]} :params} respond raise]
   {query         su/JSONString

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -113,14 +113,14 @@
    options))
 
 
-(api/defendpoint GET "/card/:uuid/query"
+(api/defendpoint ^:returns-chan GET "/card/:uuid/query"
   "Fetch a publicly-accessible Card an return query results as well as `:card` information. Does not require auth
    credentials. Public sharing must be enabled."
   [uuid parameters]
   {parameters (s/maybe su/JSONString)}
   (run-query-for-card-with-public-uuid-async uuid (json/parse-string parameters keyword)))
 
-(api/defendpoint-async GET "/card/:uuid/query/:export-format"
+(api/defendpoint-async ^:returns-chan GET "/card/:uuid/query/:export-format"
   "Fetch a publicly-accessible Card and return query results in the specified format. Does not require auth
    credentials. Public sharing must be enabled."
   [{{:keys [uuid export-format parameters]} :params}, respond raise]
@@ -262,7 +262,7 @@
       :context      context
       :constraints  constraints)))
 
-(api/defendpoint GET "/dashboard/:uuid/card/:card-id"
+(api/defendpoint ^:returns-chan GET "/dashboard/:uuid/card/:card-id"
   "Fetch the results for a Card in a publicly-accessible Dashboard. Does not require auth credentials. Public
    sharing must be enabled."
   [uuid card-id parameters]

--- a/src/metabase/async/api_response.clj
+++ b/src/metabase/async/api_response.clj
@@ -61,8 +61,11 @@
   (cond
     ;; An error has occurred, let the user know
     (instance? Throwable chunkk)
-    (json/generate-stream (let [body (:body (mw.exceptions/api-exception-response chunkk))]
-                            (cond-> body (map? body) (assoc :_status 500)))
+    (json/generate-stream (let [{:keys [body status]
+                                 :or   {status 500}} (mw.exceptions/api-exception-response chunkk)]
+                            (if (map? body)
+                              (assoc body :_status status)
+                              {:message body :_status status}))
                           out)
 
     ;; We've recevied the response, write it to the output stream and we're done

--- a/src/metabase/async/api_response.clj
+++ b/src/metabase/async/api_response.clj
@@ -194,6 +194,6 @@
 (extend-protocol Sendable
   ManyToManyChannel
   (send* [input-chan _ respond _]
-    (respond
-     (assoc (response/response input-chan)
-       :content-type "applicaton/json; charset=utf-8"))))
+    (respond (assoc (response/response input-chan)
+                    :content-type "applicaton/json; charset=utf-8"
+                    :status 202))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -4,7 +4,6 @@
             [clojure.data.csv :as csv]
             [clojure.test :refer :all]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
-            [expectations :refer [expect]]
             [medley.core :as m]
             [metabase
              [email-test :as et]

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -543,7 +543,7 @@
     (with-cards-in-writeable-collection card
       (array-map
        1 (db/select-one-field :name Card, :id (u/get-id card))
-       2 (do ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id card)) {:name "Updated Name"})
+       2 (do ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:name "Updated Name"})
              (db/select-one-field :name Card, :id (u/get-id card)))))))
 
 ;; Can we update a Card's archived status?
@@ -555,7 +555,7 @@
     (with-cards-in-writeable-collection card
       (let [archived?     (fn [] (:archived (Card (u/get-id card))))
             set-archived! (fn [archived]
-                            ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id card)) {:archived archived})
+                            ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:archived archived})
                             (archived?))]
         (array-map
          1 (archived?)
@@ -576,7 +576,7 @@
   nil
   (tt/with-temp Card [card {:description "What a nice Card"}]
     (with-cards-in-writeable-collection card
-      ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id card)) {:description nil})
+      ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:description nil})
       (db/select-one-field :description Card :id (u/get-id card)))))
 
 ;; description should be blankable as well
@@ -584,7 +584,7 @@
   ""
   (tt/with-temp Card [card {:description "What a nice Card"}]
     (with-cards-in-writeable-collection card
-      ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id card)) {:description ""})
+      ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:description ""})
       (db/select-one-field :description Card :id (u/get-id card)))))
 
 ;; Can we update a card's embedding_params?
@@ -592,7 +592,7 @@
   {:abc "enabled"}
   (tt/with-temp Card [card]
     (tu/with-temporary-setting-values [enable-embedding true]
-      ((test-users/user->client :crowberto) :put 200 (str "card/" (u/get-id card)) {:embedding_params {:abc "enabled"}}))
+      ((test-users/user->client :crowberto) :put 202 (str "card/" (u/get-id card)) {:embedding_params {:abc "enabled"}}))
     (db/select-one-field :embedding_params Card :id (u/get-id card))))
 
 ;; We shouldn't be able to update them if we're not an admin...
@@ -622,7 +622,7 @@
     (tt/with-temp Card [card]
       (with-cards-in-writeable-collection card
         ;; update the Card's query
-        ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id card))
+        ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id card))
          {:dataset_query     (mbql-count-query)
           :result_metadata   metadata
           :metadata_checksum (#'results-metadata/metadata-checksum metadata)})
@@ -645,7 +645,7 @@
     (tt/with-temp Card [card]
       (with-cards-in-writeable-collection card
         ;; update the Card's query
-        ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id card))
+        ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id card))
          {:dataset_query     (mbql-count-query)
           :result_metadata   metadata
           :metadata_checksum "ABC123"}) ; invalid checksum
@@ -657,7 +657,7 @@
   1
   (tt/with-temp Card [card]
     (with-cards-in-writeable-collection card
-      ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id card))
+      ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id card))
        {:collection_position 1})
       (db/select-one-field :collection_position Card :id (u/get-id card)))))
 
@@ -666,7 +666,7 @@
   nil
   (tt/with-temp Card [card {:collection_position 1}]
     (with-cards-in-writeable-collection card
-      ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id card))
+      ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id card))
        {:collection_position nil})
       (db/select-one-field :collection_position Card :id (u/get-id card)))))
 
@@ -728,7 +728,7 @@
                                       Card c
                                       Card d]
         (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-        ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id c))
+        ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id c))
          {:collection_position 1})
         (get-name->collection-position :rasta collection)))))
 
@@ -745,7 +745,7 @@
                                       Pulse     c
                                       Card      d]
         (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-        ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id d))
+        ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id d))
          {:collection_position 1})
         (get-name->collection-position :rasta collection)))))
 
@@ -762,7 +762,7 @@
                                       Pulse     c
                                       Dashboard d]
         (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-        ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id a))
+        ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id a))
          {:collection_position 4})
         (get-name->collection-position :rasta collection)))))
 
@@ -780,7 +780,7 @@
                     Dashboard  [_ {:name "c", :collection_id coll-id, :collection_position 2}]
                     Card       [_ {:name "d", :collection_id coll-id, :collection_position 3}]]
       (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-      ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id b))
+      ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id b))
        {:collection_position 2})
       (get-name->collection-position :rasta coll-id))))
 
@@ -797,7 +797,7 @@
                                       Dashboard c
                                       Pulse     d]
         (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-        ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id b))
+        ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id b))
          {:collection_position nil})
         (get-name->collection-position :rasta collection)))))
 
@@ -825,7 +825,7 @@
                                           Dashboard h]
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-1)
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-2)
-          ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id f))
+          ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id f))
            {:collection_id (u/get-id collection-1)})
           [(get-name->collection-position :rasta collection-1)
            (get-name->collection-position :rasta collection-2)])))))
@@ -853,7 +853,7 @@
                                           Card      h]
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-1)
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-2)
-          ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id h))
+          ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id h))
            {:collection_position 1, :collection_id (u/get-id collection-1)})
           [(get-name->collection-position :rasta collection-1)
            (get-name->collection-position :rasta collection-2)])))))
@@ -954,7 +954,7 @@
                                              Pulse     e
                                              Pulse     f]
                (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection)
-               ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id d))
+               ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id d))
                 {:collection_position 1, :collection_id (u/get-id collection)})
                (name->position ((test-users/user->client :rasta) :get 200 (format "collection/%s/items" (u/get-id collection))))))))))
 
@@ -976,23 +976,23 @@
           [{:message        "Archiving a Card should trigger Alert deletion"
             :expected-email "the question was archived by Rasta Toucan"
             :f              (fn [{:keys [card]}]
-                              ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id card)) {:archived true}))}
+                              ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:archived true}))}
            {:message        "Validate changing a display type triggers alert deletion"
             :card           {:display :table}
             :expected-email "the question was edited by Rasta Toucan"
             :f              (fn [{:keys [card]}]
-                              ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id card)) {:display :line}))}
+                              ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:display :line}))}
            {:message        "Changing the display type from line to table should force a delete"
             :card           {:display :line}
             :expected-email "the question was edited by Rasta Toucan"
             :f              (fn [{:keys [card]}]
-                              ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id card)) {:display :table}))}
+                              ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:display :table}))}
            {:message        "Removing the goal value will trigger the alert to be deleted"
             :card           {:display                :line
                              :visualization_settings {:graph.goal_value 10}}
             :expected-email "the question was edited by Rasta Toucan"
             :f              (fn [{:keys [card]}]
-                              ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id card)) {:visualization_settings {:something "else"}}))}
+                              ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:visualization_settings {:something "else"}}))}
            {:message        "Adding an additional breakout will cause the alert to be removed"
             :card           {:display                :line
                              :visualization_settings {:graph.goal_value 10}
@@ -1004,7 +1004,7 @@
                                                         "hour"]])}
             :expected-email "the question was edited by Crowberto Corv"
             :f              (fn [{:keys [card]}]
-                              ((test-users/user->client :crowberto) :put 200 (str "card/" (u/get-id card))
+                              ((test-users/user->client :crowberto) :put 202 (str "card/" (u/get-id card))
                                {:dataset_query (assoc-in (mbql-count-query (data/id) (data/id :checkins))
                                                          [:query :breakout] [[:datetime-field (data/id :checkins :date) "hour"]
                                                                              [:datetime-field (data/id :checkins :date) "minute"]])}))}]]
@@ -1058,11 +1058,11 @@
       (et/with-fake-inbox
         (array-map
          :emails-1 (do
-                     ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id card)) {:display :area})
+                     ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:display :area})
                      (et/regex-email-bodies #"the question was edited by Rasta Toucan"))
          :pulse-1  (boolean (Pulse (u/get-id pulse)))
          :emails-2 (do
-                     ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id card)) {:display :bar})
+                     ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:display :bar})
                      (et/regex-email-bodies #"the question was edited by Rasta Toucan"))
          :pulse-2  (boolean (Pulse (u/get-id pulse))))))))
 
@@ -1211,19 +1211,19 @@
 
 ;; non-"download" queries should still get the default constraints
 ;; (this also is a sanitiy check to make sure the `with-redefs` in the test above actually works)
-(expect
-  10
-  (with-redefs [constraints/default-query-constraints {:max-results 10, :max-results-bare-rows 10}]
-    (tt/with-temp Card [card {:dataset_query {:database (data/id)
-                                              :type     :query
-                                              :query    {:source-table (data/id :venues)}
-                                              :middleware
-                                              {:add-default-userland-constraints? true
-                                               :userland-query?                   true}}}]
-      (with-cards-in-readable-collection card
-        (let [{row-count :row_count, :as result}
-              ((test-users/user->client :rasta) :post 200 (format "card/%d/query" (u/get-id card)))]
-          (or row-count result))))))
+(deftest non-download-queries
+  (is (= 10
+         (with-redefs [constraints/default-query-constraints {:max-results 10, :max-results-bare-rows 10}]
+           (tt/with-temp Card [card {:dataset_query {:database (data/id)
+                                                     :type     :query
+                                                     :query    {:source-table (data/id :venues)}
+                                                     :middleware
+                                                     {:add-default-userland-constraints? true
+                                                      :userland-query?                   true}}}]
+             (with-cards-in-readable-collection card
+               (let [{row-count :row_count, :as result}
+                     ((test-users/user->client :rasta) :post 202 (format "card/%d/query" (u/get-id card)))]
+                 (or row-count result))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -1256,7 +1256,7 @@
 (expect
   (tt/with-temp* [Card       [card]
                   Collection [collection]]
-    ((test-users/user->client :crowberto) :put 200 (str "card/" (u/get-id card)) {:collection_id (u/get-id collection)})
+    ((test-users/user->client :crowberto) :put 202 (str "card/" (u/get-id card)) {:collection_id (u/get-id collection)})
     (= (db/select-one-field :collection_id Card :id (u/get-id card))
        (u/get-id collection))))
 
@@ -1298,7 +1298,7 @@
                     Card       [card                {:collection_id (u/get-id original-collection)}]]
       (perms/grant-collection-readwrite-permissions! (perms-group/all-users) original-collection)
       (perms/grant-collection-readwrite-permissions! (perms-group/all-users) new-collection)
-      ((test-users/user->client :rasta) :put 200 (str "card/" (u/get-id card)) {:collection_id (u/get-id new-collection)})
+      ((test-users/user->client :rasta) :put 202 (str "card/" (u/get-id card)) {:collection_id (u/get-id new-collection)})
       (= (db/select-one-field :collection_id Card :id (u/get-id card))
          (u/get-id new-collection)))))
 

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -569,6 +569,7 @@
              (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
              ((test-users/user->client :rasta) :put 403 (str "card/" (u/get-id card)) {:archived true}))))))
 
+;; Can we clear the description of a Card? (#4738)
 (deftest can-we-clear-the-description-of-a-card----4738-
   (is (nil? (tt/with-temp Card [card {:description "What a nice Card"}]
               (with-cards-in-writeable-collection card
@@ -1058,7 +1059,7 @@
                 ((test-users/user->client :rasta) :delete 204 (str "card/" (u/get-id card)))
                 (Card (u/get-id card)))))))
 
-
+;; deleting a card that doesn't exist should return a 404 (#1957)
 (deftest deleting-a-card-that-doesn-t-exist-should-return-a-404---1957-
   (is (= "Not found."
          ((test-users/user->client :crowberto) :delete 404 "card/12345"))))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -42,8 +42,8 @@
 ;; HELPER FNS
 
 (driver/register! ::test-driver
-  :parent :sql-jdbc
-  :abstract? true)
+                  :parent :sql-jdbc
+                  :abstract? true)
 
 (defmethod driver/connection-properties ::test-driver [_]
   nil)
@@ -115,59 +115,58 @@
 
 ;; Check that we can create a Database
 (tu/expect-schema
-  (merge
-   (m/map-vals s/eq default-db-details)
-   {:created_at       java.time.temporal.Temporal
-    :engine           (s/eq ::test-driver)
-    :id               su/IntGreaterThanZero
-    :details          (s/eq {:db "my_db"})
-    :updated_at       java.time.temporal.Temporal
-    :name             su/NonBlankString
-    :features         (s/eq (driver.u/features ::test-driver))})
-  (create-db-via-api!))
+ (merge
+  (m/map-vals s/eq default-db-details)
+  {:created_at       java.time.temporal.Temporal
+   :engine           (s/eq ::test-driver)
+   :id               su/IntGreaterThanZero
+   :details          (s/eq {:db "my_db"})
+   :updated_at       java.time.temporal.Temporal
+   :name             su/NonBlankString
+   :features         (s/eq (driver.u/features ::test-driver))})
+ (create-db-via-api!))
 
 ;; can we set `auto_run_queries` to `false` when we create the Database?
-(expect
-  {:auto_run_queries false}
-  (select-keys (create-db-via-api! {:auto_run_queries false}) [:auto_run_queries]))
+(deftest set-auto-run-queries-false
+  (is (= {:auto_run_queries false}
+         (select-keys (create-db-via-api! {:auto_run_queries false}) [:auto_run_queries]))))
 
 ;; can we set `is_full_sync` to `false` when we create the Database?
-(expect
-  {:is_full_sync false}
-  (select-keys (create-db-via-api! {:is_full_sync false}) [:is_full_sync]))
+(deftest set-is-full-sync
+  (is (= {:is_full_sync false}
+         (select-keys (create-db-via-api! {:is_full_sync false}) [:is_full_sync]))))
 
 
 ;; ## DELETE /api/database/:id
 ;; Check that we can delete a Database
-(expect
-  false
+(deftest delete-a-db
   (tt/with-temp Database [db]
     ((test-users/user->client :crowberto) :delete 204 (format "database/%d" (:id db)))
-    (db/exists? Database :id (u/get-id db))))
+    (is (false? (db/exists? Database :id (u/get-id db))))))
 
 ;; ## PUT /api/database/:id
 ;; Check that we can update fields in a Database
-(expect
-  {:details      {:host "localhost", :port 5432, :dbname "fakedb", :user "rastacan"}
-   :engine       :h2
-   :name         "Cam's Awesome Toucan Database"
-   :is_full_sync false
-   :features     (driver.u/features :h2)}
+(deftest can-update-db-fields
   (tt/with-temp Database [{db-id :id}]
     (let [updates {:name         "Cam's Awesome Toucan Database"
                    :engine       "h2"
                    :is_full_sync false
                    :details      {:host "localhost", :port 5432, :dbname "fakedb", :user "rastacan"}}]
       ((test-users/user->client :crowberto) :put 200 (format "database/%d" db-id) updates))
-    (into {} (db/select-one [Database :name :engine :details :is_full_sync], :id db-id))))
+    (is (= {:details      {:host "localhost", :port 5432, :dbname "fakedb", :user "rastacan"}
+            :engine       :h2
+            :name         "Cam's Awesome Toucan Database"
+            :is_full_sync false
+            :features     (driver.u/features :h2)}
+           (into {} (db/select-one [Database :name :engine :details :is_full_sync], :id db-id))))))
 
 ;; should be able to set `auto_run_queries` when updating a Database
-(expect
-  {:auto_run_queries false}
+(deftest set-auto-run-queries
   (tt/with-temp Database [{db-id :id}]
     (let [updates {:auto_run_queries false}]
       ((test-users/user->client :crowberto) :put 200 (format "database/%d" db-id) updates))
-    (into {} (db/select-one [Database :auto_run_queries], :id db-id))))
+    (is (= {:auto_run_queries false}
+           (into {} (db/select-one [Database :auto_run_queries], :id db-id))))))
 
 
 (def ^:private default-table-details
@@ -225,23 +224,25 @@
    (apply (test-users/user->client user-kw) :get 200 "database" options)))
 
 ;; Database details *should not* come back for Rasta since she's not a superuser
-(tt/expect-with-temp [Database [{db-id :id, db-name :name} {:engine (u/qualified-name ::test-driver)}]]
-  (sorted-databases
-   (cons
-    (test-driver-database db-id)
-    (all-test-data-databases)))
-  (api-database-list db-name :rasta))
+(deftest no-dbs-for-rasta
+  (tt/with-temp* [Database [{db-id :id, db-name :name} {:engine (u/qualified-name ::test-driver)}]]
+    (is (= (sorted-databases
+            (cons
+             (test-driver-database db-id)
+             (all-test-data-databases)))
+           (api-database-list db-name :rasta)))))
 
 ;; GET /api/databases (include tables)
-(tt/expect-with-temp [Database [{db-id :id, db-name :name} {:engine (u/qualified-name ::test-driver)}]]
-  (sorted-databases
-   (cons
-    (assoc (test-driver-database db-id) :tables [])
-    (for [db (all-test-data-databases)]
-      (assoc db :tables (->> (db/select Table, :db_id (u/get-id db), :active true)
-                             (map table-details)
-                             (sort-by (comp str/lower-case :name)))))))
-  (api-database-list db-name :rasta, :include_tables true))
+(deftest db-endpoint-includes-tables
+  (tt/with-temp* [Database [{db-id :id, db-name :name} {:engine (u/qualified-name ::test-driver)}]]
+    (is (= (sorted-databases
+            (cons
+             (assoc (test-driver-database db-id) :tables [])
+             (for [db (all-test-data-databases)]
+               (assoc db :tables (->> (db/select Table, :db_id (u/get-id db), :active true)
+                                      (map table-details)
+                                      (sort-by (comp str/lower-case :name)))))))
+           (api-database-list db-name :rasta, :include_tables true)))))
 
 
 ;; ## GET /api/database/:id/metadata
@@ -263,46 +264,45 @@
     field
     [:updated_at :id :created_at :last_analyzed :fingerprint :fingerprint_version :fk_target_field_id])))
 
-(expect
-  (merge
-   default-db-details
-   (select-keys (data/db) [:created_at :id :updated_at :timezone])
-   {:engine   "h2"
-    :name     "test-data"
-    :features (map u/qualified-name (driver.u/features :h2))
-    :tables   [(merge
-                default-table-details
-                (db/select-one [Table :created_at :updated_at :fields_hash] :id (data/id :categories))
-                {:schema       "PUBLIC"
-                 :name         "CATEGORIES"
-                 :display_name "Categories"
-                 :fields       [(merge
-                                 (field-details (Field (data/id :categories :id)))
-                                 {:table_id         (data/id :categories)
-                                  :special_type     "type/PK"
-                                  :name             "ID"
-                                  :display_name     "ID"
-                                  :database_type    "BIGINT"
-                                  :base_type        "type/BigInteger"
-                                  :visibility_type  "normal"
-                                  :has_field_values "none"})
-                                (merge
-                                 (field-details (Field (data/id :categories :name)))
-                                 {:table_id         (data/id :categories)
-                                  :special_type     "type/Name"
-                                  :name             "NAME"
-                                  :display_name     "Name"
-                                  :database_type    "VARCHAR"
-                                  :base_type        "type/Text"
-                                  :visibility_type  "normal"
-                                  :has_field_values "list"})]
-                 :segments     []
-                 :metrics      []
-                 :rows         nil
-                 :id           (data/id :categories)
-                 :db_id        (data/id)})]})
-  (let [resp ((test-users/user->client :rasta) :get 200 (format "database/%d/metadata" (data/id)))]
-    (assoc resp :tables (filter #(= "CATEGORIES" (:name %)) (:tables resp)))))
+(deftest TODO-give-this-a-name
+  (is (= (merge default-db-details
+                (select-keys (data/db) [:created_at :id :updated_at :timezone])
+                {:engine   "h2"
+                 :name     "test-data"
+                 :features (map u/qualified-name (driver.u/features :h2))
+                 :tables   [(merge
+                             default-table-details
+                             (db/select-one [Table :created_at :updated_at :fields_hash] :id (data/id :categories))
+                             {:schema       "PUBLIC"
+                              :name         "CATEGORIES"
+                              :display_name "Categories"
+                              :fields       [(merge
+                                              (field-details (Field (data/id :categories :id)))
+                                              {:table_id         (data/id :categories)
+                                               :special_type     "type/PK"
+                                               :name             "ID"
+                                               :display_name     "ID"
+                                               :database_type    "BIGINT"
+                                               :base_type        "type/BigInteger"
+                                               :visibility_type  "normal"
+                                               :has_field_values "none"})
+                                             (merge
+                                              (field-details (Field (data/id :categories :name)))
+                                              {:table_id         (data/id :categories)
+                                               :special_type     "type/Name"
+                                               :name             "NAME"
+                                               :display_name     "Name"
+                                               :database_type    "VARCHAR"
+                                               :base_type        "type/Text"
+                                               :visibility_type  "normal"
+                                               :has_field_values "list"})]
+                              :segments     []
+                              :metrics      []
+                              :rows         nil
+                              :id           (data/id :categories)
+                              :db_id        (data/id)})]})
+         (let [resp ((test-users/user->client :rasta) :get 200 (format "database/%d/metadata" (data/id)))]
+           (assoc resp :tables (filter #(= "CATEGORIES" (:name %)) (:tables resp)))))))
 
 
 ;;; GET /api/database/:id/autocomplete_suggestions
@@ -310,21 +310,19 @@
 (defn- suggestions-with-prefix [prefix]
   ((test-users/user->client :rasta) :get 200 (format "database/%d/autocomplete_suggestions" (data/id)) :prefix prefix))
 
-(expect
-  [["USERS" "Table"]
-   ["USER_ID" "CHECKINS :type/Integer :type/FK"]]
-  (suggestions-with-prefix "u"))
+(deftest succestions-with-prefix
+  (is (= [["USERS" "Table"]
+          ["USER_ID" "CHECKINS :type/Integer :type/FK"]]
+         (suggestions-with-prefix "u")))
 
-(expect
-  [["CATEGORIES" "Table"]
-   ["CHECKINS" "Table"]
-   ["CATEGORY_ID" "VENUES :type/Integer :type/FK"]]
-  (suggestions-with-prefix "c"))
+  (is (= [["CATEGORIES" "Table"]
+          ["CHECKINS" "Table"]
+          ["CATEGORY_ID" "VENUES :type/Integer :type/FK"]]
+         (suggestions-with-prefix "c")))
 
-(expect
-  [["CATEGORIES" "Table"]
-   ["CATEGORY_ID" "VENUES :type/Integer :type/FK"]]
-  (suggestions-with-prefix "cat"))
+  (is (= [["CATEGORIES" "Table"]
+          ["CATEGORY_ID" "VENUES :type/Integer :type/FK"]]
+         (suggestions-with-prefix "cat"))))
 
 
 ;;; GET /api/database?include_cards=true
@@ -361,44 +359,44 @@
     :description  nil}
    kvs))
 
-(tt/expect-with-temp [Card [card (card-with-native-query "Kanye West Quote Views Per Month")]]
-  (saved-questions-virtual-db
-    (virtual-table-for-card card))
-  (do
+(deftest saved-questions-db-is-last-on-list
+  (tt/with-temp* [Card [card (card-with-native-query "Kanye West Quote Views Per Month")]]
     ;; run the Card which will populate its result_metadata column
-    ((test-users/user->client :crowberto) :post 200 (format "card/%d/query" (u/get-id card)))
+    ((test-users/user->client :crowberto) :post 202 (format "card/%d/query" (u/get-id card)))
     ;; Now fetch the database list. The 'Saved Questions' DB should be last on the list
-    (last ((test-users/user->client :crowberto) :get 200 "database" :include_cards true))))
+    (is (= (-> card
+               virtual-table-for-card
+               saved-questions-virtual-db)
+           (last ((test-users/user->client :crowberto) :get 202 "database" :include_cards true))))))
 
 ;; Make sure saved questions are NOT included if the setting is disabled
-(expect
-  nil
-  (tt/with-temp Card [card (card-with-native-query "Kanye West Quote Views Per Month")]
-    (tu/with-temporary-setting-values [enable-nested-queries false]
-      ;; run the Card which will populate its result_metadata column
-      ((test-users/user->client :crowberto) :post 200 (format "card/%d/query" (u/get-id card)))
-      ;; Now fetch the database list. The 'Saved Questions' DB should NOT be in the list
-      (some (fn [database]
-              (when (= (u/get-id database) mbql.s/saved-questions-virtual-database-id)
-                database))
-            ((test-users/user->client :crowberto) :get 200 "database" :include_cards true)))))
+(deftest saved-questions-not-inluded-if-setting-disabled
+  (is (nil? (tt/with-temp Card [card (card-with-native-query "Kanye West Quote Views Per Month")]
+              (tu/with-temporary-setting-values [enable-nested-queries false]
+                ;; run the Card which will populate its result_metadata column
+                ((test-users/user->client :crowberto) :post 202 (format "card/%d/query" (u/get-id card)))
+                ;; Now fetch the database list. The 'Saved Questions' DB should NOT be in the list
+                (some (fn [database]
+                        (when (= (u/get-id database) mbql.s/saved-questions-virtual-database-id)
+                          database))
+                      ((test-users/user->client :crowberto) :get 202 "database" :include_cards true)))))))
 
 
 ;; make sure that GET /api/database?include_cards=true groups pretends COLLECTIONS are SCHEMAS
-(tt/expect-with-temp [Collection [stamp-collection {:name "Stamps"}]
-                      Collection [coin-collection  {:name "Coins"}]
-                      Card       [stamp-card (card-with-native-query "Total Stamp Count", :collection_id (u/get-id stamp-collection))]
-                      Card       [coin-card  (card-with-native-query "Total Coin Count",  :collection_id (u/get-id coin-collection))]]
-  (saved-questions-virtual-db
-    (virtual-table-for-card coin-card  :schema "Coins")
-    (virtual-table-for-card stamp-card :schema "Stamps"))
-  (do
+(deftest pretend-collections-are-schemas
+  (tt/with-temp* [Collection [stamp-collection {:name "Stamps"}]
+                  Collection [coin-collection  {:name "Coins"}]
+                  Card       [stamp-card (card-with-native-query "Total Stamp Count", :collection_id (u/get-id stamp-collection))]
+                  Card       [coin-card  (card-with-native-query "Total Coin Count",  :collection_id (u/get-id coin-collection))]]
     ;; run the Cards which will populate their result_metadata columns
     (doseq [card [stamp-card coin-card]]
-      ((test-users/user->client :crowberto) :post 200 (format "card/%d/query" (u/get-id card))))
+      ((test-users/user->client :crowberto) :post 202 (format "card/%d/query" (u/get-id card))))
     ;; Now fetch the database list. The 'Saved Questions' DB should be last on the list. Cards should have their
     ;; Collection name as their Schema
-    (last ((test-users/user->client :crowberto) :get 200 "database" :include_cards true))))
+    (is (= (saved-questions-virtual-db
+            (virtual-table-for-card coin-card  :schema "Coins")
+            (virtual-table-for-card stamp-card :schema "Stamps"))
+           (last ((test-users/user->client :crowberto) :get 202 "database" :include_cards true))))))
 
 (defn- fetch-virtual-database []
   (some #(when (= (:name %) "Saved Questions")
@@ -406,76 +404,80 @@
         ((test-users/user->client :crowberto) :get 200 "database" :include_cards true)))
 
 ;; make sure that GET /api/database?include_cards=true removes Cards that have ambiguous columns
-(tt/expect-with-temp [Card [ok-card         (assoc (card-with-native-query "OK Card")         :result_metadata [{:name "cam"}])]
-                      Card [cambiguous-card (assoc (card-with-native-query "Cambiguous Card") :result_metadata [{:name "cam"} {:name "cam_2"}])]]
-  (saved-questions-virtual-db
-    (virtual-table-for-card ok-card))
-  (fetch-virtual-database))
+(deftest remove-cards-with-ambiguous-columns
+  (tt/with-temp* [Card [ok-card         (assoc (card-with-native-query "OK Card")         :result_metadata [{:name "cam"}])]
+                  Card [cambiguous-card (assoc (card-with-native-query "Cambiguous Card") :result_metadata [{:name "cam"} {:name "cam_2"}])]]
+    (is (= (-> ok-card
+               virtual-table-for-card
+               saved-questions-virtual-db)
+           (fetch-virtual-database)))))
 
 ;; make sure that GET /api/database/include_cards=true removes Cards that belong to a driver that doesn't support
 ;; nested queries
 (driver/register! ::no-nested-query-support
-  :parent :sql-jdbc
-  :abstract? true)
+                  :parent :sql-jdbc
+                  :abstract? true)
 
 (defmethod driver/supports? [::no-nested-query-support :nested-queries] [_ _] false)
 
-(tt/expect-with-temp [Database [bad-db   {:engine ::no-nested-query-support, :details {}}]
-                      Card     [bad-card {:name            "Bad Card"
-                                          :dataset_query   {:database (u/get-id bad-db)
-                                                            :type     :native
-                                                            :native   {:query "[QUERY GOES HERE]"}}
-                                          :result_metadata [{:name "sparrows"}]
-                                          :database_id     (u/get-id bad-db)}]
-                      Card     [ok-card  (assoc (card-with-native-query "OK Card")
-                                           :result_metadata [{:name "finches"}])]]
-  (saved-questions-virtual-db
-    (virtual-table-for-card ok-card))
-  (fetch-virtual-database))
+(deftest TODO-name-test-1
+  (tt/with-temp* [Database [bad-db   {:engine ::no-nested-query-support, :details {}}]
+                  Card     [bad-card {:name            "Bad Card"
+                                      :dataset_query   {:database (u/get-id bad-db)
+                                                        :type     :native
+                                                        :native   {:query "[QUERY GOES HERE]"}}
+                                      :result_metadata [{:name "sparrows"}]
+                                      :database_id     (u/get-id bad-db)}]
+                  Card     [ok-card  (assoc (card-with-native-query "OK Card")
+                                            :result_metadata [{:name "finches"}])]]
+    (is (= (-> ok-card
+               virtual-table-for-card
+               saved-questions-virtual-db)
+           (fetch-virtual-database)))))
 
 
 ;; make sure that GET /api/database?include_cards=true removes Cards that use cumulative-sum and cumulative-count
 ;; aggregations
 (defn- ok-mbql-card []
   (assoc (card-with-mbql-query "OK Card"
-           :source-table (data/id :checkins))
-    :result_metadata [{:name "num_toucans"}]))
+                               :source-table (data/id :checkins))
+         :result_metadata [{:name "num_toucans"}]))
 
 ;; cumulative count
-(tt/expect-with-temp [Card [ok-card (ok-mbql-card)]
-                      Card [_ (merge
-                               (data/$ids checkins
-                                 (card-with-mbql-query "Cum Count Card"
-                                   :source-table $$checkins
-                                   :aggregation  [[:cum-count]]
-                                   :breakout     [!month.date]))
-                               {:result_metadata [{:name "num_toucans"}]})]]
-  (saved-questions-virtual-db
-    (virtual-table-for-card ok-card))
-  (fetch-virtual-database))
-
-
+(deftest cumulative-count
+  (tt/with-temp* [Card [ok-card (ok-mbql-card)]
+                  Card [_ (merge
+                           (data/$ids checkins
+                                      (card-with-mbql-query "Cum Count Card"
+                                                            :source-table $$checkins
+                                                            :aggregation  [[:cum-count]]
+                                                            :breakout     [!month.date]))
+                           {:result_metadata [{:name "num_toucans"}]})]]
+    (is (= (-> ok-card
+               virtual-table-for-card
+               saved-questions-virtual-db)
+           (fetch-virtual-database)))))
 
 ;; make sure that GET /api/database/:id/metadata works for the Saved Questions 'virtual' database
-(tt/expect-with-temp [Card [card (assoc (card-with-native-query "Birthday Card")
-                                   :result_metadata [{:name "age_in_bird_years"}])]]
-  (saved-questions-virtual-db
-    (assoc (virtual-table-for-card card)
-      :fields [{:name                     "age_in_bird_years"
-                :table_id                 (str "card__" (u/get-id card))
-                :id                       ["field-literal" "age_in_bird_years" "type/*"]
-                :special_type             nil
-                :base_type                nil
-                :default_dimension_option nil
-                :dimension_options        []}]))
-  ((test-users/user->client :crowberto) :get 200
-   (format "database/%d/metadata" mbql.s/saved-questions-virtual-database-id)))
+(deftest works-with-saved-questions-virtual-db
+  (tt/with-temp* [Card [card (assoc (card-with-native-query "Birthday Card")
+                                    :result_metadata [{:name "age_in_bird_years"}])]]
+    (is (= (saved-questions-virtual-db
+            (assoc (virtual-table-for-card card)
+                   :fields [{:name                     "age_in_bird_years"
+                             :table_id                 (str "card__" (u/get-id card))
+                             :id                       ["field-literal" "age_in_bird_years" "type/*"]
+                             :special_type             nil
+                             :base_type                nil
+                             :default_dimension_option nil
+                             :dimension_options        []}]))
+           ((test-users/user->client :crowberto) :get 200
+            (format "database/%d/metadata" mbql.s/saved-questions-virtual-database-id))))))
 
 ;; if no eligible Saved Questions exist the virtual DB metadata endpoint should just return `nil`
-(expect
-  nil
-  ((test-users/user->client :crowberto) :get 200
-   (format "database/%d/metadata" mbql.s/saved-questions-virtual-database-id)))
+(deftest return-nil-when-no-eligible-saved-questions
+  (is (nil? ((test-users/user->client :crowberto) :get 200
+             (format "database/%d/metadata" mbql.s/saved-questions-virtual-database-id)))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -495,42 +497,41 @@
    :schedule_type  "hourly"})
 
 ;; Can we create a NEW database and give it custom schedules?
-(expect
-  {:cache_field_values_schedule "0 0 23 ? * 6L *"
-   :metadata_sync_schedule      "0 0 * * * ? *"}
-  (let [db-name (tu/random-name)]
-    (try
-      (let [db (with-redefs [driver/available? (constantly true)]
-                 ((test-users/user->client :crowberto) :post 200 "database"
-                  {:name      db-name
-                   :engine    (u/qualified-name ::test-driver)
-                   :details   {:db "my_db"}
-                   :schedules {:cache_field_values schedule-map-for-last-friday-at-11pm
-                               :metadata_sync      schedule-map-for-hourly}}))]
-        (db/select-one [Database :cache_field_values_schedule :metadata_sync_schedule] :id (u/get-id db)))
-      (finally (db/delete! Database :name db-name)))))
+(deftest create-new-db-with-custom-schedules
+  (is (= {:cache_field_values_schedule "0 0 23 ? * 6L *"
+          :metadata_sync_schedule      "0 0 * * * ? *"}
+         (let [db-name (tu/random-name)]
+           (try (let [db (with-redefs [driver/available? (constantly true)]
+                           ((test-users/user->client :crowberto) :post 200 "database"
+                            {:name      db-name
+                             :engine    (u/qualified-name ::test-driver)
+                             :details   {:db "my_db"}
+                             :schedules {:cache_field_values schedule-map-for-last-friday-at-11pm
+                                         :metadata_sync      schedule-map-for-hourly}}))]
+                  (into {} (db/select-one [Database :cache_field_values_schedule :metadata_sync_schedule] :id (u/get-id db))))
+                (finally (db/delete! Database :name db-name)))))))
 
 ;; Can we UPDATE the schedules for an existing database?
-(expect
-  {:cache_field_values_schedule "0 0 23 ? * 6L *"
-   :metadata_sync_schedule      "0 0 * * * ? *"}
-  (tt/with-temp Database [db {:engine "h2", :details (:details (data/db))}]
-    ((test-users/user->client :crowberto) :put 200 (format "database/%d" (u/get-id db))
-     (assoc db
-       :schedules {:cache_field_values schedule-map-for-last-friday-at-11pm
-                   :metadata_sync      schedule-map-for-hourly}))
-    (db/select-one [Database :cache_field_values_schedule :metadata_sync_schedule] :id (u/get-id db))))
+(deftest update-schedules-for-existing-db
+  (is (= {:cache_field_values_schedule "0 0 23 ? * 6L *"
+          :metadata_sync_schedule      "0 0 * * * ? *"}
+         (tt/with-temp Database [db {:engine "h2", :details (:details (data/db))}]
+           ((test-users/user->client :crowberto) :put 200 (format "database/%d" (u/get-id db))
+            (assoc db
+                   :schedules {:cache_field_values schedule-map-for-last-friday-at-11pm
+                               :metadata_sync      schedule-map-for-hourly}))
+           (into {} (db/select-one [Database :cache_field_values_schedule :metadata_sync_schedule] :id (u/get-id db)))))))
 
 ;; If we FETCH a database will it have the correct 'expanded' schedules?
-(expect
-  {:cache_field_values_schedule "0 0 23 ? * 6L *"
-   :metadata_sync_schedule      "0 0 * * * ? *"
-   :schedules                   {:cache_field_values schedule-map-for-last-friday-at-11pm
-                                 :metadata_sync      schedule-map-for-hourly}}
-  (tt/with-temp Database [db {:metadata_sync_schedule      "0 0 * * * ? *"
-                              :cache_field_values_schedule "0 0 23 ? * 6L *"}]
-    (-> ((test-users/user->client :crowberto) :get 200 (format "database/%d" (u/get-id db)))
-        (select-keys [:cache_field_values_schedule :metadata_sync_schedule :schedules]))))
+(deftest fetch-db-with-expanded-schedules
+  (is (= {:cache_field_values_schedule "0 0 23 ? * 6L *"
+          :metadata_sync_schedule      "0 0 * * * ? *"
+          :schedules                   {:cache_field_values schedule-map-for-last-friday-at-11pm
+                                        :metadata_sync      schedule-map-for-hourly}}
+         (tt/with-temp Database [db {:metadata_sync_schedule      "0 0 * * * ? *"
+                                     :cache_field_values_schedule "0 0 23 ? * 6L *"}]
+           (-> ((test-users/user->client :crowberto) :get 200 (format "database/%d" (u/get-id db)))
+               (select-keys [:cache_field_values_schedule :metadata_sync_schedule :schedules]))))))
 
 ;; Five minutes
 (def ^:private long-timeout (* 5 60 1000))
@@ -541,59 +542,59 @@
       (deliver promise-to-deliver true))))
 
 ;; Can we trigger a metadata sync for a DB?
-(expect
-  [true true]
-  (let [sync-called?    (promise)
-        analyze-called? (promise)]
-    (tt/with-temp Database [db {:engine "h2", :details (:details (data/db))}]
-      (with-redefs [sync-metadata/sync-db-metadata! (deliver-when-db sync-called? db)
-                    analyze/analyze-db!             (deliver-when-db analyze-called? db)]
-        ((test-users/user->client :crowberto) :post 200 (format "database/%d/sync_schema" (u/get-id db)))
-        ;; Block waiting for the promises from sync and analyze to be delivered. Should be delivered instantly,
-        ;; however if something went wrong, don't hang forever, eventually timeout and fail
-        [(deref sync-called? long-timeout :sync-never-called)
-         (deref analyze-called? long-timeout :analyze-never-called)]))))
+(deftest trigger-metadata-sync-for-db
+  (is (= [true true]
+         (let [sync-called?    (promise)
+               analyze-called? (promise)]
+           (tt/with-temp Database [db {:engine "h2", :details (:details (data/db))}]
+             (with-redefs [sync-metadata/sync-db-metadata! (deliver-when-db sync-called? db)
+                           analyze/analyze-db!             (deliver-when-db analyze-called? db)]
+               ((test-users/user->client :crowberto) :post 200 (format "database/%d/sync_schema" (u/get-id db)))
+               ;; Block waiting for the promises from sync and analyze to be delivered. Should be delivered instantly,
+               ;; however if something went wrong, don't hang forever, eventually timeout and fail
+               [(deref sync-called? long-timeout :sync-never-called)
+                (deref analyze-called? long-timeout :analyze-never-called)]))))))
 
 ;; (Non-admins should not be allowed to trigger sync)
-(expect
-  "You don't have permissions to do that."
-  ((test-users/user->client :rasta) :post 403 (format "database/%d/sync_schema" (data/id))))
+(deftest non-admins-cant-trigger-sync
+  (is (= "You don't have permissions to do that."
+         ((test-users/user->client :rasta) :post 403 (format "database/%d/sync_schema" (data/id))))))
 
 ;; Can we RESCAN all the FieldValues for a DB?
-(expect
-  :sync-called
-  (let [update-field-values-called? (promise)]
-    (tt/with-temp Database [db {:engine "h2", :details (:details (data/db))}]
-      (with-redefs [field-values/update-field-values! (fn [synced-db]
-                                                        (when (= (u/get-id synced-db) (u/get-id db))
-                                                          (deliver update-field-values-called? :sync-called)))]
-        ((test-users/user->client :crowberto) :post 200 (format "database/%d/rescan_values" (u/get-id db)))
-        (deref update-field-values-called? long-timeout :sync-never-called)))))
+(deftest can-rescan-fieldvalues-for-a-db
+  (is (= :sync-called
+         (let [update-field-values-called? (promise)]
+           (tt/with-temp Database [db {:engine "h2", :details (:details (data/db))}]
+             (with-redefs [field-values/update-field-values! (fn [synced-db]
+                                                               (when (= (u/get-id synced-db) (u/get-id db))
+                                                                 (deliver update-field-values-called? :sync-called)))]
+               ((test-users/user->client :crowberto) :post 200 (format "database/%d/rescan_values" (u/get-id db)))
+               (deref update-field-values-called? long-timeout :sync-never-called)))))))
 
 ;; (Non-admins should not be allowed to trigger re-scan)
-(expect
-  "You don't have permissions to do that."
-  ((test-users/user->client :rasta) :post 403 (format "database/%d/rescan_values" (data/id))))
+(deftest nonadmins-cant-trigger-rescan
+  (is (= "You don't have permissions to do that."
+         ((test-users/user->client :rasta) :post 403 (format "database/%d/rescan_values" (data/id))))))
 
 ;; Can we DISCARD all the FieldValues for a DB?
-(expect
-  {:values-1-still-exists? false
-   :values-2-still-exists? false}
-  (tt/with-temp* [Database    [db       {:engine "h2", :details (:details (data/db))}]
-                  Table       [table-1  {:db_id (u/get-id db)}]
-                  Table       [table-2  {:db_id (u/get-id db)}]
-                  Field       [field-1  {:table_id (u/get-id table-1)}]
-                  Field       [field-2  {:table_id (u/get-id table-2)}]
-                  FieldValues [values-1 {:field_id (u/get-id field-1), :values [1 2 3 4]}]
-                  FieldValues [values-2 {:field_id (u/get-id field-2), :values [1 2 3 4]}]]
-    ((test-users/user->client :crowberto) :post 200 (format "database/%d/discard_values" (u/get-id db)))
-    {:values-1-still-exists? (db/exists? FieldValues :id (u/get-id values-1))
-     :values-2-still-exists? (db/exists? FieldValues :id (u/get-id values-2))}))
+(deftest discard-db-fieldvalues
+  (is (= {:values-1-still-exists? false
+          :values-2-still-exists? false}
+         (tt/with-temp* [Database    [db       {:engine "h2", :details (:details (data/db))}]
+                         Table       [table-1  {:db_id (u/get-id db)}]
+                         Table       [table-2  {:db_id (u/get-id db)}]
+                         Field       [field-1  {:table_id (u/get-id table-1)}]
+                         Field       [field-2  {:table_id (u/get-id table-2)}]
+                         FieldValues [values-1 {:field_id (u/get-id field-1), :values [1 2 3 4]}]
+                         FieldValues [values-2 {:field_id (u/get-id field-2), :values [1 2 3 4]}]]
+           ((test-users/user->client :crowberto) :post 200 (format "database/%d/discard_values" (u/get-id db)))
+           {:values-1-still-exists? (db/exists? FieldValues :id (u/get-id values-1))
+            :values-2-still-exists? (db/exists? FieldValues :id (u/get-id values-2))}))))
 
 ;; (Non-admins should not be allowed to discard all FieldValues)
-(expect
-  "You don't have permissions to do that."
-  ((test-users/user->client :rasta) :post 403 (format "database/%d/discard_values" (data/id))))
+(deftest nonadmins-cant-discard-all-fieldvalues
+  (is (= "You don't have permissions to do that."
+         ((test-users/user->client :rasta) :post 403 (format "database/%d/discard_values" (data/id))))))
 
 
 ;;; Tests for /POST /api/database/validate
@@ -607,35 +608,35 @@
     nil
     {:valid false, :message "Error!"}))
 
-(expect
-  "You don't have permissions to do that."
-  (with-redefs [database-api/test-database-connection test-database-connection]
-    ((test-users/user->client :rasta) :post 403 "database/validate"
-     {:details {:engine :h2, :details (:details (data/db))}})))
+(deftest nonadmins-cant-do-something
+  (is (= "You don't have permissions to do that."
+         (with-redefs [database-api/test-database-connection test-database-connection]
+           ((test-users/user->client :rasta) :post 403 "database/validate"
+            {:details {:engine :h2, :details (:details (data/db))}})))))
 
-(expect
-  (:details (data/db))
-  (with-redefs [database-api/test-database-connection test-database-connection]
-    (#'database-api/test-connection-details "h2" (:details (data/db)))))
+(deftest gets-details
+  (is (= (:details (data/db))
+         (with-redefs [database-api/test-database-connection test-database-connection]
+           (#'database-api/test-connection-details "h2" (:details (data/db)))))))
 
-(expect
-  {:valid true}
-  (with-redefs [database-api/test-database-connection test-database-connection]
-    ((test-users/user->client :crowberto) :post 200 "database/validate"
-     {:details {:engine :h2, :details (:details (data/db))}})))
+(deftest TODO-is-valid
+  (is (= {:valid true}
+         (with-redefs [database-api/test-database-connection test-database-connection]
+           ((test-users/user->client :crowberto) :post 200 "database/validate"
+            {:details {:engine :h2, :details (:details (data/db))}})))))
 
-(expect
-  {:valid false, :message "Error!"}
-  (with-redefs [database-api/test-database-connection test-database-connection]
-    (tu.log/suppress-output
-      (#'database-api/test-connection-details "h2" {:db "ABC"}))))
+(deftest TODO-rename-is-not-valid
+  (is (= {:valid false, :message "Error!"}
+         (with-redefs [database-api/test-database-connection test-database-connection]
+           (tu.log/suppress-output
+            (#'database-api/test-connection-details "h2" {:db "ABC"}))))))
 
-(expect
-  {:valid false}
-  (with-redefs [database-api/test-database-connection test-database-connection]
-    (tu.log/suppress-output
-      ((test-users/user->client :crowberto) :post 200 "database/validate"
-       {:details {:engine :h2, :details {:db "ABC"}}}))))
+(deftest TODO-rename-is-also-nt-valid
+  (is (= {:valid false}
+         (with-redefs [database-api/test-database-connection test-database-connection]
+           (tu.log/suppress-output
+            ((test-users/user->client :crowberto) :post 200 "database/validate"
+             {:details {:engine :h2, :details {:db "ABC"}}}))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -643,138 +644,138 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;; Tests for GET /api/database/:id/schemas: should work if user has full DB perms...
-(expect
-  ["schema1"]
-  (tt/with-temp* [Database [{db-id :id}]
-                  Table    [_ {:db_id db-id, :schema "schema1"}]
-                  Table    [_ {:db_id db-id, :schema "schema1"}]]
-    ((test-users/user->client :rasta) :get 200 (format "database/%d/schemas" db-id))))
+(deftest get-schemas-if-user-has-full-db-perms
+  (is (= ["schema1"]
+         (tt/with-temp* [Database [{db-id :id}]
+                         Table    [_ {:db_id db-id, :schema "schema1"}]
+                         Table    [_ {:db_id db-id, :schema "schema1"}]]
+           ((test-users/user->client :rasta) :get 200 (format "database/%d/schemas" db-id))))))
 
 ;; ...or full schema perms...
-(expect
-  ["schema1"]
-  (tt/with-temp* [Database [{db-id :id}]
-                  Table    [_ {:db_id db-id, :schema "schema1"}]
-                  Table    [_ {:db_id db-id, :schema "schema1"}]]
-    (perms/revoke-permissions! (perms-group/all-users) db-id)
-    (perms/grant-permissions!  (perms-group/all-users) db-id "schema1")
-    ((test-users/user->client :rasta) :get 200 (format "database/%d/schemas" db-id))))
+(deftest get-schema-if-user-has-full-schema-perms
+  (is (= ["schema1"]
+         (tt/with-temp* [Database [{db-id :id}]
+                         Table    [_ {:db_id db-id, :schema "schema1"}]
+                         Table    [_ {:db_id db-id, :schema "schema1"}]]
+           (perms/revoke-permissions! (perms-group/all-users) db-id)
+           (perms/grant-permissions!  (perms-group/all-users) db-id "schema1")
+           ((test-users/user->client :rasta) :get 200 (format "database/%d/schemas" db-id))))))
 
 ;; ...or just table read perms...
-(expect
-  ["schema1"]
-  (tt/with-temp* [Database [{db-id :id}]
-                  Table    [t1          {:db_id db-id, :schema "schema1"}]
-                  Table    [t2          {:db_id db-id, :schema "schema1"}]]
-    (perms/revoke-permissions! (perms-group/all-users) db-id)
-    (perms/grant-permissions!  (perms-group/all-users) db-id "schema1" t1)
-    (perms/grant-permissions!  (perms-group/all-users) db-id "schema1" t2)
-    ((test-users/user->client :rasta) :get 200 (format "database/%d/schemas" db-id))))
+(deftest get-schema-if-user-has-table-read-perms
+  (is (= ["schema1"]
+         (tt/with-temp* [Database [{db-id :id}]
+                         Table    [t1          {:db_id db-id, :schema "schema1"}]
+                         Table    [t2          {:db_id db-id, :schema "schema1"}]]
+           (perms/revoke-permissions! (perms-group/all-users) db-id)
+           (perms/grant-permissions!  (perms-group/all-users) db-id "schema1" t1)
+           (perms/grant-permissions!  (perms-group/all-users) db-id "schema1" t2)
+           ((test-users/user->client :rasta) :get 200 (format "database/%d/schemas" db-id))))))
 
 ;; Multiple schemas are ordered by name
-(expect
-  ["schema1" "schema2" "schema3"]
-  (tt/with-temp* [Database [{db-id :id}]
-                  Table    [_ {:db_id db-id, :schema "schema3"}]
-                  Table    [_ {:db_id db-id, :schema "schema2"}]
-                  Table    [_ {:db_id db-id, :schema "schema1"}]]
-    ((test-users/user->client :rasta) :get 200 (format "database/%d/schemas" db-id))))
+(deftest multiple-schemas-are-ordered-by-name
+  (is (= ["schema1" "schema2" "schema3"]
+         (tt/with-temp* [Database [{db-id :id}]
+                         Table    [_ {:db_id db-id, :schema "schema3"}]
+                         Table    [_ {:db_id db-id, :schema "schema2"}]
+                         Table    [_ {:db_id db-id, :schema "schema1"}]]
+           ((test-users/user->client :rasta) :get 200 (format "database/%d/schemas" db-id))))))
 
 ;; Can we fetch the Tables in a Schema? (If we have full DB perms)
-(expect
-  ["t1" "t3"]
-  (tt/with-temp* [Database [{db-id :id}]
-                  Table    [_ {:db_id db-id, :schema "schema1", :name "t1"}]
-                  Table    [_ {:db_id db-id, :schema "schema2"}]
-                  Table    [_ {:db_id db-id, :schema "schema1", :name "t3"}]]
-    (map :name ((test-users/user->client :rasta) :get 200 (format "database/%d/schema/%s" db-id "schema1")))))
+(deftest can-fetch-tables-in-a-schmea-with-full-db-perms
+  (is (= ["t1" "t3"]
+         (tt/with-temp* [Database [{db-id :id}]
+                         Table    [_ {:db_id db-id, :schema "schema1", :name "t1"}]
+                         Table    [_ {:db_id db-id, :schema "schema2"}]
+                         Table    [_ {:db_id db-id, :schema "schema1", :name "t3"}]]
+           (map :name ((test-users/user->client :rasta) :get 200 (format "database/%d/schema/%s" db-id "schema1")))))))
 
 ;; Can we fetch the Tables in a Schema? (If we have full schema perms)
-(expect
-  ["t1" "t3"]
-  (tt/with-temp* [Database [{db-id :id}]
-                  Table    [_ {:db_id db-id, :schema "schema1", :name "t1"}]
-                  Table    [_ {:db_id db-id, :schema "schema2"}]
-                  Table    [_ {:db_id db-id, :schema "schema1", :name "t3"}]]
-    (perms/revoke-permissions! (perms-group/all-users) db-id)
-    (perms/grant-permissions!  (perms-group/all-users) db-id "schema1")
-    (map :name ((test-users/user->client :rasta) :get 200 (format "database/%d/schema/%s" db-id "schema1")))))
+(deftest can-fetch-tables-in-a-schmea-with-full-schema-perms
+  (is (= ["t1" "t3"]
+         (tt/with-temp* [Database [{db-id :id}]
+                         Table    [_ {:db_id db-id, :schema "schema1", :name "t1"}]
+                         Table    [_ {:db_id db-id, :schema "schema2"}]
+                         Table    [_ {:db_id db-id, :schema "schema1", :name "t3"}]]
+           (perms/revoke-permissions! (perms-group/all-users) db-id)
+           (perms/grant-permissions!  (perms-group/all-users) db-id "schema1")
+           (map :name ((test-users/user->client :rasta) :get 200 (format "database/%d/schema/%s" db-id "schema1")))))))
 
 ;; Can we fetch the Tables in a Schema? (If we have full Table perms)
-(expect
-  ["t1" "t3"]
-  (tt/with-temp* [Database [{db-id :id}]
-                  Table    [t1 {:db_id db-id, :schema "schema1", :name "t1"}]
-                  Table    [_  {:db_id db-id, :schema "schema2"}]
-                  Table    [t3 {:db_id db-id, :schema "schema1", :name "t3"}]]
-        (perms/revoke-permissions! (perms-group/all-users) db-id)
-    (perms/grant-permissions!  (perms-group/all-users) db-id "schema1" t1)
-    (perms/grant-permissions!  (perms-group/all-users) db-id "schema1" t3)
-    (map :name ((test-users/user->client :rasta) :get 200 (format "database/%d/schema/%s" db-id "schema1")))))
+(deftest can-fetch-tables-in-a-schmea-with-full-table-perms
+  (is (= ["t1" "t3"]
+         (tt/with-temp* [Database [{db-id :id}]
+                         Table    [t1 {:db_id db-id, :schema "schema1", :name "t1"}]
+                         Table    [_  {:db_id db-id, :schema "schema2"}]
+                         Table    [t3 {:db_id db-id, :schema "schema1", :name "t3"}]]
+           (perms/revoke-permissions! (perms-group/all-users) db-id)
+           (perms/grant-permissions!  (perms-group/all-users) db-id "schema1" t1)
+           (perms/grant-permissions!  (perms-group/all-users) db-id "schema1" t3)
+           (map :name ((test-users/user->client :rasta) :get 200 (format "database/%d/schema/%s" db-id "schema1")))))))
 
 ;; GET /api/database/:id/schemas should return a 403 for a user that doesn't have read permissions
-(expect
-  "You don't have permissions to do that."
-  (tt/with-temp* [Database [{database-id :id}]
-                  Table    [_ {:db_id database-id, :schema "test"}]]
-    (perms/revoke-permissions! (perms-group/all-users) database-id)
-    ((test-users/user->client :rasta) :get 403 (format "database/%s/schemas" database-id))))
+(deftest return-403-when-you-aint-got-permission
+  (is (= "You don't have permissions to do that."
+         (tt/with-temp* [Database [{database-id :id}]
+                         Table    [_ {:db_id database-id, :schema "test"}]]
+           (perms/revoke-permissions! (perms-group/all-users) database-id)
+           ((test-users/user->client :rasta) :get 403 (format "database/%s/schemas" database-id))))))
 
 ;; GET /api/database/:id/schemas should exclude schemas for which the user has no perms
-(expect
-  ["schema-with-perms"]
-  (tt/with-temp* [Database [{database-id :id}]
-                  Table    [_ {:db_id database-id, :schema "schema-with-perms"}]
-                  Table    [_ {:db_id database-id, :schema "schema-without-perms"}]]
-    (perms/revoke-permissions! (perms-group/all-users) database-id)
-    (perms/grant-permissions!  (perms-group/all-users) database-id "schema-with-perms")
-    ((test-users/user->client :rasta) :get 200 (format "database/%s/schemas" database-id))))
+(deftest exclude-schemas-when-user-aint-got-perms-for-them
+  (is (= ["schema-with-perms"]
+         (tt/with-temp* [Database [{database-id :id}]
+                         Table    [_ {:db_id database-id, :schema "schema-with-perms"}]
+                         Table    [_ {:db_id database-id, :schema "schema-without-perms"}]]
+           (perms/revoke-permissions! (perms-group/all-users) database-id)
+           (perms/grant-permissions!  (perms-group/all-users) database-id "schema-with-perms")
+           ((test-users/user->client :rasta) :get 200 (format "database/%s/schemas" database-id))))))
 
 ;; GET /api/database/:id/schema/:schema should return a 403 for a user that doesn't have read permissions FOR THE DB...
-(expect
-  "You don't have permissions to do that."
-  (tt/with-temp* [Database [{database-id :id}]
-                  Table    [{table-id :id} {:db_id database-id, :schema "test"}]]
-    (perms/revoke-permissions! (perms-group/all-users) database-id)
-    ((test-users/user->client :rasta) :get 403 (format "database/%s/schema/%s" database-id "test"))))
+(deftest return-403-when-user-doesnt-have-db-permissions
+  (is (= "You don't have permissions to do that."
+         (tt/with-temp* [Database [{database-id :id}]
+                         Table    [{table-id :id} {:db_id database-id, :schema "test"}]]
+           (perms/revoke-permissions! (perms-group/all-users) database-id)
+           ((test-users/user->client :rasta) :get 403 (format "database/%s/schema/%s" database-id "test"))))))
 
 ;; ... or for the SCHEMA
-(expect
-  "You don't have permissions to do that."
-  (tt/with-temp* [Database [{database-id :id}]
-                  Table    [_ {:db_id database-id, :schema "schema-with-perms"}]
-                  Table    [_ {:db_id database-id, :schema "schema-without-perms"}]]
-    (perms/revoke-permissions! (perms-group/all-users) database-id)
-    (perms/grant-permissions!  (perms-group/all-users) database-id "schema-with-perms")
-    ((test-users/user->client :rasta) :get 403 (format "database/%s/schema/%s" database-id "schema-without-perms"))))
+(deftest return-403-when-user-doesnt-have-schema-permissions
+  (is (= "You don't have permissions to do that."
+         (tt/with-temp* [Database [{database-id :id}]
+                         Table    [_ {:db_id database-id, :schema "schema-with-perms"}]
+                         Table    [_ {:db_id database-id, :schema "schema-without-perms"}]]
+           (perms/revoke-permissions! (perms-group/all-users) database-id)
+           (perms/grant-permissions!  (perms-group/all-users) database-id "schema-with-perms")
+           ((test-users/user->client :rasta) :get 403 (format "database/%s/schema/%s" database-id "schema-without-perms"))))))
 
 ;; Looking for a database that doesn't exist should return a 404
-(expect
-  "Not found."
-  ((test-users/user->client :crowberto) :get 404 (format "database/%s/schemas" Integer/MAX_VALUE)))
+(deftest return-404-when-no-db
+  (is (= "Not found."
+         ((test-users/user->client :crowberto) :get 404 (format "database/%s/schemas" Integer/MAX_VALUE)))))
 
 ;; Check that a 404 returns if the schema isn't found
-(expect
-  "Not found."
-  (tt/with-temp* [Database [{db-id :id}]
-                  Table    [{t1-id :id} {:db_id db-id, :schema "schema1"}]]
-    ((test-users/user->client :crowberto) :get 404 (format "database/%d/schema/%s" db-id "not schema1"))))
+(deftest return-404-when-no-schema
+  (is (= "Not found."
+         (tt/with-temp* [Database [{db-id :id}]
+                         Table    [{t1-id :id} {:db_id db-id, :schema "schema1"}]]
+           ((test-users/user->client :crowberto) :get 404 (format "database/%d/schema/%s" db-id "not schema1"))))))
 
 
 ;; GET /api/database/:id/schema/:schema should exclude Tables for which the user has no perms
-(expect
-  ["table-with-perms"]
-  (tt/with-temp* [Database [{database-id :id}]
-                  Table    [table-with-perms {:db_id database-id, :schema "public", :name "table-with-perms"}]
-                  Table    [_                {:db_id database-id, :schema "public", :name "table-without-perms"}]]
-    (perms/revoke-permissions! (perms-group/all-users) database-id)
-    (perms/grant-permissions!  (perms-group/all-users) database-id "public" table-with-perms)
-    (map :name ((test-users/user->client :rasta) :get 200 (format "database/%s/schema/%s" database-id "public")))))
+(deftest db-schema-endpoint-excludes-tables-when-user-has-no-perms
+  (is (= ["table-with-perms"]
+         (tt/with-temp* [Database [{database-id :id}]
+                         Table    [table-with-perms {:db_id database-id, :schema "public", :name "table-with-perms"}]
+                         Table    [_                {:db_id database-id, :schema "public", :name "table-without-perms"}]]
+           (perms/revoke-permissions! (perms-group/all-users) database-id)
+           (perms/grant-permissions!  (perms-group/all-users) database-id "public" table-with-perms)
+           (map :name ((test-users/user->client :rasta) :get 200 (format "database/%s/schema/%s" database-id "public")))))))
 
 ;; GET /api/database/:id/schema/:schema should exclude inactive Tables
-(expect
-  ["table"]
-  (tt/with-temp* [Database [{database-id :id}]
-                  Table    [_ {:db_id database-id, :schema "public", :name "table"}]
-                  Table    [_ {:db_id database-id, :schema "public", :name "inactive-table", :active false}]]
-    (map :name ((test-users/user->client :rasta) :get 200 (format "database/%s/schema/%s" database-id "public")))))
+(deftest exclude-inactive-tables
+  (is (= ["table"])
+      (tt/with-temp* [Database [{database-id :id}]
+                      Table    [_ {:db_id database-id, :schema "public", :name "table"}]
+                      Table    [_ {:db_id database-id, :schema "public", :name "inactive-table", :active false}]]
+        (map :name ((test-users/user->client :rasta) :get 200 (format "database/%s/schema/%s" database-id "public"))))))

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -60,8 +60,8 @@
 (deftest basic-query-test
   (testing "POST /api/meta/dataset"
     (testing "Just a basic sanity check to make sure Query Processor endpoint is still working correctly."
-      (let [result ((test-users/user->client :rasta) :post 200 "dataset" (data/mbql-query checkins
-                                                                           {:aggregation [[:count]]}))]
+      (let [result ((test-users/user->client :rasta) :post 202 "dataset" (data/mbql-query checkins
+                                                                                          {:aggregation [[:count]]}))]
         (is (= {:data                   {:rows             [[1000]]
                                          :cols             [(tu/obj->json->obj (qp.test/aggregate-col :count))]
                                          :native_form      true
@@ -70,7 +70,7 @@
                 :status                 "completed"
                 :context                "ad-hoc"
                 :json_query             (-> (data/mbql-query checkins
-                                              {:aggregation [[:count]]})
+                                                             {:aggregation [[:count]]})
                                             (assoc-in [:query :aggregation] [["count"]])
                                             (assoc :type "query")
                                             (merge query-defaults))
@@ -106,11 +106,11 @@
                                                          (re-find #"Syntax error in SQL statement")
                                                          boolean))))
           result              (tu.log/suppress-output
-                                ((test-users/user->client :rasta) :post 200 "dataset" {:database (data/id)
-                                                                                       :type     "native"
-                                                                                       :native   {:query "foobar"}}))]
-      (is (= {:data         {:rows    []
-                             :cols    []}
+                               ((test-users/user->client :rasta) :post 202 "dataset" {:database (data/id)
+                                                                                      :type     "native"
+                                                                                      :native   {:query "foobar"}}))]
+      (is (= {:data         {:rows []
+                             :cols []}
               :row_count    0
               :status       "failed"
               :context      "ad-hoc"
@@ -253,7 +253,7 @@
   10
   (with-redefs [constraints/default-query-constraints {:max-results 10, :max-results-bare-rows 10}]
     (let [{row-count :row_count, :as result}
-          ((test-users/user->client :rasta) :post 200 "dataset"
+          ((test-users/user->client :rasta) :post 202 "dataset"
            {:database (data/id)
             :type     :query
             :query    {:source-table (data/id :venues)}})]

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -6,7 +6,6 @@
             [clojure.data.csv :as csv]
             [clojure.test :refer :all]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
-            [expectations :refer [expect]]
             [medley.core :as m]
             [metabase
              [query-processor-test :as qp.test]

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -4,9 +4,10 @@
              [jwt :as jwt]
              [util :as buddy-util]]
             [clj-time.core :as time]
+            [clojure
+             [string :as str]
+             [test :refer :all]]
             [clojure.data.csv :as csv]
-            [clojure.string :as str]
-            [clojure.test :refer :all]
             [crypto.random :as crypto-random]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
             [expectations :refer [expect]]

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -6,6 +6,7 @@
             [clj-time.core :as time]
             [clojure.data.csv :as csv]
             [clojure.string :as str]
+            [clojure.test :refer :all]
             [crypto.random :as crypto-random]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
             [expectations :refer [expect]]
@@ -116,57 +117,56 @@
 
 (defn- card-url [card & [additional-token-params]] (str "embed/card/" (card-token card additional-token-params)))
 
-;; it should be possible to use this endpoint successfully if all the conditions are met
-(expect
-  successful-card-info
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-card [card {:enable_embedding true}]
-      (dissoc-id-and-name
-        (http/client :get 200 (card-url card))))))
 
-;; We should fail when attempting to use an expired token
-(expect
-  #"Token is expired"
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-card [card {:enable_embedding true}]
-      (http/client :get 400 (card-url card {:exp (buddy-util/to-timestamp yesterday)})))))
+(deftest it-should-be-possible-to-use-this-endpoint-successfully-if-all-the-conditions-are-met
+  (is (= successful-card-info
+         (with-embedding-enabled-and-new-secret-key
+           (with-temp-card [card {:enable_embedding true}]
+             (dissoc-id-and-name
+              (http/client :get 200 (card-url card))))))))
 
-;; check that the endpoint doesn't work if embedding isn't enabled
-(expect
-  "Embedding is not enabled."
-  (tu/with-temporary-setting-values [enable-embedding false]
-    (with-new-secret-key
-      (with-temp-card [card]
-        (http/client :get 400 (card-url card))))))
+(deftest we-should-fail-when-attempting-to-use-an-expired-token
+  (is (re-find #"Token is expired"
+               (with-embedding-enabled-and-new-secret-key
+                 (with-temp-card [card {:enable_embedding true}]
+                   (http/client :get 400 (card-url card {:exp (buddy-util/to-timestamp yesterday)})))))))
 
-;; check that if embedding *is* enabled globally but not for the Card the request fails
-(expect
-  "Embedding is not enabled for this object."
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-card [card]
-      (http/client :get 400 (card-url card)))))
+(deftest check-that-the-endpoint-doesn-t-work-if-embedding-isn-t-enabled
+  (is (= "Embedding is not enabled."
+         (tu/with-temporary-setting-values [enable-embedding false]
+           (with-new-secret-key
+             (with-temp-card [card]
+               (http/client :get 400 (card-url card))))))))
+
+(deftest check-that-if-embedding--is--enabled-globally-but-not-for-the-card-the-request-fails
+  (is (= "Embedding is not enabled for this object."
+         (with-embedding-enabled-and-new-secret-key
+           (with-temp-card [card]
+             (http/client :get 400 (card-url card)))))))
 
 ;; check that if embedding is enabled globally and for the object that requests fail if they are signed with the wrong
 ;; key
-(expect
-  "Message seems corrupt or manipulated."
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-card [card {:enable_embedding true}]
-      (http/client :get 400 (with-new-secret-key (card-url card))))))
+(deftest global-embedding-requests-fail-with-wrong-key
+  (is (= "Message seems corrupt or manipulated."
+         (with-embedding-enabled-and-new-secret-key
+           (with-temp-card [card {:enable_embedding true}]
+             (http/client :get 400 (with-new-secret-key (card-url card))))))))
+
 
 ;; check that only ENABLED params that ARE NOT PRESENT IN THE JWT come back
-(expect
-  [{:id nil, :type "date/single", :target ["variable" ["template-tag" "d"]], :name "d", :slug "d", :default nil}]
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-card [card {:enable_embedding true
-                           :dataset_query    {:database (data/id)
-                                              :type     :native
-                                              :native   {:template-tags {:a {:type "date", :name "a", :display_name "a"}
-                                                                         :b {:type "date", :name "b", :display_name "b"}
-                                                                         :c {:type "date", :name "c", :display_name "c"}
-                                                                         :d {:type "date", :name "d", :display_name "d"}}}}
-                           :embedding_params {:a "locked", :b "disabled", :c "enabled", :d "enabled"}}]
-      (:parameters (http/client :get 200 (card-url card {:params {:c 100}}))))))
+(deftest check-that-only-enabled-params-that-are-not-present-in-the-jwt-come-back
+  (is (= [{:id nil, :type "date/single", :target ["variable" ["template-tag" "d"]], :name "d", :slug "d", :default nil}]
+         (with-embedding-enabled-and-new-secret-key
+           (with-temp-card [card {:enable_embedding true
+                                  :dataset_query    {:database (data/id)
+                                                     :type     :native
+                                                     :native   {:template-tags {:a {:type "date", :name "a", :display_name "a"}
+                                                                                :b {:type "date", :name "b", :display_name "b"}
+                                                                                :c {:type "date", :name "c", :display_name "c"}
+                                                                                :d {:type "date", :name "d", :display_name "d"}}}}
+                                  :embedding_params {:a "locked", :b "disabled", :c "enabled", :d "enabled"}}]
+             (:parameters (http/client :get 200 (card-url card {:params {:c 100}}))))))))
+
 
 
 ;;; ------------------------- GET /api/embed/card/:token/query (and JSON/CSV/XLSX variants) --------------------------
@@ -193,7 +193,7 @@
   (successful-query-results response-format)
   (with-embedding-enabled-and-new-secret-key
     (with-temp-card [card {:enable_embedding true}]
-      (http/client :get 200 (card-query-url card response-format) request-options))))
+      (http/client :get 202 (card-query-url card response-format) request-options))))
 
 ;; but if the card has an invalid query we should just get a generic "query failed" exception (rather than leaking
 ;; query info)
@@ -234,35 +234,34 @@
 ;; Downloading CSV/JSON/XLSX results shouldn't be subject to the default query constraints
 ;; -- even if the query comes in with `add-default-userland-constraints` (as will be the case if the query gets saved
 ;; from one that had it -- see #9831 and #10399)
-(expect
-  101
-  (with-redefs [constraints/default-query-constraints {:max-results 10, :max-results-bare-rows 10}]
-    (with-embedding-enabled-and-new-secret-key
-      (with-temp-card [card {:enable_embedding true
-                             :dataset_query    (assoc (data/mbql-query venues)
-                                                      :middleware
-                                                      {:add-default-userland-constraints? true
-                                                       :userland-query?                   true})}]
-        (let [results (http/client :get 200 (card-query-url card "/csv"))]
-          (count (csv/read-csv results)))))))
-
+(deftest download-formatted-without-constraints
+  (is (= 101
+         (with-redefs [constraints/default-query-constraints {:max-results 10, :max-results-bare-rows 10}]
+           (with-embedding-enabled-and-new-secret-key
+             (with-temp-card [card {:enable_embedding true
+                                    :dataset_query    (assoc (data/mbql-query venues)
+                                                             :middleware
+                                                             {:add-default-userland-constraints? true
+                                                              :userland-query?                   true})}]
+               (let [results (http/client :get 202 (card-query-url card "/csv"))]
+                 (count (csv/read-csv results)))))))))
 
 ;;; LOCKED params
 
 ;; check that if embedding is enabled globally and for the object requests fail if the token is missing a `:locked`
 ;; parameter
 (expect-for-response-formats [response-format]
-  "You must specify a value for :abc in the JWT."
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-card [card {:enable_embedding true, :embedding_params {:abc "locked"}}]
-      (http/client :get 400 (card-query-url card response-format)))))
+                             "You must specify a value for :abc in the JWT."
+                             (with-embedding-enabled-and-new-secret-key
+                               (with-temp-card [card {:enable_embedding true, :embedding_params {:abc "locked"}}]
+                                 (http/client :get 400 (card-query-url card response-format)))))
 
 ;; if `:locked` param is present, request should succeed
 (expect-for-response-formats [response-format request-options]
   (successful-query-results response-format)
   (with-embedding-enabled-and-new-secret-key
     (with-temp-card [card {:enable_embedding true, :embedding_params {:abc "locked"}}]
-      (http/client :get 200 (card-query-url card response-format {:params {:abc 100}}) request-options))))
+      (http/client :get 202 (card-query-url card response-format {:params {:abc 100}}) request-options))))
 
 ;; If `:locked` parameter is present in URL params, request should fail
 (expect-for-response-formats [response-format]
@@ -302,14 +301,14 @@
   (successful-query-results response-format)
   (with-embedding-enabled-and-new-secret-key
     (with-temp-card [card {:enable_embedding true, :embedding_params {:abc "enabled"}}]
-      (http/client :get 200 (card-query-url card response-format {:params {:abc "enabled"}}) request-options))))
+      (http/client :get 202 (card-query-url card response-format {:params {:abc "enabled"}}) request-options))))
 
 ;; If an `:enabled` param is present in URL params but *not* the JWT, that's ok
 (expect-for-response-formats [response-format request-options]
   (successful-query-results response-format)
   (with-embedding-enabled-and-new-secret-key
     (with-temp-card [card {:enable_embedding true, :embedding_params {:abc "enabled"}}]
-      (http/client :get 200 (str (card-query-url card response-format) "?abc=200") request-options))))
+      (http/client :get 202 (str (card-query-url card response-format) "?abc=200") request-options))))
 
 
 ;; make sure CSV (etc.) downloads take editable params into account (#6407)
@@ -326,78 +325,74 @@
    :enable_embedding true
    :embedding_params {:date :enabled}})
 
-(expect
-  "count\n107\n"
-  (with-embedding-enabled-and-new-secret-key
-    (tt/with-temp Card [card (card-with-date-field-filter)]
-      (http/client :get 200 (str (card-query-url card "/csv") "?date=Q1-2014")))))
+(deftest csv-reports-count
+  (is (= "count\n107\n"
+         (with-embedding-enabled-and-new-secret-key
+           (tt/with-temp Card [card (card-with-date-field-filter)]
+             (http/client :get 202 (str (card-query-url card "/csv") "?date=Q1-2014")))))))
 
-;; make sure it also works with the forwarded URL
-(expect
-  "count\n107\n"
-  (with-embedding-enabled-and-new-secret-key
-    (tt/with-temp Card [card (card-with-date-field-filter)]
-      ;; make sure the URL doesn't include /api/ at the beginning like it normally would
-      (binding [http/*url-prefix* (str/replace http/*url-prefix* #"/api/$" "/")]
-        (tu/with-temporary-setting-values [site-url http/*url-prefix*]
-          (http/client :get 200 (str "embed/question/" (card-token card) ".csv?date=Q1-2014")))))))
 
+(deftest make-sure-it-also-works-with-the-forwarded-url
+  (is (= "count\n107\n"
+         (with-embedding-enabled-and-new-secret-key
+           (tt/with-temp Card [card (card-with-date-field-filter)]
+             ;; make sure the URL doesn't include /api/ at the beginning like it normally would
+             (binding [http/*url-prefix* (str/replace http/*url-prefix* #"/api/$" "/")]
+               (tu/with-temporary-setting-values [site-url http/*url-prefix*]
+                 (http/client :get 202 (str "embed/question/" (card-token card) ".csv?date=Q1-2014")))))))))
 
 ;;; ---------------------------------------- GET /api/embed/dashboard/:token -----------------------------------------
 
 (defn- dashboard-url [dashboard & [additional-token-params]]
   (str "embed/dashboard/" (dash-token dashboard additional-token-params)))
 
-;; it should be possible to call this endpoint successfully
-(expect
-  successful-dashboard-info
-  (with-embedding-enabled-and-new-secret-key
-    (tt/with-temp Dashboard [dash {:enable_embedding true}]
-      (dissoc-id-and-name
-        (http/client :get 200 (dashboard-url dash))))))
 
-;; We should fail when attempting to use an expired token
-(expect
-  #"Token is expired"
-  (with-embedding-enabled-and-new-secret-key
-    (tt/with-temp Dashboard [dash {:enable_embedding true}]
-      (http/client :get 400 (dashboard-url dash {:exp (buddy-util/to-timestamp yesterday)})))))
+(deftest it-should-be-possible-to-call-this-endpoint-successfully
+  (is (= successful-dashboard-info
+         (with-embedding-enabled-and-new-secret-key
+           (tt/with-temp Dashboard [dash {:enable_embedding true}]
+             (dissoc-id-and-name
+              (http/client :get 200 (dashboard-url dash))))))))
 
-;; check that the endpoint doesn't work if embedding isn't enabled
-(expect
-  "Embedding is not enabled."
-  (tu/with-temporary-setting-values [enable-embedding false]
-    (with-new-secret-key
-      (tt/with-temp Dashboard [dash]
-        (http/client :get 400 (dashboard-url dash))))))
+(deftest we-should-fail-when-attempting-to-use-an-expired-token
+  (is (re-find #"Token is expired"
+               (with-embedding-enabled-and-new-secret-key
+                 (tt/with-temp Dashboard [dash {:enable_embedding true}]
+                   (http/client :get 400 (dashboard-url dash {:exp (buddy-util/to-timestamp yesterday)})))))))
 
-;; check that if embedding *is* enabled globally but not for the Dashboard the request fails
-(expect
-  "Embedding is not enabled for this object."
-  (with-embedding-enabled-and-new-secret-key
-    (tt/with-temp Dashboard [dash]
-      (http/client :get 400 (dashboard-url dash)))))
+(deftest check-that-the-dashboard-endpoint-doesn-t-work-if-embedding-isn-t-enabled
+  (is (= "Embedding is not enabled."
+         (tu/with-temporary-setting-values [enable-embedding false]
+           (with-new-secret-key
+             (tt/with-temp Dashboard [dash]
+               (http/client :get 400 (dashboard-url dash))))))))
+
+(deftest check-that-if-embedding--is--enabled-globally-but-not-for-the-dashboard-the-request-fails
+  (is (= "Embedding is not enabled for this object."
+         (with-embedding-enabled-and-new-secret-key
+           (tt/with-temp Dashboard [dash]
+             (http/client :get 400 (dashboard-url dash)))))))
 
 ;; check that if embedding is enabled globally and for the object that requests fail if they are signed with the wrong
 ;; key
-(expect
-  "Message seems corrupt or manipulated."
-  (with-embedding-enabled-and-new-secret-key
-    (tt/with-temp Dashboard [dash {:enable_embedding true}]
-      (http/client :get 400 (with-new-secret-key (dashboard-url dash))))))
+(deftest global-embedding-check-key
+  (is (= "Message seems corrupt or manipulated."
+         (with-embedding-enabled-and-new-secret-key
+           (tt/with-temp Dashboard [dash {:enable_embedding true}]
+             (http/client :get 400 (with-new-secret-key (dashboard-url dash))))))))
+
 
 ;; check that only ENABLED params that ARE NOT PRESENT IN THE JWT come back
-(expect
-  [{:slug "d", :name "d", :type "date"}]
-  (with-embedding-enabled-and-new-secret-key
-    (tt/with-temp Dashboard [dash {:enable_embedding true
-                                   :embedding_params {:a "locked", :b "disabled", :c "enabled", :d "enabled"}
-                                   :parameters       [{:slug "a", :name "a", :type "date"}
-                                                      {:slug "b", :name "b", :type "date"}
-                                                      {:slug "c", :name "c", :type "date"}
-                                                      {:slug "d", :name "d", :type "date"}]}]
-      (:parameters (http/client :get 200 (dashboard-url dash {:params {:c 100}}))))))
-
+(deftest only-enabled-params-that-are-not-present-in-the-jwt-come-back
+  (is (= [{:slug "d", :name "d", :type "date"}]
+         (with-embedding-enabled-and-new-secret-key
+           (tt/with-temp Dashboard [dash {:enable_embedding true
+                                          :embedding_params {:a "locked", :b "disabled", :c "enabled", :d "enabled"}
+                                          :parameters       [{:slug "a", :name "a", :type "date"}
+                                                             {:slug "b", :name "b", :type "date"}
+                                                             {:slug "c", :name "c", :type "date"}
+                                                             {:slug "d", :name "d", :type "date"}]}]
+             (:parameters (http/client :get 200 (dashboard-url dash {:params {:c 100}}))))))))
 
 ;;; ---------------------- GET /api/embed/dashboard/:token/dashcard/:dashcard-id/card/:card-id -----------------------
 
@@ -407,145 +402,151 @@
        "/card/" (:card_id dashcard)))
 
 ;; it should be possible to run a Card successfully if you jump through the right hoops...
-(expect
-  (successful-query-results)
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-dashcard [dashcard {:dash {:enable_embedding true}}]
-      (http/client :get 202 (dashcard-url dashcard)))))
+(deftest it-should-be-possible-to-run-a-card-successfully-if-you-jump-through-the-right-hoops---
+  (is (= (successful-query-results)
+         (with-embedding-enabled-and-new-secret-key
+           (with-temp-dashcard [dashcard {:dash {:enable_embedding true}}]
+             (http/client :get 202 (dashcard-url dashcard)))))))
+
 
 ;; Downloading CSV/JSON/XLSX results from the dashcard endpoint shouldn't be subject to the default query constraints
 ;; (#10399)
-(expect
-  101
-  (with-redefs [constraints/default-query-constraints {:max-results 10, :max-results-bare-rows 10}]
-    (with-embedding-enabled-and-new-secret-key
-      (with-temp-dashcard [dashcard {:dash {:enable_embedding true}
-                                     :card {:dataset_query (assoc (data/mbql-query venues)
-                                                                  :middleware
-                                                                  {:add-default-userland-constraints? true
-                                                                   :userland-query?                   true})}}]
-        (let [results (http/client :get 200 (str (dashcard-url dashcard) "/csv"))]
-          (count (csv/read-csv results)))))))
+(deftest downloading-csv-json-xlsx-results-from-the-dashcard-endpoint-shouldn-t-be-subject-to-the-default-query-constraints
+  (is (= 101
+         (with-redefs [constraints/default-query-constraints {:max-results 10, :max-results-bare-rows 10}]
+           (with-embedding-enabled-and-new-secret-key
+             (with-temp-dashcard [dashcard {:dash {:enable_embedding true}
+                                            :card {:dataset_query (assoc (data/mbql-query venues)
+                                                                         :middleware
+                                                                         {:add-default-userland-constraints? true
+                                                                          :userland-query?                   true})}}]
+               (let [results (http/client :get 202 (str (dashcard-url dashcard) "/csv"))]
+                 (count (csv/read-csv results)))))))))
 
 ;; but if the card has an invalid query we should just get a generic "query failed" exception (rather than leaking
 ;; query info)
-(expect
-  {:status "failed"
-   :error  "An error occurred while running the query."}
-  (tu.log/suppress-output
-   (with-embedding-enabled-and-new-secret-key
-     (with-temp-dashcard [dashcard {:dash {:enable_embedding true}
-                                    :card {:dataset_query (data/native-query {:query "SELECT * FROM XYZ"})}}]
-       (http/client :get 202 (dashcard-url dashcard))))))
 
-;; check that the endpoint doesn't work if embedding isn't enabled
-(expect
-  "Embedding is not enabled."
-  (tu/with-temporary-setting-values [enable-embedding false]
-    (with-new-secret-key
-      (with-temp-dashcard [dashcard]
-        (http/client :get 400 (dashcard-url dashcard))))))
+(deftest generic-query-failed-exception
+  (is (= {:status "failed"
+          :error  "An error occurred while running the query."}
+         (tu.log/suppress-output
+          (with-embedding-enabled-and-new-secret-key
+            (with-temp-dashcard [dashcard {:dash {:enable_embedding true}
+                                           :card {:dataset_query (data/native-query {:query "SELECT * FROM XYZ"})}}]
+              (http/client :get 202 (dashcard-url dashcard))))))))
 
-;; check that if embedding *is* enabled globally but not for the Dashboard the request fails
-(expect
-  "Embedding is not enabled for this object."
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-dashcard [dashcard]
-      (http/client :get 400 (dashcard-url dashcard)))))
+
+(deftest check-that-the-dashcard-endpoint-doesn-t-work-if-embedding-isn-t-enabled
+  (is (= "Embedding is not enabled."
+         (tu/with-temporary-setting-values [enable-embedding false]
+           (with-new-secret-key
+             (with-temp-dashcard [dashcard]
+               (http/client :get 400 (dashcard-url dashcard))))))))
+
+(deftest dashcard-check-that-if-embedding--is--enabled-globally-but-not-for-the-dashboard-the-request-fails
+  (is (= "Embedding is not enabled for this object."
+         (with-embedding-enabled-and-new-secret-key
+           (with-temp-dashcard [dashcard]
+             (http/client :get 400 (dashcard-url dashcard)))))))
 
 ;; check that if embedding is enabled globally and for the object that requests fail if they are signed with the wrong
 ;; key
-(expect
-  "Message seems corrupt or manipulated."
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-dashcard [dashcard {:dash {:enable_embedding true}}]
-      (http/client :get 400 (with-new-secret-key (dashcard-url dashcard))))))
+
+(deftest dashcard-global-embedding-check-key
+  (is (= "Message seems corrupt or manipulated."
+         (with-embedding-enabled-and-new-secret-key
+           (with-temp-dashcard [dashcard {:dash {:enable_embedding true}}]
+             (http/client :get 400 (with-new-secret-key (dashcard-url dashcard))))))))
 
 ;;; LOCKED params
 
 ;; check that if embedding is enabled globally and for the object requests fail if the token is missing a `:locked`
 ;; parameter
-(expect
-  "You must specify a value for :abc in the JWT."
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "locked"}}}]
-      (http/client :get 400 (dashcard-url dashcard)))))
+
+(deftest check-missing-locked-param
+  (is (= "You must specify a value for :abc in the JWT."
+         (with-embedding-enabled-and-new-secret-key
+           (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "locked"}}}]
+             (http/client :get 400 (dashcard-url dashcard)))))))
 
 ;; if `:locked` param is supplied, request should succeed
-(expect
-  (successful-query-results)
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "locked"}}}]
-      (http/client :get 202 (dashcard-url dashcard {:params {:abc 100}})))))
+(deftest if---locked--param-is-supplied--request-should-succeed
+  (is (= (successful-query-results)
+         (with-embedding-enabled-and-new-secret-key
+           (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "locked"}}}]
+             (http/client :get 202 (dashcard-url dashcard {:params {:abc 100}})))))))
+
 
 ;; if `:locked` parameter is present in URL params, request should fail
-(expect
-  "You must specify a value for :abc in the JWT."
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "locked"}}}]
-      (http/client :get 400 (str (dashcard-url dashcard) "?abc=100")))))
+(deftest if---locked--parameter-is-present-in-url-params--request-should-fail
+  (is (= "You must specify a value for :abc in the JWT."
+         (with-embedding-enabled-and-new-secret-key
+           (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "locked"}}}]
+             (http/client :get 400 (str (dashcard-url dashcard) "?abc=100")))))))
+
 
 ;;; DISABLED params
 
 ;; check that if embedding is enabled globally and for the object requests fail if they pass a `:disabled` parameter
-(expect
-  "You're not allowed to specify a value for :abc."
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "disabled"}}}]
-      (http/client :get 400 (dashcard-url dashcard {:params {:abc 100}})))))
+(deftest check-that-if-embedding-is-enabled-globally-and-for-the-object-requests-fail-if-they-pass-a---disabled--parameter
+  (is (= "You're not allowed to specify a value for :abc."
+         (with-embedding-enabled-and-new-secret-key
+           (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "disabled"}}}]
+             (http/client :get 400 (dashcard-url dashcard {:params {:abc 100}})))))))
 
 ;; If a `:disabled` param is passed in the URL the request should fail
-(expect
-  "You're not allowed to specify a value for :abc."
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "disabled"}}}]
-      (http/client :get 400 (str (dashcard-url dashcard) "?abc=200")))))
+(deftest if-a---disabled--param-is-passed-in-the-url-the-request-should-fail
+  (is (= "You're not allowed to specify a value for :abc."
+         (with-embedding-enabled-and-new-secret-key
+           (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "disabled"}}}]
+             (http/client :get 400 (str (dashcard-url dashcard) "?abc=200")))))))
+
 
 ;;; ENABLED params
 
 ;; If `:enabled` param is present in both JWT and the URL, the request should fail
-(expect
-  "You can't specify a value for :abc if it's already set in the JWT."
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "enabled"}}}]
-      (http/client :get 400 (str (dashcard-url dashcard {:params {:abc 100}}) "?abc=200")))))
+(deftest if---enabled--param-is-present-in-both-jwt-and-the-url--the-request-should-fail
+  (is (= "You can't specify a value for :abc if it's already set in the JWT."
+         (with-embedding-enabled-and-new-secret-key
+           (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "enabled"}}}]
+             (http/client :get 400 (str (dashcard-url dashcard {:params {:abc 100}}) "?abc=200")))))))
 
 ;; If an `:enabled` param is present in the JWT, that's ok
-(expect
-  (successful-query-results)
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "enabled"}}}]
-      (http/client :get 202 (dashcard-url dashcard {:params {:abc 100}})))))
+(deftest if-an---enabled--param-is-present-in-the-jwt--that-s-ok
+  (is (= (successful-query-results)
+         (with-embedding-enabled-and-new-secret-key
+           (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "enabled"}}}]
+             (http/client :get 202 (dashcard-url dashcard {:params {:abc 100}})))))))
 
 ;; If an `:enabled` param is present in URL params but *not* the JWT, that's ok
-(expect
-  (successful-query-results)
-  (with-embedding-enabled-and-new-secret-key
-    (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "enabled"}}}]
-      (http/client :get 202 (str (dashcard-url dashcard) "?abc=200")))))
-
+(deftest if-an---enabled--param-is-present-in-url-params-but--not--the-jwt--that-s-ok
+  (is (= (successful-query-results)
+         (with-embedding-enabled-and-new-secret-key
+           (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "enabled"}}}]
+             (http/client :get 202 (str (dashcard-url dashcard) "?abc=200")))))))
 
 ;;; -------------------------------------------------- Other Tests ---------------------------------------------------
 
 ;; parameters that are not in the `embedding-params` map at all should get removed by
 ;; `remove-locked-and-disabled-params`
-(expect
-  {:parameters []}
-  (#'embed-api/remove-locked-and-disabled-params {:parameters {:slug "foo"}} {}))
+
+(deftest emove-embedding-params
+  (is (= {:parameters []}
+         (#'embed-api/remove-locked-and-disabled-params {:parameters {:slug "foo"}} {}))))
+
 
 ;; make sure that multiline series word as expected (#4768)
-(expect
-  "completed"
-  (with-embedding-enabled-and-new-secret-key
-    (tt/with-temp Card [series-card {:dataset_query {:database (data/id)
-                                                     :type     :query
-                                                     :query    {:source-table (data/id :venues)}}}]
-      (with-temp-dashcard [dashcard {:dash {:enable_embedding true}}]
-        (tt/with-temp DashboardCardSeries [series {:dashboardcard_id (u/get-id dashcard)
-                                                   :card_id          (u/get-id series-card)
-                                                   :position         0}]
-          (:status (http/client :get 202 (str (dashcard-url (assoc dashcard :card_id (u/get-id series-card)))))))))))
-
+(deftest make-sure-that-multiline-series-word-as-expected---4768-
+  (is (= "completed"
+         (with-embedding-enabled-and-new-secret-key
+           (tt/with-temp Card [series-card {:dataset_query {:database (data/id)
+                                                            :type     :query
+                                                            :query    {:source-table (data/id :venues)}}}]
+             (with-temp-dashcard [dashcard {:dash {:enable_embedding true}}]
+               (tt/with-temp DashboardCardSeries [series {:dashboardcard_id (u/get-id dashcard)
+                                                          :card_id          (u/get-id series-card)
+                                                          :position         0}]
+                 (:status (http/client :get 202 (str (dashcard-url (assoc dashcard :card_id (u/get-id series-card)))))))))))))
 
 ;;; ------------------------------- GET /api/embed/card/:token/field/:field-id/values --------------------------------
 
@@ -573,36 +574,35 @@
        ~@body)))
 
 ;; should be able to fetch values for a Field referenced by a public Card
-(expect
-  {:values   [["20th Century Cafe"]
-              ["25°"]
-              ["33 Taps"]
-              ["800 Degrees Neapolitan Pizzeria"]
-              ["BCD Tofu House"]]
-   :field_id (data/id :venues :name)}
-  (with-embedding-enabled-and-temp-card-referencing :venues :name [card]
-    (-> (http/client :get 200 (field-values-url card (data/id :venues :name)))
-        (update :values (partial take 5)))))
+(deftest should-be-able-to-fetch-values-for-a-field-referenced-by-a-public-card
+  (is (= {:values   [["20th Century Cafe"]
+                     ["25°"]
+                     ["33 Taps"]
+                     ["800 Degrees Neapolitan Pizzeria"]
+                     ["BCD Tofu House"]]
+          :field_id (data/id :venues :name)}
+         (with-embedding-enabled-and-temp-card-referencing :venues :name [card]
+           (-> (http/client :get 200 (field-values-url card (data/id :venues :name)))
+               (update :values (partial take 5)))))))
 
 ;; but for Fields that are not referenced we should get an Exception
-(expect
-  "Not found."
-  (with-embedding-enabled-and-temp-card-referencing :venues :name [card]
-    (http/client :get 400 (field-values-url card (data/id :venues :price)))))
+(deftest but-for-fields-that-are-not-referenced-we-should-get-an-exception
+  (is (= "Not found."
+         (with-embedding-enabled-and-temp-card-referencing :venues :name [card]
+           (http/client :get 400 (field-values-url card (data/id :venues :price)))))))
 
 ;; Endpoint should fail if embedding is disabled
-(expect
- "Embedding is not enabled."
- (with-embedding-enabled-and-temp-card-referencing :venues :name [card]
-   (tu/with-temporary-setting-values [enable-embedding false]
-     (http/client :get 400 (field-values-url card (data/id :venues :name))))))
+(deftest endpoint-should-fail-if-embedding-is-disabled
+  (is (= "Embedding is not enabled."
+         (with-embedding-enabled-and-temp-card-referencing :venues :name [card]
+           (tu/with-temporary-setting-values [enable-embedding false]
+             (http/client :get 400 (field-values-url card (data/id :venues :name))))))))
 
-(expect
- "Embedding is not enabled for this object."
- (with-embedding-enabled-and-temp-card-referencing :venues :name [card]
-   (db/update! Card (u/get-id card) :enable_embedding false)
-   (http/client :get 400 (field-values-url card (data/id :venues :name)))))
-
+(deftest embedding-not-enabled-message
+  (is (= "Embedding is not enabled for this object."
+         (with-embedding-enabled-and-temp-card-referencing :venues :name [card]
+           (db/update! Card (u/get-id card) :enable_embedding false)
+           (http/client :get 400 (field-values-url card (data/id :venues :name)))))))
 
 ;;; ----------------------------- GET /api/embed/dashboard/:token/field/:field-id/values -----------------------------
 
@@ -627,36 +627,38 @@
        ~@body)))
 
 ;; should be able to use it when everything is g2g
-(expect
-  {:values   [["20th Century Cafe"]
-              ["25°"]
-              ["33 Taps"]
-              ["800 Degrees Neapolitan Pizzeria"]
-              ["BCD Tofu House"]]
-   :field_id (data/id :venues :name)}
-  (with-embedding-enabled-and-temp-dashcard-referencing :venues :name [dashboard]
-    (-> (http/client :get 200 (field-values-url dashboard (data/id :venues :name)))
-        (update :values (partial take 5)))))
+(deftest should-be-able-to-use-it-when-everything-is-g2g
+  (is (= {:values   [["20th Century Cafe"]
+                     ["25°"]
+                     ["33 Taps"]
+                     ["800 Degrees Neapolitan Pizzeria"]
+                     ["BCD Tofu House"]]
+          :field_id (data/id :venues :name)}
+         (with-embedding-enabled-and-temp-dashcard-referencing :venues :name [dashboard]
+           (-> (http/client :get 200 (field-values-url dashboard (data/id :venues :name)))
+               (update :values (partial take 5)))))))
 
 ;; shound NOT be able to use the endpoint with a Field not referenced by the Dashboard
-(expect
-  "Not found."
-  (with-embedding-enabled-and-temp-dashcard-referencing :venues :name [dashboard]
-    (http/client :get 400 (field-values-url dashboard (data/id :venues :price)))))
+(deftest shound-not-be-able-to-use-the-endpoint-with-a-field-not-referenced-by-the-dashboard
+  (is (= "Not found."
+         (with-embedding-enabled-and-temp-dashcard-referencing :venues :name [dashboard]
+           (http/client :get 400 (field-values-url dashboard (data/id :venues :price)))))))
 
 ;; Endpoint should fail if embedding is disabled
-(expect
-  "Embedding is not enabled."
-  (with-embedding-enabled-and-temp-dashcard-referencing :venues :name [dashboard]
-    (tu/with-temporary-setting-values [enable-embedding false]
-      (http/client :get 400 (field-values-url dashboard (data/id :venues :name))))))
+(deftest field-values-endpoint-should-fail-if-embedding-is-disabled
+  (is (= "Embedding is not enabled."
+         (with-embedding-enabled-and-temp-dashcard-referencing :venues :name [dashboard]
+           (tu/with-temporary-setting-values [enable-embedding false]
+             (http/client :get 400 (field-values-url dashboard (data/id :venues :name))))))))
+
 
 ;; Endpoint should fail if embedding is disabled for the Dashboard
-(expect
-  "Embedding is not enabled for this object."
-  (with-embedding-enabled-and-temp-dashcard-referencing :venues :name [dashboard]
-    (db/update! Dashboard (u/get-id dashboard) :enable_embedding false)
-    (http/client :get 400 (field-values-url dashboard (data/id :venues :name)))))
+(deftest endpoint-should-fail-if-embedding-is-disabled-for-the-dashboard
+  (is (= "Embedding is not enabled for this object."
+         (with-embedding-enabled-and-temp-dashcard-referencing :venues :name [dashboard]
+           (db/update! Dashboard (u/get-id dashboard) :enable_embedding false)
+           (http/client :get 400 (field-values-url dashboard (data/id :venues :name)))))))
+
 
 
 ;;; ----------------------- GET /api/embed/card/:token/field/:field-id/search/:search-field-id -----------------------

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -411,7 +411,7 @@
   (successful-query-results)
   (with-embedding-enabled-and-new-secret-key
     (with-temp-dashcard [dashcard {:dash {:enable_embedding true}}]
-      (http/client :get 200 (dashcard-url dashcard)))))
+      (http/client :get 202 (dashcard-url dashcard)))))
 
 ;; Downloading CSV/JSON/XLSX results from the dashcard endpoint shouldn't be subject to the default query constraints
 ;; (#10399)
@@ -433,10 +433,10 @@
   {:status "failed"
    :error  "An error occurred while running the query."}
   (tu.log/suppress-output
-    (with-embedding-enabled-and-new-secret-key
-      (with-temp-dashcard [dashcard {:dash {:enable_embedding true}
-                                     :card {:dataset_query (data/native-query {:query "SELECT * FROM XYZ"})}}]
-        (http/client :get 200 (dashcard-url dashcard))))))
+   (with-embedding-enabled-and-new-secret-key
+     (with-temp-dashcard [dashcard {:dash {:enable_embedding true}
+                                    :card {:dataset_query (data/native-query {:query "SELECT * FROM XYZ"})}}]
+       (http/client :get 202 (dashcard-url dashcard))))))
 
 ;; check that the endpoint doesn't work if embedding isn't enabled
 (expect
@@ -476,7 +476,7 @@
   (successful-query-results)
   (with-embedding-enabled-and-new-secret-key
     (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "locked"}}}]
-      (http/client :get 200 (dashcard-url dashcard {:params {:abc 100}})))))
+      (http/client :get 202 (dashcard-url dashcard {:params {:abc 100}})))))
 
 ;; if `:locked` parameter is present in URL params, request should fail
 (expect
@@ -515,14 +515,14 @@
   (successful-query-results)
   (with-embedding-enabled-and-new-secret-key
     (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "enabled"}}}]
-      (http/client :get 200 (dashcard-url dashcard {:params {:abc 100}})))))
+      (http/client :get 202 (dashcard-url dashcard {:params {:abc 100}})))))
 
 ;; If an `:enabled` param is present in URL params but *not* the JWT, that's ok
 (expect
   (successful-query-results)
   (with-embedding-enabled-and-new-secret-key
     (with-temp-dashcard [dashcard {:dash {:enable_embedding true, :embedding_params {:abc "enabled"}}}]
-      (http/client :get 200 (str (dashcard-url dashcard) "?abc=200")))))
+      (http/client :get 202 (str (dashcard-url dashcard) "?abc=200")))))
 
 
 ;;; -------------------------------------------------- Other Tests ---------------------------------------------------
@@ -544,7 +544,7 @@
         (tt/with-temp DashboardCardSeries [series {:dashboardcard_id (u/get-id dashcard)
                                                    :card_id          (u/get-id series-card)
                                                    :position         0}]
-          (:status (http/client :get 200 (str (dashcard-url (assoc dashcard :card_id (u/get-id series-card)))))))))))
+          (:status (http/client :get 202 (str (dashcard-url (assoc dashcard :card_id (u/get-id series-card)))))))))))
 
 
 ;;; ------------------------------- GET /api/embed/card/:token/field/:field-id/values --------------------------------

--- a/test/metabase/api/preview_embed_test.clj
+++ b/test/metabase/api/preview_embed_test.clj
@@ -79,7 +79,7 @@
   (embed-test/successful-query-results)
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-card [card]
-      ((test-users/user->client :crowberto) :get 200 (card-query-url card)))))
+      ((test-users/user->client :crowberto) :get 202 (card-query-url card)))))
 
 ;; ...but if the user is not an admin this endpoint should fail
 (expect
@@ -118,7 +118,7 @@
   (embed-test/successful-query-results)
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-card [card]
-      ((test-users/user->client :crowberto) :get 200 (card-query-url card {:_embedding_params {:abc "locked"}
+      ((test-users/user->client :crowberto) :get 202 (card-query-url card {:_embedding_params {:abc "locked"}
                                                                            :params            {:abc 100}})))))
 
 ;; if `:locked` parameter is present in URL params, request should fail
@@ -164,7 +164,7 @@
   (embed-test/successful-query-results)
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-card [card]
-      ((test-users/user->client :crowberto) :get 200 (card-query-url card {:_embedding_params {:abc "enabled"}
+      ((test-users/user->client :crowberto) :get 202 (card-query-url card {:_embedding_params {:abc "enabled"}
                                                                            :params            {:abc "enabled"}})))))
 
 ;; If an `:enabled` param is present in URL params but *not* the JWT, that's ok
@@ -172,7 +172,7 @@
   (embed-test/successful-query-results)
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-card [card]
-      ((test-users/user->client :crowberto) :get 200 (str (card-query-url card {:_embedding_params {:abc "enabled"}})
+      ((test-users/user->client :crowberto) :get 202 (str (card-query-url card {:_embedding_params {:abc "enabled"}})
                                                           "?abc=200")))))
 
 
@@ -241,7 +241,7 @@
   (embed-test/successful-query-results)
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-dashcard [dashcard]
-      ((test-users/user->client :crowberto) :get 200 (dashcard-url dashcard)))))
+      ((test-users/user->client :crowberto) :get 202 (dashcard-url dashcard)))))
 
 ;; ...but if the user is not an admin this endpoint should fail
 (expect
@@ -280,8 +280,8 @@
   (embed-test/successful-query-results)
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-dashcard [dashcard]
-      ((test-users/user->client :crowberto) :get 200 (dashcard-url dashcard
-                                                       {:_embedding_params {:abc "locked"}, :params {:abc 100}})))))
+      ((test-users/user->client :crowberto) :get 202 (dashcard-url dashcard
+                                                                   {:_embedding_params {:abc "locked"}, :params {:abc 100}})))))
 
 ;; If `:locked` parameter is present in URL params, request should fail
 (expect
@@ -326,7 +326,7 @@
   (embed-test/successful-query-results)
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-dashcard [dashcard]
-      ((test-users/user->client :crowberto) :get 200 (dashcard-url dashcard {:_embedding_params {:abc "enabled"}
+      ((test-users/user->client :crowberto) :get 202 (dashcard-url dashcard {:_embedding_params {:abc "enabled"}
                                                                              :params            {:abc 100}})))))
 
 ;; If an `:enabled` param is present in URL params but *not* the JWT, that's ok
@@ -334,7 +334,7 @@
   (embed-test/successful-query-results)
   (embed-test/with-embedding-enabled-and-new-secret-key
     (embed-test/with-temp-dashcard [dashcard]
-      ((test-users/user->client :crowberto) :get 200 (str (dashcard-url dashcard {:_embedding_params {:abc "enabled"}})
+      ((test-users/user->client :crowberto) :get 202 (str (dashcard-url dashcard {:_embedding_params {:abc "enabled"}})
                                                           "?abc=200")))))
 
 ;; Check that editable query params work correctly and keys get coverted from strings to keywords, even if they're
@@ -344,10 +344,10 @@
   "completed"
   (embed-test/with-embedding-enabled-and-new-secret-key
     (-> (embed-test/with-temp-dashcard [dashcard {:dash {:enable_embedding true}}]
-          ((test-users/user->client :crowberto) :get 200 (str (dashcard-url dashcard
-                                                                {:_embedding_params {:num_birds     :locked
-                                                                                     :2nd_date_seen :enabled}
-                                                                 :params            {:num_birds 2}})
+          ((test-users/user->client :crowberto) :get 202 (str (dashcard-url dashcard
+                                                                            {:_embedding_params {:num_birds     :locked
+                                                                                                 :2nd_date_seen :enabled}
+                                                                             :params            {:num_birds 2}})
                                                               "?2nd_date_seen=2018-02-14")))
         :status)))
 

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -991,4 +991,3 @@
            (tu/with-temporary-setting-values [enable-public-sharing false]
              (http/client :get 400 (field-remapping-url dashboard (data/id :venues :id) (data/id :venues :name))
                           :value "10"))))))
-

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -5,7 +5,6 @@
              [string :as str]
              [test :refer :all]]
             [dk.ative.docjure.spreadsheet :as spreadsheet]
-            [expectations :refer [expect]]
             [metabase
              [http-client :as http]
              [query-processor-test :as qp.test]
@@ -79,118 +78,118 @@
 
 ;;; ------------------------------------------- GET /api/public/card/:uuid -------------------------------------------
 
-;; Check that we *cannot* fetch a PublicCard if the setting is disabled
-(expect
-  "An error occurred."
-  (tu/with-temporary-setting-values [enable-public-sharing false]
-    (with-temp-public-card [{uuid :public_uuid}]
-      (http/client :get 400 (str "public/card/" uuid)))))
 
-;; Check that we get a 400 if the PublicCard doesn't exist
-(expect
-  "An error occurred."
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (http/client :get 400 (str "public/card/" (UUID/randomUUID)))))
+(deftest check-that-we--cannot--fetch-a-publiccard-if-the-setting-is-disabled
+  (is (= "An error occurred."
+         (tu/with-temporary-setting-values [enable-public-sharing false]
+           (with-temp-public-card [{uuid :public_uuid}]
+             (http/client :get 400 (str "public/card/" uuid)))))))
 
-;; Check that we *cannot* fetch a PublicCard if the Card has been archived
-(expect
-  "An error occurred."
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (with-temp-public-card [{uuid :public_uuid} {:archived true}]
-      (http/client :get 400 (str "public/card/" uuid)))))
 
-;; Check that we can fetch a PublicCard
-(expect
-  #{:dataset_query :description :display :id :name :visualization_settings :param_values :param_fields}
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (with-temp-public-card [{uuid :public_uuid}]
-      (set (keys (http/client :get 200 (str "public/card/" uuid)))))))
+(deftest check-that-we-get-a-400-if-the-publiccard-doesn-t-exist
+  (is (= "An error occurred."
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (http/client :get 400 (str "public/card/" (UUID/randomUUID)))))))
 
-;; make sure :param_values get returned as expected
-(expect
-  {(data/id :categories :name) {:values                75
-                                :human_readable_values {}
-                                :field_id              (data/id :categories :name)}}
-  (tt/with-temp Card [card {:dataset_query
-                            {:database (data/id)
-                             :type     :native
-                             :native   {:query         (str "SELECT COUNT(*) "
-                                                            "FROM venues "
-                                                            "LEFT JOIN categories ON venues.category_id = categories.id "
-                                                            "WHERE {{category}}")
-                                        :collection    "CATEGORIES"
-                                        :template-tags {:category {:name         "category"
-                                                                   :display-name "Category"
-                                                                   :type         "dimension"
-                                                                   :dimension    ["field-id" (data/id :categories :name)]
-                                                                   :widget-type  "category"
-                                                                   :required     true}}}}}]
-    (-> (:param_values (#'public-api/public-card :id (u/get-id card)))
-        (update-in [(data/id :categories :name) :values] count))))
+(deftest check-that-we--cannot--fetch-a-publiccard-if-the-card-has-been-archived
+  (is (= "An error occurred."
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (with-temp-public-card [{uuid :public_uuid} {:archived true}]
+             (http/client :get 400 (str "public/card/" uuid)))))))
+
+
+(deftest check-that-we-can-fetch-a-publiccard
+  (is (= #{:dataset_query :description :display :id :name :visualization_settings :param_values :param_fields}
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (with-temp-public-card [{uuid :public_uuid}]
+             (set (keys (http/client :get 200 (str "public/card/" uuid)))))))))
+
+
+
+(deftest make-sure--param-values-get-returned-as-expected
+  (is (= {(data/id :categories :name) {:values                75
+                                       :human_readable_values {}
+                                       :field_id              (data/id :categories :name)}}
+         (tt/with-temp Card [card {:dataset_query
+                                   {:database (data/id)
+                                    :type     :native
+                                    :native   {:query         (str "SELECT COUNT(*) "
+                                                                   "FROM venues "
+                                                                   "LEFT JOIN categories ON venues.category_id = categories.id "
+                                                                   "WHERE {{category}}")
+                                               :collection    "CATEGORIES"
+                                               :template-tags {:category {:name         "category"
+                                                                          :display-name "Category"
+                                                                          :type         "dimension"
+                                                                          :dimension    ["field-id" (data/id :categories :name)]
+                                                                          :widget-type  "category"
+                                                                          :required     true}}}}}]
+           (-> (:param_values (#'public-api/public-card :id (u/get-id card)))
+               (update-in [(data/id :categories :name) :values] count)
+               (update (data/id :categories :name) #(into {} %)))))))
+
 
 
 ;;; ------------------------- GET /api/public/card/:uuid/query (and JSON/CSV/XSLX versions) --------------------------
 
-;; Check that we *cannot* execute a PublicCard if the setting is disabled
-(expect
-  "An error occurred."
-  (tu/with-temporary-setting-values [enable-public-sharing false]
-    (with-temp-public-card [{uuid :public_uuid}]
-      (http/client :get 400 (str "public/card/" uuid "/query")))))
+
+(deftest check-that-we--cannot--execute-a-publiccard-if-the-setting-is-disabled
+  (is (= "An error occurred."
+         (tu/with-temporary-setting-values [enable-public-sharing false]
+           (with-temp-public-card [{uuid :public_uuid}]
+             (http/client :get 400 (str "public/card/" uuid "/query")))))))
 
 
-;; Check that we get a 400 if the PublicCard doesn't exist
-(expect
-  "An error occurred."
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (http/client :get 400 (str "public/card/" (UUID/randomUUID) "/query"))))
 
-;; Check that we *cannot* execute a PublicCard if the Card has been archived
-(expect
-  "An error occurred."
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (with-temp-public-card [{uuid :public_uuid} {:archived true}]
-      (http/client :get 400 (str "public/card/" uuid "/query")))))
 
-;; Check that we can exec a PublicCard
-(expect
-  [[100]]
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (with-temp-public-card [{uuid :public_uuid}]
-      (qp.test/rows (http/client :get 202 (str "public/card/" uuid "/query"))))))
+(deftest check-that-we-get-a-400-if-the-publiccard-doesn-t-exist
+  (is (= "An error occurred."
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (http/client :get 400 (str "public/card/" (UUID/randomUUID) "/query"))))))
 
-;; Check that we can exec a PublicCard and get results as JSON
-(expect
+
+(deftest check-that-we--cannot--execute-a-publiccard-if-the-card-has-been-archived
+  (is (= "An error occurred."
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (with-temp-public-card [{uuid :public_uuid} {:archived true}]
+             (http/client :get 400 (str "public/card/" uuid "/query")))))))
+
+
+(deftest check-that-we-can-exec-a-publiccard
+  (is (= [[100]]
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (with-temp-public-card [{uuid :public_uuid}]
+             (qp.test/rows (http/client :get 202 (str "public/card/" uuid "/query"))))))))
+
+
+(deftest check-that-we-can-exec-a-publiccard-and-get-results-as-json
   (tu/with-temporary-setting-values [enable-public-sharing true]
     (with-temp-public-card [{uuid :public_uuid}]
       (http/client :get 202 (str "public/card/" uuid "/query/json")))))
 
-;; Check that we can exec a PublicCard and get results as CSV
 (deftest get-csv
   (is (= "Count\n100\n"
          (tu/with-temporary-setting-values [enable-public-sharing true]
            (with-temp-public-card [{uuid :public_uuid}]
              (http/client :get 202 (str "public/card/" uuid "/query/csv"), :format :csv))))))
 
-;; Check that we can exec a PublicCard and get results as XLSX
-(expect
-  [{:col "Count"} {:col 100.0}]
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (with-temp-public-card [{uuid :public_uuid}]
-      (->> (http/client :get 202 (str "public/card/" uuid "/query/xlsx") {:request-options {:as :byte-array}})
-           ByteArrayInputStream.
-           spreadsheet/load-workbook
-           (spreadsheet/select-sheet "Query result")
-           (spreadsheet/select-columns {:A :col})))))
+(deftest check-that-we-can-exec-a-publiccard-and-get-results-as-xlsx
+  (is (= [{:col "Count"} {:col 100.0}]
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (with-temp-public-card [{uuid :public_uuid}]
+             (->> (http/client :get 202 (str "public/card/" uuid "/query/xlsx") {:request-options {:as :byte-array}})
+                  ByteArrayInputStream.
+                  spreadsheet/load-workbook
+                  (spreadsheet/select-sheet "Query result")
+                  (spreadsheet/select-columns {:A :col})))))))
 
-;; Check that we can exec a PublicCard with `?parameters`
-(expect
-  [{:name "Venue ID", :slug "venue_id", :type "id", :value 2}]
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (with-temp-public-card [{uuid :public_uuid}]
-      (get-in (http/client :get 202 (str "public/card/" uuid "/query")
-                           :parameters (json/encode [{:name "Venue ID", :slug "venue_id", :type "id", :value 2}]))
-              [:json_query :parameters]))))
+(deftest check-that-we-can-exec-a-publiccard-with---parameters-
+  (is (= [{:name "Venue ID", :slug "venue_id", :type "id", :value 2}]
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (with-temp-public-card [{uuid :public_uuid}]
+             (get-in (http/client :get 202 (str "public/card/" uuid "/query")
+                                  :parameters (json/encode [{:name "Venue ID", :slug "venue_id", :type "id", :value 2}]))
+                     [:json_query :parameters]))))))
 
 ;; Cards with required params
 (defn- do-with-required-param-card [f]
@@ -206,16 +205,16 @@
                                                                   :required     true}}}}}]
       (f uuid))))
 
-;; should be able to run a Card with a required param
-(expect
-  [[22]]
-  (do-with-required-param-card
-   (fn [uuid]
-     (qp.test/rows
-      (http/client :get 202 (str "public/card/" uuid "/query")
-                   :parameters (json/encode [{:type   "category"
-                                              :target [:variable [:template-tag "price"]]
-                                              :value  1}]))))))
+
+(deftest should-be-able-to-run-a-card-with-a-required-param
+  (is (= [[22]]
+         (do-with-required-param-card
+          (fn [uuid]
+            (qp.test/rows
+             (http/client :get 202 (str "public/card/" uuid "/query")
+                          :parameters (json/encode [{:type   "category"
+                                                     :target [:variable [:template-tag "price"]]
+                                                     :value  1}]))))))))
 
 (deftest missing-required-param-error-message-test
   (testing (str "If you're missing a required param, the error message should get passed thru, rather than the normal "
@@ -227,74 +226,74 @@
             (fn [uuid]
               (http/client :get 202 (str "public/card/" uuid "/query"))))))))
 
-;; make sure CSV (etc.) downloads take editable params into account (#6407)
+
 
 (defn- card-with-date-field-filter []
   (assoc (shared-obj)
-    :dataset_query {:database (data/id)
-                    :type     :native
-                    :native   {:query         "SELECT COUNT(*) AS \"count\" FROM CHECKINS WHERE {{date}}"
-                               :template-tags {:date {:name         "date"
-                                                      :display-name "Date"
-                                                      :type         "dimension"
-                                                      :dimension    [:field-id (data/id :checkins :date)]
-                                                      :widget-type  "date/quarter-year"}}}}))
+         :dataset_query {:database (data/id)
+                         :type     :native
+                         :native   {:query         "SELECT COUNT(*) AS \"count\" FROM CHECKINS WHERE {{date}}"
+                                    :template-tags {:date {:name         "date"
+                                                           :display-name "Date"
+                                                           :type         "dimension"
+                                                           :dimension    [:field-id (data/id :checkins :date)]
+                                                           :widget-type  "date/quarter-year"}}}}))
 
-(expect
-  "count\n107\n"
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (tt/with-temp Card [{uuid :public_uuid} (card-with-date-field-filter)]
-      (http/client :get 202 (str "public/card/" uuid "/query/csv")
-                   :parameters (json/encode [{:type   :date/quarter-year
-                                              :target [:dimension [:template-tag :date]]
-                                              :value  "Q1-2014"}])))))
 
-;; make sure it also works with the forwarded URL
-(expect
-  "count\n107\n"
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (tt/with-temp Card [{uuid :public_uuid} (card-with-date-field-filter)]
-      ;; make sure the URL doesn't include /api/ at the beginning like it normally would
-      (binding [http/*url-prefix* (str/replace http/*url-prefix* #"/api/$" "/")]
-        (tu/with-temporary-setting-values [site-url http/*url-prefix*]
-          (http/client :get 202 (str "public/question/" uuid ".csv")
-                       :parameters (json/encode [{:type   :date/quarter-year
-                                                  :target [:dimension [:template-tag :date]]
-                                                  :value  "Q1-2014"}])))))))
+(deftest make-sure-csv--etc---downloads-take-editable-params-into-account---6407----
+  (is (= "count\n107\n"
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (tt/with-temp Card [{uuid :public_uuid} (card-with-date-field-filter)]
+             (http/client :get 202 (str "public/card/" uuid "/query/csv")
+                          :parameters (json/encode [{:type   :date/quarter-year
+                                                     :target [:dimension [:template-tag :date]]
+                                                     :value  "Q1-2014"}])))))))
 
-;; make sure we include all the relevant fields like `:insights`
+
+(deftest make-sure-it-also-works-with-the-forwarded-url
+  (is (= "count\n107\n"
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (tt/with-temp Card [{uuid :public_uuid} (card-with-date-field-filter)]
+             ;; make sure the URL doesn't include /api/ at the beginning like it normally would
+             (binding [http/*url-prefix* (str/replace http/*url-prefix* #"/api/$" "/")]
+               (tu/with-temporary-setting-values [site-url http/*url-prefix*]
+                 (http/client :get 202 (str "public/question/" uuid ".csv")
+                              :parameters (json/encode [{:type   :date/quarter-year
+                                                         :target [:dimension [:template-tag :date]]
+                                                         :value  "Q1-2014"}])))))))))
+
 (defn- card-with-trendline []
   (assoc (shared-obj)
-    :dataset_query {:database (data/id)
-                    :type     :query
-                    :query   {:source-table (data/id :checkins)
-                              :breakout     [[:datetime-field [:field-id (data/id :checkins :date)]  :month]]
-                              :aggregation  [[:count]]}}))
+         :dataset_query {:database (data/id)
+                         :type     :query
+                         :query   {:source-table (data/id :checkins)
+                                   :breakout     [[:datetime-field [:field-id (data/id :checkins :date)]  :month]]
+                                   :aggregation  [[:count]]}}))
 
-(expect
-  #{:cols :rows :insights :results_timezone}
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (tt/with-temp Card [{uuid :public_uuid} (card-with-trendline)]
-      (-> (http/client :get 202 (str "public/card/" uuid "/query"))
-          :data
-          keys
-          set))))
+(deftest make-sure-we-include-all-the-relevant-fields-like-insights
+  (is (= #{:cols :rows :insights :results_timezone}
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (tt/with-temp Card [{uuid :public_uuid} (card-with-trendline)]
+             (-> (http/client :get 202 (str "public/card/" uuid "/query"))
+                 :data
+                 keys
+                 set))))))
+
 
 
 ;;; ---------------------------------------- GET /api/public/dashboard/:uuid -----------------------------------------
 
-;; Check that we *cannot* fetch PublicDashboard if setting is disabled
-(expect
-  "An error occurred."
-  (tu/with-temporary-setting-values [enable-public-sharing false]
-    (with-temp-public-dashboard [{uuid :public_uuid}]
-      (http/client :get 400 (str "public/dashboard/" uuid)))))
 
-;; Check that we get a 400 if the PublicDashboard doesn't exis
-(expect
-  "An error occurred."
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (http/client :get 400 (str "public/dashboard/" (UUID/randomUUID)))))
+(deftest check-that-we--cannot--fetch-publicdashboard-if-setting-is-disabled
+  (is (= "An error occurred."
+         (tu/with-temporary-setting-values [enable-public-sharing false]
+           (with-temp-public-dashboard [{uuid :public_uuid}]
+             (http/client :get 400 (str "public/dashboard/" uuid)))))))
+
+(deftest check-that-we-get-a-400-if-the-publicdashboard-doesn-t-exis
+  (is (= "An error occurred."
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (http/client :get 400 (str "public/dashboard/" (UUID/randomUUID)))))))
 
 (defn- fetch-public-dashboard [{uuid :public_uuid}]
   (-> (http/client :get 200 (str "public/dashboard/" uuid))
@@ -302,21 +301,19 @@
       (update :name boolean)
       (update :ordered_cards count)))
 
-;; Check that we can fetch a PublicDashboard
-(expect
-  {:name true, :ordered_cards 1}
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (with-temp-public-dashboard-and-card [dash card]
-      (fetch-public-dashboard dash))))
 
-;; Check that we don't see Cards that have been archived
-(expect
-  {:name true, :ordered_cards 0}
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (with-temp-public-dashboard-and-card [dash card]
-      (db/update! Card (u/get-id card), :archived true)
-      (fetch-public-dashboard dash))))
+(deftest check-that-we-can-fetch-a-publicdashboard
+  (is (= {:name true, :ordered_cards 1}
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (with-temp-public-dashboard-and-card [dash card]
+             (fetch-public-dashboard dash))))))
 
+(deftest check-that-we-don-t-see-cards-that-have-been-archived
+  (is (= {:name true, :ordered_cards 0}
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (with-temp-public-dashboard-and-card [dash card]
+             (db/update! Card (u/get-id card), :archived true)
+             (fetch-public-dashboard dash))))))
 
 ;;; --------------------------------- GET /api/public/dashboard/:uuid/card/:card-id ----------------------------------
 
@@ -324,67 +321,62 @@
   (str "public/dashboard/" (:public_uuid dash) "/card/" (u/get-id card)))
 
 
-;; Check that we *cannot* exec PublicCard via PublicDashboard if setting is disabled
-(expect
-  "An error occurred."
-  (tu/with-temporary-setting-values [enable-public-sharing false]
-    (with-temp-public-dashboard-and-card [dash card]
-      (http/client :get 400 (dashcard-url dash card)))))
 
-;; Check that we get a 400 if PublicDashboard doesn't exist
-(expect
-  "An error occurred."
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (with-temp-public-dashboard-and-card [_ card]
-      (http/client :get 400 (dashcard-url {:public_uuid (UUID/randomUUID)} card)))))
+(deftest check-that-we--cannot--exec-publiccard-via-publicdashboard-if-setting-is-disabled
+  (is (= "An error occurred."
+         (tu/with-temporary-setting-values [enable-public-sharing false]
+           (with-temp-public-dashboard-and-card [dash card]
+             (http/client :get 400 (dashcard-url dash card)))))))
+
+(deftest check-that-we-get-a-400-if-publicdashboard-doesn-t-exist
+  (is (= "An error occurred."
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (with-temp-public-dashboard-and-card [_ card]
+             (http/client :get 400 (dashcard-url {:public_uuid (UUID/randomUUID)} card)))))))
+
+(deftest check-that-we-get-a-400-if-publiccard-doesn-t-exist
+  (is (= "An error occurred."
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (with-temp-public-dashboard-and-card [dash _]
+             (http/client :get 400 (dashcard-url dash Integer/MAX_VALUE)))))))
+
+(deftest check-that-we-get-a-400-if-the-card-does-exist-but-it-s-not-part-of-this-dashboard
+  (is (= "An error occurred."
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (with-temp-public-dashboard-and-card [dash _]
+             (tt/with-temp Card [card]
+               (http/client :get 400 (dashcard-url dash card))))))))
 
 
-;; Check that we get a 400 if PublicCard doesn't exist
-(expect
-  "An error occurred."
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (with-temp-public-dashboard-and-card [dash _]
-      (http/client :get 400 (dashcard-url dash Integer/MAX_VALUE)))))
+(deftest check-that-we--cannot--execute-a-publiccard-via-a-publicdashboard-if-the-card-has-been-archived
+  (is (= "An error occurred."
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (with-temp-public-dashboard-and-card [dash card]
+             (db/update! Card (u/get-id card), :archived true)
+             (http/client :get 400 (dashcard-url dash card)))))))
 
-;; Check that we get a 400 if the Card does exist but it's not part of this Dashboard
-(expect
-  "An error occurred."
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (with-temp-public-dashboard-and-card [dash _]
-      (tt/with-temp Card [card]
-        (http/client :get 400 (dashcard-url dash card))))))
+(deftest check-that-we-can-exec-a-publiccard-via-a-publicdashboard
+  (is (= [[100]]
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (with-temp-public-dashboard-and-card [dash card]
+             (qp.test/rows (http/client :get 202 (dashcard-url dash card))))))))
 
-;; Check that we *cannot* execute a PublicCard via a PublicDashboard if the Card has been archived
-(expect
-  "An error occurred."
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (with-temp-public-dashboard-and-card [dash card]
-      (db/update! Card (u/get-id card), :archived true)
-      (http/client :get 400 (dashcard-url dash card)))))
+(deftest check-that-we-can-exec-a-publiccard-via-a-publicdashboard-with---parameters-
+  (is (= [{:name    "Venue ID"
+           :slug    "venue_id"
+           :target  ["dimension" (data/id :venues :id)]
+           :value   [10]
+           :default nil
+           :type    "id"}]
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (with-temp-public-dashboard-and-card [dash card]
+             (get-in (http/client :get 202 (dashcard-url dash card)
+                                  :parameters (json/encode [{:name   "Venue ID"
+                                                             :slug   :venue_id
+                                                             :target [:dimension (data/id :venues :id)]
+                                                             :value  [10]}]))
+                     [:json_query :parameters]))))))
 
-;; Check that we can exec a PublicCard via a PublicDashboard
-(expect
-  [[100]]
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (with-temp-public-dashboard-and-card [dash card]
-      (qp.test/rows (http/client :get 202 (dashcard-url dash card))))))
-
-;; Check that we can exec a PublicCard via a PublicDashboard with `?parameters`
-(expect
-  [{:name    "Venue ID"
-    :slug    "venue_id"
-    :target  ["dimension" (data/id :venues :id)]
-    :value   [10]
-    :default nil
-    :type    "id"}]
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (with-temp-public-dashboard-and-card [dash card]
-      (get-in (http/client :get 202 (dashcard-url dash card)
-                           :parameters (json/encode [{:name   "Venue ID"
-                                                      :slug   :venue_id
-                                                      :target [:dimension (data/id :venues :id)]
-                                                      :value  [10]}]))
-              [:json_query :parameters]))))
 
 ;; Make sure params are validated: this should pass because venue_id *is* one of the Dashboard's :parameters
 (deftest params-are-validated
@@ -398,153 +390,152 @@
                                                          :value  [10]}]))
                  qp.test/rows))))))
 
-;; Make sure params are validated: this should fail because venue_name is *not* one of the Dashboard's :parameters
-(expect
- "An error occurred."
- (tu/with-temporary-setting-values [enable-public-sharing true]
-   (with-temp-public-dashboard-and-card [dash card]
-     (http/client :get 400 (dashcard-url dash card)
-                  :parameters (json/encode [{:name   "Venue Name"
-                                             :slug   :venue_name
-                                             :target [:dimension (data/id :venues :name)]
-                                             :value  ["PizzaHacker"]}])))))
+(deftest make-sure-params-are-validated--this-should-fail-because-venue-name-is--not--one-of-the-dashboard-s--parameters
+  (is (= "An error occurred."
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (with-temp-public-dashboard-and-card [dash card]
+             (http/client :get 400 (dashcard-url dash card)
+                          :parameters (json/encode [{:name   "Venue Name"
+                                                     :slug   :venue_name
+                                                     :target [:dimension (data/id :venues :name)]
+                                                     :value  ["PizzaHacker"]}])))))))
 
-;; Check that an additional Card series works as well
-(expect
-  [[100]]
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (with-temp-public-dashboard-and-card [dash card]
-      (with-temp-public-card [card-2]
-        (tt/with-temp DashboardCardSeries [_ {:dashboardcard_id (db/select-one-id DashboardCard
-                                                                                  :card_id      (u/get-id card)
-                                                                                  :dashboard_id (u/get-id dash))
-                                              :card_id          (u/get-id card-2)}]
-          (qp.test/rows (http/client :get 202 (dashcard-url dash card-2))))))))
+(deftest check-that-an-additional-card-series-works-as-well
+  (is (= [[100]]
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (with-temp-public-dashboard-and-card [dash card]
+             (with-temp-public-card [card-2]
+               (tt/with-temp DashboardCardSeries [_ {:dashboardcard_id (db/select-one-id DashboardCard
+                                                                                         :card_id      (u/get-id card)
+                                                                                         :dashboard_id (u/get-id dash))
+                                                     :card_id          (u/get-id card-2)}]
+                 (qp.test/rows (http/client :get 202 (dashcard-url dash card-2))))))))))
 
-;; Make sure that parameters actually work correctly (#7212)
-(expect
-  [[50]]
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (tt/with-temp Card [card {:dataset_query {:database (data/id)
-                                              :type     :native
-                                              :native   {:query         "SELECT {{num}} AS num"
-                                                         :template-tags {:num {:name         "num"
-                                                                               :display-name "Num"
-                                                                               :type         "number"
-                                                                               :required     true
-                                                                               :default      "1"}}}}}]
-      (with-temp-public-dashboard [dash {:parameters [{:name "Num"
-                                                       :slug "num"
-                                                       :id   "537e37b4"
-                                                       :type "category"}]}]
-        (add-card-to-dashboard! card dash
-          :parameter_mappings [{:card_id      (u/get-id card)
-                                :target       [:variable
-                                               [:template-tag :num]]
-                                :parameter_id "537e37b4"}])
-        (-> ((test-users/user->client :crowberto)
-             :get (str (dashcard-url dash card)
-                       "?parameters="
-                       (json/generate-string
-                        [{:type   :category
-                          :target [:variable [:template-tag :num]]
-                          :value  "50"}])))
-            qp.test/rows)))))
 
-;; ...with MBQL Cards as well...
-(expect
-  [[1]]
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (tt/with-temp Card [card {:dataset_query {:database (data/id)
-                                              :type     :query
-                                              :query    {:source-table (data/id :venues)
-                                                         :aggregation  [:count]}}}]
-      (with-temp-public-dashboard [dash {:parameters [{:name "Venue ID"
-                                                       :slug "venue_id"
-                                                       :id   "22486e00"
-                                                       :type "id"}]}]
-        (add-card-to-dashboard! card dash
-          :parameter_mappings [{:parameter_id "22486e00"
-                                :card_id      (u/get-id card)
-                                :target       [:dimension
-                                               [:field-id
-                                                (data/id :venues :id)]]}])
-        (-> ((test-users/user->client :crowberto)
-             :get (str (dashcard-url dash card)
-                       "?parameters="
-                       (json/generate-string
-                        [{:type   :id
-                          :target [:dimension [:field-id (data/id :venues :id)]]
-                          :value  "50"}])))
-            qp.test/rows)))))
 
-;; ...and also for DateTime params
-(expect
-  [[733]]
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (tt/with-temp Card [card {:dataset_query {:database (data/id)
-                                              :type     :query
-                                              :query    {:source-table (data/id :checkins)
-                                                         :aggregation  [:count]}}}]
-      (with-temp-public-dashboard [dash {:parameters [{:name "Date Filter"
-                                                       :slug "date_filter"
-                                                       :id   "18a036ec"
-                                                       :type "date/all-options"}]}]
-        (add-card-to-dashboard! card dash
-          :parameter_mappings [{:parameter_id "18a036ec"
-                                :card_id      (u/get-id card)
-                                :target       [:dimension
-                                               [:field-id
-                                                (data/id :checkins :date)]]}])
-        (-> ((test-users/user->client :crowberto)
-             :get (str (dashcard-url dash card)
-                       "?parameters="
-                       (json/generate-string
-                        [{:type   "date/all-options"
-                          :target [:dimension [:field-id (data/id :checkins :date)]]
-                          :value  "~2015-01-01"}])))
-            qp.test/rows)))))
+(deftest make-sure-that-parameters-actually-work-correctly---7212-
+  (is (= [[50]]
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (tt/with-temp Card [card {:dataset_query {:database (data/id)
+                                                     :type     :native
+                                                     :native   {:query         "SELECT {{num}} AS num"
+                                                                :template-tags {:num {:name         "num"
+                                                                                      :display-name "Num"
+                                                                                      :type         "number"
+                                                                                      :required     true
+                                                                                      :default      "1"}}}}}]
+             (with-temp-public-dashboard [dash {:parameters [{:name "Num"
+                                                              :slug "num"
+                                                              :id   "537e37b4"
+                                                              :type "category"}]}]
+               (add-card-to-dashboard! card dash
+                                       :parameter_mappings [{:card_id      (u/get-id card)
+                                                             :target       [:variable
+                                                                            [:template-tag :num]]
+                                                             :parameter_id "537e37b4"}])
+               (-> ((test-users/user->client :crowberto)
+                    :get (str (dashcard-url dash card)
+                              "?parameters="
+                              (json/generate-string
+                               [{:type   :category
+                                 :target [:variable [:template-tag :num]]
+                                 :value  "50"}])))
+                   qp.test/rows)))))))
+
+(deftest ---with-mbql-cards-as-well---
+  (is (= [[1]]
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (tt/with-temp Card [card {:dataset_query {:database (data/id)
+                                                     :type     :query
+                                                     :query    {:source-table (data/id :venues)
+                                                                :aggregation  [:count]}}}]
+             (with-temp-public-dashboard [dash {:parameters [{:name "Venue ID"
+                                                              :slug "venue_id"
+                                                              :id   "22486e00"
+                                                              :type "id"}]}]
+               (add-card-to-dashboard! card dash
+                                       :parameter_mappings [{:parameter_id "22486e00"
+                                                             :card_id      (u/get-id card)
+                                                             :target       [:dimension
+                                                                            [:field-id
+                                                                             (data/id :venues :id)]]}])
+               (-> ((test-users/user->client :crowberto)
+                    :get (str (dashcard-url dash card)
+                              "?parameters="
+                              (json/generate-string
+                               [{:type   :id
+                                 :target [:dimension [:field-id (data/id :venues :id)]]
+                                 :value  "50"}])))
+                   qp.test/rows)))))))
+
+
+(deftest ---and-also-for-datetime-params
+  (is (= [[733]]
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (tt/with-temp Card [card {:dataset_query {:database (data/id)
+                                                     :type     :query
+                                                     :query    {:source-table (data/id :checkins)
+                                                                :aggregation  [:count]}}}]
+             (with-temp-public-dashboard [dash {:parameters [{:name "Date Filter"
+                                                              :slug "date_filter"
+                                                              :id   "18a036ec"
+                                                              :type "date/all-options"}]}]
+               (add-card-to-dashboard! card dash
+                                       :parameter_mappings [{:parameter_id "18a036ec"
+                                                             :card_id      (u/get-id card)
+                                                             :target       [:dimension
+                                                                            [:field-id
+                                                                             (data/id :checkins :date)]]}])
+               (-> ((test-users/user->client :crowberto)
+                    :get (str (dashcard-url dash card)
+                              "?parameters="
+                              (json/generate-string
+                               [{:type   "date/all-options"
+                                 :target [:dimension [:field-id (data/id :checkins :date)]]
+                                 :value  "~2015-01-01"}])))
+                   qp.test/rows)))))))
+
 
 ;; make sure DimensionValue params also work if they have a default value, even if some is passed in for some reason
 ;; as part of the query (#7253)
 ;; If passed in as part of the query however make sure it doesn't override what's actually in the DB
-(expect
-  [["Wow"]]
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (tt/with-temp Card [card {:dataset_query {:database (data/id)
-                                              :type     :native
-                                              :native   {:query         "SELECT {{msg}} AS message"
-                                                         :template-tags {:msg {:id           "181da7c5"
-                                                                               :name         "msg"
-                                                                               :display-name "Message"
-                                                                               :type         "text"
-                                                                               :required     true
-                                                                               :default      "Wow"}}}}}]
-      (with-temp-public-dashboard [dash {:parameters [{:name "Message"
-                                                       :slug "msg"
-                                                       :id   "181da7c5"
-                                                       :type "category"}]}]
-        (add-card-to-dashboard! card dash
-          :parameter_mappings [{:card_id      (u/get-id card)
-                                :target       [:variable [:template-tag :msg]]
-                                :parameter_id "181da7c5"}])
-        (-> ((test-users/user->client :crowberto)
-             :get (str (dashcard-url dash card)
-                       "?parameters="
-                       (json/generate-string
-                        [{:type    :category
-                          :target  [:variable [:template-tag :msg]]
-                          :value   nil
-                          :default "Hello"}])))
-            qp.test/rows)))))
 
+
+(deftest dimensionvalue-params-work
+  (is (= [["Wow"]]
+         (tu/with-temporary-setting-values [enable-public-sharing true]
+           (tt/with-temp Card [card {:dataset_query {:database (data/id)
+                                                     :type     :native
+                                                     :native   {:query         "SELECT {{msg}} AS message"
+                                                                :template-tags {:msg {:id           "181da7c5"
+                                                                                      :name         "msg"
+                                                                                      :display-name "Message"
+                                                                                      :type         "text"
+                                                                                      :required     true
+                                                                                      :default      "Wow"}}}}}]
+             (with-temp-public-dashboard [dash {:parameters [{:name "Message"
+                                                              :slug "msg"
+                                                              :id   "181da7c5"
+                                                              :type "category"}]}]
+               (add-card-to-dashboard! card dash
+                                       :parameter_mappings [{:card_id      (u/get-id card)
+                                                             :target       [:variable [:template-tag :msg]]
+                                                             :parameter_id "181da7c5"}])
+               (-> ((test-users/user->client :crowberto)
+                    :get (str (dashcard-url dash card)
+                              "?parameters="
+                              (json/generate-string
+                               [{:type    :category
+                                 :target  [:variable [:template-tag :msg]]
+                                 :value   nil
+                                 :default "Hello"}])))
+                   qp.test/rows)))))))
 
 ;;; --------------------------- Check that parameter information comes back with Dashboard ---------------------------
 
-;; double-check that the Field has FieldValues
-(expect
-  [1 2 3 4]
-  (db/select-one-field :values FieldValues :field_id (data/id :venues :price)))
+(deftest double-check-that-the-field-has-fieldvalues
+  (is (= [1 2 3 4]
+         (db/select-one-field :values FieldValues :field_id (data/id :venues :price)))))
 
 (defn- price-param-values []
   {(keyword (str (data/id :venues :price))) {:values                [1 2 3 4]
@@ -562,37 +553,33 @@
   (tu/with-temporary-setting-values [enable-public-sharing true]
     (:param_values (http/client :get 200 (str "public/dashboard/" (:public_uuid dashboard))))))
 
-;; Check that param info comes back for SQL Cards
-(expect
-  (price-param-values)
-  (with-temp-public-dashboard-and-card [dash card dashcard]
-    (db/update! Card (u/get-id card)
-      :dataset_query {:database (data/id)
-                      :type     :native
-                      :native   {:template-tags {:price {:name         "price"
-                                                         :display-name "Price"
-                                                         :type         "dimension"
-                                                         :dimension    ["field-id" (data/id :venues :price)]}}}})
-    (add-price-param-to-dashboard! dash)
-    (add-dimension-param-mapping-to-dashcard! dashcard card ["template-tag" "price"])
-    (GET-param-values dash)))
+(deftest check-that-param-info-comes-back-for-sql-cards
+  (is (= (price-param-values)
+         (with-temp-public-dashboard-and-card [dash card dashcard]
+           (db/update! Card (u/get-id card)
+                       :dataset_query {:database (data/id)
+                                       :type     :native
+                                       :native   {:template-tags {:price {:name         "price"
+                                                                          :display-name "Price"
+                                                                          :type         "dimension"
+                                                                          :dimension    ["field-id" (data/id :venues :price)]}}}})
+           (add-price-param-to-dashboard! dash)
+           (add-dimension-param-mapping-to-dashcard! dashcard card ["template-tag" "price"])
+           (GET-param-values dash)))))
 
-;; Check that param info comes back for MBQL Cards (field-id)
-(expect
-  (price-param-values)
-  (with-temp-public-dashboard-and-card [dash card dashcard]
-    (add-price-param-to-dashboard! dash)
-    (add-dimension-param-mapping-to-dashcard! dashcard card ["field-id" (data/id :venues :price)])
-    (GET-param-values dash)))
+(deftest check-that-param-info-comes-back-for-mbql-cards--field-id-
+  (is (= (price-param-values)
+         (with-temp-public-dashboard-and-card [dash card dashcard]
+           (add-price-param-to-dashboard! dash)
+           (add-dimension-param-mapping-to-dashcard! dashcard card ["field-id" (data/id :venues :price)])
+           (GET-param-values dash)))))
 
-;; Check that param info comes back for MBQL Cards (fk->)
-(expect
-  (price-param-values)
-  (with-temp-public-dashboard-and-card [dash card dashcard]
-    (add-price-param-to-dashboard! dash)
-    (add-dimension-param-mapping-to-dashcard! dashcard card ["fk->" (data/id :checkins :venue_id) (data/id :venues :price)])
-    (GET-param-values dash)))
-
+(deftest check-that-param-info-comes-back-for-mbql-cards--fk---
+  (is (= (price-param-values)
+         (with-temp-public-dashboard-and-card [dash card dashcard]
+           (add-price-param-to-dashboard! dash)
+           (add-dimension-param-mapping-to-dashcard! dashcard card ["fk->" (data/id :checkins :venue_id) (data/id :venues :price)])
+           (GET-param-values dash)))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                        New FieldValues search endpoints                                        |
@@ -626,70 +613,65 @@
 
 ;;; ------------------------------------------- card->referenced-field-ids -------------------------------------------
 
-(expect
-  #{}
-  (tt/with-temp Card [card (mbql-card-referencing-nothing)]
-    (#'public-api/card->referenced-field-ids card)))
+(deftest card-referencing-nothing
+  (is (= #{}
+         (tt/with-temp Card [card (mbql-card-referencing-nothing)]
+           (#'public-api/card->referenced-field-ids card)))))
 
-;; It should pick up on Fields referenced in the MBQL query itself...
-(expect
- #{(data/id :venues :name)}
- (tt/with-temp Card [card (mbql-card-referencing-venue-name)]
-   (#'public-api/card->referenced-field-ids card)))
+(deftest it-should-pick-up-on-fields-referenced-in-the-mbql-query-itself
+  (is (= #{(data/id :venues :name)}
+         (tt/with-temp Card [card (mbql-card-referencing-venue-name)]
+           (#'public-api/card->referenced-field-ids card)))))
 
-;; ...as well as template tag "implict" params for SQL queries
-(expect
-  #{(data/id :venues :name)}
-  (tt/with-temp Card [card (sql-card-referencing-venue-name)]
-    (#'public-api/card->referenced-field-ids card)))
-
+(deftest ---as-well-as-template-tag--implict--params-for-sql-queries
+  (is (= #{(data/id :venues :name)}
+         (tt/with-temp Card [card (sql-card-referencing-venue-name)]
+           (#'public-api/card->referenced-field-ids card)))))
 
 ;;; --------------------------------------- check-field-is-referenced-by-card ----------------------------------------
 
-;; Check that the check succeeds when Field is referenced
-(expect
+
+(deftest check-that-the-check-succeeds-when-field-is-referenced
   (tt/with-temp Card [card (mbql-card-referencing-venue-name)]
     (#'public-api/check-field-is-referenced-by-card (data/id :venues :name) (u/get-id card))))
 
-;; check that exception is thrown if the Field isn't referenced
-(expect
-  Exception
-  (tt/with-temp Card [card (mbql-card-referencing-venue-name)]
-    (#'public-api/check-field-is-referenced-by-card (data/id :venues :category_id) (u/get-id card))))
+
+(deftest check-that-exception-is-thrown-if-the-field-isn-t-referenced
+  (is (thrown? Exception
+               (tt/with-temp Card [card (mbql-card-referencing-venue-name)]
+                 (#'public-api/check-field-is-referenced-by-card (data/id :venues :category_id) (u/get-id card))))))
 
 
 ;;; ----------------------------------------- check-search-field-is-allowed ------------------------------------------
 
 ;; search field is allowed IF:
 ;; A) search-field is the same field as the other one
-(expect
-  (#'public-api/check-search-field-is-allowed (data/id :venues :id) (data/id :venues :id)))
-
-(expect
-  Exception
-  (#'public-api/check-search-field-is-allowed (data/id :venues :id) (data/id :venues :category_id)))
+(deftest search-field-allowed-if-same-field-as-other-one
+  (#'public-api/check-search-field-is-allowed (data/id :venues :id) (data/id :venues :id))
+  (is (thrown? Exception
+               (#'public-api/check-search-field-is-allowed (data/id :venues :id) (data/id :venues :category_id)))))
 
 ;; B) there's a Dimension that lists search field as the human_readable_field for the other field
-(expect
-  (tt/with-temp Dimension [_ {:field_id (data/id :venues :id), :human_readable_field_id (data/id :venues :category_id)}]
-    (#'public-api/check-search-field-is-allowed (data/id :venues :id) (data/id :venues :category_id))))
+(deftest search-field-allowed-with-dimension
+  (is (tt/with-temp Dimension [_ {:field_id (data/id :venues :id), :human_readable_field_id (data/id :venues :category_id)}]
+        (#'public-api/check-search-field-is-allowed (data/id :venues :id) (data/id :venues :category_id)))))
 
 ;; C) search-field is a Name Field belonging to the same table as the other field, which is a PK
-(expect
-  (do ;tu/with-temp-vals-in-db Field (data/id :venues :name) {:special_type "type/Name"}
-    (#'public-api/check-search-field-is-allowed (data/id :venues :id) (data/id :venues :name))))
+(deftest search-field-allowed-with-name-field
+  (is (#'public-api/check-search-field-is-allowed (data/id :venues :id) (data/id :venues :name))))
 
 ;; not allowed if search field isn't a NAME
-(expect
-  Exception
-  (tu/with-temp-vals-in-db Field (data/id :venues :name) {:special_type "type/Latitude"}
-    (#'public-api/check-search-field-is-allowed (data/id :venues :id) (data/id :venues :name))))
+(deftest search-field-not-allowed-if-search-field-isnt-a-name
+  (is (thrown? Exception
+               (tu/with-temp-vals-in-db Field (data/id :venues :name) {:special_type "type/Latitude"}
+                 (#'public-api/check-search-field-is-allowed (data/id :venues :id) (data/id :venues :name))))))
 
-;; not allowed if search field belongs to a different TABLE
-(expect
-  Exception
-  (tu/with-temp-vals-in-db Field (data/id :categories :name) {:special_type "type/Name"}
-    (#'public-api/check-search-field-is-allowed (data/id :venues :id) (data/id :categories :name))))
+
+(deftest not-allowed-if-search-field-belongs-to-a-different-table
+  (is (thrown? Exception
+               (tu/with-temp-vals-in-db Field (data/id :categories :name) {:special_type "type/Name"}
+                 (#'public-api/check-search-field-is-allowed (data/id :venues :id) (data/id :categories :name))))))
+
 
 
 ;;; ------------------------------------- check-field-is-referenced-by-dashboard -------------------------------------
@@ -700,66 +682,65 @@
    :parameter_mappings [{:card_id (u/get-id card)
                          :target  [:dimension [:field-id (data/id :venues :id)]]}]})
 
-;; Field is "referenced" by Dashboard if it's one of the Dashboard's params...
-(expect
-  (tt/with-temp* [Dashboard     [dashboard]
-                  Card          [card]
-                  DashboardCard [_ (dashcard-with-param-mapping-to-venue-id dashboard card)]]
-    (#'public-api/check-field-is-referenced-by-dashboard (data/id :venues :id) (u/get-id dashboard))))
 
-(expect
-  Exception
-  (tt/with-temp* [Dashboard     [dashboard]
-                  Card          [card]
-                  DashboardCard [_ (dashcard-with-param-mapping-to-venue-id dashboard card)]]
-    (#'public-api/check-field-is-referenced-by-dashboard (data/id :venues :name) (u/get-id dashboard))))
+(deftest field-is--referenced--by-dashboard-if-it-s-one-of-the-dashboard-s-params---
+  (is (tt/with-temp* [Dashboard     [dashboard]
+                      Card          [card]
+                      DashboardCard [_ (dashcard-with-param-mapping-to-venue-id dashboard card)]]
+        (#'public-api/check-field-is-referenced-by-dashboard (data/id :venues :id) (u/get-id dashboard)))))
+
+
+(deftest TODO-name-this-exception
+  (is (thrown? Exception
+               (tt/with-temp* [Dashboard     [dashboard]
+                               Card          [card]
+                               DashboardCard [_ (dashcard-with-param-mapping-to-venue-id dashboard card)]]
+                 (#'public-api/check-field-is-referenced-by-dashboard (data/id :venues :name) (u/get-id dashboard))))))
 
 ;; ...*or* if it's a so-called "implicit" param (a Field Filter Template Tag (FFTT) in a SQL Card)
-(expect
-  (tt/with-temp* [Dashboard     [dashboard]
-                  Card          [card (sql-card-referencing-venue-name)]
-                  DashboardCard [_ {:dashboard_id (u/get-id dashboard), :card_id (u/get-id card)}]]
-    (#'public-api/check-field-is-referenced-by-dashboard (data/id :venues :name) (u/get-id dashboard))))
+(deftest implicit-param
+  (is (tt/with-temp* [Dashboard     [dashboard]
+                      Card          [card (sql-card-referencing-venue-name)]
+                      DashboardCard [_ {:dashboard_id (u/get-id dashboard), :card_id (u/get-id card)}]]
+        (#'public-api/check-field-is-referenced-by-dashboard (data/id :venues :name) (u/get-id dashboard))))
 
-(expect
-  Exception
-  (tt/with-temp* [Dashboard     [dashboard]
-                  Card          [card (sql-card-referencing-venue-name)]
-                  DashboardCard [_ {:dashboard_id (u/get-id dashboard), :card_id (u/get-id card)}]]
-    (#'public-api/check-field-is-referenced-by-dashboard (data/id :venues :id) (u/get-id dashboard))))
-
+  (is (thrown? Exception
+               (tt/with-temp* [Dashboard     [dashboard]
+                               Card          [card (sql-card-referencing-venue-name)]
+                               DashboardCard [_ {:dashboard_id (u/get-id dashboard), :card_id (u/get-id card)}]]
+                 (#'public-api/check-field-is-referenced-by-dashboard (data/id :venues :id) (u/get-id dashboard))))))
 
 ;;; ------------------------------------------- card-and-field-id->values --------------------------------------------
 
-;; We should be able to get values for a Field referenced by a Card
-(expect
-  {:values   [["20th Century Cafe"]
-              ["25°"]
-              ["33 Taps"]
-              ["800 Degrees Neapolitan Pizzeria"]
-              ["BCD Tofu House"]]
-   :field_id (data/id :venues :name)}
-  (tt/with-temp Card [card (mbql-card-referencing :venues :name)]
-    (-> (public-api/card-and-field-id->values (u/get-id card) (data/id :venues :name))
-        (update :values (partial take 5)))))
+(deftest we-should-be-able-to-get-values-for-a-field-referenced-by-a-card
+  (is (= {:values   [["20th Century Cafe"]
+                     ["25°"]
+                     ["33 Taps"]
+                     ["800 Degrees Neapolitan Pizzeria"]
+                     ["BCD Tofu House"]]
+          :field_id (data/id :venues :name)}
+         (tt/with-temp Card [card (mbql-card-referencing :venues :name)]
+           (into {} (-> (public-api/card-and-field-id->values (u/get-id card) (data/id :venues :name))
+                        (update :values (partial take 5))))))))
 
-;; SQL param field references should work just as well as MBQL field referenced
-(expect
-  {:values   [["20th Century Cafe"]
-              ["25°"]
-              ["33 Taps"]
-              ["800 Degrees Neapolitan Pizzeria"]
-              ["BCD Tofu House"]]
-   :field_id (data/id :venues :name)}
-  (tt/with-temp Card [card (sql-card-referencing-venue-name)]
-    (-> (public-api/card-and-field-id->values (u/get-id card) (data/id :venues :name))
-        (update :values (partial take 5)))))
+(deftest sql-param-field-references-should-work-just-as-well-as-mbql-field-referenced
+  (is (= {:values   [["20th Century Cafe"]
+                     ["25°"]
+                     ["33 Taps"]
+                     ["800 Degrees Neapolitan Pizzeria"]
+                     ["BCD Tofu House"]]
+          :field_id (data/id :venues :name)}
+         (tt/with-temp Card [card (sql-card-referencing-venue-name)]
+           (into {} (-> (public-api/card-and-field-id->values (u/get-id card) (data/id :venues :name))
+                        (update :values (partial take 5))))))))
 
-;; But if the Field is not referenced we should get an Exception
-(expect
-  Exception
-  (tt/with-temp Card [card (mbql-card-referencing :venues :price)]
-    (public-api/card-and-field-id->values (u/get-id card) (data/id :venues :name))))
+
+
+(deftest but-if-the-field-is-not-referenced-we-should-get-an-exception
+  (is (thrown? Exception
+               (tt/with-temp Card [card (mbql-card-referencing :venues :price)]
+                 (public-api/card-and-field-id->values (u/get-id card) (data/id :venues :name))))))
+
 
 
 ;;; ------------------------------- GET /api/public/card/:uuid/field/:field-id/values --------------------------------
@@ -786,32 +767,28 @@
      (fn [~card-binding]
        ~@body)))
 
-;; should be able to fetch values for a Field referenced by a public Card
-(expect
-  {:values   [["20th Century Cafe"]
-              ["25°"]
-              ["33 Taps"]
-              ["800 Degrees Neapolitan Pizzeria"]
-              ["BCD Tofu House"]]
-   :field_id (data/id :venues :name)}
-  (with-sharing-enabled-and-temp-card-referencing :venues :name [card]
-    (-> (http/client :get 200 (field-values-url card (data/id :venues :name)))
-        (update :values (partial take 5)))))
 
-;; but for Fields that are not referenced we should get an Exception
-(expect
- "An error occurred."
- (with-sharing-enabled-and-temp-card-referencing :venues :name [card]
-   (http/client :get 400 (field-values-url card (data/id :venues :price)))))
+(deftest should-be-able-to-fetch-values-for-a-field-referenced-by-a-public-card
+  (is (= {:values   [["20th Century Cafe"]
+                     ["25°"]
+                     ["33 Taps"]
+                     ["800 Degrees Neapolitan Pizzeria"]
+                     ["BCD Tofu House"]]
+          :field_id (data/id :venues :name)}
+         (with-sharing-enabled-and-temp-card-referencing :venues :name [card]
+           (-> (http/client :get 200 (field-values-url card (data/id :venues :name)))
+               (update :values (partial take 5)))))))
 
-;; Endpoint should fail if public sharing is disabled
-(expect
- "An error occurred."
- (with-sharing-enabled-and-temp-card-referencing :venues :name [card]
-   (tu/with-temporary-setting-values [enable-public-sharing false]
-     (http/client :get 400 (field-values-url card (data/id :venues :name))))))
+(deftest but-for-fields-that-are-not-referenced-we-should-get-an-exception
+  (is (= "An error occurred."
+         (with-sharing-enabled-and-temp-card-referencing :venues :name [card]
+           (http/client :get 400 (field-values-url card (data/id :venues :price)))))))
 
-
+(deftest field-value-endpoint-should-fail-if-public-sharing-is-disabled
+  (is (= "An error occurred."
+         (with-sharing-enabled-and-temp-card-referencing :venues :name [card]
+           (tu/with-temporary-setting-values [enable-public-sharing false]
+             (http/client :get 400 (field-values-url card (data/id :venues :name))))))))
 
 ;;; ----------------------------- GET /api/public/dashboard/:uuid/field/:field-id/values -----------------------------
 
@@ -834,51 +811,52 @@
      (fn [~(or dashboard-binding '_) ~(or card-binding '_) ~(or dashcard-binding '_)]
        ~@body)))
 
-;; should be able to use it when everything is g2g
-(expect
-  {:values   [["20th Century Cafe"]
-              ["25°"]
-              ["33 Taps"]
-              ["800 Degrees Neapolitan Pizzeria"]
-              ["BCD Tofu House"]]
-   :field_id (data/id :venues :name)}
-  (with-sharing-enabled-and-temp-dashcard-referencing :venues :name [dashboard]
-    (-> (http/client :get 200 (field-values-url dashboard (data/id :venues :name)))
-        (update :values (partial take 5)))))
+(deftest should-be-able-to-use-it-when-everything-is-g2g
+  (is (= {:values   [["20th Century Cafe"]
+                     ["25°"]
+                     ["33 Taps"]
+                     ["800 Degrees Neapolitan Pizzeria"]
+                     ["BCD Tofu House"]]
+          :field_id (data/id :venues :name)}
+         (with-sharing-enabled-and-temp-dashcard-referencing :venues :name [dashboard]
+           (-> (http/client :get 200 (field-values-url dashboard (data/id :venues :name)))
+               (update :values (partial take 5)))))))
 
-;; shound NOT be able to use the endpoint with a Field not referenced by the Dashboard
-(expect
- "An error occurred."
- (with-sharing-enabled-and-temp-dashcard-referencing :venues :name [dashboard]
-   (http/client :get 400 (field-values-url dashboard (data/id :venues :price)))))
+(deftest shound-not-be-able-to-use-the-endpoint-with-a-field-not-referenced-by-the-dashboard
+  (is (= "An error occurred."
+         (with-sharing-enabled-and-temp-dashcard-referencing :venues :name [dashboard]
+           (http/client :get 400 (field-values-url dashboard (data/id :venues :price)))))))
 
-;; Endpoint should fail if public sharing is disabled
-(expect
- "An error occurred."
- (with-sharing-enabled-and-temp-dashcard-referencing :venues :name [dashboard]
-   (tu/with-temporary-setting-values [enable-public-sharing false]
-     (http/client :get 400 (field-values-url dashboard (data/id :venues :name))))))
+(deftest endpoint-should-fail-if-public-sharing-is-disabled
+  (is (= "An error occurred."
+         (with-sharing-enabled-and-temp-dashcard-referencing :venues :name [dashboard]
+           (tu/with-temporary-setting-values [enable-public-sharing false]
+             (http/client :get 400 (field-values-url dashboard (data/id :venues :name))))))))
+
 
 
 ;;; ----------------------------------------------- search-card-fields -----------------------------------------------
 
-(expect
- [[93 "33 Taps"]]
- (with-sharing-enabled-and-temp-card-referencing :venues :id [card]
-   (do ;tu/with-temp-vals-in-db Field (data/id :venues :name) {:special_type "type/Name"}
-     (public-api/search-card-fields (u/get-id card) (data/id :venues :id) (data/id :venues :name) "33 T" 10))))
 
-;; shouldn't work if the search-field isn't allowed to be used in combination with the other Field
-(expect
- Exception
- (with-sharing-enabled-and-temp-card-referencing :venues :id [card]
-   (public-api/search-card-fields (u/get-id card) (data/id :venues :id) (data/id :venues :price) "33 T" 10)))
+(deftest search-card-fields
+  (is (= [[93 "33 Taps"]]
+         (with-sharing-enabled-and-temp-card-referencing :venues :id [card]
+           (public-api/search-card-fields (u/get-id card) (data/id :venues :id) (data/id :venues :name) "33 T" 10)))))
 
-;; shouldn't work if the field isn't referenced by CARD
-(expect
- Exception
- (with-sharing-enabled-and-temp-card-referencing :venues :name [card]
-   (public-api/search-card-fields (u/get-id card) (data/id :venues :id) (data/id :venues :id) "33 T" 10)))
+
+
+(deftest shouldn-t-work-if-the-search-field-isn-t-allowed-to-be-used-in-combination-with-the-other-field
+  (is (thrown? Exception
+               (with-sharing-enabled-and-temp-card-referencing :venues :id [card]
+                 (public-api/search-card-fields (u/get-id card) (data/id :venues :id) (data/id :venues :price) "33 T" 10)))))
+
+
+
+(deftest shouldn-t-work-if-the-field-isn-t-referenced-by-card
+  (is (thrown? Exception
+               (with-sharing-enabled-and-temp-card-referencing :venues :name [card]
+                 (public-api/search-card-fields (u/get-id card) (data/id :venues :id) (data/id :venues :id) "33 T" 10)))))
+
 
 
 ;;; ----------------------- GET /api/public/card/:uuid/field/:field-id/search/:search-field-id -----------------------
@@ -892,64 +870,61 @@
        "/field/" (u/get-id field-or-id)
        "/search/" (u/get-id search-field-or-id)))
 
-(expect
- [[93 "33 Taps"]]
- (with-sharing-enabled-and-temp-card-referencing :venues :id [card]
-   (http/client :get 200 (field-search-url card (data/id :venues :id) (data/id :venues :name))
-                :value "33 T")))
+(deftest field-search-with-venue
+  (is (= [[93 "33 Taps"]]
+         (with-sharing-enabled-and-temp-card-referencing :venues :id [card]
+           (http/client :get 200 (field-search-url card (data/id :venues :id) (data/id :venues :name))
+                        :value "33 T")))))
 
-;; if search field isn't allowed to be used with the other Field endpoint should return exception
-(expect
- "An error occurred."
- (with-sharing-enabled-and-temp-card-referencing :venues :id [card]
-   (http/client :get 400 (field-search-url card (data/id :venues :id) (data/id :venues :price))
-                :value "33 T")))
+(deftest if-search-field-isn-t-allowed-to-be-used-with-the-other-field-endpoint-should-return-exception
+  (is (= "An error occurred."
+         (with-sharing-enabled-and-temp-card-referencing :venues :id [card]
+           (http/client :get 400 (field-search-url card (data/id :venues :id) (data/id :venues :price))
+                        :value "33 T")))))
 
-;; Endpoint should fail if public sharing is disabled
-(expect
-  "An error occurred."
-  (with-sharing-enabled-and-temp-card-referencing :venues :id [card]
-    (tu/with-temporary-setting-values [enable-public-sharing false]
-      (http/client :get 400 (field-search-url card (data/id :venues :id) (data/id :venues :name))
-                   :value "33 T"))))
+(deftest search-endpoint-should-fail-if-public-sharing-is-disabled
+  (is (= "An error occurred."
+         (with-sharing-enabled-and-temp-card-referencing :venues :id [card]
+           (tu/with-temporary-setting-values [enable-public-sharing false]
+             (http/client :get 400 (field-search-url card (data/id :venues :id) (data/id :venues :name))
+                          :value "33 T"))))))
+
 
 
 ;;; -------------------- GET /api/public/dashboard/:uuid/field/:field-id/search/:search-field-id ---------------------
 
-(expect
-  [[93 "33 Taps"]]
- (with-sharing-enabled-and-temp-dashcard-referencing :venues :id [dashboard]
-   (http/client :get (field-search-url dashboard (data/id :venues :id) (data/id :venues :name))
-                :value "33 T")))
 
-;; if search field isn't allowed to be used with the other Field endpoint should return exception
-(expect
-  "An error occurred."
-  (with-sharing-enabled-and-temp-dashcard-referencing :venues :id [dashboard]
-    (http/client :get 400 (field-search-url dashboard (data/id :venues :id) (data/id :venues :price))
-                 :value "33 T")))
+(deftest dashboard
+  (is (= [[93 "33 Taps"]]
+         (with-sharing-enabled-and-temp-dashcard-referencing :venues :id [dashboard]
+           (http/client :get (field-search-url dashboard (data/id :venues :id) (data/id :venues :name))
+                        :value "33 T")))))
 
-;; Endpoint should fail if public sharing is disabled
-(expect
-  "An error occurred."
-  (with-sharing-enabled-and-temp-dashcard-referencing :venues :id [dashboard]
-    (tu/with-temporary-setting-values [enable-public-sharing false]
-      (http/client :get 400 (field-search-url dashboard (data/id :venues :name) (data/id :venues :name))
-                   :value "33 T"))))
+(deftest dashboard-if-search-field-isn-t-allowed-to-be-used-with-the-other-field-endpoint-should-return-exception
+  (is (= "An error occurred."
+         (with-sharing-enabled-and-temp-dashcard-referencing :venues :id [dashboard]
+           (http/client :get 400 (field-search-url dashboard (data/id :venues :id) (data/id :venues :price))
+                        :value "33 T")))))
+
+(deftest dashboard-endpoint-should-fail-if-public-sharing-is-disabled
+  (is (= "An error occurred."
+         (with-sharing-enabled-and-temp-dashcard-referencing :venues :id [dashboard]
+           (tu/with-temporary-setting-values [enable-public-sharing false]
+             (http/client :get 400 (field-search-url dashboard (data/id :venues :name) (data/id :venues :name))
+                          :value "33 T"))))))
 
 ;;; --------------------------------------------- field-remapped-values ----------------------------------------------
 
 ;; `field-remapped-values` should return remappings in the expected format when the combination of Fields is allowed.
 ;; It should parse the value string (it comes back from the API as a string since it is a query param)
-(expect
- [10 "Fred 62"]
- (#'public-api/field-remapped-values (data/id :venues :id) (data/id :venues :name) "10"))
 
-;; if the Field isn't allowed
-(expect
-  Exception
-  (#'public-api/field-remapped-values (data/id :venues :id) (data/id :venues :price) "10"))
+(deftest should-parse-string
+  (is (= [10 "Fred 62"]
+         (#'public-api/field-remapped-values (data/id :venues :id) (data/id :venues :name) "10"))))
 
+(deftest if-the-field-isn-t-allowed
+  (is (thrown? Exception
+               (#'public-api/field-remapped-values (data/id :venues :id) (data/id :venues :price) "10"))))
 
 ;;; ----------------------- GET /api/public/card/:uuid/field/:field-id/remapping/:remapped-id ------------------------
 
@@ -962,63 +937,58 @@
        "/field/" (u/get-id field-or-id)
        "/remapping/" (u/get-id remapped-field-or-id)))
 
-;; we should be able to use the API endpoint and get the same results we get by calling the function above directly
-(expect
- [10 "Fred 62"]
- (with-sharing-enabled-and-temp-card-referencing :venues :id [card]
-   (http/client :get 200 (field-remapping-url card (data/id :venues :id) (data/id :venues :name))
-                :value "10")))
 
-;; shouldn't work if Card doesn't reference the Field in question
-(expect
- "An error occurred."
- (with-sharing-enabled-and-temp-card-referencing :venues :price [card]
-   (http/client :get 400 (field-remapping-url card (data/id :venues :id) (data/id :venues :name))
-                :value "10")))
+(deftest we-should-be-able-to-use-the-api-endpoint-and-get-the-same-results-we-get-by-calling-the-function-above-directly
+  (is (= [10 "Fred 62"]
+         (with-sharing-enabled-and-temp-card-referencing :venues :id [card]
+           (http/client :get 200 (field-remapping-url card (data/id :venues :id) (data/id :venues :name))
+                        :value "10")))))
 
-;; ...or if the remapping Field isn't allowed to be used with the other Field
-(expect
- "An error occurred."
- (with-sharing-enabled-and-temp-card-referencing :venues :id [card]
-   (http/client :get 400 (field-remapping-url card (data/id :venues :id) (data/id :venues :price))
-                :value "10")))
+(deftest shouldn-t-work-if-card-doesn-t-reference-the-field-in-question
+  (is (= "An error occurred."
+         (with-sharing-enabled-and-temp-card-referencing :venues :price [card]
+           (http/client :get 400 (field-remapping-url card (data/id :venues :id) (data/id :venues :name))
+                        :value "10")))))
 
-;; ...or if public sharing is disabled
-(expect
- "An error occurred."
- (with-sharing-enabled-and-temp-card-referencing :venues :id [card]
-   (tu/with-temporary-setting-values [enable-public-sharing false]
-     (http/client :get 400 (field-remapping-url card (data/id :venues :id) (data/id :venues :name))
-                  :value "10"))))
 
+(deftest ---or-if-the-remapping-field-isn-t-allowed-to-be-used-with-the-other-field
+  (is (= "An error occurred."
+         (with-sharing-enabled-and-temp-card-referencing :venues :id [card]
+           (http/client :get 400 (field-remapping-url card (data/id :venues :id) (data/id :venues :price))
+                        :value "10")))))
+
+(deftest ---or-if-public-sharing-is-disabled
+  (is (= "An error occurred."
+         (with-sharing-enabled-and-temp-card-referencing :venues :id [card]
+           (tu/with-temporary-setting-values [enable-public-sharing false]
+             (http/client :get 400 (field-remapping-url card (data/id :venues :id) (data/id :venues :name))
+                          :value "10"))))))
 
 ;;; --------------------- GET /api/public/dashboard/:uuid/field/:field-id/remapping/:remapped-id ---------------------
 
-;; we should be able to use the API endpoint and get the same results we get by calling the function above directly
-(expect
- [10 "Fred 62"]
- (with-sharing-enabled-and-temp-dashcard-referencing :venues :id [dashboard]
-   (http/client :get 200 (field-remapping-url dashboard (data/id :venues :id) (data/id :venues :name))
-                :value "10")))
 
-;; shouldn't work if Card doesn't reference the Field in question
-(expect
- "An error occurred."
- (with-sharing-enabled-and-temp-dashcard-referencing :venues :price [dashboard]
-   (http/client :get 400 (field-remapping-url dashboard (data/id :venues :id) (data/id :venues :name))
-                :value "10")))
+(deftest api-endpoint-should-return-same-results-as-function
+  (is (= [10 "Fred 62"]
+         (with-sharing-enabled-and-temp-dashcard-referencing :venues :id [dashboard]
+           (http/client :get 200 (field-remapping-url dashboard (data/id :venues :id) (data/id :venues :name))
+                        :value "10")))))
 
-;; ...or if the remapping Field isn't allowed to be used with the other Field
-(expect
- "An error occurred."
- (with-sharing-enabled-and-temp-dashcard-referencing :venues :id [dashboard]
-   (http/client :get 400 (field-remapping-url dashboard (data/id :venues :id) (data/id :venues :price))
-                :value "10")))
+(deftest field-remapping-shouldn-t-work-if-card-doesn-t-reference-the-field-in-question
+  (is (= "An error occurred."
+         (with-sharing-enabled-and-temp-dashcard-referencing :venues :price [dashboard]
+           (http/client :get 400 (field-remapping-url dashboard (data/id :venues :id) (data/id :venues :name))
+                        :value "10")))))
 
-;; ...or if public sharing is disabled
-(expect
- "An error occurred."
- (with-sharing-enabled-and-temp-dashcard-referencing :venues :id [dashboard]
-   (tu/with-temporary-setting-values [enable-public-sharing false]
-     (http/client :get 400 (field-remapping-url dashboard (data/id :venues :id) (data/id :venues :name))
-                  :value "10"))))
+(deftest remapping-or-if-the-remapping-field-isn-t-allowed-to-be-used-with-the-other-field
+  (is (= "An error occurred."
+         (with-sharing-enabled-and-temp-dashcard-referencing :venues :id [dashboard]
+           (http/client :get 400 (field-remapping-url dashboard (data/id :venues :id) (data/id :venues :price))
+                        :value "10")))))
+
+(deftest remapping-or-if-public-sharing-is-disabled
+  (is (= "An error occurred."
+         (with-sharing-enabled-and-temp-dashcard-referencing :venues :id [dashboard]
+           (tu/with-temporary-setting-values [enable-public-sharing false]
+             (http/client :get 400 (field-remapping-url dashboard (data/id :venues :id) (data/id :venues :name))
+                          :value "10"))))))
+

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -451,7 +451,7 @@
                                  :fingerprint  (:latitude mutil/venue-fingerprints)})])})
   (do
     ;; run the Card which will populate its result_metadata column
-    ((test-users/user->client :crowberto) :post 200 (format "card/%d/query" (u/get-id card)))
+    ((test-users/user->client :crowberto) :post 202 (format "card/%d/query" (u/get-id card)))
     ;; Now fetch the metadata for this "table"
     (->> card
          u/get-id
@@ -499,7 +499,7 @@
                                                                               :latest   "2014-12-05T15:15:00"}}}}]})
   (do
     ;; run the Card which will populate its result_metadata column
-    ((test-users/user->client :crowberto) :post 200 (format "card/%d/query" (u/get-id card)))
+    ((test-users/user->client :crowberto) :post 202 (format "card/%d/query" (u/get-id card)))
     ;; Now fetch the metadata for this "table"
     (->> card
          u/get-id
@@ -679,7 +679,7 @@
                                             :type    :query
                                             :query    {:source-query {:source-table (data/id :venues)}}}}]
     ;; run the Card which will populate its result_metadata column
-    ((test-users/user->client :crowberto) :post 200 (format "card/%d/query" (u/get-id card)))
+    ((test-users/user->client :crowberto) :post 202 (format "card/%d/query" (u/get-id card)))
     (let [response ((test-users/user->client :crowberto) :get 200 (format "table/card__%d/query_metadata" (u/get-id card)))]
       (map #(dimension-options-for-field response %)
            ["latitude" "longitude"]))))

--- a/test/metabase/http_client.clj
+++ b/test/metabase/http_client.clj
@@ -127,7 +127,7 @@
       (throw (ex-info message {:status-code actual-status-code}))))
   ;; all other status codes should be test assertions against the expected status code if one was specified
   (when expected-status-code
-    (t/is (= actual-status-code expected-status-code)
+    (t/is (= expected-status-code actual-status-code)
           (format "%s %s expected a status code of %d, got %d."
                   method-name url expected-status-code actual-status-code))))
 

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -87,7 +87,7 @@
                                     :dataset_query   (native-query "SELECT * FROM VENUES")
                                     :result_metadata [{:name "NAME", :display_name "Name", :base_type "type/Text"}]}]]
     (perms/grant-collection-read-permissions! (group/all-users) collection)
-    ((users/user->client :rasta) :post 200 "dataset" {:database mbql.s/saved-questions-virtual-database-id
+    ((users/user->client :rasta) :post 202 "dataset" {:database mbql.s/saved-questions-virtual-database-id
                                                       :type     :query
                                                       :query    {:source-table (str "card__" (u/get-id card))}})
     (card-metadata card)))


### PR DESCRIPTION
Updates response handling so that streaming endpoints return a 202 status. This allows all endpoints to take advantage of the recent FE work in #11726 which makes it possible for the FE to show error messages for streaming responses.

In the course of writing this, I ended up updating a ton of tests to use `deftest` instead of `expect` in order to better support running REPL tests. Hopefully the changes in `src` files are small enough to be easily reviewable, despite all the noise from tests.

I also added `^:returns-chan` metadata for handlers that return a chan. This doesn't affect behavior; it only serves as documentation. I thought it'd be useful if/when we want to implement further changes to endpoints that stream responses.

closes #11783