### PR TITLE
Add more special field type groupings and reorganize them

### DIFF
--- a/frontend/src/metabase/lib/core.js
+++ b/frontend/src/metabase/lib/core.js
@@ -2,6 +2,7 @@ import { TYPE } from "metabase/lib/types";
 import { t } from "ttag";
 
 export const field_special_types = [
+  /* Overall Row */
   {
     id: TYPE.PK,
     name: t`Entity Key`,
@@ -20,219 +21,11 @@ export const field_special_types = [
     section: t`Overall Row`,
     description: t`Points to another table to make a connection.`,
   },
-  {
-    id: TYPE.AvatarURL,
-    name: t`Avatar Image URL`,
-    section: t`Common`,
-  },
+
+  /* Common */
   {
     id: TYPE.Category,
     name: t`Category`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.City,
-    name: t`City`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Country,
-    name: t`Country`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Currency,
-    name: t`Currency`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Description,
-    name: t`Description`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Email,
-    name: t`Email`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Enum,
-    name: t`Enum`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.ImageURL,
-    name: t`Image URL`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.SerializedJSON,
-    name: t`Field containing JSON`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Latitude,
-    name: t`Latitude`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Longitude,
-    name: t`Longitude`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Number,
-    name: t`Number`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.State,
-    name: t`State`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.UNIXTimestampSeconds,
-    name: t`UNIX Timestamp (Seconds)`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.UNIXTimestampMilliseconds,
-    name: t`UNIX Timestamp (Milliseconds)`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.URL,
-    name: t`URL`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.ZipCode,
-    name: t`Zip Code`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Quantity,
-    name: t`Quantity`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Income,
-    name: t`Income`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Discount,
-    name: t`Discount`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.CreationTimestamp,
-    name: t`Creation timestamp`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.CreationTime,
-    name: t`Creation time`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.CreationDate,
-    name: t`Creation date`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.CancelationTimestamp,
-    name: t`Cancelation timestamp`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.CancelationTime,
-    name: t`Cancelation time`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.CancelationDate,
-    name: t`Cancelation date`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.DeletionTimestamp,
-    name: t`Deletion timestamp`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.DeletionTime,
-    name: t`Deletion time`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.DeletionDate,
-    name: t`Deletion date`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Product,
-    name: t`Product`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.User,
-    name: t`User`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Source,
-    name: t`Source`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Price,
-    name: t`Price`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.JoinTimestamp,
-    name: t`Join timestamp`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.JoinTime,
-    name: t`Join time`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.JoinDate,
-    name: t`Join date`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Share,
-    name: t`Share`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Owner,
-    name: t`Owner`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Company,
-    name: t`Company`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Subscription,
-    name: t`Subscription`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Score,
-    name: t`Score`,
-    section: t`Common`,
-  },
-  {
-    id: TYPE.Title,
-    name: t`Title`,
     section: t`Common`,
   },
   {
@@ -241,19 +34,245 @@ export const field_special_types = [
     section: t`Common`,
   },
   {
+    id: TYPE.Description,
+    name: t`Description`,
+    section: t`Common`,
+  },
+  {
+    id: TYPE.Number,
+    name: t`Number`,
+    section: t`Common`,
+  },
+  {
+    id: TYPE.Title,
+    name: t`Title`,
+    section: t`Common`,
+  },
+
+  /* Location */
+  {
+    id: TYPE.City,
+    name: t`City`,
+    section: t`Location`,
+  },
+  {
+    id: TYPE.Country,
+    name: t`Country`,
+    section: t`Location`,
+  },
+  {
+    id: TYPE.Latitude,
+    name: t`Latitude`,
+    section: t`Location`,
+  },
+  {
+    id: TYPE.Longitude,
+    name: t`Longitude`,
+    section: t`Location`,
+  },
+  {
+    id: TYPE.State,
+    name: t`State`,
+    section: t`Location`,
+  },
+  {
+    id: TYPE.ZipCode,
+    name: t`Zip Code`,
+    section: t`Location`,
+  },
+
+  /* Financial */
+  {
     id: TYPE.Cost,
     name: t`Cost`,
-    section: t`Common`,
+    section: t`Financial`,
+  },
+  {
+    id: TYPE.Currency,
+    name: t`Currency`,
+    section: t`Financial`,
+  },
+  {
+    id: TYPE.Discount,
+    name: t`Discount`,
+    section: t`Financial`,
   },
   {
     id: TYPE.GrossMargin,
     name: t`Gross margin`,
-    section: t`Common`,
+    section: t`Financial`,
   },
+  {
+    id: TYPE.Income,
+    name: t`Income`,
+    section: t`Financial`,
+  },
+  {
+    id: TYPE.Price,
+    name: t`Price`,
+    section: t`Financial`,
+  },
+
+  /* Numeric */
+  {
+    id: TYPE.Quantity,
+    name: t`Quantity`,
+    section: t`Numeric`,
+  },
+  {
+    id: TYPE.Score,
+    name: t`Score`,
+    section: t`Numeric`,
+  },
+  {
+    id: TYPE.Share,
+    name: t`Share`,
+    section: t`Numeric`,
+  },
+
+  /* Profile */
   {
     id: TYPE.Birthdate,
     name: t`Birthday`,
-    section: t`Common`,
+    section: t`Profile`,
+  },
+  {
+    id: TYPE.Company,
+    name: t`Company`,
+    section: t`Profile`,
+  },
+  {
+    id: TYPE.Email,
+    name: t`Email`,
+    section: t`Profile`,
+  },
+  {
+    id: TYPE.Owner,
+    name: t`Owner`,
+    section: t`Profile`,
+  },
+  {
+    id: TYPE.Subscription,
+    name: t`Subscription`,
+    section: t`Profile`,
+  },
+  {
+    id: TYPE.User,
+    name: t`User`,
+    section: t`Profile`,
+  },
+
+  /* Date and Time */
+  {
+    id: TYPE.CancelationDate,
+    name: t`Cancelation date`,
+    section: t`Date and Time`,
+  },
+  {
+    id: TYPE.CancelationTime,
+    name: t`Cancelation time`,
+    section: t`Date and Time`,
+  },
+  {
+    id: TYPE.CancelationTimestamp,
+    name: t`Cancelation timestamp`,
+    section: t`Date and Time`,
+  },
+  {
+    id: TYPE.CreationDate,
+    name: t`Creation date`,
+    section: t`Date and Time`,
+  },
+  {
+    id: TYPE.CreationTime,
+    name: t`Creation time`,
+    section: t`Date and Time`,
+  },
+  {
+    id: TYPE.CreationTimestamp,
+    name: t`Creation timestamp`,
+    section: t`Date and Time`,
+  },
+  {
+    id: TYPE.DeletionDate,
+    name: t`Deletion date`,
+    section: t`Date and Time`,
+  },
+  {
+    id: TYPE.DeletionTime,
+    name: t`Deletion time`,
+    section: t`Date and Time`,
+  },
+  {
+    id: TYPE.DeletionTimestamp,
+    name: t`Deletion timestamp`,
+    section: t`Date and Time`,
+  },
+  {
+    id: TYPE.JoinDate,
+    name: t`Join date`,
+    section: t`Date and Time`,
+  },
+  {
+    id: TYPE.JoinTime,
+    name: t`Join time`,
+    section: t`Date and Time`,
+  },
+  {
+    id: TYPE.JoinTimestamp,
+    name: t`Join timestamp`,
+    section: t`Date and Time`,
+  },
+  {
+    id: TYPE.UNIXTimestampMilliseconds,
+    name: t`UNIX Timestamp (Milliseconds)`,
+    section: t`Date and Time`,
+  },
+  {
+    id: TYPE.UNIXTimestampSeconds,
+    name: t`UNIX Timestamp (Seconds)`,
+    section: t`Date and Time`,
+  },
+
+  /* Categorical */
+  {
+    id: TYPE.Enum,
+    name: t`Enum`,
+    section: t`Categorical`,
+  },
+  {
+    id: TYPE.Product,
+    name: t`Product`,
+    section: t`Categorical`,
+  },
+  {
+    id: TYPE.Source,
+    name: t`Source`,
+    section: t`Categorical`,
+  },
+
+  /* URLs */
+  {
+    id: TYPE.AvatarURL,
+    name: t`Avatar Image URL`,
+    section: t`URLs`,
+  },
+  {
+    id: TYPE.ImageURL,
+    name: t`Image URL`,
+    section: t`URLs`,
+  },
+  {
+    id: TYPE.URL,
+    name: t`URL`,
+    section: t`URLs`,
+  },
+
+  /* Other */
+  {
+    id: TYPE.SerializedJSON,
+    name: t`Field containing JSON`,
+    section: t`Other`,
   },
 ];
 

--- a/frontend/test/metabase/internal/__snapshots__/components.unit.spec.js.snap
+++ b/frontend/test/metabase/internal/__snapshots__/components.unit.spec.js.snap
@@ -1023,7 +1023,7 @@ exports[`Select should render "kitchen_sink" correctly 1`] = `
         , 
       </span>
       <span>
-        Avatar Image URL
+        Category
         
       </span>
     </span>
@@ -1064,7 +1064,7 @@ exports[`Select should render "multiple" correctly 1`] = `
         , 
       </span>
       <span>
-        Avatar Image URL
+        Category
         
       </span>
     </span>


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/7586

**Main question:** how do we feel about the grouping labels I've chosen, and about which types go into which group? Here's an easier to scan [IA spreadsheet](https://docs.google.com/spreadsheets/d/1gPTEa7v067AdmiRvrESR2eGOTEBV1d-EUs_ERFemYLw/edit?usp=sharing).

## Before
Besides "Entire row," "Common," and "Other," there were no field type groupings at all. Madness. Cats marrying dogs.

![image](https://user-images.githubusercontent.com/2223916/74969445-6ff7c300-53d1-11ea-82e1-b09c583846d1.png)

## After
Blissful logical groupings, which are sorted alphabetically within each group.

![grouped-field-types](https://user-images.githubusercontent.com/2223916/74969649-cb29b580-53d1-11ea-9528-c88ebea47abb.gif)
