### PR TITLE
Don't pass gridSize if it was computed from null width/height

### DIFF
--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -453,7 +453,7 @@ export default class Visualization extends React.PureComponent {
     );
 
     let { gridSize, gridUnit, classNameWidgets } = this.props;
-    if (!gridSize && gridUnit) {
+    if (!gridSize && gridUnit && width != null && height != null) {
       gridSize = {
         width: Math.round(width / (gridUnit * 4)),
         height: Math.round(height / (gridUnit * 3)),

--- a/frontend/src/metabase/visualizations/components/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization.jsx
@@ -453,7 +453,14 @@ export default class Visualization extends React.PureComponent {
     );
 
     let { gridSize, gridUnit, classNameWidgets } = this.props;
-    if (!gridSize && gridUnit && width != null && height != null) {
+    if (
+      !gridSize &&
+      gridUnit &&
+      // Check that width/height are set. If they're not, we want to pass
+      // undefined rather than {width: 0, height: 0}. Passing 0 will hide axes.
+      width != null &&
+      height != null
+    ) {
       gridSize = {
         width: Math.round(width / (gridUnit * 4)),
         height: Math.round(height / (gridUnit * 3)),


### PR DESCRIPTION
Fixes #12018

When computing `gridSize` `Visualization` uses width/height from `ExplicitSize`. These are briefly null initially, so `{width: 0, height: 0}` was passed as the initial value of `gridSize`. Instead. passing an undefined `gridSize`, does the right thing in `LineAreaBarChart`'s [`getFidelity` function.](https://github.com/metabase/metabase/blob/fix-12018/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx#L221)

I didn't see a good way to test this since Visualization is wrapped by ExplicitSize.