### PR TITLE
Include html in bin/build-for-test hash

### DIFF
--- a/bin/build-for-test
+++ b/bin/build-for-test
@@ -8,7 +8,7 @@ source-hash() {
   # hash all the files that might change a backend-only uberjar build (for integration tests)
   (
     find src project.clj resources/sample-dataset.db.mv.db -type f -print0 | xargs -0 shasum ;
-    find resources -type f \( -iname \*.clj -o -iname \*.edn -o -iname \*.yaml -o -iname \*.properties \) -not -name "version.properties" -print0 | xargs -0 shasum ;
+    find resources -type f \( -iname \*.clj -o -iname \*.edn -o -iname \*.yaml -o -iname \*.properties -o -iname \*.html \) -not -name "version.properties" -print0 | xargs -0 shasum ;
   ) | shasum | awk '{ print $1 }'
 }
 


### PR DESCRIPTION
@kdoh spotted an issue where running `yarn test-cypress` before `yarn build-hot` and `yarn test-cypress-open` wouldn't use the webpack dev server. `yarn test-cypress-open` would try and build the uberjar again, but because the new `index.html` wasn't hashed, the uberjar wouldn't be rebuilt.