### PR TITLE
Restyle SQL variables side panel

### DIFF
--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx
@@ -239,7 +239,7 @@ const TagEditorHelp = ({
   }
 
   return (
-    <div className="px3 text-paragraph">
+    <div className="px3 text-spaced">
       <h4>{t`What's this for?`}</h4>
       <p>
         {t`Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL.`}

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx
@@ -237,7 +237,7 @@ const TagEditorHelp = ({
   }
 
   return (
-    <div>
+    <div className="px3">
       <h4>{t`What's this for?`}</h4>
       <p>
         {t`Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL.`}

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { t, jt } from "ttag";
 import Code from "metabase/components/Code";
+import Button from "metabase/components/Button";
 import MetabaseSettings from "metabase/lib/settings";
 import Utils from "metabase/lib/utils";
 
@@ -200,13 +201,14 @@ const TagExample = ({ datasetQuery, setDatasetQuery }) => (
     <p>
       <Code>{datasetQuery.native.query}</Code>
       {setDatasetQuery && (
-        <div
-          className="Button Button--small mt1"
+        <Button
+          medium
+          className="mt1"
           data-metabase-event="QueryBuilder;Template Tag Example Query Used"
           onClick={() => setDatasetQuery(datasetQuery, true)}
         >
           {t`Try it`}
-        </div>
+        </Button>
       )}
     </p>
   </div>
@@ -237,7 +239,7 @@ const TagEditorHelp = ({
   }
 
   return (
-    <div className="px3">
+    <div className="px3 text-paragraph">
       <h4>{t`What's this for?`}</h4>
       <p>
         {t`Variables in native queries let you dynamically replace values in your queries using filter widgets or through the URL.`}

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -5,7 +5,6 @@ import { connect } from "react-redux";
 import { Link } from "react-router";
 
 import Toggle from "metabase/components/Toggle";
-import Card from "metabase/components/Card";
 import InputBlurChange from "metabase/components/InputBlurChange";
 import Select, { Option } from "metabase/components/Select";
 import ParameterValueWidget from "metabase/parameters/components/ParameterValueWidget";
@@ -126,11 +125,16 @@ export default class TagEditorParam extends Component {
     const hasSelectedDimensionField =
       isDimension && Array.isArray(tag.dimension);
     const hasWidgetOptions = widgetOptions && widgetOptions.length > 0;
-    return (
-      <div className="p2 mb3 rounded bg-light">
-        <h3 className="pb2 text-brand">{tag.name}</h3>
 
-        <div className="pb3">
+    return (
+      <div className="px3 pt3 mb1 rounded border-top">
+        <div className="mt1 mb2">
+          <h4 className="py1 px2 inline text-white bg-purple circular">
+            {tag.name}
+          </h4>
+        </div>
+
+        <div className="pt2 pb3">
           <h4 className="pb1">{t`Filter label`}</h4>
           <InputBlurChange
             type="text"

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -127,29 +127,14 @@ export default class TagEditorParam extends Component {
     const hasWidgetOptions = widgetOptions && widgetOptions.length > 0;
 
     return (
-      <div className="px3 pt3 mb1 rounded border-top">
-        <div className="mt1 mb2">
-          <h4 className="py1 px2 inline text-white bg-purple circular">
-            {tag.name}
-          </h4>
-        </div>
+      <div className="px3 pt3 mb1 border-top">
+        <h4 className="text-medium py1">{t`Variable name`}</h4>
+        <h3 className="text-heavy text-brand align-self-end mb4">{tag.name}</h3>
 
-        <div className="pt2 pb3">
-          <h4 className="pb1">{t`Filter label`}</h4>
-          <InputBlurChange
-            type="text"
-            value={tag["display-name"]}
-            className="AdminSelect p1 text-bold text-dark bordered border-medium rounded full"
-            onBlurChange={e =>
-              this.setParameterAttribute("display-name", e.target.value)
-            }
-          />
-        </div>
-
-        <div className="pb3">
-          <h4 className="pb1">{t`Variable type`}</h4>
+        <div className="pb4">
+          <h4 className="text-medium pb1">{t`Variable type`}</h4>
           <Select
-            className="border-medium bg-white block"
+            className="block"
             value={tag.type}
             onChange={e => this.setType(e.target.value)}
             isInitiallyOpen={!tag.type}
@@ -164,8 +149,8 @@ export default class TagEditorParam extends Component {
         </div>
 
         {tag.type === "dimension" && (
-          <div className="pb3">
-            <h4 className="pb1">
+          <div className="pb4">
+            <h4 className="text-medium pb1">
               {t`Field to map to`}
               {tag.dimension == null && (
                 <span className="text-error mx1">(required)</span>
@@ -190,10 +175,10 @@ export default class TagEditorParam extends Component {
         )}
 
         {hasSelectedDimensionField && (
-          <div className="pb3">
-            <h4 className="pb1">{t`Filter widget type`}</h4>
+          <div className="pb4">
+            <h4 className="text-medium pb1">{t`Filter widget type`}</h4>
             <Select
-              className="border-med bg-white block"
+              className="block"
               value={tag["widget-type"]}
               onChange={e =>
                 this.setParameterAttribute("widget-type", e.target.value)
@@ -210,7 +195,7 @@ export default class TagEditorParam extends Component {
                 ))}
             </Select>
             {!hasWidgetOptions && (
-              <p className="pb1">
+              <p>
                 {t`There aren't any filter widgets for this type of field yet.`}{" "}
                 <Link
                   to={MetabaseSettings.docsUrl(
@@ -227,8 +212,22 @@ export default class TagEditorParam extends Component {
           </div>
         )}
 
-        <div className="pb2">
-          <h4 className="pb1">{t`Required?`}</h4>
+        {(hasWidgetOptions || !isDimension) && (
+          <div className="pb4">
+            <h4 className="text-medium pb1">{t`Filter widget label`}</h4>
+            <InputBlurChange
+              type="text"
+              value={tag["display-name"]}
+              className="AdminSelect p1 text-bold text-dark bordered border-medium rounded full"
+              onBlurChange={e =>
+                this.setParameterAttribute("display-name", e.target.value)
+              }
+            />
+          </div>
+        )}
+
+        <div className="pb3">
+          <h4 className="text-medium pb1">{t`Required?`}</h4>
           <Toggle
             value={tag.required}
             onChange={value => this.setRequired(value)}
@@ -237,8 +236,8 @@ export default class TagEditorParam extends Component {
 
         {((tag.type !== "dimension" && tag.required) ||
           (tag.type === "dimension" || tag["widget-type"])) && (
-          <div className="pb2">
-            <h4 className="pb1">{t`Default filter widget value`}</h4>
+          <div className="pb3">
+            <h4 className="text-medium pb1">{t`Default filter widget value`}</h4>
             <ParameterValueWidget
               parameter={{
                 type:

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -127,7 +127,7 @@ export default class TagEditorParam extends Component {
       isDimension && Array.isArray(tag.dimension);
     const hasWidgetOptions = widgetOptions && widgetOptions.length > 0;
     return (
-      <Card className="p2 mb2">
+      <div className="p2 mb3 rounded bg-light">
         <h3 className="pb2 text-brand">{tag.name}</h3>
 
         <div className="pb3">
@@ -249,7 +249,7 @@ export default class TagEditorParam extends Component {
             />
           </div>
         )}
-      </Card>
+      </div>
     );
   }
 }

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
@@ -82,8 +82,8 @@ export default class TagEditorSidebar extends React.Component {
 
     return (
       <SidebarContent title={t`Variables`} onClose={onClose}>
-        <div className="mx3">
-          <div className="text-centered Button-group Button-group--brand text-uppercase mb2 flex flex-full">
+        <div>
+          <div className="mx3 text-centered Button-group Button-group--brand text-uppercase mb2 flex flex-full">
             <a
               className={cx("Button flex-full Button--small", {
                 "Button--active": section === "settings",

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
@@ -82,17 +82,17 @@ export default class TagEditorSidebar extends React.Component {
 
     return (
       <SidebarContent title={t`Variables`} onClose={onClose}>
-        <div className="mx4">
-          <div className="Button-group Button-group--brand text-uppercase mb2">
+        <div className="mx3">
+          <div className="text-centered Button-group Button-group--brand text-uppercase mb2 flex flex-full">
             <a
-              className={cx("Button Button--small", {
+              className={cx("Button flex-full Button--small", {
                 "Button--active": section === "settings",
                 disabled: tags.length === 0,
               })}
               onClick={() => this.setSection("settings")}
             >{t`Settings`}</a>
             <a
-              className={cx("Button Button--small", {
+              className={cx("Button flex-full Button--small", {
                 "Button--active": section === "help",
               })}
               onClick={() => this.setSection("help")}

--- a/frontend/test/metabase/scenarios/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/public.cy.spec.js
@@ -51,7 +51,7 @@ describe("public and embeds", () => {
         win.document.querySelectorAll(".ace_text-input")[0].disabled = true;
       });
 
-      cy.contains("Filter label")
+      cy.contains("Filter widget label")
         .siblings("input")
         .type("Category");
 


### PR DESCRIPTION
This removes the drop shadow styling on the individual variables in the side panel. I had previously added it in the first place, but in practice I don't love how it looks when you open popovers on top of it (double drop shadows look weird).

I've also:
- reordered the variable inputs to make them make more sense, and made it so that the filer widget label input doesn't appear if there is no widget
- tried to make the variable names stand out a bit
- changed the color of the input labels to match the style we started implementing in the <Form> refactor
- made the left and right spacing of the cards align correctly with the side panel title and close button
- made the button group tabs full width
- tweaked the line spacing of the help text tab

## Before

![image](https://user-images.githubusercontent.com/2223916/74577567-aef6c600-4f44-11ea-9292-ad6ffbd4f09d.png)

![image](https://user-images.githubusercontent.com/2223916/74889843-16db5100-5337-11ea-87a7-e506a166c900.png)


## After

![image](https://user-images.githubusercontent.com/2223916/74889667-9a487280-5336-11ea-8a04-f573c28375de.png)

![image](https://user-images.githubusercontent.com/2223916/74889816-0925cb80-5337-11ea-89b0-9ca27140db4e.png)
