### PR TITLE
Don't use `system` command as alias with MySQL

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -116,25 +116,27 @@
 
 (defmethod driver/db-default-timezone :mysql
   [_ db]
-  (let [spec                             (sql-jdbc.conn/db->pooled-connection-spec db)
-        sql                              (str "SELECT @@GLOBAL.time_zone AS global,"
-                                              " @@system_time_zone AS system,"
-                                              " time_format("
-                                              "   timediff(now(), convert_tz(now(), @@GLOBAL.time_zone, '+00:00')),"
-                                              "  '%H:%i'"
-                                              " ) AS offset;")
-        [{:keys [global system offset]}] (jdbc/query spec sql)
-        the-valid-id                     (fn [zone-id]
-                                           (when zone-id
-                                             (try
-                                               (.getId (t/zone-id zone-id))
-                                               (catch Throwable _))))]
+  (let [spec                                   (sql-jdbc.conn/db->pooled-connection-spec db)
+        sql                                    (str "SELECT @@GLOBAL.time_zone AS global_tz,"
+                                                    " @@system_time_zone AS system_tz,"
+                                                    " time_format("
+                                                    "   timediff("
+                                                    "      now(), convert_tz(now(), @@GLOBAL.time_zone, '+00:00')"
+                                                    "   ),"
+                                                    "   '%H:%i'"
+                                                    " ) AS offset;")
+        [{:keys [global_tz system_tz offset]}] (jdbc/query spec sql)
+        the-valid-id                           (fn [zone-id]
+                                                 (when zone-id
+                                                   (try
+                                                     (.getId (t/zone-id zone-id))
+                                                     (catch Throwable _))))]
     (or
      ;; if global timezone ID is 'SYSTEM', then try to use the system timezone ID
-     (when (= global "SYSTEM")
-       (the-valid-id system))
+     (when (= global_tz "SYSTEM")
+       (the-valid-id system_tz))
      ;; otherwise try to use the global ID
-     (the-valid-id global)
+     (the-valid-id global_tz)
      ;; failing that, calculate the offset between now in the global timezone and now in UTC. Non-negative offsets
      ;; don't come back with `+` so add that if needed
      (if (str/starts-with? offset "-")

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -98,21 +98,28 @@
                                                       [result-row]
                                                       (apply orig spec sql-args options))))]
                          (driver/db-default-timezone driver/*driver* db))))]
-      (is (= "US/Pacific"
-             (timezone {:global "US/Pacific", :system "UTC"}))
-          "Should use global timezone by default")
-      (is (= "UTC"
-             (timezone {:global "SYSTEM", :system "UTC"}))
-          "If global timezone is 'SYSTEM', should use system timezone")
-      (is (= "+00:00"
-             (timezone {:offset "00:00"}))
-          "Should fall back to returning `offset` if global/system aren't present")
-      (is (= "-08:00"
-             (timezone {:global "PDT", :system "PDT", :offset "-08:00"}))
-          "If global timezone is invalid, should fall back to offset")
-      (is (= "+00:00"
-             (timezone {:global "PDT", :system "UTC", :offset "00:00"}))
-          "Should add a `+` if needed to offset"))))
+      (testing "Should use global timezone by default"
+        (is (= "US/Pacific"
+               (timezone {:global_tz "US/Pacific", :system_tz "UTC"}))))
+      (testing "If global timezone is 'SYSTEM', should use system timezone"
+        (is (= "UTC"
+               (timezone {:global_tz "SYSTEM", :system_tz "UTC"}))))
+      (testing "Should fall back to returning `offset` if global/system aren't present"
+        (is (= "+00:00"
+               (timezone {:offset "00:00"}))))
+      (testing "If global timezone is invalid, should fall back to offset"
+        (is (= "-08:00"
+               (timezone {:global_tz "PDT", :system_tz "PDT", :offset "-08:00"}))))
+      (testing "Should add a `+` if needed to offset"
+        (is (= "+00:00"
+               (timezone {:global_tz "PDT", :system_tz "UTC", :offset "00:00"})))))
+
+    (testing "real timezone query doesn't fail"
+      (is (nil? (try
+                  (driver/db-default-timezone driver/*driver* (data/db))
+                  nil
+                  (catch Throwable e
+                    e)))))))
 
 
 (def ^:private before-daylight-savings #t "2018-03-10T10:00:00Z")


### PR DESCRIPTION
Using `system` in even a simple queries like `SELECT 1 AS system;` on MySQL, causes errors like the following:

```
ERROR 1064 (42000) at line 1: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'system' at line 1
```

It seems like it's a client command. I'm not exactly sure when it was introduced, but seems to be at least MySQL [5.6](https://dev.mysql.com/doc/refman/5.6/en/mysql-commands.html).