### PR TITLE
Russian ruble have symbol "₽"

### DIFF
--- a/frontend/src/metabase/lib/currency.js
+++ b/frontend/src/metabase/lib/currency.js
@@ -830,7 +830,7 @@ export default {
   RUB: {
     symbol: "₽",
     name: "Russian Ruble",
-    symbol_native: "руб.",
+    symbol_native: "₽",
     decimal_digits: 2,
     rounding: 0,
     code: "RUB",

--- a/frontend/src/metabase/lib/currency.js
+++ b/frontend/src/metabase/lib/currency.js
@@ -828,7 +828,7 @@ export default {
     name_plural: "Serbian dinars",
   },
   RUB: {
-    symbol: "RUB",
+    symbol: "₽",
     name: "Russian Ruble",
     symbol_native: "руб.",
     decimal_digits: 2,


### PR DESCRIPTION
Russian ruble have symbol "₽"

References:
- https://en.wikipedia.org/wiki/Ruble_sign
- https://www.businessinsider.com/russia-introduces-new-currency-symbol-2013-12