### PR TITLE
Fix support for H2/Postgres CLOB types

### DIFF
--- a/src/metabase/db/jdbc_protocols.clj
+++ b/src/metabase/db/jdbc_protocols.clj
@@ -6,10 +6,10 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [java-time :as t]
+            [metabase.driver.h2 :as h2]
             [metabase.plugins.classloader :as classloader]
             [metabase.util.date-2 :as u.date])
-  (:import java.io.BufferedReader
-           [java.sql PreparedStatement ResultSet ResultSetMetaData Types]
+  (:import [java.sql PreparedStatement ResultSet ResultSetMetaData Types]
            [java.time Instant LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime]))
 
 (def ^:private db-type
@@ -73,16 +73,7 @@
 
   org.h2.jdbc.JdbcClob
   (result-set-read-column [clob _ _]
-    (letfn [(clob->str [^BufferedReader buffered-reader]
-              (loop [acc []]
-                (if-let [line (.readLine buffered-reader)]
-                  (recur (conj acc line))
-                  (str/join "\n" acc))))]
-      (with-open [reader (.getCharacterStream clob)]
-        (if (instance? BufferedReader reader)
-          (clob->str reader)
-          (with-open [buffered-reader (BufferedReader. reader)]
-            (clob->str buffered-reader)))))))
+    (h2/clob->str clob)))
 
 (defmulti ^:private read-column
   {:arglists '([rs rsmeta i])}

--- a/src/metabase/db/jdbc_protocols.clj
+++ b/src/metabase/db/jdbc_protocols.clj
@@ -6,10 +6,10 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [java-time :as t]
-            [metabase.driver.h2 :as h2]
             [metabase.plugins.classloader :as classloader]
             [metabase.util.date-2 :as u.date])
-  (:import [java.sql PreparedStatement ResultSet ResultSetMetaData Types]
+  (:import java.io.BufferedReader
+           [java.sql PreparedStatement ResultSet ResultSetMetaData Types]
            [java.time Instant LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime]))
 
 (def ^:private db-type
@@ -66,6 +66,21 @@
   (set-parameter [t stmt i]
     (jdbc/set-parameter (t/offset-date-time t) stmt i)))
 
+(defn clob->str
+  "Convert an H2 clob to a String."
+  ^String [^org.h2.jdbc.JdbcClob clob]
+  (when clob
+    (letfn [(->str [^BufferedReader buffered-reader]
+              (loop [acc []]
+                (if-let [line (.readLine buffered-reader)]
+                  (recur (conj acc line))
+                  (str/join "\n" acc))))]
+      (with-open [reader (.getCharacterStream clob)]
+        (if (instance? BufferedReader reader)
+          (->str reader)
+          (with-open [buffered-reader (BufferedReader. reader)]
+            (->str buffered-reader)))))))
+
 (extend-protocol jdbc/IResultSetReadColumn
   org.postgresql.util.PGobject
   (result-set-read-column [clob _ _]
@@ -73,7 +88,7 @@
 
   org.h2.jdbc.JdbcClob
   (result-set-read-column [clob _ _]
-    (h2/clob->str clob)))
+    (clob->str clob)))
 
 (defmulti ^:private read-column
   {:arglists '([rs rsmeta i])}

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -341,6 +341,15 @@
     (fn []
       (.getObject rs i))))
 
+;; de-CLOB any CLOB values that come back
+(defmethod sql-jdbc.execute/read-column-thunk :postgres
+  [_ ^ResultSet rs _ ^Integer i]
+  (fn []
+    (let [obj (.getObject rs i)]
+      (if (instance? org.postgresql.util.PGobject obj)
+        (.getValue ^org.postgresql.util.PGobject obj)
+        obj))))
+
 ;; Postgres doesn't support OffsetTime
 (defmethod sql-jdbc.execute/set-parameter [:postgres OffsetTime]
   [driver prepared-statement i t]

--- a/src/metabase/query_processor/context/default.clj
+++ b/src/metabase/query_processor/context/default.clj
@@ -63,8 +63,7 @@
                                   (context/raisef (ex-info (tru "Error reducing result rows")
                                                            {:type error-type/qp}
                                                            e)
-                                                  context)
-                                  nil))]
+                                                  context)))]
         (context/reducedf metadata reduced-rows context)))))
 
 (defn- default-runf [query rf context]

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -82,3 +82,18 @@
   (testing "Non-fractional seconds should remain seconds, but be cast to longs"
     (is (= (hsql/call :dateadd (hx/literal "second") 100 :%now)
            (sql.qp/add-interval-honeysql-form :h2 :%now 100.0 :second)))))
+
+(deftest clob-test
+  (mt/test-driver :h2
+    (testing "Make sure we properly handle rows that come back as `org.h2.jdbc.JdbcClob`"
+      (let [results (qp/process-query (mt/native-query {:query "SELECT cast('Conchúr Tihomir' AS clob) AS name;"}))]
+        (testing "rows"
+          (is (= [["Conchúr Tihomir"]]
+                 (mt/rows results))))
+        (testing "cols"
+          (is (= [{:display_name "NAME"
+                   :base_type    :type/Text
+                   :source       :native
+                   :field_ref    [:field-literal "NAME" :type/Text]
+                   :name         "NAME"}]
+                 (mt/cols results))))))))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -476,3 +476,18 @@
             {:database (mt/id)
              :type     :native
              :native   {:query "SELECT adsasdasd;"}}))))))
+
+(deftest pgobject-test
+  (mt/test-driver :postgres
+    (testing "Make sure PGobjects are decoded correctly"
+      (let [results (qp/process-query (mt/native-query {:query "SELECT pg_sleep(0.1) AS sleep;"}))]
+        (testing "rows"
+          (is (= [[""]]
+                 (mt/rows results))))
+        (testing "cols"
+          (is (= [{:display_name "sleep"
+                   :base_type    :type/*
+                   :source       :native
+                   :field_ref    [:field-literal "sleep" :type/*]
+                   :name         "sleep"}]
+                 (mt/cols results))))))))


### PR DESCRIPTION
Fix support for values coming back as Postgres `PGobject` or H2 `JdbcClob` with the new streaming QP