### PR TITLE
Harden sync agains errors in downstream steps

### DIFF
--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -58,7 +58,7 @@
   {:arglists '([field])}
   (fn [{:keys [base_type special_type unit] :as field}]
     [(cond
-       (u.date/extract-units unit)    :type/Integer
+       (u.date/extract-units unit)     :type/Integer
        (field/unix-timestamp? field)   :type/DateTime
        ;; for historical reasons the Temporal fingerprinter is still called `:type/DateTime` so anything that derives
        ;; from `Temporal` (such as DATEs and TIMEs) should still use the `:type/DateTime` fingerprinter

--- a/test/metabase/sync/analyze_test.clj
+++ b/test/metabase/sync/analyze_test.clj
@@ -96,4 +96,4 @@
 
 (deftest survive-classify-table-errors
   (testing "Make sure we survive table classification failing"
-    (sync-survives-crash? classifiers.name/infer-entity-type crash-fn)))
+    (sync-survives-crash? classifiers.name/infer-entity-type)))

--- a/test/metabase/sync/analyze_test.clj
+++ b/test/metabase/sync/analyze_test.clj
@@ -17,7 +17,7 @@
             [metabase.sync.analyze.fingerprint.fingerprinters :as fingerprinters]
             [metabase.test
              [data :as data]
-             [sync :as test.sync :refer [crash-fn sync-steps-run-to-competion]]]
+             [sync :as test.sync :refer [sync-survives-crash?]]]
             [metabase.util :as u]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
@@ -85,21 +85,15 @@
 
 (deftest survive-fingerprinting-errors
   (testing "Make sure we survive fingerprinting failing"
-    (with-redefs [fingerprinters/fingerprinter crash-fn]
-      (is (= (sync-steps-run-to-competion (analyze/analyze-db! (Database (data/id)))) 4)))))
+    (sync-survives-crash? fingerprinters/fingerprinter)))
 
 (deftest survive-classify-fields-errors
   (testing "Make sure we survive field classification failing"
-    (with-redefs [classifiers.name/special-type-for-name-and-base-type crash-fn]
-      (is (= (sync-steps-run-to-competion (analyze/analyze-db! (Database (data/id)))) 4)))
-    (with-redefs [classifiers.category/infer-is-category-or-list crash-fn]
-      (is (= (sync-steps-run-to-competion (analyze/analyze-db! (Database (data/id)))) 4)))
-    (with-redefs [classifiers.no-preview-display/infer-no-preview-display crash-fn]
-      (is (= (sync-steps-run-to-competion (analyze/analyze-db! (Database (data/id)))) 4)))
-    (with-redefs [classifiers.text-fingerprint/infer-special-type crash-fn]
-      (is (= (sync-steps-run-to-competion (analyze/analyze-db! (Database (data/id)))) 4)))))
+    (sync-survives-crash? classifiers.name/special-type-for-name-and-base-type)
+    (sync-survives-crash? classifiers.category/infer-is-category-or-list)
+    (sync-survives-crash? classifiers.no-preview-display/infer-no-preview-display)
+    (sync-survives-crash? classifiers.text-fingerprint/infer-special-type)))
 
 (deftest survive-classify-table-errors
   (testing "Make sure we survive table classification failing"
-    (with-redefs [classifiers.name/infer-entity-type crash-fn]
-      (is (= (sync-steps-run-to-competion (analyze/analyze-db! (Database (data/id)))) 4)))))
+    (sync-survives-crash? classifiers.name/infer-entity-type crash-fn)))

--- a/test/metabase/sync/sync_metadata_test.clj
+++ b/test/metabase/sync/sync_metadata_test.clj
@@ -1,42 +1,31 @@
 (ns metabase.sync.sync-metadata-test
   (:require [clojure.test :refer :all]
-            [metabase.models.database :refer [Database]]
-            [metabase.sync.sync-metadata :as sync-metadata]
             [metabase.sync.sync-metadata
              [fields :as sync-fields]
              [fks :as sync-fks]
              [metabase-metadata :as metabase-metadata]
              [sync-timezone :as sync-tz]
              [tables :as sync-tables]]
-            [metabase.test
-             [data :as data]
-             [sync :as test.sync :refer [crash-fn sync-steps-run-to-competion]]]))
+            [metabase.test.sync :refer [sync-survives-crash?]]))
 
 (deftest survive-metadata-errors
   (testing "Make sure we survive metadata sync failing"
-    (with-redefs [metabase-metadata/sync-metabase-metadata! crash-fn]
-      (is (= (sync-steps-run-to-competion (sync-metadata/sync-db-metadata! (Database (data/id)))) 6)))))
+    (sync-survives-crash? metabase-metadata/sync-metabase-metadata!)))
 
 (deftest survive-tz-errors
   (testing "Make sure we survive metadataDB timezone sync failing"
-    (with-redefs [sync-tz/sync-timezone! crash-fn]
-      (is (= (sync-steps-run-to-competion (sync-metadata/sync-db-metadata! (Database (data/id)))) 6)))))
+    (sync-survives-crash? sync-tz/sync-timezone!)))
 
 (deftest survive-fields-errors
   (testing "Make sure we survive field sync failing"
-    (with-redefs [sync-fields/sync-and-update! crash-fn]
-      (is (= (sync-steps-run-to-competion (sync-metadata/sync-db-metadata! (Database (data/id)))) 6)))))
+    (sync-survives-crash? sync-fields/sync-and-update!)))
 
 (deftest survive-table-errors
   (testing "Make sure we survive table sync failing"
-    (with-redefs [sync-tables/create-or-reactivate-tables! crash-fn]
-      (is (= (sync-steps-run-to-competion (sync-metadata/sync-db-metadata! (Database (data/id)))) 6)))
-    (with-redefs [sync-tables/retire-tables! crash-fn]
-      (is (= (sync-steps-run-to-competion (sync-metadata/sync-db-metadata! (Database (data/id)))) 6)))
-    (with-redefs [sync-tables/update-table-description! crash-fn]
-      (is (= (sync-steps-run-to-competion (sync-metadata/sync-db-metadata! (Database (data/id)))) 6)))))
+    (sync-survives-crash? sync-tables/create-or-reactivate-tables!)
+    (sync-survives-crash? sync-tables/retire-tables!)
+    (sync-survives-crash? sync-tables/update-table-description!)))
 
 (deftest survive-fk-errors
   (testing "Make sure we survive FK sync failing"
-    (with-redefs [sync-fks/mark-fk! crash-fn]
-      (is (= (sync-steps-run-to-competion (sync-metadata/sync-db-metadata! (Database (data/id)))) 6)))))
+    (sync-survives-crash? sync-fks/mark-fk!)))

--- a/test/metabase/sync/sync_metadata_test.clj
+++ b/test/metabase/sync/sync_metadata_test.clj
@@ -1,0 +1,42 @@
+(ns metabase.sync.sync-metadata-test
+  (:require [clojure.test :refer :all]
+            [metabase.models.database :refer [Database]]
+            [metabase.sync.sync-metadata :as sync-metadata]
+            [metabase.sync.sync-metadata
+             [fields :as sync-fields]
+             [fks :as sync-fks]
+             [metabase-metadata :as metabase-metadata]
+             [sync-timezone :as sync-tz]
+             [tables :as sync-tables]]
+            [metabase.test
+             [data :as data]
+             [sync :as test.sync :refer [crash-fn sync-steps-run-to-competion]]]))
+
+(deftest survive-metadata-errors
+  (testing "Make sure we survive metadata sync failing"
+    (with-redefs [metabase-metadata/sync-metabase-metadata! crash-fn]
+      (is (= (sync-steps-run-to-competion (sync-metadata/sync-db-metadata! (Database (data/id)))) 6)))))
+
+(deftest survive-tz-errors
+  (testing "Make sure we survive metadataDB timezone sync failing"
+    (with-redefs [sync-tz/sync-timezone! crash-fn]
+      (is (= (sync-steps-run-to-competion (sync-metadata/sync-db-metadata! (Database (data/id)))) 6)))))
+
+(deftest survive-fields-errors
+  (testing "Make sure we survive field sync failing"
+    (with-redefs [sync-fields/sync-and-update! crash-fn]
+      (is (= (sync-steps-run-to-competion (sync-metadata/sync-db-metadata! (Database (data/id)))) 6)))))
+
+(deftest survive-table-errors
+  (testing "Make sure we survive table sync failing"
+    (with-redefs [sync-tables/create-or-reactivate-tables! crash-fn]
+      (is (= (sync-steps-run-to-competion (sync-metadata/sync-db-metadata! (Database (data/id)))) 6)))
+    (with-redefs [sync-tables/retire-tables! crash-fn]
+      (is (= (sync-steps-run-to-competion (sync-metadata/sync-db-metadata! (Database (data/id)))) 6)))
+    (with-redefs [sync-tables/update-table-description! crash-fn]
+      (is (= (sync-steps-run-to-competion (sync-metadata/sync-db-metadata! (Database (data/id)))) 6)))))
+
+(deftest survive-fk-errors
+  (testing "Make sure we survive FK sync failing"
+    (with-redefs [sync-fks/mark-fk! crash-fn]
+      (is (= (sync-steps-run-to-competion (sync-metadata/sync-db-metadata! (Database (data/id)))) 6)))))

--- a/test/metabase/test/sync.clj
+++ b/test/metabase/test/sync.clj
@@ -1,16 +1,28 @@
 (ns metabase.test.sync
-  (:require [metabase.models.task-history :refer [TaskHistory]]
+  (:require [clojure.test :refer :all]
+            [metabase.models
+             [database :refer [Database]]
+             [task-history :refer [TaskHistory]]]
+            [metabase.sync :as sync]
             [metabase.test.data :as data]
             [toucan.db :as db]))
 
-(defmacro sync-steps-run-to-competion
-  "Runs `body` presumably containing calls to sync steps and counts the number of completed steps"
-  [& body]
-  `(data/with-temp-copy-of-db
-     ~@body
-     (db/count TaskHistory :db_id (data/id))))
+(defn sync-steps-run-to-completion
+  "Returns the number of sync steps that run succesfully by counting entries in `TaskHistory`"
+  []
+  (data/with-temp-copy-of-db
+    ;; `sync-database!` does both sync an analysis steps
+    (sync/sync-database! (Database (data/id)))
+    (db/count TaskHistory :db_id (data/id))))
 
 (defn crash-fn
   "A function that always crashes"
   [& _]
   (throw (Exception. "simulated exception")))
+
+(defmacro sync-survives-crash?
+  "Can sync process survive `f` crashing?"
+  [f]
+  `(is (= (sync-steps-run-to-completion)
+          (with-redefs [~f crash-fn]
+            (sync-steps-run-to-completion)))))

--- a/test/metabase/test/sync.clj
+++ b/test/metabase/test/sync.clj
@@ -1,0 +1,16 @@
+(ns metabase.test.sync
+  (:require [metabase.models.task-history :refer [TaskHistory]]
+            [metabase.test.data :as data]
+            [toucan.db :as db]))
+
+(defmacro sync-steps-run-to-competion
+  "Runs `body` presumably containing calls to sync steps and counts the number of completed steps"
+  [& body]
+  `(data/with-temp-copy-of-db
+     ~@body
+     (db/count TaskHistory :db_id (data/id))))
+
+(defn crash-fn
+  "A function that always crashes"
+  [& _]
+  (throw (Exception. "simulated exception")))


### PR DESCRIPTION
Fixes a couple of places where the whole sync process could be disrupted and adds survivability tests.

Note: as it's a change to sync and potentially dicey I think it's better to release this as part of .35, hence it's based off master. 