### PR TITLE
Don't let metadata permissions error block QB init

### DIFF
--- a/frontend/src/metabase/redux/metadata.js
+++ b/frontend/src/metabase/redux/metadata.js
@@ -336,4 +336,4 @@ export const loadMetadataForQuery = query => dispatch =>
         console.warn(`loadQueryMetadata: type ${type} not implemented`);
       }
     }),
-  );
+  ).catch(e => console.error("Failed loading metadata for query", e));

--- a/frontend/test/metabase/scenarios/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions.cy.spec.js
@@ -31,4 +31,10 @@ describe("permissions", () => {
     cy.get(".Icon-key");
     cy.contains("Sorry, you don’t have permission to see that.");
   });
+
+  it("should let a user with no data permissions view questions", () => {
+    signIn("nodata");
+    cy.visit("/question/1");
+    cy.contains("February 11, 2019, 9:40 PM"); // check that the data loads
+  });
 });


### PR DESCRIPTION
Fixes #11932

Calling `loadMetadataForQuery` would fail and break query builder initialization. 

I think we've fixed this bug a bunch of times, so I added a simple Cypress test to ensure questions still load without data perms.

@tlrobinson do you think it's worth being careful about sending these metadata requests when there aren't data perms? Or, should we just be graceful when they fail?