### PR TITLE
Simplify new QP middleware pattern

### DIFF
--- a/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics_test.clj
+++ b/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics_test.clj
@@ -286,9 +286,9 @@
                                (#'ga.execute/add-col-metadata query col))
                      rows    [["Toucan Sighting" 1000]]
                      context {:timeout 500
-                              :runf    (fn [query xformf context]
+                              :runf    (fn [query rff context]
                                          (let [metadata (qp.context/metadataf {:cols cols} context)]
-                                           (qp.context/reducef xformf context metadata rows)))}
+                                           (qp.context/reducef rff context metadata rows)))}
                      qp      (fn [query]
                                (qp/process-query query context))]
                  (is (= {:row_count 1

--- a/src/metabase/query_processor/context.clj
+++ b/src/metabase/query_processor/context.clj
@@ -19,10 +19,10 @@
 (defn runf
   "Called by pivot fn to run preprocessed query. Normally, this simply calls `executef`, but you can override this for
   test purposes. The result of this function is ignored."
-  {:arglists '([query xformf context])}
-  [query xformf {runf* :runf, :as context}]
+  {:arglists '([query rff context])}
+  [query rff {runf* :runf, :as context}]
   {:pre [(fn? runf*)]}
-  (runf* query xformf context)
+  (runf* query rff context)
   nil)
 
 (defn executef
@@ -43,10 +43,10 @@
   "Called by `runf` (inside the `respond` callback provided by it) to reduce results of query. `reducedf` is called with
   the reduced results. The actual output of this function is ignored, but the entire result set must be reduced and
   passed to `reducedf` before this function completes."
-  {:arglists '([xformf context metadata reducible-rows])}
-  [xformf {reducef* :reducef, :as context} metadata reducible-rows]
+  {:arglists '([rff context metadata reducible-rows])}
+  [rff {reducef* :reducef, :as context} metadata reducible-rows]
   {:pre [(fn? reducef*)]}
-  (reducef* xformf context metadata reducible-rows)
+  (reducef* rff context metadata reducible-rows)
   nil)
 
 (defn reducedf
@@ -104,15 +104,6 @@
   [{timeout* :timeout}]
   {:pre [(int? timeout*)]}
   timeout*)
-
-(defn base-xformf
-  "xformf passed to the first middleware.
-
-    (xformf metadata) -> xform"
-  {:arglists '([context])}
-  [{base-xformf* :base-xformf}]
-  {:pre [(fn? base-xformf*)]}
-  base-xformf*)
 
 (defn rff
   "Reducing function.

--- a/src/metabase/query_processor/middleware/add_implicit_clauses.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_clauses.clj
@@ -143,5 +143,5 @@
   "Add an implicit `fields` clause to queries with no `:aggregation`, `breakout`, or explicit `:fields` clauses.
    Add implicit `:order-by` clauses for fields specified in a `:breakout`."
   [qp]
-  (fn [query xformf context]
-    (qp (maybe-add-implicit-clauses query) xformf context)))
+  (fn [query rff context]
+    (qp (maybe-add-implicit-clauses query) rff context)))

--- a/src/metabase/query_processor/middleware/add_implicit_joins.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_joins.clj
@@ -241,5 +241,5 @@
 
   This middleware also replaces all `fk->` clauses with `joined-field` clauses, which are easier to work with."
   [qp]
-  (fn [query xformf context]
-    (qp (add-implicit-joins* query) xformf context)))
+  (fn [query rff context]
+    (qp (add-implicit-joins* query) rff context)))

--- a/src/metabase/query_processor/middleware/add_source_metadata.clj
+++ b/src/metabase/query_processor/middleware/add_source_metadata.clj
@@ -101,5 +101,5 @@
   source queries that do not specify this information, we can often infer it by looking at the shape of the source
   query."
   [qp]
-  (fn [query xformf context]
-    (qp (add-source-metadata-for-source-queries* query) xformf context)))
+  (fn [query rff context]
+    (qp (add-source-metadata-for-source-queries* query) rff context)))

--- a/src/metabase/query_processor/middleware/add_timezone_info.clj
+++ b/src/metabase/query_processor/middleware/add_timezone_info.clj
@@ -11,8 +11,8 @@
 (defn add-timezone-info
   "Add `:results_timezone` and `:requested_timezone` info to query results."
   [qp]
-  (fn [query xformf context]
+  (fn [query rff context]
     (qp query
         (fn [metadata]
-          (xformf (add-timezone-metadata metadata)))
+          (rff (add-timezone-metadata metadata)))
         context)))

--- a/src/metabase/query_processor/middleware/async.clj
+++ b/src/metabase/query_processor/middleware/async.clj
@@ -12,10 +12,10 @@
 (defn count-in-flight-queries
   "Middleware that tracks the current number of queries in flight."
   [qp]
-  (fn [query xformf context]
+  (fn [query rff context]
     (send in-flight* inc)
     (let [out-chan (context/out-chan context)]
       (a/go
         (a/<! out-chan)
         (send in-flight* dec)))
-    (qp query xformf context)))
+    (qp query rff context)))

--- a/src/metabase/query_processor/middleware/async_wait.clj
+++ b/src/metabase/query_processor/middleware/async_wait.clj
@@ -76,19 +76,19 @@
   InterruptedExceptions."
   false)
 
-(defn- runnable ^Runnable [qp query xformf context]
+(defn- runnable ^Runnable [qp query rff context]
   (bound-fn []
     (binding [*already-in-thread-pool?* true]
       (try
-        (qp query xformf context)
+        (qp query rff context)
         (catch Throwable e
           (context/raisef e context))))))
 
-(defn- run-in-thread-pool [qp {database-id :database, :as query} xformf context]
+(defn- run-in-thread-pool [qp {database-id :database, :as query} rff context]
   {:pre [(integer? database-id)]}
   (try
     (let [pool          (db-thread-pool database-id)
-          futur         (.submit pool (runnable qp query xformf context))
+          futur         (.submit pool (runnable qp query rff context))
           canceled-chan (context/canceled-chan context)]
       (a/go
         (when (a/<! canceled-chan)
@@ -102,8 +102,8 @@
   "Middleware that throttles the number of concurrent queries for each connected database, parking the thread until it
   is allowed to run."
   [qp]
-  (fn [query xformf context]
+  (fn [query rff context]
     {:pre [(map? query)]}
     (if (or *already-in-thread-pool?* *disable-async-wait*)
-      (qp query xformf context)
-      (run-in-thread-pool qp query xformf context))))
+      (qp query rff context)
+      (run-in-thread-pool qp query rff context))))

--- a/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
+++ b/src/metabase/query_processor/middleware/auto_bucket_datetimes.clj
@@ -121,5 +121,5 @@
   Applies to any unbucketed Field in a breakout, or fields in a filter clause being compared against `yyyy-MM-dd`
   format datetime strings."
   [qp]
-  (fn [query xformf context]
-    (qp (auto-bucket-datetimes* query) xformf context)))
+  (fn [query rff context]
+    (qp (auto-bucket-datetimes* query) rff context)))

--- a/src/metabase/query_processor/middleware/binning.clj
+++ b/src/metabase/query_processor/middleware/binning.clj
@@ -225,5 +225,5 @@
   the binned field. This middleware looks for that criteria, then updates the related min/max values and calculates
   the bin-width based on the criteria values (or global min/max information)."
   [qp]
-  (fn [query xformf context]
-    (qp (update-binning-strategy* query) xformf context)))
+  (fn [query rff context]
+    (qp (update-binning-strategy* query) rff context)))

--- a/src/metabase/query_processor/middleware/catch_exceptions.clj
+++ b/src/metabase/query_processor/middleware/catch_exceptions.clj
@@ -148,7 +148,7 @@
   exceptions to the `result-chan`."
   [qp]
 
-  (fn [query xformf {:keys [preprocessedf nativef raisef], :as context}]
+  (fn [query rff {:keys [preprocessedf nativef raisef], :as context}]
     (let [extra-info (atom nil)]
       (letfn [(preprocessedf* [query context]
                 (swap! extra-info assoc :preprocessed query)
@@ -163,7 +163,7 @@
                     (log/tracef "raisef* got %s, returning formatted exception" (class e))
                     (context/resultf (format-exception* query e @extra-info) context))))]
         (try
-          (qp query xformf (assoc context
+          (qp query rff (assoc context
                                   :preprocessedf preprocessedf*
                                   :nativef nativef*
                                   :raisef raisef*))

--- a/src/metabase/query_processor/middleware/check_features.clj
+++ b/src/metabase/query_processor/middleware/check_features.clj
@@ -38,5 +38,5 @@
 (defn check-features
   "Middleware that checks that drivers support the `:features` required to use certain clauses, like `:stddev`."
   [qp]
-  (fn [query xformf context]
-    (qp (check-features* query) xformf context)))
+  (fn [query rff context]
+    (qp (check-features* query) rff context)))

--- a/src/metabase/query_processor/middleware/constraints.clj
+++ b/src/metabase/query_processor/middleware/constraints.clj
@@ -38,5 +38,5 @@
   "Middleware that optionally adds default `max-results` and `max-results-bare-rows` constraints to queries, meant for
   use with `process-query-and-save-with-max-results-constraints!`, which ultimately powers most QP API endpoints."
   [qp]
-  (fn [query xformf context]
-    (qp (add-default-userland-constraints* query) xformf context)))
+  (fn [query rff context]
+    (qp (add-default-userland-constraints* query) rff context)))

--- a/src/metabase/query_processor/middleware/desugar.clj
+++ b/src/metabase/query_processor/middleware/desugar.clj
@@ -18,5 +18,5 @@
   `inside` with lower-level clauses like `between`. This is done to minimize the number of MBQL clauses individual
   drivers need to support. Clauses replaced by this middleware are marked `^:sugar` in the MBQL schema."
   [qp]
-  (fn [query xformf context]
-    (qp (desugar* query) xformf context)))
+  (fn [query rff context]
+    (qp (desugar* query) rff context)))

--- a/src/metabase/query_processor/middleware/expand_macros.clj
+++ b/src/metabase/query_processor/middleware/expand_macros.clj
@@ -154,5 +154,5 @@
   "Middleware that looks for `:metric` and `:segment` macros in an unexpanded MBQL query and substitute the macros for
   their contents."
   [qp]
-  (fn [query xformf context]
-    (qp (expand-macros* query) xformf context)))
+  (fn [query rff context]
+    (qp (expand-macros* query) rff context)))

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -239,5 +239,5 @@
   "Middleware that assocs the `:source-query` for this query if it was specified using the shorthand `:source-table`
   `card__n` format."
   [qp]
-  (fn [query xformf context]
-    (qp (resolve-card-id-source-tables* query) xformf context)))
+  (fn [query rff context]
+    (qp (resolve-card-id-source-tables* query) rff context)))

--- a/src/metabase/query_processor/middleware/format_rows.clj
+++ b/src/metabase/query_processor/middleware/format_rows.clj
@@ -77,10 +77,10 @@
 (defn format-rows
   "Format individual query result values as needed.  Ex: format temporal values as ISO-8601 strings w/ timezone offset."
   [qp]
-  (fn [{{:keys [format-rows?] :or {format-rows? true}} :middleware, :as query} xformf context]
+  (fn [{{:keys [format-rows?] :or {format-rows? true}} :middleware, :as query} rff context]
     (qp query
         (if format-rows?
           (fn [metadata]
-            (comp format-rows-xform (xformf metadata)))
-          xformf)
+            (format-rows-xform (rff metadata)))
+          rff)
         context)))

--- a/src/metabase/query_processor/middleware/mbql_to_native.clj
+++ b/src/metabase/query_processor/middleware/mbql_to_native.clj
@@ -18,7 +18,7 @@
   "Middleware that handles conversion of MBQL queries to native (by calling driver QP methods) so the queries
    can be executed. For queries that are already native, this function is effectively a no-op."
   [qp]
-  (fn [{query-type :type, :as query} xformf context]
+  (fn [{query-type :type, :as query} rff context]
     (let [query        (context/preprocessedf query context)
           native-query (context/nativef (query->native-form query) context)]
       (log/trace (u/format-color 'yellow "\nPreprocessed:\n%s" (u/pprint-to-str query)))
@@ -28,5 +28,5 @@
          (= query-type :query)
          (assoc :native native-query))
        (fn [metadata]
-         (xformf (assoc metadata :native_form native-query)))
+         (rff (assoc metadata :native_form native-query)))
        context))))

--- a/src/metabase/query_processor/middleware/normalize_query.clj
+++ b/src/metabase/query_processor/middleware/normalize_query.clj
@@ -10,13 +10,13 @@
   into standard `lisp-case` ones, removing/rewriting legacy clauses, removing empty ones, etc. This is done to
   simplifiy the logic in the QP steps following this."
   [qp]
-  (fn [query xformf context]
+  (fn [query rff context]
     (let [query' (try
                    (u/prog1 (normalize/normalize query)
                      (log/tracef "Normalized query:\n%s" (u/pprint-to-str <>)))
                    (catch Throwable e
                      (throw (ex-info (.getMessage e)
-                              {:type  error-type/invalid-query
-                               :query query}
-                              e))))]
-      (qp query' xformf context))))
+                                     {:type  error-type/invalid-query
+                                      :query query}
+                                     e))))]
+      (qp query' rff context))))

--- a/src/metabase/query_processor/middleware/optimize_datetime_filters.clj
+++ b/src/metabase/query_processor/middleware/optimize_datetime_filters.clj
@@ -129,5 +129,5 @@
   This namespace expects to run *after* the `wrap-value-literals` middleware, meaning datetime literal strings like
   `\"2019-09-24\"` should already have been converted to `:absolute-datetime` clauses."
   [qp]
-  (fn [query xformf context]
-    (qp (optimize-datetime-filters* query) xformf context)))
+  (fn [query rff context]
+    (qp (optimize-datetime-filters* query) rff context)))

--- a/src/metabase/query_processor/middleware/parameters.clj
+++ b/src/metabase/query_processor/middleware/parameters.clj
@@ -93,5 +93,5 @@
   A SQL query with a param like `{{param}}` will have that part of the query replaced with an appropriate snippet as
   well as any prepared statement args needed. MBQL queries will have additional filter clauses added."
   [qp]
-  (fn [query xformf context]
-    (qp (substitute-parameters* query) xformf context)))
+  (fn [query rff context]
+    (qp (substitute-parameters* query) rff context)))

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -54,9 +54,9 @@
   be checked separately before allowing the relevant objects to be create (e.g., when saving a new Pulse or
   'publishing' a Card)."
   [qp]
-  (fn [query xformf context]
+  (fn [query rff context]
     (check-query-permissions* query)
-    (qp query xformf context)))
+    (qp query rff context)))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/query_processor/middleware/pre_alias_aggregations.clj
+++ b/src/metabase/query_processor/middleware/pre_alias_aggregations.clj
@@ -36,5 +36,5 @@
 (defn pre-alias-aggregations
   "Middleware that generates aliases for all aggregations anywhere in a query, and makes sure they're unique."
   [qp]
-  (fn [query xformf context]
-    (qp (maybe-pre-alias-aggregations query) xformf context)))
+  (fn [query rff context]
+    (qp (maybe-pre-alias-aggregations query) rff context)))

--- a/src/metabase/query_processor/middleware/reconcile_breakout_and_order_by_bucketing.clj
+++ b/src/metabase/query_processor/middleware/reconcile_breakout_and_order_by_bucketing.clj
@@ -94,5 +94,5 @@
    {:query {:breakout [[:datetime-field [:field-id 1] :day]]
             :order-by [[:datetime-field [:asc [:field-id 1]] :day]]}"
   [qp]
-  (fn [query xformf context]
-    (qp (reconcile-bucketing-if-needed query) xformf context)))
+  (fn [query rff context]
+    (qp (reconcile-bucketing-if-needed query) rff context)))

--- a/src/metabase/query_processor/middleware/resolve_database_and_driver.clj
+++ b/src/metabase/query_processor/middleware/resolve_database_and_driver.clj
@@ -18,7 +18,7 @@
   "Middleware that resolves the Database referenced by the query under that `:database` key and stores it in the QP
   Store."
   [qp]
-  (fn [{database-id :database, :as query} xformf context]
+  (fn [{database-id :database, :as query} rff context]
     (when-not ((every-pred integer? pos?) database-id)
       (throw (ex-info (tru "Unable to resolve database for query: missing or invalid `:database` ID.")
                {:database database-id
@@ -29,4 +29,4 @@
                           (catch Throwable e
                             (throw (ex-info (tru "Unable to resolve driver for query")
                                      {:type error-type/invalid-query}))))
-      (qp query xformf context))))
+      (qp query rff context))))

--- a/src/metabase/query_processor/middleware/resolve_fields.clj
+++ b/src/metabase/query_processor/middleware/resolve_fields.clj
@@ -17,5 +17,5 @@
   "Fetch the Fields referenced by `:field-id` clauses in a query and store them in the Query Processor Store for the
   duration of the Query Execution."
   [qp]
-  (fn [query xformf context]
-    (qp (resolve-fields* query) xformf context)))
+  (fn [query rff context]
+    (qp (resolve-fields* query) rff context)))

--- a/src/metabase/query_processor/middleware/resolve_joins.clj
+++ b/src/metabase/query_processor/middleware/resolve_joins.clj
@@ -179,5 +179,5 @@
 (defn resolve-joins
   "Add any Tables and Fields referenced by the `:joins` clause to the QP store."
   [qp]
-  (fn [query xformf context]
-    (qp (resolve-joins* query) xformf context)))
+  (fn [query rff context]
+    (qp (resolve-joins* query) rff context)))

--- a/src/metabase/query_processor/middleware/resolve_source_table.clj
+++ b/src/metabase/query_processor/middleware/resolve_source_table.clj
@@ -41,6 +41,6 @@
   "Middleware that will take any `:source-table`s (integer IDs) anywhere in the query and fetch and save the
   corresponding Table in the Query Processor Store."
   [qp]
-  (fn [query xformf context]
+  (fn [query rff context]
     (resolve-source-tables* query)
-    (qp query xformf context)))
+    (qp query rff context)))

--- a/src/metabase/query_processor/middleware/splice_params_in_response.clj
+++ b/src/metabase/query_processor/middleware/splice_params_in_response.clj
@@ -28,8 +28,8 @@
   queries without `:params` (which will be all of them for drivers that don't support the equivalent of prepared
   statement parameters, like Druid), this middleware does nothing."
   [qp]
-  (fn [query xformf context]
+  (fn [query rff context]
     (qp query
         (fn [metadata]
-          (xformf (splice-params-in-metadata metadata)))
+          (rff (splice-params-in-metadata metadata)))
         context)))

--- a/src/metabase/query_processor/middleware/store.clj
+++ b/src/metabase/query_processor/middleware/store.clj
@@ -6,6 +6,6 @@
 (defn initialize-store
   "Initialize the QP Store (resolved objects cache) for this query execution."
   [qp]
-  (fn [query xformf context]
+  (fn [query rff context]
     (qp.store/with-store
-      (qp query xformf context))))
+      (qp query rff context))))

--- a/src/metabase/query_processor/middleware/validate.clj
+++ b/src/metabase/query_processor/middleware/validate.clj
@@ -5,6 +5,6 @@
 (defn validate-query
   "Middleware that validates a query immediately after normalization."
   [qp]
-  (fn [query xformf context]
+  (fn [query rff context]
     (mbql.s/validate-query query)
-    (qp query xformf context)))
+    (qp query rff context)))

--- a/src/metabase/query_processor/middleware/wrap_value_literals.clj
+++ b/src/metabase/query_processor/middleware/wrap_value_literals.clj
@@ -133,5 +133,5 @@
   to make it easier for drivers to write implementations that rely on multimethod dispatch (by clause name) -- they
   can dispatch directly off of these clauses."
   [qp]
-  (fn [query xformf context]
-    (qp (wrap-value-literals* query) xformf context)))
+  (fn [query rff context]
+    (qp (wrap-value-literals* query) rff context)))

--- a/src/metabase/query_processor/reducible.clj
+++ b/src/metabase/query_processor/reducible.clj
@@ -29,14 +29,14 @@
 
 (defn pivot
   "The initial value of `qp` passed to QP middleware."
-  [query xformf context]
-  (context/runf query xformf context))
+  [query rff context]
+  (context/runf query rff context))
 
 (defn combine-middleware
   "Combine a collection of QP middleware into a single QP function. The QP function, like the middleware, will have the
   signature:
 
-    (qp query xformf context)"
+    (qp query rff context)"
   [middleware]
   (reduce
    (fn [qp middleware]
@@ -71,7 +71,7 @@
 (defn async-qp
   "Wrap a QP function (middleware or a composition of middleware created with `combine-middleware`) with the signature:
 
-    (qp query xformf context)
+    (qp query rff context)
 
   And return a function with the signatures:
 
@@ -79,7 +79,7 @@
     (qp query context)
 
   While you can use a 3-arg QP function directly, this makes the function more user-friendly by providing a base
-  `xformf` and a default `context`,"
+  `rff` and a default `context`,"
   [qp]
   (fn qp*
     ([query]
@@ -90,7 +90,7 @@
      (let [context (merge (context.default/default-context) context)]
        (wire-up-context-channels! context)
        (try
-         (qp query (context/base-xformf context) context)
+         (qp query (context/rff context) context)
          (catch Throwable e
            (context/raisef e context)))
        (quittable-out-chan (context/out-chan context))))))

--- a/src/metabase/sync/analyze/query_results.clj
+++ b/src/metabase/sync/analyze/query_results.clj
@@ -65,7 +65,7 @@
 
 (defn insights-rf
   "A reducing function that calculates what is ultimately returned as `[:data :results_metadata]` in userland QP
-  results. `metadata` is the usual QP results metadata e.g. as recieved by an `xformf`."
+  results. `metadata` is the usual QP results metadata e.g. as recieved by an `rff`."
   {:arglists '([metadata])}
   [{:keys [cols]}]
   (let [cols (for [col cols]

--- a/test/metabase/query_processor/middleware/cumulative_aggregations_test.clj
+++ b/test/metabase/query_processor/middleware/cumulative_aggregations_test.clj
@@ -25,11 +25,10 @@
            (#'cumulative-aggregations/diff-indecies [:a :b :c] [:a 100 :c])))))
 
 (defn- sum-rows [replaced-indecies rows]
-  (let [xform (#'cumulative-aggregations/cumulative-ags-xform replaced-indecies)
-        rf    (xform (fn
-                       ([] [])
-                       ([acc] acc)
-                       ([acc row] (conj acc row))))]
+  (let [rf (#'cumulative-aggregations/cumulative-ags-xform replaced-indecies (fn
+                                                                               ([] [])
+                                                                               ([acc] acc)
+                                                                               ([acc row] (conj acc row))))]
     (transduce identity rf rows)))
 
 (deftest transduce-results-test

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -89,10 +89,10 @@
           "Result should have query execution info. empty `:data` should get added to failures"))))
 
 (defn- async-middleware [qp]
-  (fn async-middleware-qp [query xformf context]
+  (fn async-middleware-qp [query rff context]
     (future
       (try
-        (qp query xformf context)
+        (qp query rff context)
         (catch Throwable e
           (context/raisef e context))))
     nil))

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -215,11 +215,11 @@
                       [middleware-fn])))
          context  (merge
                    {:timeout 500
-                    :runf    (fn [query xformf context]
+                    :runf    (fn [query rff context]
                                (try
                                  (when run (run))
                                  (let [metadata (qp.context/metadataf metadata context)]
-                                   (qp.context/reducef xformf context (assoc metadata :pre query) rows))
+                                   (qp.context/reducef rff context (assoc metadata :pre query) rows))
                                  (catch Throwable e
                                    (println "Error in test-qp-middleware runf:" e)
                                    (throw e))))}


### PR DESCRIPTION
Tweaks the **new** QP middleware pattern from

```clj
(qp query xformf context)
```

to 

```clj
(qp query rff context)
```

As mentioned elsewhere, `xformf` here means a function that takes initial query result metadata and returns a transducer (i.e., a transformation of a reducing function), while `rff` means a function that takes initial query result metadata and returns a reducing a function.

We don't do anything special with the transducers other than apply them the normal way to the reducing function returned by `rff`. `rff` is already in place before query processing starts. 

Now middleware transforms the `rff` directly instead of transforming a transform for it, which simplifies things quite a bit.