### PR TITLE
Avoid calling /database/:id/metadata in BrowseApp

### DIFF
--- a/frontend/src/metabase/components/BrowseApp.jsx
+++ b/frontend/src/metabase/components/BrowseApp.jsx
@@ -32,7 +32,14 @@ export class SchemaBrowser extends React.Component {
       <Box>
         <Schema.ListLoader query={{ dbId }}>
           {({ schemas }) =>
-            schemas.length > 1 ? (
+            schemas.length === 1 ? (
+              <TableBrowser
+                {...this.props}
+                params={{ ...this.props.params, schemaName: schemas[0].name }}
+                // hide the schema since there's only one
+                showSchemaInHeader={false}
+              />
+            ) : (
               <Box>
                 <BrowseHeader
                   crumbs={[
@@ -71,13 +78,6 @@ export class SchemaBrowser extends React.Component {
                   ))}
                 </Grid>
               </Box>
-            ) : (
-              <TableBrowser
-                {...this.props}
-                params={{ ...this.props.params, schemaName: schemas[0].name }}
-                // hide the schema since there's only one
-                showSchemaInHeader={false}
-              />
             )
           }
         </Schema.ListLoader>

--- a/frontend/src/metabase/components/BrowseApp.jsx
+++ b/frontend/src/metabase/components/BrowseApp.jsx
@@ -72,7 +72,12 @@ export class SchemaBrowser extends React.Component {
                 </Grid>
               </Box>
             ) : (
-              <TableBrowser {...this.props} />
+              <TableBrowser
+                {...this.props}
+                params={{ ...this.props.params, schemaName: schemas[0].name }}
+                // hide the schema since there's only one
+                showSchemaInHeader={false}
+              />
             )
           }
         </Schema.ListLoader>
@@ -90,6 +95,7 @@ export class TableBrowser extends React.Component {
     const {
       metadata,
       params: { dbId, schemaName },
+      showSchemaInHeader = true,
     } = this.props;
     return (
       <Box>
@@ -104,7 +110,7 @@ export class TableBrowser extends React.Component {
                       title: <Database.Name id={dbId} />,
                       to: `browse/${dbId}`,
                     },
-                    schemaName != null && { title: schemaName },
+                    showSchemaInHeader && { title: schemaName },
                   ]}
                 />
                 <Grid>

--- a/frontend/src/metabase/components/BrowseApp.jsx
+++ b/frontend/src/metabase/components/BrowseApp.jsx
@@ -47,36 +47,40 @@ export class SchemaBrowser extends React.Component {
                     { title: <Database.Name id={dbId} /> },
                   ]}
                 />
-                <Grid>
-                  {schemas.map(schema => (
-                    <GridItem w={ITEM_WIDTHS} key={schema.id}>
-                      <Link
-                        to={`/browse/${dbId}/schema/${schema.name}`}
-                        mb={1}
-                        hover={{ color: color("accent2") }}
-                        data-metabase-event={`${ANALYTICS_CONTEXT};Schema Click`}
-                        className="overflow-hidden"
-                      >
-                        <Card hoverable px={1}>
-                          <Flex align="center">
-                            <EntityItem
-                              name={schema.name}
-                              iconName="folder"
-                              iconColor={color("accent2")}
-                              item={schema}
-                            />
-                            <Box ml="auto">
-                              <Icon name="reference" />
-                              <Tooltip tooltip={t`X-ray this schema`}>
-                                <Icon name="bolt" mx={1} />
-                              </Tooltip>
-                            </Box>
-                          </Flex>
-                        </Card>
-                      </Link>
-                    </GridItem>
-                  ))}
-                </Grid>
+                {schemas.length === 0 ? (
+                  <h2 className="full text-centered text-medium">{t`This database doesn't have any tables.`}</h2>
+                ) : (
+                  <Grid>
+                    {schemas.map(schema => (
+                      <GridItem w={ITEM_WIDTHS} key={schema.id}>
+                        <Link
+                          to={`/browse/${dbId}/schema/${schema.name}`}
+                          mb={1}
+                          hover={{ color: color("accent2") }}
+                          data-metabase-event={`${ANALYTICS_CONTEXT};Schema Click`}
+                          className="overflow-hidden"
+                        >
+                          <Card hoverable px={1}>
+                            <Flex align="center">
+                              <EntityItem
+                                name={schema.name}
+                                iconName="folder"
+                                iconColor={color("accent2")}
+                                item={schema}
+                              />
+                              <Box ml="auto">
+                                <Icon name="reference" />
+                                <Tooltip tooltip={t`X-ray this schema`}>
+                                  <Icon name="bolt" mx={1} />
+                                </Tooltip>
+                              </Box>
+                            </Flex>
+                          </Card>
+                        </Link>
+                      </GridItem>
+                    ))}
+                  </Grid>
+                )}
               </Box>
             )
           }


### PR DESCRIPTION
If we fetch tables with just a `dbId`, the tables entity fetches all db metadata since that's the only endpoint it can use. I updated BrowseApp to pass `schemaName` even if there's just one schema so we can load tables by schema rather than fetching everything.