### PR TITLE
Add search boxes to data model pickers

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/ColumnItem.jsx
@@ -219,6 +219,7 @@ export class SpecialTypeAndTargetPicker extends Component {
           optionValueFn={o => o.id}
           optionSectionFn={o => o.section}
           placeholder={t`Select a special type`}
+          searchProp="name"
         />
         {showCurrencyTypeSelect && selectSeparator}
         {// TODO - now that we have multiple "nested" options like choosing a
@@ -252,6 +253,7 @@ export class SpecialTypeAndTargetPicker extends Component {
           <Select
             className={cx("TableEditor-field-target text-wrap", className)}
             placeholder={t`Select a target`}
+            searchProp="name"
             value={field.fk_target_field_id}
             onChange={this.handleChangeTarget}
             options={idfields}


### PR DESCRIPTION
Adds search boxes to the data model special type and foreign key pickers thanks to the spiffy new `<Select>`.

Implements https://github.com/metabase/metabase/issues/2805
Partially addresses: https://github.com/metabase/metabase/issues/7586

## Special type picker

![Screen Shot 2020-02-13 at 4 23 19 PM](https://user-images.githubusercontent.com/2223916/74490543-b3a47700-4e7d-11ea-8af7-b7077f7a2520.png)

## FK field picker

![Screen Shot 2020-02-13 at 4 25 36 PM](https://user-images.githubusercontent.com/2223916/74490549-b7d09480-4e7d-11ea-9578-fae4511058ae.png)
