### PR TITLE
Adds support for empty title

### DIFF
--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -279,13 +279,15 @@ export default class LineAreaBarChart extends Component {
 
     const hasTitle = showTitle && settings["card.title"];
 
-    const defaultSeries = [{
-      card: {
-        name: " ",
-        id: series[0].card.id,
-        dataset_query: series[0].card.dataset_query,
+    const defaultSeries = [
+      {
+        card: {
+          name: " ",
+          id: series[0].card.id,
+          dataset_query: series[0].card.dataset_query,
+        },
       },
-    }];
+    ];
 
     return (
       <div

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -272,9 +272,9 @@ export default class LineAreaBarChart extends Component {
 
     const settings = this.getSettings();
 
-    let multiseriesHeaderSeries;
+    let hasMultiSeriesHeaderSeries = false;
     if (series.length > 1 || onAddSeries || onEditSeries || onRemoveSeries) {
-      multiseriesHeaderSeries = series;
+      hasMultiSeriesHeaderSeries = true;
     }
 
     const hasTitle = showTitle && settings["card.title"];
@@ -283,8 +283,6 @@ export default class LineAreaBarChart extends Component {
       {
         card: {
           name: " ",
-          id: series[0].card.id,
-          dataset_query: series[0].card.dataset_query,
         },
       },
     ];
@@ -305,10 +303,10 @@ export default class LineAreaBarChart extends Component {
             actionButtons={actionButtons}
           />
         )}
-        {multiseriesHeaderSeries || (!hasTitle && actionButtons) ? ( // always show action buttons if we have them
+        {hasMultiSeriesHeaderSeries || (!hasTitle && actionButtons) ? ( // always show action buttons if we have them
           <LegendHeader
             className="flex-no-shrink"
-            series={multiseriesHeaderSeries || defaultSeries}
+            series={hasMultiSeriesHeaderSeries ? series : defaultSeries}
             settings={settings}
             hovered={hovered}
             onHoverChange={this.props.onHoverChange}

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -272,10 +272,12 @@ export default class LineAreaBarChart extends Component {
 
     const settings = this.getSettings();
 
-    let hasMultiSeriesHeaderSeries = false;
-    if (series.length > 1 || onAddSeries || onEditSeries || onRemoveSeries) {
-      hasMultiSeriesHeaderSeries = true;
-    }
+    const hasMultiSeriesHeaderSeries = !!(
+      series.length > 1 ||
+      onAddSeries ||
+      onEditSeries ||
+      onRemoveSeries
+    );
 
     const hasTitle = showTitle && settings["card.title"];
 

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -279,6 +279,14 @@ export default class LineAreaBarChart extends Component {
 
     const hasTitle = showTitle && settings["card.title"];
 
+    const defaultSeries = [{
+      card: {
+        name: " ",
+        id: series[0].card.id,
+        dataset_query: series[0].card.dataset_query,
+      },
+    }];
+
     return (
       <div
         className={cx(
@@ -298,7 +306,7 @@ export default class LineAreaBarChart extends Component {
         {multiseriesHeaderSeries || (!hasTitle && actionButtons) ? ( // always show action buttons if we have them
           <LegendHeader
             className="flex-no-shrink"
-            series={multiseriesHeaderSeries}
+            series={multiseriesHeaderSeries || defaultSeries}
             settings={settings}
             hovered={hovered}
             onHoverChange={this.props.onHoverChange}

--- a/frontend/test/metabase/visualizations/components/Visualization.e2e.spec.js
+++ b/frontend/test/metabase/visualizations/components/Visualization.e2e.spec.js
@@ -114,6 +114,13 @@ describe("Visualization", () => {
         });
         expect(getTitles(viz)).toEqual([["Foo_name"]]);
       });
+      it("should render a blank title", () => {
+        const viz = renderVisualization({
+          rawSeries: [LineCard("")],
+          showTitle: true,
+        });
+        expect(getTitles(viz)).toEqual([["_name"]]);
+      })
       it("should render normal title and breakout multiseries titles", () => {
         const viz = renderVisualization({
           rawSeries: [MultiseriesLineCard("Foo")],

--- a/frontend/test/metabase/visualizations/components/Visualization.e2e.spec.js
+++ b/frontend/test/metabase/visualizations/components/Visualization.e2e.spec.js
@@ -120,7 +120,7 @@ describe("Visualization", () => {
           showTitle: true,
         });
         expect(getTitles(viz)).toEqual([["_name"]]);
-      })
+      });
       it("should render normal title and breakout multiseries titles", () => {
         const viz = renderVisualization({
           rawSeries: [MultiseriesLineCard("Foo")],


### PR DESCRIPTION
Resolves #11163 

### Steps to reproduce
It'd help to have a read through #11163 first, but to replicate the error, create a simple dashboard with a line graph on it. Edit the card and give it a blank title. Save the dashboard and you should receive a "save failed" message on the save button. 

This seems to be related to `frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx`. Line 280 reads `const hasTitle = showTitle && settings["card.title"]` which sets `hasTitle` to false. Then in the render function there is a check to render `<TitleLegendHeader>` if the title exists or `<LegendHeader>` if it doesn't. The problem is that `<LegendHeader>` gets passed `multiseriesHeaderSeries` which in this case is still `undefined`. To remedy that I pass a default series, with the minimal properties required to make it work.

Not sure if this is the preferred solution, I'm pretty new to the project so happy to take some guidance.

### Tests
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
