### PR TITLE
Tiny Troubleshooting link correction

### DIFF
--- a/frontend/src/metabase/admin/tasks/containers/Help.jsx
+++ b/frontend/src/metabase/admin/tasks/containers/Help.jsx
@@ -46,14 +46,14 @@ Add any other context about the problem here.
 
 function githubIssueLink(bugReportDetails) {
   return (
-    "https://github.com/metabase/metabase/issues/new?title=&labels=Type:Bug&body=" +
+    "https://github.com/metabase/metabase/issues/new?title=&labels=.Needs+Triage%2C+Type%3ABug&body=" +
     encodeURIComponent(template + "\n```json\n" + bugReportDetails + "\n```")
   );
 }
 
 function discourseLink(bugReportDetails) {
   return (
-    "http://discourse.metabase.com/new-topic?category_id=7&body=" +
+    "https://discourse.metabase.com/new-topic?category_id=7&body=" +
     encodeURIComponent("```json\n" + bugReportDetails + "\n```")
   );
 }


### PR DESCRIPTION
Just noticed issues created from within Metabase didn't have any labels.