### PR TITLE
Add setting for chart value formatting

### DIFF
--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -251,6 +251,16 @@ function formatNumberScientific(
 }
 
 const DISPLAY_COMPACT_DECIMALS_CUTOFF = 1000;
+export const COMPACT_CURRENCY_OPTIONS = {
+  // Currencies vary in how many decimals they display, so this is probably
+  // wrong in some cases. Intl.NumberFormat has some of that data built-in, but
+  // I couldn't figure out how to use it here.
+  digits: 2,
+  currency_style: "symbol",
+  // We need this to ensure the settings are used. Otherwise, a cached
+  // _numberFormatter would take precedence.
+  _numberFormatter: undefined,
+};
 
 function formatNumberCompact(value: number, options: FormattingOptions) {
   if (options.number_style === "percent") {
@@ -260,11 +270,7 @@ function formatNumberCompact(value: number, options: FormattingOptions) {
     try {
       const nf = numberFormatterForOptions({
         ...options,
-        currency_style: "symbol",
-        // Currencies vary in how many decimals they display, so this is
-        // probably wrong in some cases. Intl.NumberFormat has some of that data
-        // built-in, but I couldn't figure out how to use it here.
-        digits: 2,
+        ...COMPACT_CURRENCY_OPTIONS,
       });
 
       if (Math.abs(value) < DISPLAY_COMPACT_DECIMALS_CUTOFF) {

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -257,9 +257,6 @@ export const COMPACT_CURRENCY_OPTIONS = {
   // I couldn't figure out how to use it here.
   digits: 2,
   currency_style: "symbol",
-  // We need this to ensure the settings are used. Otherwise, a cached
-  // _numberFormatter would take precedence.
-  _numberFormatter: undefined,
 };
 
 function formatNumberCompact(value: number, options: FormattingOptions) {

--- a/frontend/src/metabase/lib/formatting.js
+++ b/frontend/src/metabase/lib/formatting.js
@@ -250,7 +250,7 @@ function formatNumberScientific(
   }
 }
 
-const DISPLAY_CENTS_CUTOFF = 1000;
+const DISPLAY_COMPACT_DECIMALS_CUTOFF = 1000;
 
 function formatNumberCompact(value: number, options: FormattingOptions) {
   if (options.number_style === "percent") {
@@ -261,10 +261,13 @@ function formatNumberCompact(value: number, options: FormattingOptions) {
       const nf = numberFormatterForOptions({
         ...options,
         currency_style: "symbol",
-        minimumFractionDigits: 2,
+        // Currencies vary in how many decimals they display, so this is
+        // probably wrong in some cases. Intl.NumberFormat has some of that data
+        // built-in, but I couldn't figure out how to use it here.
+        digits: 2,
       });
 
-      if (Math.abs(value) < DISPLAY_CENTS_CUTOFF) {
+      if (Math.abs(value) < DISPLAY_COMPACT_DECIMALS_CUTOFF) {
         return nf.format(value);
       }
       const { value: currency } = nf
@@ -291,7 +294,7 @@ function formatNumberCompactWithoutOptions(value: number) {
   if (value === 0) {
     // 0 => 0
     return "0";
-  } else if (Math.abs(value) < 10) {
+  } else if (Math.abs(value) < DISPLAY_COMPACT_DECIMALS_CUTOFF) {
     // 0.1 => 0.1
     return PRECISION_NUMBER_FORMATTER(value).replace(/\.?0+$/, "");
   } else {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -281,12 +281,17 @@ function onRenderValueLabels(chart, formatYValue, [data]) {
   } else {
     // for "auto" we use compact if it shortens avg label length by >3 chars
     const getAvgLength = compact => {
-      const lengths = data.map(
+      const options = {
+        compact,
         // We include compact currency options here for both compact and
         // non-compact formatting. This prevents auto's logic from depending on
         // those settings.
-        d => formatYValue(d.y, { compact, ...COMPACT_CURRENCY_OPTIONS }).length,
-      );
+        ...COMPACT_CURRENCY_OPTIONS,
+        // We need this to ensure the settings are used. Otherwise, a cached
+        // _numberFormatter would take precedence.
+        _numberFormatter: undefined,
+      };
+      const lengths = data.map(d => formatYValue(d.y, options).length);
       return lengths.reduce((sum, l) => sum + l, 0) / lengths.length;
     };
     compact = getAvgLength(true) < getAvgLength(false) - 3;

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -271,6 +271,21 @@ function onRenderValueLabels(chart, formatYValue, [data]) {
     return { x, y, showLabelBelow };
   });
 
+  const formattingSetting = chart.settings["graph.label_value_formatting"];
+  let compact;
+  if (formattingSetting === "compact") {
+    compact = true;
+  } else if (formattingSetting === "full") {
+    compact = false;
+  } else {
+    // for "auto" we use compact if it shortens avg label length by >3 chars
+    const getAvgLength = compact => {
+      const lengths = data.map(d => formatYValue(d.y, { compact }).length);
+      return lengths.reduce((sum, l) => sum + l, 0) / lengths.length;
+    };
+    compact = getAvgLength(true) < getAvgLength(false) - 3;
+  }
+
   // use the chart body so things line up properly
   const parent = chart.svg().select(".chart-body");
 
@@ -322,7 +337,7 @@ function onRenderValueLabels(chart, formatYValue, [data]) {
         .append("text")
         .attr("class", klass)
         .attr("text-anchor", "middle")
-        .text(({ y }) => formatYValue(y, { compact: true })),
+        .text(({ y }) => formatYValue(y, { compact })),
     );
   };
 

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -5,6 +5,7 @@ import _ from "underscore";
 
 import { color } from "metabase/lib/colors";
 import { clipPathReference } from "metabase/lib/dom";
+import { COMPACT_CURRENCY_OPTIONS } from "metabase/lib/formatting";
 import { adjustYAxisTicksIfNeeded } from "./apply_axis";
 import { isHistogramBar } from "./renderer_utils";
 
@@ -280,7 +281,12 @@ function onRenderValueLabels(chart, formatYValue, [data]) {
   } else {
     // for "auto" we use compact if it shortens avg label length by >3 chars
     const getAvgLength = compact => {
-      const lengths = data.map(d => formatYValue(d.y, { compact }).length);
+      const lengths = data.map(
+        // We include compact currency options here for both compact and
+        // non-compact formatting. This prevents auto's logic from depending on
+        // those settings.
+        d => formatYValue(d.y, { compact, ...COMPACT_CURRENCY_OPTIONS }).length,
+      );
       return lengths.reduce((sum, l) => sum + l, 0) / lengths.length;
     };
     compact = getAvgLength(true) < getAvgLength(false) - 3;

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -346,6 +346,24 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS = {
     default: "fit",
     readDependencies: ["graph.show_values"],
   },
+  "graph.label_value_formatting": {
+    section: t`Display`,
+    title: t`Value formatting`,
+    widget: "radio",
+    getHidden: (series, vizSettings) =>
+      series.length > 1 ||
+      vizSettings["graph.show_values"] !== true ||
+      vizSettings["stackable.stack_type"] === "normalized",
+    props: {
+      options: [
+        { name: t`Auto`, value: "auto" },
+        { name: t`Compact`, value: "compact" },
+        { name: t`Full`, value: "full" },
+      ],
+    },
+    default: "auto",
+    readDependencies: ["graph.show_values"],
+  },
 };
 
 export const GRAPH_COLORS_SETTINGS = {

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -41,8 +41,10 @@ describe("formatting", () => {
         expect(formatNumber(-0.01, { compact: true })).toEqual("-0.01");
       });
       it("should round up and down", () => {
-        expect(formatNumber(1.001, { compact: true })).toEqual("1");
-        expect(formatNumber(-1.009, { compact: true })).toEqual("-1.01");
+        expect(formatNumber(1.01, { compact: true })).toEqual("1.01");
+        expect(formatNumber(-1.01, { compact: true })).toEqual("-1.01");
+        expect(formatNumber(1.9, { compact: true })).toEqual("1.9");
+        expect(formatNumber(-1.9, { compact: true })).toEqual("-1.9");
       });
       it("should format large numbers with metric units", () => {
         expect(formatNumber(1, { compact: true })).toEqual("1");
@@ -56,7 +58,7 @@ describe("formatting", () => {
         expect(formatNumber(0.0001, options)).toEqual("0.01%");
         expect(formatNumber(0.001234, options)).toEqual("0.12%");
         expect(formatNumber(0.1, options)).toEqual("10%");
-        expect(formatNumber(0.1234, options)).toEqual("12%");
+        expect(formatNumber(0.1234, options)).toEqual("12.34%");
         expect(formatNumber(0.019, options)).toEqual("1.9%");
         expect(formatNumber(0.021, options)).toEqual("2.1%");
         expect(formatNumber(11.11, options)).toEqual("1.1k%");
@@ -79,12 +81,9 @@ describe("formatting", () => {
         };
         expect(formatNumber(0, options)).toEqual("$0.00");
         expect(formatNumber(0.001, options)).toEqual("$0.00");
-        expect(formatNumber(0.00987654, options)).toEqual("$0.01");
-        expect(formatNumber(0.09876543, options)).toEqual("$0.10");
         expect(formatNumber(7.24, options)).toEqual("$7.24");
-        expect(formatNumber(7.301, options)).toEqual("$7.30");
-        expect(formatNumber(73.01, options)).toEqual("$73.01");
-        expect(formatNumber(730.1, options)).toEqual("$730.10");
+        expect(formatNumber(7.249, options)).toEqual("$7.25");
+        expect(formatNumber(724.9, options)).toEqual("$724.90");
         expect(formatNumber(1234.56, options)).toEqual("$1.2k");
         expect(formatNumber(1234567.89, options)).toEqual("$1.2M");
         expect(formatNumber(-1234567.89, options)).toEqual("$-1.2M");
@@ -300,6 +299,16 @@ describe("formatting", () => {
         }),
       ).toEqual("data:text/plain;charset=utf-8,hello%20world");
     });
+    it("should return link component for type/URL and  view_as = link", () => {
+      const formatted = formatUrl("http://whatever", {
+        jsx: true,
+        rich: true,
+        column: { special_type: TYPE.URL },
+        view_as: "link",
+      });
+      expect(isElementOfType(formatted, ExternalLink)).toEqual(true);
+    });
+
     it("should not crash if column is null", () => {
       expect(
         formatUrl("foobar", {

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -37,14 +37,12 @@ describe("formatting", () => {
       it("shouldn't display small numbers as 0", () => {
         expect(formatNumber(0.1, { compact: true })).toEqual("0.1");
         expect(formatNumber(-0.1, { compact: true })).toEqual("-0.1");
-        expect(formatNumber(0.01, { compact: true })).toEqual("~ 0");
-        expect(formatNumber(-0.01, { compact: true })).toEqual("~ 0");
+        expect(formatNumber(0.01, { compact: true })).toEqual("0.01");
+        expect(formatNumber(-0.01, { compact: true })).toEqual("-0.01");
       });
       it("should round up and down", () => {
-        expect(formatNumber(1.01, { compact: true })).toEqual("1");
-        expect(formatNumber(-1.01, { compact: true })).toEqual("-1");
-        expect(formatNumber(1.9, { compact: true })).toEqual("2");
-        expect(formatNumber(-1.9, { compact: true })).toEqual("-2");
+        expect(formatNumber(1.001, { compact: true })).toEqual("1");
+        expect(formatNumber(-1.009, { compact: true })).toEqual("-1.01");
       });
       it("should format large numbers with metric units", () => {
         expect(formatNumber(1, { compact: true })).toEqual("1");
@@ -55,12 +53,12 @@ describe("formatting", () => {
         const options = { compact: true, number_style: "percent" };
         expect(formatNumber(0, options)).toEqual("0%");
         expect(formatNumber(0.001, options)).toEqual("0.1%");
-        expect(formatNumber(0.0001, options)).toEqual("~ 0%");
+        expect(formatNumber(0.0001, options)).toEqual("0.01%");
         expect(formatNumber(0.001234, options)).toEqual("0.12%");
         expect(formatNumber(0.1, options)).toEqual("10%");
         expect(formatNumber(0.1234, options)).toEqual("12%");
-        expect(formatNumber(0.019, options)).toEqual("2%");
-        expect(formatNumber(0.021, options)).toEqual("2%");
+        expect(formatNumber(0.019, options)).toEqual("1.9%");
+        expect(formatNumber(0.021, options)).toEqual("2.1%");
         expect(formatNumber(11.11, options)).toEqual("1.1k%");
         expect(formatNumber(-0.22, options)).toEqual("-22%");
       });
@@ -79,9 +77,14 @@ describe("formatting", () => {
           number_style: "currency",
           currency: "USD",
         };
-        expect(formatNumber(0, options)).toEqual("$0");
-        expect(formatNumber(0.001, options)).toEqual("~$0");
-        expect(formatNumber(7.24, options)).toEqual("$7");
+        expect(formatNumber(0, options)).toEqual("$0.00");
+        expect(formatNumber(0.001, options)).toEqual("$0.00");
+        expect(formatNumber(0.00987654, options)).toEqual("$0.01");
+        expect(formatNumber(0.09876543, options)).toEqual("$0.10");
+        expect(formatNumber(7.24, options)).toEqual("$7.24");
+        expect(formatNumber(7.301, options)).toEqual("$7.30");
+        expect(formatNumber(73.01, options)).toEqual("$73.01");
+        expect(formatNumber(730.1, options)).toEqual("$730.10");
         expect(formatNumber(1234.56, options)).toEqual("$1.2k");
         expect(formatNumber(1234567.89, options)).toEqual("$1.2M");
         expect(formatNumber(-1234567.89, options)).toEqual("$-1.2M");


### PR DESCRIPTION
Resolves #11565 

I added a new setting that lets users pick how chart values are formatted.
* Compact – always use compact formatting
* Full – always use full-length formatting
* Auto – use compact only if it decreases the average label length by more than three characters
  * 100,000.01 => 100k 👍 
  * 1.01 => 1 👎 

Alternate approach:

I had started off exploring how to update the behavior of compact formatting. Ideally, compact formatting would avoid abbreviating when it reduces precision without substantial reduction in length. However, I decided to do it at a higher level to ensure that all values are consistently formatted (e.g. avoid 10.01 => 10 right next to 1.01 => 1.01).

## Examples

### Short labels

![1](https://user-images.githubusercontent.com/691495/74367282-95684980-4d9f-11ea-9dd0-4fb38fb85ce0.gif)

### Longer labels

![2](https://user-images.githubusercontent.com/691495/74367284-97caa380-4d9f-11ea-8c41-dd0531f79abd.gif)

### Some weirdness

This does lead to surprising behavior when adjusting settings that interact with compact formatting. For example, since compact formatting always uses "$" rather than "USD", switching currency symbol can cause auto to switch between compact/full formatting. Anyone have clever ideas for how to avoid that?

![3](https://user-images.githubusercontent.com/691495/74367289-99946700-4d9f-11ea-9237-0347cc6940b5.gif)
