### PR TITLE
Remove QP context cancelf and metadataf fn which aren't needed/used

### DIFF
--- a/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics_test.clj
+++ b/modules/drivers/googleanalytics/test/metabase/driver/googleanalytics_test.clj
@@ -287,7 +287,7 @@
                      rows    [["Toucan Sighting" 1000]]
                      context {:timeout 500
                               :runf    (fn [query rff context]
-                                         (let [metadata (qp.context/metadataf {:cols cols} context)]
+                                         (let [metadata {:cols cols}]
                                            (qp.context/reducef rff context metadata rows)))}
                      qp      (fn [query]
                                (qp/process-query query context))]

--- a/src/metabase/query_processor/context/default.clj
+++ b/src/metabase/query_processor/context/default.clj
@@ -43,7 +43,6 @@
        (vswap! rows conj row)
        result))))
 
-;; TODO - not 100% this makes sense -- should rows always be merged into metadata?
 (defn- default-reducedf [metadata reduced-result context]
   (context/resultf reduced-result context))
 
@@ -53,18 +52,17 @@
   `metabase.query-processor.reducible-test/write-rows-to-file-test` for an example of a custom implementation."
   [rff context metadata reducible-rows]
   {:pre [(fn? rff)]}
-  (let [metadata  (context/metadataf metadata context)]
-    ;; TODO -- how to pass updated metadata to reducedf?
-    (let [rf (rff metadata)]
-      (assert (fn? rf))
-      (when-let [reduced-rows (try
-                                (transduce identity rf reducible-rows)
-                                (catch Throwable e
-                                  (context/raisef (ex-info (tru "Error reducing result rows")
-                                                           {:type error-type/qp}
-                                                           e)
-                                                  context)))]
-        (context/reducedf metadata reduced-rows context)))))
+  ;; TODO -- how to pass updated metadata to reducedf?
+  (let [rf (rff metadata)]
+    (assert (fn? rf))
+    (when-let [reduced-rows (try
+                              (transduce identity rf reducible-rows)
+                              (catch Throwable e
+                                (context/raisef (ex-info (tru "Error reducing result rows")
+                                                         {:type error-type/qp}
+                                                         e)
+                                                context)))]
+      (context/reducedf metadata reduced-rows context))))
 
 (defn- default-runf [query rf context]
   (try
@@ -95,12 +93,6 @@
                        :type   error-type/timed-out})
                     context)))
 
-(defn- default-cancelf [context]
-  (log/debug (trs "Query canceled before finishing."))
-  (let [canceled-chan (context/canceled-chan context)]
-    (a/>!! canceled-chan :cancel)
-    (a/close! canceled-chan)))
-
 (defn- identity1
   "Util fn. Takes 2 args and returns the first arg as-is."
   [x _]
@@ -116,11 +108,9 @@
    :executef      driver/execute-reducible-query
    :reducef       default-reducef
    :reducedf      default-reducedf
-   :metadataf     identity1
    :preprocessedf identity1
    :nativef       identity1
-   :cancelf       default-cancelf
    :timeoutf      default-timeoutf
    :resultf       default-resultf
-   :canceled-chan (a/promise-chan identity identity)
-   :out-chan      (a/promise-chan identity identity)})
+   :canceled-chan (a/promise-chan)
+   :out-chan      (a/promise-chan)})

--- a/src/metabase/query_processor/reducible.clj
+++ b/src/metabase/query_processor/reducible.clj
@@ -9,7 +9,7 @@
   "Wire up the core.async channels in a QP `context`."
   [context]
   ;; 1) If query doesn't complete by `timeoutf`, call `timeoutf`, which should raise an Exception
-  ;; 2) when `out-chan` is closed prematurely, call `cancelf` to send a message to `canceled-chan`
+  ;; 2) when `out-chan` is closed prematurely, send a message to `canceled-chan`
   ;; 3) when `out-chan` is closed or gets a result, close both out-chan and canceled-chan
   (let [out-chan      (context/out-chan context)
         canceled-chan (context/canceled-chan context)
@@ -21,7 +21,7 @@
                     val)
         (cond
           (not= port out-chan) (context/timeoutf context)
-          (nil? val)           (context/cancelf context))
+          (nil? val)           (a/>!! canceled-chan ::cancel))
         (log/tracef "Closing out-chan.")
         (a/close! out-chan)
         (a/close! canceled-chan)))

--- a/test/metabase/async/streaming_response_test.clj
+++ b/test/metabase/async/streaming_response_test.clj
@@ -108,14 +108,13 @@
     (with-redefs [streaming-response/keepalive-interval-ms 50]
       (with-test-driver-db
         (reset! canceled? false)
-        (let [futur (http/post (test-client/build-url "dataset" nil)
-                               (assoc (test-client/build-request-map (mt/user->credentials :lucky)
-                                                                     {:database (mt/id)
-                                                                      :type     "native"
-                                                                      :native   {:query {:sleep 5000}}})
-                                      :async true)
-                               identity
-                               (fn [e] (throw e)))]
+        (let [url     (test-client/build-url "dataset" nil)
+              request (test-client/build-request-map (mt/user->credentials :lucky)
+                                                     {:database (mt/id)
+                                                      :type     "native"
+                                                      :native   {:query {:sleep 5000}}})
+              futur   (http/post url (assoc request :async true) identity (fn [e] (throw e)))]
+          (println "futur:" futur) ; NOCOMMIT
           (Thread/sleep 100)
           (future-cancel futur)
           (Thread/sleep 100)

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -115,7 +115,7 @@
             (is (= 'canceled-chan
                    (if (= port canceled-chan) 'canceled-chan 'timeout))
                 "port")
-            (is (= :cancel
+            (is (= :metabase.query-processor.reducible/cancel
                    val)
                 "val")))
         (testing "No QueryExecution should get saved when a query is canceled"

--- a/test/metabase/query_processor/reducible_test.clj
+++ b/test/metabase/query_processor/reducible_test.clj
@@ -96,7 +96,6 @@
                :query    {:source-table (mt/id :venues), :limit 2, :order-by [[:asc (mt/id :venues :id)]]}}
               {:rff maps-rff}))))))
 
-;; TODO - fix me
 (deftest cancelation-test
   (testing "Example of canceling a query early before results are returned."
     (letfn [(process-query [canceled-chan timeout]
@@ -114,14 +113,14 @@
       (mt/with-open-channels [canceled-chan (a/promise-chan)]
         (let [out-chan (process-query canceled-chan 1000)]
           (a/close! out-chan)
-          (is (= :cancel
+          (is (= ::qp.reducible/cancel
                  (first (a/alts!! [canceled-chan (a/timeout 500)]))))))
       (mt/with-open-channels [canceled-chan (a/promise-chan)]
         (let [out-chan (process-query canceled-chan 1000)]
           (future
             (Thread/sleep 50)
             (a/close! out-chan))
-          (is (= :cancel
+          (is (= ::qp.reducible/cancel
                  (a/<!! canceled-chan)))
           (is (= nil
                  (a/<!! out-chan)))))

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -219,8 +219,7 @@
                     :runf    (fn [query rff context]
                                (try
                                  (when run (run))
-                                 (let [metadata (qp.context/metadataf metadata context)]
-                                   (qp.context/reducef rff context (assoc metadata :pre query) rows))
+                                 (qp.context/reducef rff context (assoc metadata :pre query) rows)
                                  (catch Throwable e
                                    (println "Error in test-qp-middleware runf:" e)
                                    (throw e))))}


### PR DESCRIPTION
Noticed this while fixing some merge issues in EE.

The context functions had a purpose at one point but aren't used/needed any more so this PR removes them to simplify the code a bit.

Also improved some documentation around the context interface