### PR TITLE
Fix occasional cache test failure

### DIFF
--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -105,7 +105,6 @@
       ([] (rf))
 
       ([result]
-       ;; TODO - what about the final result? Are we ignoring it completely?
        (a/close! in-chan)
        (let [duration-ms (- (System/currentTimeMillis) start-time)]
          (log/info (trs "Query took {0} to run; miminum for cache eligibility is {1}"

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -103,17 +103,18 @@
     (let [orig @save-chan*]
       (try
         (reset! save-chan* save-chan)
-        (let [orig impl/serialize-async]
-          (with-redefs [impl/serialize-async (fn [& args]
-                                               (u/prog1 (apply orig args)
-                                                 (a/go
-                                                   (let [result (a/<! (:out-chan <>))]
-                                                     (when (instance? Throwable result)
-                                                       (a/>!! save-chan (or (:type (ex-data result))
-                                                                            ::exception)))))))]
+        (let [orig (var-get #'cache/cache-results-async!)]
+          (with-redefs [cache/cache-results-async! (fn [query-hash out-chan]
+                                                     (a/go
+                                                       (when-let [result (a/<! out-chan)]
+                                                         (when (instance? Throwable result)
+                                                           (a/>!! save-chan (or (:type (ex-data result))
+                                                                                ::exception)))))
+                                                     (orig query-hash out-chan))]
             (u/prog1 (thunk)
-              (is (= expected-result
-                     (mt/wait-for-result save-chan 500))))))
+              (testing "waiting for save"
+                (is (= expected-result
+                       (mt/wait-for-result save-chan 1000)))))))
         (finally
           (reset! save-chan* orig))))))
 
@@ -129,8 +130,9 @@
       (try
         (reset! purge-chan* purge-chan)
         (u/prog1 (thunk)
-          (is (= expected-result
-                 (mt/wait-for-result purge-chan 500))))
+          (testing "waiting for purge"
+            (is (= expected-result
+                   (mt/wait-for-result purge-chan 500)))))
         (finally (reset! purge-chan* orig))))))
 
 (defmacro ^:private wait-for-purge-result {:style/indent 1} [expected-result & body]


### PR DESCRIPTION
There's a new test in I added as part of the streaming QP overhaul that fails maybe 5% of the time. This is an attempt to fix it. Time will tell if it actually fixed it