### PR TITLE
[WIP] Change card source

### DIFF
--- a/src/metabase/cmd/change_card_source.clj
+++ b/src/metabase/cmd/change_card_source.clj
@@ -1,8 +1,9 @@
 (ns metabase.cmd.change-card-source
   (:require [clojure.walk :as walk]
-            [toucan.db :as tdb]
-            [metabase.models.card :as card]
-            [metabase.models.field :as field]))
+            [metabase.models
+             [card :as card]
+             [field :as field]]
+            [toucan.db :as tdb]))
 
 (defn add-field-mapping
   "Given a user mapping of old/new table and database, plus field names,

--- a/src/metabase/cmd/change_card_source.clj
+++ b/src/metabase/cmd/change_card_source.clj
@@ -1,5 +1,6 @@
 (ns metabase.cmd.change-card-source
-  (:require [toucan.db :as tdb]
+  (:require [clojure.walk :as walk]
+            [toucan.db :as tdb]
             [metabase.models.card :as card]
             [metabase.models.field :as field]))
 
@@ -19,13 +20,21 @@
 (defn remap-card
   "Updates table_id, database_id, and field_ids in card"
   [mapping card-id]
-  (let [original-card (tdb/select-one card/Card :id card-id)]
+  (let [original-card (tdb/select-one card/Card :id card-id)
+        db-id         (:new (:database mapping))
+        table-id      (:new (:table mapping))]
     (-> original-card
-        (assoc :table_id    (:table-id mapping)
-               :database_id (:database-id mapping)))))
+        (assoc :table_id    table-id
+               :database_id db-id)
+        (assoc-in [:dataset_query :database] db-id)
+        (assoc-in [:dataset_query :query :source-table] table-id)
+        (update-in [:dataset_query :query]
+                   (fn [query]
+                     (walk/postwalk (fn [x]
+                                      (if (and (vector? x)
+                                               (= :field-id (first x)))
+                                        (update x 1 (fn [old-field-id]
+                                                      (get-in mapping [:fields old-field-id])))
+                                        x))
+                                    query))))))
 
-{:table {:old 1572
-         :new 1586}
- :database {:old 1429
-            :new 1430}
- :fields {"ts" "created_at"}}

--- a/src/metabase/cmd/change_card_source.clj
+++ b/src/metabase/cmd/change_card_source.clj
@@ -4,7 +4,7 @@
             [metabase.models.card :as card]
             [metabase.models.field :as field]))
 
-(defn build-mapping
+(defn add-field-mapping
   "Given a user mapping of old/new table and database, plus field names,
   finds field ids to be remapped"
   [{:keys [table] :as user-mapping}]
@@ -38,7 +38,18 @@
                                     query))))))
 
 (defn remap-cards
-  "Finds all relevant cards, remaps them"
+  "Finds all relevant cards, remaps them
+
+  Example mapping:
+
+  {:table    {:old 1572
+            :new 1586}
+  :database {:old 1429
+            :new 1430}
+  :fields   {\"ts\"               \"created_at\"
+             \"dislikes_comment\" \"dislikes_comments\"}}
+  "
   [mapping]
-  (let [original-cards (tdb/select card/Card :table_id (:old (:table mapping)))]
-    (map #(remap-card mapping %) original-cards)))
+  (let [original-cards (tdb/select card/Card :table_id (:old (:table mapping)))
+        full-mapping   (add-field-mapping mapping)]
+    (map #(remap-card full-mapping %) original-cards)))

--- a/src/metabase/cmd/change_card_source.clj
+++ b/src/metabase/cmd/change_card_source.clj
@@ -1,0 +1,31 @@
+(ns metabase.cmd.change-card-source
+  (:require [toucan.db :as tdb]
+            [metabase.models.card :as card]
+            [metabase.models.field :as field]))
+
+(defn build-mapping
+  "Given a user mapping of old/new table and database, plus field names,
+  finds field ids to be remapped"
+  [{:keys [table] :as user-mapping}]
+  (let [old-fields (tdb/select field/Field :table_id (:old table))
+        new-fields (group-by :name (tdb/select field/Field :table_id (:new table)))]
+
+    (reduce (fn [field-map old-field]
+              (let [new-field-name (get-in user-mapping [:fields (:name old-field)] (:name old-field))]
+                (assoc-in field-map [:fields (:id old-field)] (:id (first (get new-fields new-field-name))))))
+            user-mapping
+            old-fields)))
+
+(defn remap-card
+  "Updates table_id, database_id, and field_ids in card"
+  [mapping card-id]
+  (let [original-card (tdb/select-one card/Card :id card-id)]
+    (-> original-card
+        (assoc :table_id    (:table-id mapping)
+               :database_id (:database-id mapping)))))
+
+{:table {:old 1572
+         :new 1586}
+ :database {:old 1429
+            :new 1430}
+ :fields {"ts" "created_at"}}

--- a/src/metabase/cmd/change_card_source.clj
+++ b/src/metabase/cmd/change_card_source.clj
@@ -10,10 +10,12 @@
   [{:keys [table] :as user-mapping}]
   (let [old-fields (tdb/select field/Field :table_id (:old table))
         new-fields (group-by :name (tdb/select field/Field :table_id (:new table)))]
-
     (reduce (fn [field-map old-field]
-              (let [new-field-name (get-in user-mapping [:fields (:name old-field)] (:name old-field))]
-                (assoc-in field-map [:fields (:id old-field)] (:id (first (get new-fields new-field-name))))))
+              (let [new-field-name (get-in user-mapping [:fields (:name old-field)])]
+                (assoc-in field-map
+                          [:fields (:id old-field)]
+                          (or (:id (first (get new-fields new-field-name)))
+                              (:id old-field)))))
             user-mapping
             old-fields)))
 

--- a/src/metabase/cmd/change_card_source.clj
+++ b/src/metabase/cmd/change_card_source.clj
@@ -19,9 +19,8 @@
 
 (defn remap-card
   "Updates table_id, database_id, and field_ids in card"
-  [mapping card-id]
-  (let [original-card (tdb/select-one card/Card :id card-id)
-        db-id         (:new (:database mapping))
+  [mapping original-card]
+  (let [db-id         (:new (:database mapping))
         table-id      (:new (:table mapping))]
     (-> original-card
         (assoc :table_id    table-id
@@ -38,3 +37,8 @@
                                         x))
                                     query))))))
 
+(defn remap-cards
+  "Finds all relevant cards, remaps them"
+  [mapping]
+  (let [original-cards (tdb/select card/Card :table_id (:old (:table mapping)))]
+    (map #(remap-card mapping %) original-cards)))

--- a/test/metabase/cmd/change_card_source_test.clj
+++ b/test/metabase/cmd/change_card_source_test.clj
@@ -1,28 +1,44 @@
 (ns metabase.cmd.change-card-source-test
   (:require [metabase.cmd.change-card-source :as sut]
             [metabase.models :refer [Card Database Field Table]]
-            [metabase.test.data :as data]
-            [metabase.util :as u]
             [clojure.test :refer :all]
             [toucan.util.test :as tt]))
 
-(deftest remap-cards
-  (tt/with-temp* [Database [db-1 {}]
-                  Database [db-2 {}]
-                  Table    [table-1 {}]
-                  Table    [table-2 {}]
-                  Field    [field-1 {:table_id (u/get-id table-1) :name "field 1"}]
-                  Field    [field-2 {:table_id (u/get-id table-1) :name "field 2"}]
-                  Field    [field-3 {:table_id (u/get-id table-2) :name "field 3"}]
-                  Field    [field-4 {:table_id (u/get-id table-2) :name "field 4"}]
-                  Card     [card {:database_id   db-1
-                                  :table_id      table-1
-                                  :dataset_query {:query    (str {:source-table table-1
-                                                                  :filter       [:time-interval [:field-id field-1]]
-                                                                  :aggregation  [[:sum [:field-id field-2]]]})
-                                                  :database db-1}}]]
+(deftest add-field-mapping
+  (tt/with-temp* [Table [{table-1-id :id} {}]
+                  Field [{field-1-id :id} {:table_id table-1-id :name "field 1"}]
+                  Field [{field-2-id :id} {:table_id table-1-id :name "field 2"}]]
 
-    (is (= []
-           (sut/remap-cards {:database {:old db-1 :new db-2}
-                             :table    {:old table-1 :new table-2}
-                             :fields   {"field 1" "field 3"}})))))
+    (is (= {:table  {:old table-1-id :new table-1-id}
+            :fields {"field 1"  "field 2"
+                     field-1-id field-2-id
+                     field-2-id field-2-id}}
+           (sut/add-field-mapping {:table  {:old table-1-id :new table-1-id}
+                                   :fields {"field 1" "field 2"}})))))
+
+(deftest remap-cards
+  (tt/with-temp* [Database [{db-1-id :id} {}]
+                  Database [{db-2-id :id} {}]
+                  Table    [{table-1-id :id} {}]
+                  Table    [{table-2-id :id} {}]
+                  Field    [{field-1-id :id} {:table_id table-1-id :name "field 1"}]
+                  Field    [{field-2-id :id} {:table_id table-1-id :name "field 2"}]
+                  Field    [{field-3-id :id} {:table_id table-2-id :name "field 3"}]
+                  Field    [{field-4-id :id} {:table_id table-2-id :name "field 4"}]
+                  Card     [card {:database_id   db-1-id
+                                  :table_id      table-1-id
+                                  :dataset_query {:query    {:source-table table-1-id
+                                                             :filter       [:time-interval [:field-id field-1-id] "-30" :day]
+                                                             :aggregation  [[:sum [:field-id field-2-id]]]}
+                                                  :database db-1-id}}]]
+
+    (is (= [{:database_id   db-2-id
+             :table_id      table-2-id
+             :dataset_query {:query    {:source-table table-2-id
+                                        :filter       [:time-interval [:field-id field-3-id] :-30 :day]
+                                        :aggregation  [[:sum [:field-id field-2-id]]]}
+                             :database db-2-id}}]
+           (map #(select-keys % [:database_id :table_id :dataset_query])
+                (sut/remap-cards {:database {:old db-1-id :new db-2-id}
+                                  :table    {:old table-1-id :new table-2-id}
+                                  :fields   {"field 1" "field 3"}}))))))

--- a/test/metabase/cmd/change_card_source_test.clj
+++ b/test/metabase/cmd/change_card_source_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.cmd.change-card-source-test
-  (:require [metabase.cmd.change-card-source :as sut]
+  (:require [clojure.test :refer :all]
+            [metabase.cmd.change-card-source :as sut]
             [metabase.models :refer [Card Database Field Table]]
-            [clojure.test :refer :all]
             [toucan.util.test :as tt]))
 
 (deftest add-field-mapping

--- a/test/metabase/cmd/change_card_source_test.clj
+++ b/test/metabase/cmd/change_card_source_test.clj
@@ -1,0 +1,28 @@
+(ns metabase.cmd.change-card-source-test
+  (:require [metabase.cmd.change-card-source :as sut]
+            [metabase.models :refer [Card Database Field Table]]
+            [metabase.test.data :as data]
+            [metabase.util :as u]
+            [clojure.test :refer :all]
+            [toucan.util.test :as tt]))
+
+(deftest remap-cards
+  (tt/with-temp* [Database [db-1 {}]
+                  Database [db-2 {}]
+                  Table    [table-1 {}]
+                  Table    [table-2 {}]
+                  Field    [field-1 {:table_id (u/get-id table-1) :name "field 1"}]
+                  Field    [field-2 {:table_id (u/get-id table-1) :name "field 2"}]
+                  Field    [field-3 {:table_id (u/get-id table-2) :name "field 3"}]
+                  Field    [field-4 {:table_id (u/get-id table-2) :name "field 4"}]
+                  Card     [card {:database_id   db-1
+                                  :table_id      table-1
+                                  :dataset_query {:query    (str {:source-table table-1
+                                                                  :filter       [:time-interval [:field-id field-1]]
+                                                                  :aggregation  [[:sum [:field-id field-2]]]})
+                                                  :database db-1}}]]
+
+    (is (= []
+           (sut/remap-cards {:database {:old db-1 :new db-2}
+                             :table    {:old table-1 :new table-2}
+                             :fields   {"field 1" "field 3"}})))))


### PR DESCRIPTION
This code addresses the problem of needing to recreate cards (and then possibly dashboards that use the original cards) when you migrate a table to a new database. For example, if you wanted to migrate your digital ocean db to AWS, you'd want to be able to use the same cards but have them point to the AWS db and table instead of the digital ocean one.

What I have so far is very basic. It will update database and table references. It also updates field references, including allowing you to handle renamed fields.

I want to check that I'm on the right track. What am I missing?

Missing:
* saving the updated card
* the actual command line interface, including input format (I think EDN is fine)