### PR TITLE
Switch Docker image used for building from openjdk to adoptopenjdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 # STAGE 1: builder
 ###################
 
-FROM openjdk:8-jdk-alpine as builder
+# Build currently doesn't work on > Java 11 (i18n utils are busted) so build on 8 until we fix this
+FROM adoptopenjdk/openjdk8:alpine-jre as builder
 
 WORKDIR /app/source
 


### PR DESCRIPTION
After #11577 our DockerHub build stopped working. The new code that does font registration at compile time is failing:

```clj
(defonce
  ^{:doc     "Makes custom fonts available to Java so that CSSBox can render them"
    :private true}
  register-fonts
  (delay (doseq [weight ["regular" "700" "900"]]
           (.registerFont (java.awt.GraphicsEnvironment/getLocalGraphicsEnvironment)
                          (java.awt.Font/createFont
                           java.awt.Font/TRUETYPE_FONT
                           (-> (format "frontend_client/app/fonts/lato-v16-latin/lato-v16-latin-%s.ttf" weight)
                               io/resource
                               io/input-stream))))))

@register-fonts
```

Error:

```
Syntax error macroexpanding at (png.clj:1:1).

Execution error (IOException) at java.awt.Font/createFont0 (Font.java:1000).
Problem reading font data.
```

This seems to be a bug with the JRE — see https://github.com/AdoptOpenJDK/openjdk-build/issues/682. IIRC `openjdk` is the legacy version of the base image anyway so by switching to `adoptopenjdk/openjdk8` I'm hoping the build is fixed. (We similarly switched from `openjdk` to `adoptopenjdk/openjdk11` for the base image for actually running Metabase a while back, so this change brings the build more in line with the actually environment Metabase runs in.)

If this doesn't fix the issue, I will add code to skip font registration during compile time, since there's no reason it needs be done at any point until we render PNGs. (It would probably be an even better change to delay font registration until we render a PNG, to speed up launch time.)

Even if this doesn't fix the issue it is still a good change so worth keeping either way