### PR TITLE
Custom drill with URL template stored in field settings

### DIFF
--- a/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/FieldApp.jsx
@@ -173,6 +173,15 @@ export default class FieldApp extends React.Component {
     return this.onUpdateFieldProperties({ settings });
   };
 
+  updateCustomActionDebounced = _.debounce(url => {
+    return this.onUpdateFieldProperties({ settings: { custom_actions: { url: url }}});
+  }, 300);
+
+  onUpdateCustomAction = (e: { target: HTMLInputElement }) => {
+    const url = e.target.value;
+    this.updateCustomActionDebounced(url);
+  };
+
   render() {
     const {
       metadata,
@@ -243,6 +252,7 @@ export default class FieldApp extends React.Component {
                   onUpdateFieldProperties={this.onUpdateFieldProperties}
                   onUpdateFieldDimension={this.onUpdateFieldDimension}
                   onDeleteFieldDimension={this.onDeleteFieldDimension}
+                  onUpdateCustomAction={this.onUpdateCustomAction}
                   rescanFieldValues={rescanFieldValues}
                   discardFieldValues={discardFieldValues}
                   fetchTableMetadata={fetchTableMetadata}
@@ -270,6 +280,7 @@ const FieldGeneralPane = ({
   onUpdateFieldProperties,
   onUpdateFieldDimension,
   onDeleteFieldDimension,
+  onUpdateCustomAction,
   rescanFieldValues,
   discardFieldValues,
   fetchTableMetadata,
@@ -336,6 +347,19 @@ const FieldGeneralPane = ({
         updateFieldDimension={onUpdateFieldDimension}
         deleteFieldDimension={onDeleteFieldDimension}
         fetchTableMetadata={fetchTableMetadata}
+      />
+    </Section>
+
+    <Section>
+      <SectionHeader
+        title={t`Custom actions`}
+        description={t`Link this field value to a custom URL`}
+      />
+      <InputBlurChange
+        className="text AdminInput bordered input text-measure block full"
+        value={field.settings && field.settings.custom_actions && field.settings.custom_actions.url}
+        onChange={onUpdateCustomAction}
+        placeholder={t`https://example.com/{value}`}
       />
     </Section>
 

--- a/frontend/src/metabase/modes/components/drill/CustomDrill.jsx
+++ b/frontend/src/metabase/modes/components/drill/CustomDrill.jsx
@@ -1,0 +1,60 @@
+/* @flow */
+
+import React from "react";
+import { jt } from "ttag";
+import { isFK, isPK } from "metabase/lib/types";
+import { singularize, stripId } from "metabase/lib/formatting";
+import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+
+import type {
+  ClickAction,
+  ClickActionProps,
+} from "metabase/meta/types/Visualization";
+
+function getCustomDrill(column) {
+  if (column.settings && column.settings.custom_actions) {
+    return { name: "page", url: column.settings.custom_actions.url };
+  } else if (isFK(column.special_type)) {
+    //FIXME how to access metadata of target column?
+  }
+
+  return null;
+}
+
+export default ({ question, clicked }: ClickActionProps): ClickAction[] => {
+  const query = question.query();
+  if (
+    !(query instanceof StructuredQuery) ||
+    !clicked ||
+    !clicked.column ||
+    clicked.column.id == null ||
+    clicked.value == undefined
+  ) {
+    return [];
+  }
+
+  const { value, column } = clicked;
+  const customDrill = getCustomDrill(column);
+
+  if (!customDrill) {
+    return [];
+  }
+
+  return [
+    {
+      name: "custom-url",
+      section: "custom",
+      title: (
+        <span>
+          {jt`View this ${singularize(
+            isPK(column.special_type) ? query.table().display_name : stripId(column.display_name),
+          )}'s ${customDrill.name}`}
+        </span>
+      ),
+      url: () => {
+        // FIXME Use rfc6570 implementation
+        return customDrill.url.replace('{value}', value);
+      },
+    },
+  ];
+};

--- a/frontend/src/metabase/modes/components/drill/index.js
+++ b/frontend/src/metabase/modes/components/drill/index.js
@@ -9,6 +9,7 @@ import AutomaticDashboardDrill from "./AutomaticDashboardDrill";
 import CompareToRestDrill from "./CompareToRestDrill";
 import ZoomDrill from "./ZoomDrill";
 import FormatAction from "./FormatAction";
+import CustomDrill from "./CustomDrill";
 
 import { PLUGIN_DRILLS } from "metabase/plugins";
 
@@ -22,5 +23,6 @@ export const getDefaultDrills = () => [
   AutomaticDashboardDrill,
   CompareToRestDrill,
   FormatAction,
+  CustomDrill,
   ...PLUGIN_DRILLS,
 ];


### PR DESCRIPTION
### Context

WIP implementation of #8461 / #9074.
The goal is to let the admin associate a URL template to a field, so that when a value of that field is displayed the end user will be given the possibility to visit that URL when clicking on the value.

### Screenshots
#### Admin
![custom-url-admin](https://user-images.githubusercontent.com/7570541/73937463-5fc9e900-48e5-11ea-84b5-36bad55bb30e.png)

#### Drilling
![custom-url-drill](https://user-images.githubusercontent.com/7570541/73937475-65bfca00-48e5-11ea-8143-6abd8ef2d11a.png)


### Implementation

The URL is not associated to the table but to the field, since the feature may be useful for more than IDs. The URL is currently stored in the `settings` JSON property of the field, mostly to avoid managing migration while working on this. I'll gladly change this to a proper column if that's better, once the design is more thought out.

When such a URL template has been defined, the frontend will add a `CustomDrill` to the list of available drills for the clicked value, and replace `{value}` in the URL template with the value of the field

### To finish / improve

 - Right now it is possible to store only one URL per field, but I can imagine how it could be useful to have more (e.g. view this contact profile in backend system and view the dashboard for this contact's orders.)
 - I hard-coded the text of the link to `View this <objectName>'s page`, it would probably be good to let the admin customise the word "page" or even the whole text with a small template.
 - In the future there might be more custom action types, other than visiting a URL. The design might need some future-proofing to allow for this.
 - The URL template should support RFC 6570, not sure what's the process to add a new dependency for that
 - It would be nice that when a field is a foreign key and has no URL template, it uses the URL template of the target field if any. This would allow that if a URL is defined for the primary key of a table, any id pointing to it can be linked to the URL. However I'm not sure technically how to access the data needed for that in the drill code.

My main questions for now are: is this the right approach to implement #8461? Is it likely to be merged if I continue working on it? Any opinion / hints on the improvements listed above?
