### PR TITLE
Fix date filter brush bug

### DIFF
--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -335,7 +335,7 @@ function transformSingleSeries(s, series, seriesIndex) {
   const { card, data } = s;
 
   // HACK: prevents cards from being transformed too many times
-  if (card._transformed) {
+  if (data._transformed) {
     return [s];
   }
 
@@ -396,7 +396,6 @@ function transformSingleSeries(s, series, seriesIndex) {
         ]
           .filter(n => n)
           .join(": "),
-        _transformed: true,
         _breakoutValue: breakoutValue,
         _breakoutColumn: cols[seriesColumnIndex],
       },
@@ -404,6 +403,7 @@ function transformSingleSeries(s, series, seriesIndex) {
         rows: breakoutRowsByValue.get(breakoutValue),
         cols: rowColumnIndexes.map(i => cols[i]),
         _rawCols: cols,
+        _transformed: true,
       },
       // for when the legend header for the breakout is clicked
       clicked: {
@@ -439,7 +439,6 @@ function transformSingleSeries(s, series, seriesIndex) {
         card: {
           ...card,
           name: name,
-          _transformed: true,
           _seriesIndex: seriesIndex,
           // use underlying column name as the seriesKey since it should be unique
           // EXCEPT for dashboard multiseries, so check seriesIndex == 0
@@ -453,6 +452,7 @@ function transformSingleSeries(s, series, seriesIndex) {
             return newRow;
           }),
           cols: rowColumnIndexes.map(i => cols[i]),
+          _transformed: true,
           _rawCols: cols,
         },
       };

--- a/frontend/test/metabase/scenarios/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/chart_drill.cy.spec.js
@@ -1,0 +1,51 @@
+import { signInAsAdmin } from "__support__/cypress";
+
+describe("chart drill", () => {
+  beforeEach(signInAsAdmin);
+
+  it("should allow brush date filter", () => {
+    cy.visit("/question/new");
+    cy.contains("Simple question").click();
+    cy.contains("Sample Dataset").click();
+    cy.contains("Orders").click();
+    cy.contains("37.65");
+
+    // count by month created and product category
+    cy.contains("Summarize").click();
+    cy.contains("Summarize by")
+      .parent()
+      .parent()
+      .as("summarizeSidebar");
+
+    cy.get("@summarizeSidebar")
+      .contains("Created At")
+      .click();
+    cy.get("@summarizeSidebar")
+      .contains("Category")
+      .parent()
+      .find(".Icon-add")
+      .click({ force: true });
+
+    cy.contains("Done").click();
+
+    // wait for chart to expand and display legend/labels
+    cy.contains("Gadget");
+    cy.contains("January, 2017");
+
+    // drag across to filter
+    cy.get(".dc-chart svg")
+      .trigger("mousedown", 100, 200)
+      .trigger("mousemove", 200, 200)
+      .trigger("mouseup", 200, 200);
+
+    // new filter applied
+    cy.contains("Created At between June, 2016 October, 2016");
+    // more granular axis labels
+    cy.contains("June, 2016");
+    // confirm that product category is still broken out
+    cy.contains("Gadget");
+    cy.contains("Doohickey");
+    cy.contains("Gizmo");
+    cy.contains("Widget");
+  });
+});

--- a/frontend/test/metabase/scenarios/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/chart_drill.cy.spec.js
@@ -31,6 +31,7 @@ describe("chart drill", () => {
     // wait for chart to expand and display legend/labels
     cy.contains("Gadget");
     cy.contains("January, 2017");
+    cy.wait(500); // wait longer to avoid grabbing the svg before a chart redraw
 
     // drag across to filter
     cy.get(".dc-chart svg")


### PR DESCRIPTION
Resolves #11796

## The bug

Start with a breakout multiseries line/area/bar chart (e.g. Orders by month and product category). After filtering the date range by brushing, the new query runs successfully but the chart is broken. Because the card was already marked as `_transformed`, the new data isn't broken out in to separate series.

## The fix

I first tried to remove the `_transformed` flag entirely. If `LineAreaBarChart.transformSeries` returned the same series when called on an already transformed series, we wouldn't need to mark it as already transformed. Essentially, it's a hack to ensure idempotency because the logic isn't already idempotent.

I abandoned that approach because there were a handful of differences introduced when calling `transformSeries` on an already transformed series that I wasn't sure how to handle. Some were just a matter of including data that was removed, but I didn't know how many fields were being used.

Instead, I kept the `_transformed` flag, but moved it from `card` to `data`. Now, when the data is replaced, we no longer block transforming.

## Questions

* Is double transforming the card always safe?
When the new data is swapped in, we transform both the `data` _and_ the `card`. The card was already transformed however. That seems ok since the changes are less than what happens to data. Mostly, it seems like the card is renamed to match series names.
If this might be an issue, we could split out card/data transforming.
* What transformations require multiple calls to `transformSeries`?
In `getVisualizationTransformed`, we loop until `transformSeries` returns the same series it was passed. What are some examples of series that need multiple passes?