### PR TITLE
Fix chart settings selectors with undefined values

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
@@ -5,7 +5,9 @@ import Select, { Option } from "metabase/components/Select";
 import cx from "classnames";
 
 const ChartSettingSelect = ({
-  value,
+  // Use null if value is undefined. If we pass undefined, Select will create an
+  // uncontrolled component because it's wrapped with Uncontrollable.
+  value = null,
   onChange,
   options = [],
   isInitiallyOpen,

--- a/frontend/test/metabase/scenarios/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/maps.cy.spec.js
@@ -10,7 +10,6 @@ describe("maps", () => {
     cy.contains("Native query").click();
     cy.get(".ace_content").type(
       "select -80 as lng, 40 as lat union all select -120 as lng, 40 as lat",
-      { delay: 0 },
     );
     cy.get(".NativeQueryEditor .Icon-play").click();
 

--- a/frontend/test/metabase/scenarios/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/maps.cy.spec.js
@@ -1,0 +1,52 @@
+import { signInAsNormalUser, restore, popover } from "__support__/cypress";
+
+describe("maps", () => {
+  before(restore);
+  beforeEach(signInAsNormalUser);
+
+  it("should display a pin map for a native query", () => {
+    // create a native query with lng/lat fields
+    cy.visit("/question/new");
+    cy.contains("Native query").click();
+    cy.get(".ace_content").type(
+      "select -80 as lng, 40 as lat union all select -120 as lng, 40 as lat",
+      { delay: 0 },
+    );
+    cy.get(".NativeQueryEditor .Icon-play").click();
+
+    // switch to a pin map visualization
+    cy.contains("Visualization").click();
+    cy.get(".Icon-pinmap").click();
+
+    cy.contains("Map type")
+      .next()
+      .click();
+    popover()
+      .contains("Pin map")
+      .click();
+
+    // When the settings sidebar opens, both latitude and longitude selects are
+    // open. That makes it difficult to select each in Cypress, so we click
+    // outside twice to close both of them before reopening them one-by-one. :(
+    cy.contains("New question").click();
+    cy.contains("New question").click();
+
+    // select both columns
+    cy.contains("Latitude field")
+      .next()
+      .click();
+    popover()
+      .contains("LAT")
+      .click();
+
+    cy.contains("Longitude field")
+      .next()
+      .click();
+    popover()
+      .contains("LNG")
+      .click();
+
+    // check that a map appears
+    cy.get(".leaflet-container");
+  });
+});


### PR DESCRIPTION
Resolves #11816

Note: This is a bugfix, but the issue only exists on master, so the fix should be merged there.

I'm not sure if any other settings were broken besides lng/lat. The issue occurred with the recent select changes. If the passed value is `undefined`, `Uncontrollable` will stop calling `onChange`.

To fix this, I prevented `ChartSettingSelect` from passing `undefined`. Instead, we pass `null`. 