### PR TITLE
Preload databases and tables in Query Builder init

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -60,6 +60,7 @@ import { getCardAfterVisualizationClick } from "metabase/visualizations/lib/util
 import { getPersistableDefaultSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
 
 import Questions from "metabase/entities/questions";
+import Databases from "metabase/entities/databases";
 
 import { getMetadata } from "metabase/selectors/metadata";
 import { setRequestUnloaded } from "metabase/redux/requests";
@@ -297,6 +298,10 @@ export const initializeQB = (location, params) => {
     // do this immediately to ensure old state is cleared before the user sees it
     dispatch(resetQB());
     dispatch(cancelQuery());
+
+    // preload metadata that's used in DataSelector
+    dispatch(Databases.actions.fetchList({ include: "tables" }));
+    dispatch(Databases.actions.fetchList({ saved: true }));
 
     const { currentUser } = getState();
 

--- a/frontend/test/metabase/scenarios/question/query_builder_loading.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/query_builder_loading.cy.spec.js
@@ -27,15 +27,14 @@ describe("query builder loading behavior", () => {
   });
 
   it("should incrementally load data if not preloaded", () => {
-    // we visit the new question page but refresh after starting a simple
-    // question to wipe out the preloaded data.
+    cy.server();
+    // stub out the preload call to fetch all tables
+    cy.route({ url: "/api/database?include=tables", response: [] });
+    // let the other preload happen since it matches the actual call from the component
+    cy.route({ url: "/api/database?saved=true" }).as("fetch1");
     cy.visit("/question/new");
     cy.contains("Simple question").click();
-    cy.server();
-    cy.reload();
 
-    cy.route({ url: "/api/database?include=tables" }).as("preload");
-    cy.route({ url: "/api/database?saved=true" }).as("fetch1");
     cy.route({ url: "/api/database/1/schemas" }).as("fetch2");
     cy.route({ url: "/api/database/1/schema/PUBLIC" }).as("fetch3");
 
@@ -47,6 +46,5 @@ describe("query builder loading behavior", () => {
     cy.get("@fetch1").should("exist");
     cy.get("@fetch2").should("exist");
     cy.get("@fetch3").should("exist");
-    cy.get("@preload").should("not.exist");
   });
 });


### PR DESCRIPTION
We already preload on `/question/new`. This covers cases where the user goes directly to a question to edit it or starts in `/browse`.

There's some chance that this new preload kicks off while the ones from `/question/new` are in flight. I confirmed that our API code handles that gracefully. It neither cancels the first request nor sends a duplicate request.