### PR TITLE
Fix bug in chart column settings back behavior

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -197,6 +197,8 @@ class ChartSettings extends Component {
       addField: addField,
       onShowWidget: this.handleShowWidget,
       onEndShowWidget: this.handleEndShowWidget,
+      onShowSection: this.handleShowSection,
+      hasMultipleSections: sectionNames.length > 1,
     };
 
     const sectionPicker = (

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -191,14 +191,20 @@ class ChartSettings extends Component {
       visibleWidgets = sections[currentSection] || [];
     }
 
+    // This checks whether the current section contains a column settings widget
+    // at the top level. If it does, we avoid hiding the section tabs and
+    // overriding the sidebar title.
+    const currentSectionHasColumnSettings = (
+      sections[currentSection] || []
+    ).some(widget => widget.id === "column_settings");
+
     const extraWidgetProps = {
       // NOTE: special props to support adding additional fields
       question: question,
       addField: addField,
       onShowWidget: this.handleShowWidget,
       onEndShowWidget: this.handleEndShowWidget,
-      onShowSection: this.handleShowSection,
-      hasMultipleSections: sectionNames.length > 1,
+      currentSectionHasColumnSettings,
     };
 
     const sectionPicker = (
@@ -241,7 +247,9 @@ class ChartSettings extends Component {
       // hide the section picker if the only widget is column_settings
       !(
         visibleWidgets.length === 1 &&
-        visibleWidgets[0].id === "column_settings"
+        visibleWidgets[0].id === "column_settings" &&
+        // and this section doesn't doesn't have that as a direct child
+        !currentSectionHasColumnSettings
       );
 
     // default layout with visualization

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingColumns.jsx
@@ -45,17 +45,19 @@ class ColumnWidgets extends React.Component {
       onShowSection,
     } = this.props;
 
+    // These two props (title and onBack) are overridden to display a column
+    // name instead of the visualization type when viewing a column's settings.
     if (setSidebarPropsOverride) {
       const overrides = { title: displayNameForColumn(object) };
-      if (hasMultipleSections) {
-        // We override `onBack` when there are multple hidden sections. If
-        // section headers are hidden because we only have one, clicking back
-        // should still return us to the visualization list.
-        overrides.onBack =
-          // If there is just one object, we reset the section when going back.
-          // If there are multiple objects, we reset object selection to return
-          // to the list of columns but stay in the current section.
-          objects.length === 1 ? onShowSection : onChangeEditingObject;
+      if (objects.length > 1) {
+        // If there are multiple objects, we reset object selection to return
+        // to the list of columns but stay in the current section.
+        overrides.onBack = onChangeEditingObject;
+      } else if (hasMultipleSections) {
+        // If there is just one object, we reset the section when going back. If
+        // there aren't multiple sections clicking back should still return us
+        // to the visualization list, so we don't override `onBack` at all.
+        overrides.onBack = onShowSection;
       }
       setSidebarPropsOverride(overrides);
     }

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingColumns.jsx
@@ -52,11 +52,13 @@ class ColumnWidgets extends React.Component {
       if (objects.length > 1) {
         // If there are multiple objects, we reset object selection to return
         // to the list of columns but stay in the current section.
+        // $FlowFixMe onBack isn't always set
         overrides.onBack = onChangeEditingObject;
       } else if (hasMultipleSections) {
         // If there is just one object, we reset the section when going back. If
         // there aren't multiple sections clicking back should still return us
         // to the visualization list, so we don't override `onBack` at all.
+        // $FlowFixMe onBack isn't always set
         overrides.onBack = onShowSection;
       }
       setSidebarPropsOverride(overrides);

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingColumns.jsx
@@ -38,15 +38,26 @@ class ColumnWidgets extends React.Component {
   componentDidMount() {
     const {
       setSidebarPropsOverride,
-      onChangeEditingObject,
       object,
+      objects,
+      hasMultipleSections,
+      onChangeEditingObject,
+      onShowSection,
     } = this.props;
 
     if (setSidebarPropsOverride) {
-      setSidebarPropsOverride({
-        title: displayNameForColumn(object),
-        onBack: () => onChangeEditingObject(),
-      });
+      const overrides = { title: displayNameForColumn(object) };
+      if (hasMultipleSections) {
+        // We override `onBack` when there are multple hidden sections. If
+        // section headers are hidden because we only have one, clicking back
+        // should still return us to the visualization list.
+        overrides.onBack =
+          // If there is just one object, we reset the section when going back.
+          // If there are multiple objects, we reset object selection to return
+          // to the list of columns but stay in the current section.
+          objects.length === 1 ? onShowSection : onChangeEditingObject;
+      }
+      setSidebarPropsOverride(overrides);
     }
   }
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingColumns.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingColumns.jsx
@@ -39,29 +39,20 @@ class ColumnWidgets extends React.Component {
     const {
       setSidebarPropsOverride,
       object,
-      objects,
-      hasMultipleSections,
-      onChangeEditingObject,
-      onShowSection,
+      onEndShowWidget,
+      currentSectionHasColumnSettings,
     } = this.props;
 
     // These two props (title and onBack) are overridden to display a column
     // name instead of the visualization type when viewing a column's settings.
-    if (setSidebarPropsOverride) {
-      const overrides = { title: displayNameForColumn(object) };
-      if (objects.length > 1) {
-        // If there are multiple objects, we reset object selection to return
-        // to the list of columns but stay in the current section.
-        // $FlowFixMe onBack isn't always set
-        overrides.onBack = onChangeEditingObject;
-      } else if (hasMultipleSections) {
-        // If there is just one object, we reset the section when going back. If
-        // there aren't multiple sections clicking back should still return us
-        // to the visualization list, so we don't override `onBack` at all.
-        // $FlowFixMe onBack isn't always set
-        overrides.onBack = onShowSection;
-      }
-      setSidebarPropsOverride(overrides);
+    // If the column setting is directly within the section rather than an
+    // additional widget we drilled into, clicking back should still return us
+    // to the visualization list. In that case, we don't override these at all.
+    if (setSidebarPropsOverride && !currentSectionHasColumnSettings) {
+      setSidebarPropsOverride({
+        title: displayNameForColumn(object),
+        onBack: onEndShowWidget,
+      });
     }
   }
 

--- a/frontend/test/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.unit.spec.js
@@ -7,13 +7,13 @@ import { SAMPLE_DATASET } from "__support__/sample_dataset_fixture";
 import ChartSettingsSidebar from "metabase/query_builder/components/view/sidebars/ChartSettingsSidebar";
 
 describe("ChartSettingsSidebar", () => {
+  const data = {
+    rows: [[1]],
+    cols: [{ base_type: "type/Integer", name: "foo", display_name: "foo" }],
+  };
   afterEach(cleanup);
 
   it("should hide title and section picker when viewing column settings", () => {
-    const data = {
-      rows: [["bar"]],
-      cols: [{ base_type: "type/Text", name: "foo", display_name: "foo" }],
-    };
     const { container, getByText, queryByText } = render(
       <ChartSettingsSidebar
         question={SAMPLE_DATASET.question()}
@@ -27,11 +27,7 @@ describe("ChartSettingsSidebar", () => {
     expect(queryByText("Conditional Formatting")).toBe(null);
   });
 
-  it("should for gauge charts", () => {
-    const data = {
-      rows: [[1]],
-      cols: [{ base_type: "type/Integer", name: "foo", display_name: "foo" }],
-    };
+  it("should not hide the title for gauge charts", () => {
     const { getByText, queryByText } = render(
       <ChartSettingsSidebar
         question={SAMPLE_DATASET.question().setDisplay("gauge")}
@@ -46,15 +42,23 @@ describe("ChartSettingsSidebar", () => {
     // click on formatting section
     fireEvent.click(getByText("Formatting"));
 
-    // former header and sections are gone
-    expect(queryByText("Gauge options")).toBe(null);
-    expect(queryByText("Formatting")).toBe(null);
-    expect(queryByText("Display")).toBe(null);
-
-    // click on new "foo" (column name) header to return
-    fireEvent.click(getByText("foo"));
+    // you see the formatting stuff
+    getByText("Style");
+    // but the sections and back title are unchanged
     getByText("Gauge options");
     getByText("Formatting");
     getByText("Display");
+  });
+
+  it("should not hide the title for scalar charts", () => {
+    const { getByText, queryByText } = render(
+      <ChartSettingsSidebar
+        question={SAMPLE_DATASET.question().setDisplay("scalar")}
+        result={{ data }}
+      />,
+    );
+    // see header with formatting fields
+    getByText("Number options");
+    getByText("Style");
   });
 });

--- a/frontend/test/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.unit.spec.js
@@ -28,7 +28,7 @@ describe("ChartSettingsSidebar", () => {
   });
 
   it("should not hide the title for gauge charts", () => {
-    const { getByText, queryByText } = render(
+    const { getByText } = render(
       <ChartSettingsSidebar
         question={SAMPLE_DATASET.question().setDisplay("gauge")}
         result={{ data }}
@@ -51,7 +51,7 @@ describe("ChartSettingsSidebar", () => {
   });
 
   it("should not hide the title for scalar charts", () => {
-    const { getByText, queryByText } = render(
+    const { getByText } = render(
       <ChartSettingsSidebar
         question={SAMPLE_DATASET.question().setDisplay("scalar")}
         result={{ data }}

--- a/frontend/test/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.unit.spec.js
@@ -1,12 +1,14 @@
 import React from "react";
 import "@testing-library/jest-dom/extend-expect";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, cleanup } from "@testing-library/react";
 
 import { SAMPLE_DATASET } from "__support__/sample_dataset_fixture";
 
 import ChartSettingsSidebar from "metabase/query_builder/components/view/sidebars/ChartSettingsSidebar";
 
 describe("ChartSettingsSidebar", () => {
+  afterEach(cleanup);
+
   it("should hide title and section picker when viewing column settings", () => {
     const data = {
       rows: [["bar"]],

--- a/frontend/test/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.unit.spec.js
@@ -24,4 +24,35 @@ describe("ChartSettingsSidebar", () => {
     expect(queryByText("Table options")).toBe(null);
     expect(queryByText("Conditional Formatting")).toBe(null);
   });
+
+  it("should for gauge charts", () => {
+    const data = {
+      rows: [[1]],
+      cols: [{ base_type: "type/Integer", name: "foo", display_name: "foo" }],
+    };
+    const { container, getByText, queryByText, debug } = render(
+      <ChartSettingsSidebar
+        question={SAMPLE_DATASET.question().setDisplay("gauge")}
+        result={{ data }}
+      />,
+    );
+    // see options header with sections
+    getByText("Gauge options");
+    getByText("Formatting");
+    getByText("Display");
+
+    // click on formatting section
+    fireEvent.click(getByText("Formatting"));
+
+    // former header and sections are gone
+    expect(queryByText("Gauge options")).toBe(null);
+    expect(queryByText("Formatting")).toBe(null);
+    expect(queryByText("Display")).toBe(null);
+
+    // click on new "foo" (column name) header to return
+    fireEvent.click(getByText("foo"));
+    getByText("Gauge options");
+    getByText("Formatting");
+    getByText("Display");
+  });
 });

--- a/frontend/test/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.unit.spec.js
@@ -30,7 +30,7 @@ describe("ChartSettingsSidebar", () => {
       rows: [[1]],
       cols: [{ base_type: "type/Integer", name: "foo", display_name: "foo" }],
     };
-    const { container, getByText, queryByText, debug } = render(
+    const { getByText, queryByText } = render(
       <ChartSettingsSidebar
         question={SAMPLE_DATASET.question().setDisplay("gauge")}
         result={{ data }}

--- a/frontend/test/metabase/visualizations/components/ChartSettings.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/ChartSettings.unit.spec.js
@@ -131,13 +131,21 @@ describe("ChartSettings", () => {
   });
 
   it("should not show the section picker if showing a column setting", () => {
+    const columnSettingsWidget = widget({
+      title: "Something",
+      section: "Formatting",
+      hidden: true,
+      id: "column_settings",
+    });
     const { queryByText } = render(
       <ChartSettings
         {...DEFAULT_PROPS}
         widgets={[
-          widget({ title: "Something", section: "Foo", id: "column_settings" }),
+          widget({ title: "List of columns", section: "Foo", id: "thing" }),
           widget({ title: "Other Thing", section: "Bar", id: "other_thing" }),
+          columnSettingsWidget,
         ]}
+        initial={{ widget: columnSettingsWidget }}
       />,
     );
     expect(queryByText("Foo")).toBe(null);


### PR DESCRIPTION
Resolves #11775

## Fix

This PR updates how nested columns settings override the back behavior of the settings sidebar. Previously, the back behavior was always set to unselect the current column. This was ineffective if there was only one column because it was immediately reselected. Now, we unset the current _section_ if there's just one column.

Another issue, was for settings with just one section. There resetting the current section wouldn't do anything, so we leave the standard back behavior of returning to the visualization types.

## Gifs

### Table

![table](https://user-images.githubusercontent.com/691495/73571487-a7abc480-443c-11ea-9de4-d54f5ca385fe.gif)


### Gauge

![gauge](https://user-images.githubusercontent.com/691495/73571494-ad090f00-443c-11ea-8399-691f385afbb4.gif)


### Number

![number](https://user-images.githubusercontent.com/691495/73571499-af6b6900-443c-11ea-9ec3-b94c3a67d2aa.gif)

@mazameli this one seems a bit weird to me. What do you think about not overriding title with the column name in this case?


## Design

It feels wrong that the nested settings are aware of all this external context. It seemed like the alternative was to spread the behavior across multiple components so I left it this way.