### PR TITLE
Replace util fns with ones from (updated) medley

### DIFF
--- a/modules/drivers/druid/src/metabase/driver/druid/execute.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/execute.clj
@@ -2,6 +2,7 @@
   (:require [cheshire.core :as json]
             [clojure.math.numeric-tower :as math]
             [java-time :as t]
+            [medley.core :as m]
             [metabase.driver.druid.query-processor :as druid.qp]
             [metabase.query-processor
              [error-type :as qp.error-type]
@@ -58,14 +59,14 @@
    :results     (let [results (-> results first :result)]
                   (if (:format-rows? middleware true)
                     results
-                    (map #(u/update-when % :timestamp u.date/parse) results)))})
+                    (map #(m/update-existing % :timestamp u.date/parse) results)))})
 
 (defmethod post-process ::druid.qp/groupBy
   [_ projections {:keys [middleware]} results]
   {:projections projections
    :results     (if (:format-rows? middleware true)
                   (map :event results)
-                  (map (comp #(u/update-when % :timestamp u.date/parse)
+                  (map (comp #(m/update-existing % :timestamp u.date/parse)
                              :event)
                        results))})
 

--- a/project.clj
+++ b/project.clj
@@ -107,7 +107,7 @@
                  com.sun.jdmk/jmxtools
                  com.sun.jmx/jmxri]]
    [me.raynes/fs "1.4.6"]                                             ; Filesystem tools
-   [medley "1.2.0"]                                                   ; lightweight lib of useful functions
+   [medley "1.3.0"]                                                   ; lightweight lib of useful functions
    [metabase/connection-pool "1.1.1"]                                 ; simple wrapper around C3P0. JDBC connection pools
    [metabase/throttle "1.0.2"]                                        ; Tools for throttling access to API endpoints and other code pathways
    [net.sf.cssbox/cssbox "4.12" :exclusions [org.slf4j/slf4j-api]]    ; HTML / CSS rendering

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -562,10 +562,10 @@
   (let [dimension->name (comp vector :name dimensions)
         metric->name    (comp vector first :metric metrics)]
     [k (-> v
-           (u/update-when :map.latitude_column dimension->name)
-           (u/update-when :map.longitude_column dimension->name)
-           (u/update-when :graph.metrics metric->name)
-           (u/update-when :graph.dimensions dimension->name))]))
+           (m/update-existing :map.latitude_column dimension->name)
+           (m/update-existing :map.longitude_column dimension->name)
+           (m/update-existing :graph.metrics metric->name)
+           (m/update-existing :graph.dimensions dimension->name))]))
 
 (defn capitalize-first
   "Capitalize only the first letter in a given string."
@@ -585,7 +585,7 @@
                s))
            form))
        x)
-      (u/update-when :visualization #(instantate-visualization % bindings (:metrics context)))))
+      (m/update-existing :visualization #(instantate-visualization % bindings (:metrics context)))))
 
 (defn- valid-breakout-dimension?
   [{:keys [base_type engine fingerprint aggregation]}]

--- a/src/metabase/automagic_dashboards/populate.clj
+++ b/src/metabase/automagic_dashboards/populate.clj
@@ -2,6 +2,7 @@
   "Create and save models that make up automagic dashboards."
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [medley.core :as m]
             [metabase.api.common :as api]
             [metabase.automagic-dashboards.filters :as filters]
             [metabase.models
@@ -323,8 +324,8 @@
                                                      (update :row + offset (if skip-titles?
                                                                              0
                                                                              group-heading-height))
-                                                     (u/update-in-when [:visualization_settings :text]
-                                                                       downsize-titles)
+                                                     (m/update-existing-in [:visualization_settings :text]
+                                                                           downsize-titles)
                                                      (assoc :parameter_mappings
                                                        (when-let [card-id (:card_id %)]
                                                          (for [mapping parameter-mappings]

--- a/src/metabase/automagic_dashboards/populate.clj
+++ b/src/metabase/automagic_dashboards/populate.clj
@@ -9,7 +9,6 @@
              [card :as card]
              [collection :as collection]]
             [metabase.query-processor.util :as qp.util]
-            [metabase.util :as u]
             [metabase.util.i18n :refer [trs]]
             [toucan.db :as db]))
 

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -129,8 +129,8 @@
   "When fingerprinting decimal columns, NaN and Infinity values are possible. Serializing these values to JSON just
   yields a string, not a value double. This function will attempt to coerce any of those values to double objects"
   [fingerprint]
-  (u/update-in-when fingerprint [:type :type/Number]
-                    (partial m/map-vals maybe-parse-special-numeric-values)))
+  (m/update-existing-in fingerprint [:type :type/Number]
+                        (partial m/map-vals maybe-parse-special-numeric-values)))
 
 (models/add-type! :json-for-fingerprints
   :in  i/json-in

--- a/src/metabase/query_processor/middleware/desugar.clj
+++ b/src/metabase/query_processor/middleware/desugar.clj
@@ -1,17 +1,17 @@
 (ns metabase.query-processor.middleware.desugar
-  (:require [metabase.mbql
+  (:require [medley.core :as m]
+            [metabase.mbql
              [predicates :as mbql.preds]
              [schema :as mbql.s]
              [util :as mbql.u]]
-            [metabase.util :as u]
             [schema.core :as s]))
 
 (s/defn ^:private desugar* :- mbql.s/Query
   [query]
-  (u/update-when query :query (fn [query]
-                                (mbql.u/replace query
-                                  (filter-clause :guard mbql.preds/Filter?)
-                                  (mbql.u/desugar-filter-clause filter-clause)))))
+  (m/update-existing query :query (fn [query]
+                                    (mbql.u/replace query
+                                                    (filter-clause :guard mbql.preds/Filter?)
+                                                    (mbql.u/desugar-filter-clause filter-clause)))))
 
 (defn desugar
   "Middleware that uses MBQL lib functions to replace high-level 'syntactic sugar' clauses like `time-interval` and

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -596,22 +596,6 @@
     (long (math/floor (/ (Math/log (math/abs x))
                          (Math/log 10))))))
 
-(defn update-when
-  "Like `clojure.core/update` but does not create a new key if it does not exist. Useful when you don't want to create
-  cruft."
-  [m k f & args]
-  (if (contains? m k)
-    (apply update m k f args)
-    m))
-
-(defn update-in-when
-  "Like `clojure.core/update-in` but does not create new keys if they do not exist. Useful when you don't want to create
-  cruft."
-  [m k f & args]
-  (if (not= ::not-found (get-in m k ::not-found))
-    (apply update-in m k f args)
-    m))
-
 (defn index-of
   "Return index of the first element in `coll` for which `pred` reutrns true."
   [pred coll]

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -192,18 +192,6 @@
     0     0
     -1444 3))
 
-(deftest update-when-test
-  (testing "update-when"
-    (are [m expected] (= expected
-                         (u/update-when m :bar inc))
-      {:foo 2}        {:foo 2}
-      {:foo 2 :bar 2} {:foo 2 :bar 3}))
-  (testing "update-in-when"
-    (are [m expected] (= expected
-                         (u/update-in-when m [:foo :bar] inc))
-      {:foo 2}        {:foo 2}
-      {:foo {:bar 2}} {:foo {:bar 3}})))
-
 (deftest index-of-test
   (are [input expected] (= expected
                            (u/index-of pos? input))


### PR DESCRIPTION
Medley 1.3.0 was released a few hours ago, and includes the `update-existing-in` we [were discussing](https://github.com/metabase/metabase/pull/11965#discussion_r387963768).

I went ahead and replaced usages of `u/update-when` with `m/update-existing` while I was at it.