### PR TITLE
Fix bug displaying settings for trend with single column data

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
@@ -39,7 +39,12 @@ export default class Smart extends React.Component {
         ],
         settings,
       ) => [
-        _.find(cols, col => col.name === settings["scalar.field"]) || cols[1],
+        // try and find a selected field setting
+        cols.find(col => col.name === settings["scalar.field"]) ||
+          // fall back to the second column
+          cols[1] ||
+          // but if there's only one column use that
+          cols[0],
       ],
     }),
     "scalar.switch_positive_negative": {

--- a/frontend/test/metabase/visualizations/components/SmartScalar.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/SmartScalar.unit.spec.js
@@ -4,6 +4,7 @@ import { render, cleanup } from "@testing-library/react";
 import { NumberColumn, DateTimeColumn } from "../__support__/visualizations";
 
 import Visualization from "metabase/visualizations/components/Visualization";
+import { getSettingsWidgetsForSeries } from "metabase/visualizations/lib/settings/visualization";
 
 const series = ({ rows, insights }) => {
   const cols = [
@@ -92,5 +93,11 @@ describe("SmartScalar", () => {
       <Visualization rawSeries={series({ rows, insights })} />,
     );
     getAllByText("8,000%");
+  });
+
+  it("shouldn't throw an error getting settings for single-column data", () => {
+    const card = { display: "smartscalar", visualization_settings: {} };
+    const data = { cols: [NumberColumn({ name: "Count" })], rows: [[100]] };
+    expect(() => getSettingsWidgetsForSeries([{ card, data }])).not.toThrow();
   });
 });


### PR DESCRIPTION
Resolves #11861

The trend visualization assumed there were at least two columns. 

I'm not sure the test really adds anything since a regression in this exact spot seems unlikely, but I figured I'd add one anyways.