### PR TITLE
Make wait-for-port and fetch-jdbc-driver generic CI steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,8 +186,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - be-deps-{{ checksum "project.clj" }}
-            - be-deps-
+            - be-deps-v2-{{ checksum "project.clj" }}
+            - be-deps-v2-
 
   restore-fe-deps-cache:
     steps:
@@ -214,6 +214,32 @@ commands:
           command: yarn << parameters.command >>
           no_output_timeout: 5m
 
+  wait-for-port:
+    parameters:
+      port:
+        type: integer
+    steps:
+      - run:
+          name: Wait for port << parameters.port >> to be ready
+          command: >
+            while ! nc -z localhost << parameters.port >>; do sleep 0.1; done
+          no_output_timeout: 5m
+
+  fetch-jdbc-driver:
+    parameters:
+      source:
+        type: string
+      dest:
+        type: string
+    steps:
+      - run:
+          name: Make plugins dir
+          command: mkdir /home/circleci/metabase/metabase/plugins
+      - run:
+          name: Download JDBC driver JAR << parameters.dest >>
+          command: >
+            wget --output-document=plugins/<< parameters.dest >> ${<< parameters.source >>}
+          no_output_timeout: 5m
 
 jobs:
 
@@ -308,7 +334,7 @@ jobs:
       - restore-be-deps-cache
       - run: lein with-profile +include-all-drivers deps
       - save_cache:
-          key: be-deps-{{ checksum "project.clj" }}
+          key: be-deps-v2-{{ checksum "project.clj" }}
           paths:
             - /home/circleci/.m2
 
@@ -355,15 +381,9 @@ jobs:
       timeout:
         type: string
         default: 5m
-      jdbc-driver-source:
-        type: string
-        default: ""
-      jdbc-driver-dest:
-        type: string
-        default: ""
-      wait-for-port:
-        type: string
-        default: ""
+      before-steps:
+        type: steps
+        default: []
       auto-retry:
         type: boolean
         default: false
@@ -374,27 +394,7 @@ jobs:
     steps:
       - attach-workspace
       - restore-be-deps-cache
-      - when:
-          condition: << parameters.wait-for-port >>
-          steps:
-            - run:
-                name: Wait for << parameters.driver >> to be ready
-                command: >
-                  /home/circleci/metabase/metabase/.circleci/skip-driver-tests.sh << parameters.driver >> ||
-                  while ! nc -z localhost << parameters.wait-for-port >>; do sleep 0.1; done
-                no_output_timeout: 5m
-      - when:
-          condition: << parameters.jdbc-driver-source >>
-          steps:
-            - run:
-                name: Make plugins dir
-                command: mkdir /home/circleci/metabase/metabase/plugins
-            - run:
-                name: Download << parameters.driver >> JDBC driver JAR
-                command: >
-                  /home/circleci/metabase/metabase/.circleci/skip-driver-tests.sh << parameters.driver >> ||
-                  wget --output-document=plugins/<< parameters.jdbc-driver-dest >> ${<< parameters.jdbc-driver-source >>}
-                no_output_timeout: 5m
+      - steps: << parameters.before-steps >>
       - unless:
           condition: << parameters.auto-retry >>
           steps:
@@ -724,8 +724,10 @@ workflows:
           name: be-tests-oracle
           requires:
             - be-tests
-          jdbc-driver-source: ORACLE_JDBC_JAR
-          jdbc-driver-dest: ojdbc8.jar
+          before-steps:
+            - fetch-jdbc-driver:
+                source: ORACLE_JDBC_JAR
+                dest: ojdbc8.jar
           driver: oracle
 
       - test-driver:
@@ -749,7 +751,9 @@ workflows:
           requires:
             - be-tests
           e: presto
-          wait-for-port: "8080"
+          before-steps:
+            - wait-for-port:
+                port: 8080
           driver: presto
 
       - test-driver:
@@ -771,7 +775,9 @@ workflows:
           requires:
             - be-tests
           e: sparksql
-          wait-for-port: "10000"
+          before-steps:
+            - wait-for-port:
+                port: 10000
           driver: sparksql
 
       - test-driver:
@@ -792,8 +798,10 @@ workflows:
           requires:
             - be-tests
           e: vertica
-          jdbc-driver-source: VERTICA_JDBC_JAR
-          jdbc-driver-dest: vertica-jdbc-7.1.2-0.jar
+          before-steps:
+            - fetch-jdbc-driver:
+                source: VERTICA_JDBC_JAR
+                dest: vertica-jdbc-7.1.2-0.jar
           driver: vertica
           auto-retry: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@
 /node_modules/
 /osx-artifacts
 /plugins
+/process.yml
 /reset-password-artifacts
 /resources/frontend_client/app/dist/
 /resources/frontend_client/app/locales


### PR DESCRIPTION
*  Instead of having `wait-for-port` and `fetch-jdbc-driver` be parameters for the `test-driver` step, I made them first-class commands so they can be ran anywhere, and replaced their usage in `test-driver` with a new `before-steps` command, which allows you to run arbitrary steps before running driver tests
*  Switch the backend deps key, our cached `~/.m2` directory was getting a little long in the tooth. This reduces the cache size from ~600 MB to ~150 MB which should speed up CI times.