### PR TITLE
Make question reference vars look like other vars in sidebar

### DIFF
--- a/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
@@ -73,8 +73,8 @@ export default class CardTagEditor extends Component {
     } = this.props;
 
     return (
-      <Card className="p2 mb2">
-        <h3 className="text-brand mb2">
+      <div className="px3 py4 border-top">
+        <h3 className="text-heavy text-brand mb1">
           {cardId == null ? (
             t`Question #…`
           ) : (
@@ -104,19 +104,19 @@ export default class CardTagEditor extends Component {
           </p>
         )}
         {question && !this.errorMessage() && (
-          <div className="bg-light text-medium py1 px2 mt2">
+          <div className="bg-light text-medium text-small py1 px2 mt1">
             {question.collection && (
               <div className="flex align-center">
                 <Icon name="all" size={12} mr={1} /> {question.collection.name}
               </div>
             )}
-            <div className="flex align-center">
+            <div className="flex align-center mt1">
               <Icon name="calendar" size={12} mr={1} />{" "}
               {t`Last edited ${formatDate(question.updated_at)}`}
             </div>
           </div>
         )}
-      </Card>
+      </div>
     );
   }
 }

--- a/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/CardTagEditor.jsx
@@ -3,7 +3,6 @@ import { Link } from "react-router";
 import { t } from "ttag";
 
 import Icon from "metabase/components/Icon";
-import Card from "metabase/components/Card";
 import QuestionPicker from "metabase/containers/QuestionPicker";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import SelectButton from "metabase/components/SelectButton";


### PR DESCRIPTION
This just drops the use of `<Card>` to remove the drop shadow to match the stylistic changes I made to this side panel the other week. Also massaged the spacing of the elements a bit.

## Before
![Screen Shot 2020-03-06 at 2 32 43 PM](https://user-images.githubusercontent.com/2223916/76128796-3a9aca00-5fba-11ea-9c76-3884db05b45a.png)

## After
![Screen Shot 2020-03-06 at 2 51 36 PM](https://user-images.githubusercontent.com/2223916/76128814-438b9b80-5fba-11ea-8547-ba28324a8b3b.png)

