### PR TITLE
Use "card-id" rather than "card_id" in subquery reference tags

### DIFF
--- a/frontend/src/metabase-lib/lib/queries/NativeQuery.js
+++ b/frontend/src/metabase-lib/lib/queries/NativeQuery.js
@@ -343,14 +343,14 @@ export default class NativeQuery extends AtomicQuery {
           // renaming
           const newTag = { ...templateTags[oldTags[0]] };
 
-          if (newTag.display_name === humanize(oldTags[0])) {
-            newTag.display_name = humanize(newTags[0]);
+          if (newTag["display-name"] === humanize(oldTags[0])) {
+            newTag["display-name"] = humanize(newTags[0]);
           }
 
           newTag.name = newTags[0];
           if (isCardQueryName(newTag.name)) {
             newTag.type = "card";
-            newTag.card_id = cardTagCardId(newTag.name);
+            newTag["card-id"] = cardTagCardId(newTag.name);
           }
           templateTags[newTag.name] = newTag;
           delete templateTags[oldTags[0]];
@@ -365,7 +365,7 @@ export default class NativeQuery extends AtomicQuery {
             templateTags[tagName] = {
               id: Utils.uuid(),
               name: tagName,
-              display_name: humanize(tagName),
+              "display-name": humanize(tagName),
               type: "text",
             };
 
@@ -373,7 +373,7 @@ export default class NativeQuery extends AtomicQuery {
             if (isCardQueryName(tagName)) {
               templateTags[tagName] = Object.assign(templateTags[tagName], {
                 type: "card",
-                card_id: cardTagCardId(tagName),
+                "card-id": cardTagCardId(tagName),
               });
             }
           }

--- a/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
@@ -15,7 +15,7 @@ import { formatDateTimeWithUnit } from "metabase/lib/formatting";
 import MetabaseSettings from "metabase/lib/settings";
 
 @Questions.load({
-  id: (state, { tag }) => tag.card_id,
+  id: (state, { tag }) => tag["card-id"],
   loadingAndErrorWrapper: false,
 })
 export default class CardTagEditor extends Component {
@@ -51,7 +51,7 @@ export default class CardTagEditor extends Component {
     const { tag, question } = this.props;
     return (
       <SelectButton>
-        {tag.card_id == null ? (
+        {tag["card-id"] == null ? (
           <span className="text-medium">{t`Pick a saved question`}</span>
         ) : this.errorMessage() ? (
           <span className="text-medium">{t`Pick a different question`}</span>
@@ -67,7 +67,7 @@ export default class CardTagEditor extends Component {
 
   render() {
     const {
-      tag: { card_id },
+      tag: { "card-id": cardId },
       loading,
       question,
     } = this.props;
@@ -75,10 +75,10 @@ export default class CardTagEditor extends Component {
     return (
       <Card className="p2 mb2">
         <h3 className="text-brand mb2">
-          {card_id == null ? (
+          {cardId == null ? (
             t`Question #…`
           ) : (
-            <Link to={questionUrl(card_id)}>{t`Question #${card_id}`}</Link>
+            <Link to={questionUrl(cardId)}>{t`Question #${cardId}`}</Link>
           )}
         </h3>
         {loading ? (

--- a/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
@@ -185,7 +185,7 @@ describe("NativeQuery", () => {
         );
         const tagMaps = newQuery.templateTagsMap();
         expect(tagMaps["max_price"].name).toEqual("max_price");
-        expect(tagMaps["max_price"].display_name).toEqual("Max price");
+        expect(tagMaps["max_price"]["display-name"]).toEqual("Max price");
       });
     });
     describe("Invalid template tags prevent the query from running", () => {
@@ -215,7 +215,7 @@ describe("NativeQuery", () => {
     describe("card template tags", () => {
       it("should parse card tags", () => {
         const q = makeQuery().setQueryText("{{#1}} {{ #2 }} {{ #1 }}");
-        expect(q.templateTags().map(v => v.card_id)).toEqual([1, 2]);
+        expect(q.templateTags().map(v => v["card-id"])).toEqual([1, 2]);
       });
     });
     describe("replaceCardId", () => {
@@ -227,8 +227,8 @@ describe("NativeQuery", () => {
         expect(query.queryText()).toBe("SELECT * from {{#321}}");
         const tags = query.templateTags();
         expect(tags.length).toBe(1);
-        const [{ card_id, type, name }] = tags;
-        expect(card_id).toEqual(321);
+        const [{ "card-id": cardId, type, name }] = tags;
+        expect(cardId).toEqual(321);
         expect(type).toEqual("card");
         expect(name).toEqual("#321");
       });
@@ -262,7 +262,7 @@ describe("NativeQuery", () => {
       );
       const variables = q.variables();
       expect(variables).toHaveLength(1);
-      expect(variables.map(v => v.displayName())).toEqual(["category"]);
+      expect(variables.map(v => v.displayName())).toEqual(["Category"]);
     });
     it("should not return variable for dimension template tag", () => {
       const q = makeQuery()


### PR DESCRIPTION
@walterl spotted that we weren't displaying the saved subquery card details in the sidebar when loading a saved question. The client was sending up `card_id`, but receiving `card-id` in the response. Since tags are part of the query, they should standardize on `card-id`.

I started adding a e2e test to catch this, but it felt to specific to this error case. The general problem of receiving unexpected keys from the server requires e2e tests, but here we already have unit tests asserting that we're using hyphens in the key name.