### PR TITLE
Don't use ParameterFieldWidget if any targets are variables not dimensions

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
@@ -114,6 +114,17 @@ export default class DashCardCardParameterMapper extends Component {
       mapping.overlapMax === 1
     );
 
+    let selectedFieldWarning = null;
+    if (
+      // variable targets can't accept an list of values like dimension targets
+      target &&
+      target[0] === "variable" &&
+      // date parameters only accept a single value anyways, so hide the warning
+      !parameter.type.startsWith("date/")
+    ) {
+      selectedFieldWarning = t`This field only accepts a single value.`;
+    }
+
     return (
       <div className="mx1 flex flex-column align-center drag-disabled">
         {dashcard.series && dashcard.series.length > 0 && (
@@ -185,6 +196,9 @@ export default class DashCardCardParameterMapper extends Component {
             </Tooltip>
           )}
         </ParameterTargetWidget>
+        {selectedFieldWarning && (
+          <span style={{ height: 0 }}>{selectedFieldWarning}</span>
+        )}
       </div>
     );
   }

--- a/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
@@ -122,7 +122,7 @@ export default class DashCardCardParameterMapper extends Component {
       // date parameters only accept a single value anyways, so hide the warning
       !parameter.type.startsWith("date/")
     ) {
-      selectedFieldWarning = t`This field only accepts a single value.`;
+      selectedFieldWarning = t`This field only accepts a single value because it's used in a SQL query.`;
     }
 
     return (
@@ -197,7 +197,9 @@ export default class DashCardCardParameterMapper extends Component {
           )}
         </ParameterTargetWidget>
         {selectedFieldWarning && (
-          <span style={{ height: 0 }}>{selectedFieldWarning}</span>
+          <span style={{ height: 0 }} className="pt1 px4 text-centered">
+            {selectedFieldWarning}
+          </span>
         )}
       </div>
     );

--- a/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashCardCardParameterMapper.jsx
@@ -197,7 +197,7 @@ export default class DashCardCardParameterMapper extends Component {
           )}
         </ParameterTargetWidget>
         {selectedFieldWarning && (
-          <span style={{ height: 0 }} className="pt1 px4 text-centered">
+          <span style={{ height: 0 }} className="mt1 mbn1 px4 text-centered">
             {selectedFieldWarning}
           </span>
         )}

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -196,10 +196,15 @@ export const getParameters = createSelector(
   [getMetadata, getDashboard, getMappingsByParameter],
   (metadata, dashboard, mappingsByParameter) =>
     ((dashboard && dashboard.parameters) || []).map(parameter => {
+      const mappings = Object.values(
+        mappingsByParameter[parameter.id] || {},
+      ).flatMap(Object.values);
+
+      // we change out widgets if a parameter is connected to non-field targets
+      const hasOnlyFieldTargets = mappings.every(x => x.field_id != null);
+
       // get the unique list of field IDs these mappings reference
-      const fieldIds = _.chain(mappingsByParameter[parameter.id])
-        .map(_.values)
-        .flatten()
+      const fieldIds = _.chain(mappings)
         .map(m => m.field_id)
         .uniq()
         .filter(fieldId => fieldId != null)
@@ -219,6 +224,7 @@ export const getParameters = createSelector(
           fieldIdsWithFKResolved.length === 1
             ? fieldIdsWithFKResolved[0]
             : null,
+        hasOnlyFieldTargets,
       };
     }),
 );

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -196,9 +196,9 @@ export const getParameters = createSelector(
   [getMetadata, getDashboard, getMappingsByParameter],
   (metadata, dashboard, mappingsByParameter) =>
     ((dashboard && dashboard.parameters) || []).map(parameter => {
-      const mappings = Object.values(
-        mappingsByParameter[parameter.id] || {},
-      ).flatMap(Object.values);
+      const mappings = _.flatten(
+        _.map(mappingsByParameter[parameter.id] || {}, _.values),
+      );
 
       // we change out widgets if a parameter is connected to non-field targets
       const hasOnlyFieldTargets = mappings.every(x => x.field_id != null);

--- a/frontend/src/metabase/meta/Card.js
+++ b/frontend/src/metabase/meta/Card.js
@@ -145,6 +145,7 @@ export function getParametersWithExtras(
     if (fieldId != null) {
       parameter = assoc(parameter, "field_id", fieldId);
     }
+    parameter = assoc(parameter, "hasOnlyFieldTargets", fieldId != null);
     return parameter;
   });
 }

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -95,7 +95,7 @@ export default class ParameterValueWidget extends Component {
     const { parameter } = this.props;
     if (DATE_WIDGETS[parameter.type]) {
       return DATE_WIDGETS[parameter.type];
-    } else if (this.getFields().length > 0) {
+    } else if (this.getFields().length > 0 && parameter.hasOnlyFieldTargets) {
       return ParameterFieldWidget;
     } else {
       return TextWidget;

--- a/frontend/test/metabase/dashboard/selectors.unit.spec.js
+++ b/frontend/test/metabase/dashboard/selectors.unit.spec.js
@@ -49,6 +49,7 @@ describe("dashboard/selectors", () => {
           id: 1,
           field_ids: [],
           field_id: null,
+          hasOnlyFieldTargets: true,
         },
       ]);
     });
@@ -66,6 +67,7 @@ describe("dashboard/selectors", () => {
           id: 1,
           field_ids: [],
           field_id: null,
+          hasOnlyFieldTargets: false,
         },
       ]);
     });
@@ -83,6 +85,7 @@ describe("dashboard/selectors", () => {
           id: 1,
           field_ids: [1],
           field_id: 1,
+          hasOnlyFieldTargets: true,
         },
       ]);
     });
@@ -105,6 +108,7 @@ describe("dashboard/selectors", () => {
           id: 1,
           field_ids: [1],
           field_id: 1,
+          hasOnlyFieldTargets: true,
         },
       ]);
     });
@@ -127,6 +131,7 @@ describe("dashboard/selectors", () => {
           id: 1,
           field_ids: [1],
           field_id: 1,
+          hasOnlyFieldTargets: false,
         },
       ]);
     });
@@ -149,6 +154,7 @@ describe("dashboard/selectors", () => {
           id: 1,
           field_ids: [1, 2],
           field_id: null,
+          hasOnlyFieldTargets: true,
         },
       ]);
     });


### PR DESCRIPTION
Resolves #11882

There were two underlying causes of the bug:
1. `FieldValuesWidget` parses values
2. `FieldValuesWidget` passes an array of values

This dodges both of them by falling back to a `TextWidget` if any target is a variable.

---

I thought it might be confusing when some dashboard parameters were limited to one value, so I added a warning when mapping the param to a variable.

![image](https://user-images.githubusercontent.com/691495/75569503-394e2800-5a23-11ea-8a04-e160cf4de365.png)
