### PR TITLE
Fix stack overflow when using non-existent MetaBot command

### DIFF
--- a/src/metabase/metabot/command.clj
+++ b/src/metabase/metabot/command.clj
@@ -196,9 +196,9 @@
 
 (def ^:private kanye-quotes
   (delay
-   (log/debug (trs "Loading Kanye quotes..."))
-   (when-let [url (io/resource "kanye-quotes.edn")]
-     (edn/read-string (slurp url)))))
+    (log/debug (trs "Loading Kanye quotes..."))
+    (when-let [url (io/resource "kanye-quotes.edn")]
+      (edn/read-string (slurp url)))))
 
 (defmethod command :kanye [& _]
   (str ":kanye:\n> " (rand-nth @kanye-quotes)))

--- a/src/metabase/metabot/command.clj
+++ b/src/metabase/metabot/command.clj
@@ -107,27 +107,19 @@
 
 (defn- list-cards []
   (filter-metabot-readable
-   (let [collection-ids                  (metabot-visible-collection-ids)
-         root-collection-perms?          (contains? collection-ids nil)
-         other-visible-collection-ids    (filter some? collection-ids)
-
-         root-collection-filter-clause   (when root-collection-perms?
-                                           [:= :collection_id nil])
-         other-collections-filter-clause (when (seq other-visible-collection-ids)
-                                           [:in :collection_id other-visible-collection-ids])]
-     (db/select [Card :id :name :dataset_query :collection_id]
-       {:order-by [[:id :desc]]
-        :limit    20
-        :where    [:and
-                   [:= :archived false]
-                   (collection/visible-collection-ids->honeysql-filter-clause
-                    (metabot-visible-collection-ids))]}))))
+   (db/select [Card :id :name :dataset_query :collection_id]
+     {:order-by [[:id :desc]]
+      :limit    20
+      :where    [:and
+                 [:= :archived false]
+                 (collection/visible-collection-ids->honeysql-filter-clause
+                  (metabot-visible-collection-ids))]})))
 
 (defmethod command :list [& _]
   (let [cards (list-cards)]
     (str (deferred-tru "Here''s your {0} most recent cards:" (count cards))
          "\n"
-          (format-cards-list cards))))
+         (format-cards-list cards))))
 
 
 ;;; ------------------------------------------------------ show ------------------------------------------------------
@@ -204,9 +196,9 @@
 
 (def ^:private kanye-quotes
   (delay
-    (log/debug (trs "Loading Kanye quotes..."))
-    (when-let [url (io/resource "kanye-quotes.edn")]
-      (edn/read-string (slurp url)))))
+   (log/debug (trs "Loading Kanye quotes..."))
+   (when-let [url (io/resource "kanye-quotes.edn")]
+     (edn/read-string (slurp url)))))
 
 (defmethod command :kanye [& _]
   (str ":kanye:\n> " (rand-nth @kanye-quotes)))

--- a/src/metabase/metabot/command.clj
+++ b/src/metabase/metabot/command.clj
@@ -83,7 +83,7 @@
   (str
    (tru "I don''t know how to `{0}`." command-name)
    " "
-   (command :help)))
+   (command "help")))
 
 
 (defmulti ^:private unlisted?
@@ -174,7 +174,7 @@
   ;; If the card name comes without spaces, e.g. (show 'my 'wacky 'card) turn it into a string an recur: (show "my
   ;; wacky card")
   ([_ word & more]
-   (command :show (str/join " " (cons word more)))))
+   (command "show" (str/join " " (cons word more)))))
 
 
 ;;; ------------------------------------------------------ help ------------------------------------------------------

--- a/src/metabase/metabot/events.clj
+++ b/src/metabase/metabot/events.clj
@@ -38,7 +38,7 @@
   (when (seq text)
     (second (re-matches #"^mea?ta?boa?t\s*(.*)$" text)))) ; handle typos like metaboat or meatbot
 
-(defn- respond-to-message! [message response]
+(defn- respond-to-message! [response]
   (when response
     (let [response (if (coll? response) (str "```\n" (u/pprint-to-str response) "```")
                        (str response))]
@@ -46,7 +46,7 @@
         (metabot.slack/post-chat-message! response)))))
 
 (defn- handle-slack-message [message]
-  (respond-to-message! message (eval-command-str (message->command-str message))))
+  (respond-to-message! (eval-command-str (message->command-str message))))
 
 (defn- human-message?
   "Was this Slack WebSocket event one about a *human* sending a message?"

--- a/test/metabase/metabot/command_test.clj
+++ b/test/metabase/metabot/command_test.clj
@@ -119,3 +119,9 @@
                   Card       [{card-id :id} {:collection_id (u/get-id collection), :dataset_query (venues-count-query)}]]
     (perms/revoke-collection-permissions! (group/metabot) collection)
     (command "show" card-id)))
+
+;; If you try to use a command that doesn't exist, it should notify user and show results of `help` command.
+(expect
+  {:response (tru "I don''t know how to `overflow stack`. Here''s what I can do: `help`, `list`, `show`")
+   :messages []}
+  (command "overflow stack"))


### PR DESCRIPTION
Giving a Slack message to MetaBot with a command that doesn't exist (e.g., `metabot cool`) causes a stack overflow and responds with a null error message:
![image](https://user-images.githubusercontent.com/1365334/75202622-d5cdad00-5739-11ea-999a-c4215a98eceb.png)

This PR fixes that bug, and another instance of the same bug within `metabot show`.

Also, an (unused?) let form was removed. Let me know if you want me to revert that (i.e., if it was being kept around for some reason). And, I have aggressive-indent-mode on, so let me know if you want me to undo the automatic indentation changes.
