### PR TITLE
Don't get parameter options for text box cards

### DIFF
--- a/frontend/src/metabase/meta/Dashboard.js
+++ b/frontend/src/metabase/meta/Dashboard.js
@@ -206,6 +206,10 @@ export function getParameterMappingOptions(
   card: Card,
 ): ParameterMappingUIOption[] {
   const options = [];
+  if (card.display === "text") {
+    // text cards don't have parameters
+    return [];
+  }
 
   const query = new Question(card, metadata).query();
 

--- a/frontend/test/metabase/dashboard/dashboard.cy.spec.js
+++ b/frontend/test/metabase/dashboard/dashboard.cy.spec.js
@@ -1,4 +1,4 @@
-import { signInAsAdmin } from "__support__/cypress";
+import { signInAsAdmin, popover, modal } from "__support__/cypress";
 
 describe("dashboard", () => {
   beforeEach(signInAsAdmin);
@@ -74,6 +74,42 @@ var iframeUrl = METABASE_SITE_URL + "/embed/dashboard/" + token + "#bordered=tru
     cy.get(".Header-title input")
       .last()
       .clear();
+    cy.contains("Save").click();
+  });
+
+  it("should let you add a parameter to a dashboard with a text box", () => {
+    cy.visit("/dashboard/1");
+    // click pencil icon to edit
+    cy.get(".Icon-pencil").click();
+    // add text box with text
+    cy.get(".Icon-string").click();
+    cy.get(".DashCard")
+      .last()
+      .find("textarea")
+      .type("text text text");
+    cy.get(".Icon-funnel_add").click();
+    popover()
+      .contains("Other Categories")
+      .click();
+    cy.contains("Done").click();
+    cy.contains("Save").click();
+
+    // confirm text box and filter are still there
+    cy.contains("text text text");
+    cy.get("input[placeholder=Category]");
+
+    // reset
+    // remove text box
+    cy.get(".Icon-pencil").click();
+    cy.get(".DashCard")
+      .last()
+      .find(".Icon-close")
+      .click({ force: true });
+    modal()
+      .contains("button", "Remove")
+      .click({ force: true });
+    // remove filter
+    cy.contains("Remove").click();
     cy.contains("Save").click();
   });
 });


### PR DESCRIPTION
Resolves #11927 

We assumed every card has a query, but dashboard text boxes are "cards" too. I'm guessing this broke in #11827.

I added a cypress test to check that cards and filters play nicely and can be saved. Since this is on the release branch without db snapshotting, I added manual reset code.