### PR TITLE
fix selected state in single date widget

### DIFF
--- a/frontend/src/metabase/components/Calendar.jsx
+++ b/frontend/src/metabase/components/Calendar.jsx
@@ -158,7 +158,10 @@ export default class Calendar extends Component {
     return (
       <div
         className={cx("Calendar Grid-cell", {
-          "Calendar--range": this.props.selected && this.props.selectedEnd,
+          "Calendar--range":
+            this.props.isRangePicker &&
+            this.props.selected &&
+            this.props.selectedEnd,
         })}
       >
         {this.renderMonthHeader(current, side)}

--- a/frontend/src/metabase/parameters/components/widgets/DateSingleWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateSingleWidget.jsx
@@ -11,6 +11,7 @@ const DateSingleWidget = ({ value, setValue, onClose }) => {
         initial={value}
         selected={value}
         selectedEnd={value}
+        isRangePicker={false}
         onChange={value => {
           setValue(value);
           onClose();


### PR DESCRIPTION
DateSingleWidget wasn't explicitly setting itself to not be a range
picker nor were we checking that prop in the css class we applied which
resulted in an inconsistent selected state in the single date widget.

### Before
<img width="304" alt="Screen Shot 2020-02-21 at 3 00 11 PM" src="https://user-images.githubusercontent.com/5248953/75078602-e3c1ca80-54ba-11ea-8a58-2bdc24d481d4.png">

### After
<img width="335" alt="Screen Shot 2020-02-21 at 2 55 23 PM" src="https://user-images.githubusercontent.com/5248953/75078603-e4f2f780-54ba-11ea-83ae-fcc35ea67d3d.png">
