### PR TITLE
Faster CI & JUnit output for backend tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,15 @@ jobs:
             done;
             echo `md5sum yarn.lock` >> frontend-checksums.txt
             echo `md5sum webpack.config.js` >> frontend-checksums.txt
+      - run:
+          name: Save last git commit message
+          command: git log -1 --oneline > commit.txt
+      - run:
+          name: Remove .git directory (not needed for tests)
+          command: rm -rf /home/circleci/metabase/metabase/.git
+      - run:
+          name: Remove ./OSX directory (not needed for tests)
+          command: rm -rf /home/circleci/metabase/metabase/OSX
       - persist_to_workspace:
           root: /home/circleci/
           paths:
@@ -310,6 +319,9 @@ jobs:
         default: clojure
       lein-command:
         type: string
+      store-results:
+        type: boolean
+        default: false
     executor: << parameters.e >>
     steps:
       - attach-workspace
@@ -317,6 +329,11 @@ jobs:
       - run:
           command: lein with-profile +ci << parameters.lein-command >>
           no_output_timeout: 5m
+      - when:
+          condition: << parameters.store-results >>
+          steps:
+            - store_test_results:
+                path: /home/circleci/metabase/metabase/target/test
 
   be-linter-reflection-warnings:
     executor: clojure
@@ -389,6 +406,8 @@ jobs:
                   /home/circleci/metabase/metabase/.circleci/skip-driver-tests.sh << parameters.driver >> ||
                   lein with-profile +ci test
                 no_output_timeout: << parameters.timeout >>
+            - store_test_results:
+                path: /home/circleci/metabase/metabase/target/test
       # This is exactly the same as without auto-retry but will try running the tests a second time if they fail
       - when:
           condition: << parameters.auto-retry >>
@@ -401,7 +420,8 @@ jobs:
                   /home/circleci/metabase/metabase/.circleci/skip-driver-tests.sh << parameters.driver >> ||
                   lein with-profile +ci test || lein with-profile +ci test
                 no_output_timeout: << parameters.timeout >>
-
+            - store_test_results:
+                path: /home/circleci/metabase/metabase/target/test
 
   test-migrate-from-h2:
     parameters:
@@ -600,6 +620,7 @@ workflows:
           requires:
             - be-deps
           lein-command: test
+          store-results: true
 
       - lein:
           name: be-tests-java-11
@@ -607,6 +628,7 @@ workflows:
             - be-deps
           e: java-11
           lein-command: test
+          store-results: true
 
       - lein:
           name: be-linter-eastwood

--- a/.circleci/skip-driver-tests.sh
+++ b/.circleci/skip-driver-tests.sh
@@ -9,7 +9,7 @@
 
 set -eu
 
-COMMIT_MESSAGE=`git log -1 --oneline`
+COMMIT_MESSAGE=`cat commit.txt`
 
 ! [[ "$CIRCLE_BRANCH" =~ ^master|release-.+$ ]] &&
     ! [[ "$COMMIT_MESSAGE" == *"[ci all]"* ]] &&

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
    "run"                               ["with-profile" "+run" "run"]
    "run-with-repl"                     ["with-profile" "+run-with-repl" "repl"]
    "ring"                              ["with-profile" "+ring" "ring"]
-   "test"                              ["with-profile" "+test" "test"]
+   "test"                              ["with-profile" "+test" "eftest"]
    "bikeshed"                          ["with-profile" "+bikeshed" "bikeshed"
                                         "--max-line-length" "205"
                                         ;; see https://github.com/dakrone/lein-bikeshed/issues/41
@@ -30,7 +30,6 @@
    "repl"                              ["with-profile" "+repl" "repl"]
    "strip-and-compress"                ["with-profile" "+strip-and-compress" "run"]
    "compare-h2-dbs"                    ["with-profile" "+compare-h2-dbs" "run"]}
-
 
   ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   ;; !!                                   PLEASE KEEP THESE ORGANIZED ALPHABETICALLY                                  !!
@@ -174,6 +173,7 @@
 
     :dependencies
     [[clj-http-fake "1.0.3" :exclusions [slingshot]]                  ; Library to mock clj-http responses
+     [eftest "0.5.9"]
      [jonase/eastwood "0.3.6" :exclusions [org.clojure/clojure]]      ; to run Eastwood
      [methodical "0.9.4-alpha"]
      [pjstadig/humane-test-output "0.9.0"]
@@ -201,7 +201,9 @@
     {:init-ns user}} ; starting in the user namespace is a lot faster than metabase.core since it has less deps
 
    :ci
-   {:jvm-opts ["-Xmx2500m"]}
+   {:jvm-opts ["-Xmx2500m"]
+    :eftest   {:report         eftest.report.junit/report
+               :report-to-file "target/test/junit.xml"}}
 
    :install
    {}
@@ -256,11 +258,17 @@
 
    :test
    [:with-include-drivers-middleware
-    {:resource-paths
+    {:plugins
+     [[lein-eftest "0.5.9"]]
+
+     :resource-paths
      ["test_resources"]
 
      :env
      {:mb-run-mode "test"}
+
+     :eftest
+     {:multithread? false}
 
      :jvm-opts
      ["-Duser.timezone=UTC"


### PR DESCRIPTION
*  By deleting some directories that aren't needed for tests (`.git`, `OSX`, etc.) in the `checkout` step, the persisted workspace archive, which is loaded for every single CI task, is reduced from about ~210 MB to ~10 MB. When CircleCI is working normally this shaves somewhere 5-10 seconds off from each task. When CircleCI's network connections are slow up this saves as much as two minutes. The end result is that CI is now close to one minute faster in most situations and sometimes several minutes faster.
*  Generate JUnit test output so we can more easily see test failures in CircleCI.