### PR TITLE
Don't consider text box dashcards for loading timer

### DIFF
--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -1133,7 +1133,7 @@ const loadingDashCards = handleActions(
       next: (state, { payload }) => ({
         ...state,
         dashcardIds: Object.values(payload.entities.dashcard || {})
-          .filter(dc => dc.card.display !== "text")
+          .filter(dc => !isVirtualDashCard(dc))
           .map(dc => dc.id),
       }),
     },

--- a/frontend/src/metabase/dashboard/dashboard.js
+++ b/frontend/src/metabase/dashboard/dashboard.js
@@ -1132,9 +1132,9 @@ const loadingDashCards = handleActions(
     [FETCH_DASHBOARD]: {
       next: (state, { payload }) => ({
         ...state,
-        dashcardIds: Object.values(payload.entities.dashcard || {}).map(
-          dc => dc.id,
-        ),
+        dashcardIds: Object.values(payload.entities.dashcard || {})
+          .filter(dc => dc.card.display !== "text")
+          .map(dc => dc.id),
       }),
     },
     [FETCH_DASHBOARD_CARD_DATA]: {


### PR DESCRIPTION
Resolves #11926

Note: merging into master since this feature isn't in v0.34.

This is the second "text boxes weren't considered" bug recently. (The other is #11929). I don't think it's yet worth adding more structure to separate out these two categories of dashcards, but it's worth considering going forward.