### PR TITLE
Fix bug when expanding one multi-schema db when another was already open

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -530,9 +530,14 @@ export class UnconnectedDataSelector extends Component {
     }
   };
 
-  onChangeDatabase = async (database, schemaInSameStep = false) => {
+  onChangeDatabase = async database => {
     if (this.props.setDatabaseFn) {
       this.props.setDatabaseFn(database && database.id);
+    }
+    if (this.state.selectedDatabaseId != null) {
+      // If we already had a database selected, we need to go back and clear
+      // data before advancing to the next step.
+      await this.previousStep();
     }
     await this.nextStep({ selectedDatabaseId: database && database.id });
   };
@@ -789,7 +794,7 @@ const DatabaseSchemaPicker = ({
           // still return "true" to let the AccordionList collapse that section.
           return true;
         }
-        onChangeDatabase(databases[sectionIndex], true);
+        onChangeDatabase(databases[sectionIndex]);
         return true;
       }}
       itemIsSelected={schema => schema === selectedSchema}

--- a/frontend/test/__support__/sample_dataset_fixture.js
+++ b/frontend/test/__support__/sample_dataset_fixture.js
@@ -12,6 +12,7 @@ export const SAMPLE_DATASET_ID = 1;
 export const ANOTHER_DATABASE_ID = 2;
 export const MONGO_DATABASE_ID = 3;
 export const MULTI_SCHEMA_DATABASE_ID = 4;
+export const OTHER_MULTI_SCHEMA_DATABASE_ID = 5;
 
 export const MAIN_METRIC_ID = 1;
 
@@ -46,6 +47,9 @@ export const ANOTHER_DATABASE = metadata.database(ANOTHER_DATABASE_ID);
 export const MONGO_DATABASE = metadata.database(MONGO_DATABASE_ID);
 export const MULTI_SCHEMA_DATABASE = metadata.database(
   MULTI_SCHEMA_DATABASE_ID,
+);
+export const OTHER_MULTI_SCHEMA_DATABASE = metadata.database(
+  OTHER_MULTI_SCHEMA_DATABASE_ID,
 );
 
 export const ORDERS = SAMPLE_DATASET.ORDERS;

--- a/frontend/test/__support__/sample_dataset_fixture.json
+++ b/frontend/test/__support__/sample_dataset_fixture.json
@@ -15,6 +15,16 @@
         "id": "4:second_schema",
         "name": "second_schema",
         "database": 4
+      },
+      "5:other_first_schema": {
+        "id": "5:other_first_schema",
+        "name": "other_first_schema",
+        "database": 5
+      },
+      "5:other_second_schema": {
+        "id": "5:other_second_schema",
+        "name": "other_second_schema",
+        "database": 5
       }
     },
     "metrics": {
@@ -173,6 +183,31 @@
         },
         "is_sample": true,
         "id": 4,
+        "engine": "h2",
+        "created_at": "2017-06-14T23:22:55.349Z",
+        "points_of_interest": null
+      },
+      "5": {
+        "description": null,
+        "features": [
+          "basic-aggregations",
+          "standard-deviation-aggregations",
+          "expression-aggregations",
+          "foreign-keys",
+          "native-parameters",
+          "expressions"
+        ],
+        "name": "Other Multi-schema Database",
+        "caveats": null,
+        "tables": [],
+        "is_full_sync": true,
+        "updated_at": "2017-06-14T23:22:55.349Z",
+        "native_permissions": "write",
+        "details": {
+          "db": "zip:/private/tmp/metabase.jar!/sample-dataset.db;USER=GUEST;PASSWORD=guest"
+        },
+        "is_sample": true,
+        "id": 5,
         "engine": "h2",
         "created_at": "2017-06-14T23:22:55.349Z",
         "points_of_interest": null

--- a/frontend/test/metabase/query_builder/components/DataSelector.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/DataSelector.unit.spec.js
@@ -9,6 +9,7 @@ import {
   SAMPLE_DATASET,
   ANOTHER_DATABASE,
   MULTI_SCHEMA_DATABASE,
+  OTHER_MULTI_SCHEMA_DATABASE,
   metadata,
   makeMetadata,
   state as fixtureData,
@@ -177,7 +178,7 @@ describe("DataSelector", () => {
     expect(fetchDatabases).toHaveBeenCalled();
   });
 
-  it("should click into a single-schema db after expanding a multi-schema db", () => {
+  it("should click into a single-schema db after expanding a multi-schema db", async () => {
     const { getByText } = render(
       <DataSelector
         steps={["DATABASE", "SCHEMA", "TABLE"]}
@@ -192,6 +193,7 @@ describe("DataSelector", () => {
     fireEvent.click(getByText("Multi-schema Database"));
     getByText("First Schema");
     fireEvent.click(getByText("Sample Dataset"));
+    await delay(1);
     getByText("Orders");
   });
 
@@ -220,7 +222,7 @@ describe("DataSelector", () => {
     getByText("Table in First Schema");
   });
 
-  it("should expand schemas after viewing tables on a single-schema db", () => {
+  it("should expand schemas after viewing tables on a single-schema db", async () => {
     // This is the same and the previous test except that it first opens/closes
     // the multi-schema db. This left some lingering traces in component state
     // which caused a bug tha that the previous test didn't catch.
@@ -242,6 +244,7 @@ describe("DataSelector", () => {
 
     // click into a single schema db, check for a table, and then return to db list
     fireEvent.click(getByText("Sample Dataset"));
+    await delay(1);
     getByText("Orders");
     fireEvent.click(getByText("Sample Dataset"));
 
@@ -326,6 +329,27 @@ describe("DataSelector", () => {
     );
 
     getByText("Sample Dataset", { selector: ".List-item--selected h4" });
+  });
+
+  it("should move between selected multi-schema dbs", () => {
+    const { getByText } = render(
+      <DataSelector
+        steps={["DATABASE", "SCHEMA", "TABLE"]}
+        databases={[MULTI_SCHEMA_DATABASE, OTHER_MULTI_SCHEMA_DATABASE]}
+        combineDatabaseSchemaSteps
+        triggerElement={<div />}
+        metadata={metadata}
+        isOpen={true}
+      />,
+    );
+
+    fireEvent.click(getByText("Multi-schema Database"));
+    getByText("First Schema");
+    getByText("Second Schema");
+
+    fireEvent.click(getByText("Other Multi-schema Database"));
+    getByText("Other First Schema");
+    getByText("Other Second Schema");
   });
 });
 


### PR DESCRIPTION
Having one multi-schema db open and clicking to expand another would advance you to the table step incorrectly. This PR fixes that by first calling `previousStep` if there's already a selected database.