### PR TITLE
Fixes some remapping tests spewing fingerprinting errors

### DIFF
--- a/src/metabase/query_processor/middleware/add_dimension_projections.clj
+++ b/src/metabase/query_processor/middleware/add_dimension_projections.clj
@@ -147,7 +147,9 @@
    :display_name  col-name
    :target        nil
    :remapped_from remapped-from
-   :remapped_to   nil})
+   :remapped_to   nil
+   :base_type     :type/*
+   :special_type  nil})
 
 (defn- transform-values-for-col
   "Converts `values` to a type compatible with the base_type found for `col`. These values should be directly comparable

--- a/src/metabase/query_processor/middleware/add_dimension_projections.clj
+++ b/src/metabase/query_processor/middleware/add_dimension_projections.clj
@@ -139,7 +139,7 @@
          {:display_name  dimension-name
           :remapped_from (:name (get column-id->column remapped-from-id))})))))
 
-(defn- create-remapped-col [col-name remapped-from]
+(defn- create-remapped-col [col-name remapped-from base-type]
   {:description   nil
    :id            nil
    :table_id      nil
@@ -148,7 +148,7 @@
    :target        nil
    :remapped_from remapped-from
    :remapped_to   nil
-   :base_type     :type/*
+   :base_type     base-type
    :special_type  nil})
 
 (defn- transform-values-for-col
@@ -175,6 +175,18 @@
    ;; Info about the new column we will tack on to end of `:cols`
    :new-column      su/Map})
 
+(defn- infer-human-readable-values-type
+  [values]
+  (let [types (keys (group-by (fn [v]
+                                (cond
+                                  (string? v) :type/Text
+                                  (number? v) :type/Number
+                                  :else       :type/*))
+                              values))]
+    (if (= (count types) 1)
+      (first types)
+      :type/*)))
+
 (s/defn ^:private col->dim-map :- (s/maybe InternalDimensionInfo)
   "Given a `:col` map from the results, return a map of information about the `internal` dimension used for remapping
   it."
@@ -189,7 +201,8 @@
        :to              remap-to
        :value->readable (zipmap (transform-values-for-col col values)
                                 human-readable-values)
-       :new-column      (create-remapped-col remap-to remap-from)})))
+       :new-column      (create-remapped-col remap-to remap-from
+                                             (infer-human-readable-values-type human-readable-values))})))
 
 (s/defn ^:private make-row-map-fn :- (s/maybe (s/pred fn? "function"))
   "Return a function that will add internally-remapped values to each row in the results. (If there is no remapping to

--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -114,7 +114,9 @@
    :remapped_to     nil
    :id              nil
    :target          nil
-   :display_name    "Foo"})
+   :display_name    "Foo"
+   :base_type       :type/Text
+   :special_type    nil})
 
 (defn- add-remapping [query metadata rows]
   (:result (mt/test-qp-middleware add-dim-projections/add-remapping query metadata rows)))

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -78,35 +78,27 @@
          :order-by    [[:desc $user_id]]
          :limit       10}))))
 
-;; TODO - I have no idea what exactly this test is testing??? Someone please determine and then write a description.
-(deftest mystery-test
+(deftest internal-remapping-test
   (mt/test-drivers (mt/normal-drivers)
     (data/with-temp-objects
-      (fn []
-        (let [venue-names (data/dataset-field-values "categories" "name")]
-          [(db/insert! Dimension {:field_id (data/id :venues :category_id)
-                                  :name     "Foo"
-                                  :type     :internal})
-           (db/insert! FieldValues {:field_id              (data/id :venues :category_id)
-                                    :values                (json/generate-string (range 0 (count venue-names)))
-                                    :human_readable_values (json/generate-string venue-names)})]))
+      (data/create-venue-category-remapping "Foo")
       (let [{:keys [rows cols]} (qp.test/rows-and-cols
                                   (qp.test/format-rows-by [int int str]
                                     (data/run-mbql-query venues
                                       {:aggregation [[:count]]
                                        :breakout    [$category_id]
                                        :limit       5})))]
-        (is (= [(assoc (qp.test/breakout-col :venues :category_id)
-                       :remapped_to "Foo")
+        (is (= [(assoc (qp.test/breakout-col :venues :category_id) :remapped_to "Foo")
                 (qp.test/aggregate-col :count)
                 (#'add-dim-projections/create-remapped-col "Foo" (data/format-name "category_id"))]
                cols))
-        (is (= [[2 8 "Artisan"]
-                [3 2 "Asian"]
-                [4 2 "BBQ"]
-                [5 7 "Bakery"]
-                [6 2 "Bar"]]
-               rows))))))
+        (is (= [[2 8 "American"]
+                [3 2 "Artisan"]
+                [4 2 "Asian"]
+                [5 7 "BBQ"]
+                [6 2 "Bakery"]]
+               rows))
+        cols))))
 
 (deftest order-by-test
   (datasets/test-drivers (mt/normal-drivers-with-feature :foreign-keys)

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -97,8 +97,7 @@
                 [4 2 "Asian"]
                 [5 7 "BBQ"]
                 [6 2 "Bakery"]]
-               rows))
-        cols))))
+               rows))))))
 
 (deftest order-by-test
   (datasets/test-drivers (mt/normal-drivers-with-feature :foreign-keys)

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.query-processor-test.breakout-test
   "Tests for the `:breakout` clause."
-  (:require [cheshire.core :as json]
-            [clojure.test :refer :all]
+  (:require [clojure.test :refer :all]
             [metabase
              [query-processor :as qp]
              [query-processor-test :as qp.test]

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -11,8 +11,7 @@
             [metabase.models
              [card :refer [Card]]
              [dimension :refer [Dimension]]
-             [field :refer [Field]]
-             [field-values :refer [FieldValues]]]
+             [field :refer [Field]]]
             [metabase.query-processor.middleware
              [add-dimension-projections :as add-dim-projections]
              [add-source-metadata :as add-source-metadata]]
@@ -90,7 +89,7 @@
                                        :limit       5})))]
         (is (= [(assoc (qp.test/breakout-col :venues :category_id) :remapped_to "Foo")
                 (qp.test/aggregate-col :count)
-                (#'add-dim-projections/create-remapped-col "Foo" (data/format-name "category_id"))]
+                (#'add-dim-projections/create-remapped-col "Foo" (data/format-name "category_id") :type/Text)]
                cols))
         (is (= [[2 8 "American"]
                 [3 2 "Artisan"]

--- a/test/metabase/query_processor_test/remapping_test.clj
+++ b/test/metabase/query_processor_test/remapping_test.clj
@@ -18,7 +18,7 @@
          ["800 Degrees Neapolitan Pizzeria" 58 "Pizza"]]
   :cols [(qp.test/col :venues :name)
          (assoc (qp.test/col :venues :category_id) :remapped_to "Foo")
-         (#'add-dimension-projections/create-remapped-col "Foo" (data/format-name "category_id"))]}
+         (#'add-dimension-projections/create-remapped-col "Foo" (data/format-name "category_id") :type/Text)]}
   (data/with-temp-objects
     (data/create-venue-category-remapping "Foo")
     (qp.test/rows-and-cols


### PR DESCRIPTION
A few tests were failing fingerprinting due to internal remapped cols not conforming to col spec. This is a temporary fix to not have the annoying errors pollute the output, a better and more long term solution would be implement internal remappings with `case`. That would save us a bunch of special casing and fully work with fingerprinting and nested queries. 