### PR TITLE
Improve month picker legibility

### DIFF
--- a/frontend/src/metabase/parameters/components/widgets/DateMonthYearWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateMonthYearWidget.jsx
@@ -1,21 +1,18 @@
-import React, { Component } from "react";
-
+import React from "react";
 import YearPicker from "./YearPicker";
+import { Flex } from "grid-styled";
 
 import moment from "moment";
 import _ from "underscore";
 import cx from "classnames";
 
-export default class DateMonthYearWidget extends Component {
+export default class DateMonthYearWidget extends React.Component {
   constructor(props, context) {
     super(props, context);
 
     const initial = moment(this.props.value, "YYYY-MM");
     if (initial.isValid()) {
-      this.state = {
-        month: initial.month(),
-        year: initial.year(),
-      };
+      this.state = { month: initial.month(), year: initial.year() };
     } else {
       this.state = {
         month: null,
@@ -49,49 +46,45 @@ export default class DateMonthYearWidget extends Component {
     const { onClose } = this.props;
     const { month, year } = this.state;
     return (
-      <div className="py2">
-        <div className="flex flex-column align-center px1">
+      <div style={{ maxWidth: 320 }}>
+        <div className="border-bottom flex justify-center py1">
           <YearPicker
             value={year}
             onChange={year => this.setState({ year: year })}
           />
         </div>
-        <div className="flex">
-          <ol className="flex flex-column">
-            {_.range(0, 6).map(m => (
+        <Flex flexWrap="wrap" w="100%" p={1}>
+          {_.range(0, 12).map(m => (
+            <Flex w={1 / 3} align="center" justifyContent="center">
               <Month
                 key={m}
                 month={m}
                 selected={m === month}
                 onClick={() => this.setState({ month: m }, onClose)}
               />
-            ))}
-          </ol>
-          <ol className="flex flex-column">
-            {_.range(6, 12).map(m => (
-              <Month
-                key={m}
-                month={m}
-                selected={m === month}
-                onClick={() => this.setState({ month: m }, onClose)}
-              />
-            ))}
-          </ol>
-        </div>
+            </Flex>
+          ))}
+        </Flex>
       </div>
     );
   }
 }
 
 const Month = ({ month, selected, onClick }) => (
-  <li
-    className={cx("cursor-pointer px3 py1 text-bold text-brand-hover", {
-      "text-brand": selected,
-    })}
+  <div
+    className={cx(
+      "cursor-pointer text-bold full text-centered py1 px2 circular my1",
+      {
+        "bg-light-hover": !selected,
+      },
+      {
+        "text-white bg-brand": selected,
+      },
+    )}
     onClick={onClick}
   >
     {moment()
       .month(month)
       .format("MMMM")}
-  </li>
+  </div>
 );

--- a/frontend/src/metabase/parameters/components/widgets/DateMonthYearWidget.jsx
+++ b/frontend/src/metabase/parameters/components/widgets/DateMonthYearWidget.jsx
@@ -12,7 +12,10 @@ export default class DateMonthYearWidget extends React.Component {
 
     const initial = moment(this.props.value, "YYYY-MM");
     if (initial.isValid()) {
-      this.state = { month: initial.month(), year: initial.year() };
+      this.state = {
+        month: initial.month(),
+        year: initial.year(),
+      };
     } else {
       this.state = {
         month: null,
@@ -76,8 +79,6 @@ const Month = ({ month, selected, onClick }) => (
       "cursor-pointer text-bold full text-centered py1 px2 circular my1",
       {
         "bg-light-hover": !selected,
-      },
-      {
         "text-white bg-brand": selected,
       },
     )}


### PR DESCRIPTION
The two column nature of the current month picker has been bugging me. I find the 3 up grid reads a bit more naturally LTR as opposed to the columnar style of the current one.

### Old
<img width="323" alt="Screen Shot 2020-02-21 at 2 33 13 PM" src="https://user-images.githubusercontent.com/5248953/75203454-f50d1000-5722-11ea-8471-bfa9e7155588.png">

### New
<img width="410" alt="Screen Shot 2020-02-24 at 4 31 30 PM" src="https://user-images.githubusercontent.com/5248953/75203523-2554ae80-5723-11ea-9676-8d79654f486f.png">
