### PR TITLE
Fix automatic dashboards candidate-tables for Tables with no Fields

### DIFF
--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -1239,7 +1239,6 @@
                                         :having   [:= :%count.* 1]}))
                            (into #{} (map :table_id)))
           ;; Table comprised entierly of join keys
-          _ (println "field-count:" field-count) ; NOCOMMIT
           link-table? (when (seq field-count)
                         (->> (db/query {:select   [:table_id [:%count.* "count"]]
                                         :from     [Field]

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -1239,20 +1239,22 @@
                                         :having   [:= :%count.* 1]}))
                            (into #{} (map :table_id)))
           ;; Table comprised entierly of join keys
-          link-table? (->> (db/query {:select   [:table_id [:%count.* "count"]]
-                                      :from     [Field]
-                                      :where    [:and [:in :table_id (keys field-count)]
-                                                 [:= :active true]
-                                                 [:in :special_type ["type/PK" "type/FK"]]]
-                                      :group-by [:table_id]})
-                           (filter (fn [{:keys [table_id count]}]
-                                     (= count (field-count table_id))))
-                           (into #{} (map :table_id)))]
+          _ (println "field-count:" field-count) ; NOCOMMIT
+          link-table? (when (seq field-count)
+                        (->> (db/query {:select   [:table_id [:%count.* "count"]]
+                                        :from     [Field]
+                                        :where    [:and [:in :table_id (keys field-count)]
+                                                   [:= :active true]
+                                                   [:in :special_type ["type/PK" "type/FK"]]]
+                                        :group-by [:table_id]})
+                             (filter (fn [{:keys [table_id count]}]
+                                       (= count (field-count table_id))))
+                             (into #{} (map :table_id))))]
       (for [table tables]
         (let [table-id (u/get-id table)]
           (assoc table :stats {:num-fields  (field-count table-id 0)
-                               :list-like?  (boolean (list-like? table-id))
-                               :link-table? (boolean (link-table? table-id))}))))))
+                               :list-like?  (boolean (contains? list-like? table-id))
+                               :link-table? (boolean (contains? link-table? table-id))}))))))
 
 (def ^:private ^:const ^Long max-candidate-tables
   "Maximal number of tables per schema shown in `candidate-tables`."

--- a/test/metabase/automagic_dashboards/comparison_test.clj
+++ b/test/metabase/automagic_dashboards/comparison_test.clj
@@ -11,6 +11,7 @@
             [metabase.test
              [automagic-dashboards :refer :all]
              [data :as data]]
+            [metabase.test :as mt]
             [toucan.util.test :as tt]))
 
 (def ^:private segment
@@ -29,7 +30,7 @@
 
 (expect
   (tt/with-temp* [Segment [{segment-id :id} @segment]]
-    (with-rasta
+    (mt/with-test-user :rasta
       (with-dashboard-cleanup
         (and (test-comparison (Table (data/id :venues)) (Segment segment-id))
              (test-comparison (Segment segment-id) (Table (data/id :venues))))))))
@@ -38,12 +39,12 @@
   (tt/with-temp* [Segment [{segment1-id :id} @segment]
                   Segment [{segment2-id :id} {:table_id (data/id :venues)
                                               :definition {:filter [:< [:field-id (data/id :venues :price)] 4]}}]]
-    (with-rasta
+    (mt/with-test-user :rasta
       (with-dashboard-cleanup
         (test-comparison (Segment segment1-id) (Segment segment2-id))))))
 
 (expect
-  (with-rasta
+  (mt/with-test-user :rasta
     (with-dashboard-cleanup
       (let [q (query/adhoc-query {:query {:filter (-> @segment :definition :filter)
                                           :source-table (data/id :venues)}
@@ -57,6 +58,6 @@
                                                                :source-table (data/id :venues)}
                                                        :type :query
                                                        :database (data/id)}}]]
-    (with-rasta
+    (mt/with-test-user :rasta
       (with-dashboard-cleanup
         (test-comparison (Table (data/id :venues)) (Card card-id))))))

--- a/test/metabase/automagic_dashboards/comparison_test.clj
+++ b/test/metabase/automagic_dashboards/comparison_test.clj
@@ -1,17 +1,15 @@
 (ns metabase.automagic-dashboards.comparison-test
   (:require [expectations :refer :all]
+            [metabase
+             [models :refer [Card Segment Table]]
+             [test :as mt]]
             [metabase.automagic-dashboards
              [comparison :as c :refer :all]
              [core :refer [automagic-analysis]]]
-            [metabase.models
-             [card :refer [Card]]
-             [query :as query]
-             [segment :refer [Segment]]
-             [table :as table :refer [Table]]]
+            [metabase.models.query :as query]
             [metabase.test
              [automagic-dashboards :refer :all]
              [data :as data]]
-            [metabase.test :as mt]
             [toucan.util.test :as tt]))
 
 (def ^:private segment

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -18,6 +18,7 @@
              [query :as query]
              [table :as table :refer [Table]]]
             [metabase.query-processor.async :as qp.async]
+            [metabase.test :as mt]
             [metabase.test
              [automagic-dashboards :refer :all]
              [data :as data]
@@ -78,13 +79,13 @@
         (valid-dashboard? (automagic-analysis entity {:cell-query cell-query :show 1})))))
 
 (expect
-  (with-rasta
+  (mt/with-test-user :rasta
     (with-dashboard-cleanup
       (->> (db/select Table :db_id (data/id))
            (every? test-automagic-analysis)))))
 
 (expect
-  (with-rasta
+  (mt/with-test-user :rasta
     (with-dashboard-cleanup
       (->> (automagic-analysis (Table (data/id :venues)) {:show 1})
            :ordered_cards
@@ -93,7 +94,7 @@
            (= 1)))))
 
 (expect
-  (with-rasta
+  (mt/with-test-user :rasta
     (with-dashboard-cleanup
       (->> (db/select Field
              :table_id [:in (db/select-field :id Table :db_id (data/id))]
@@ -103,7 +104,7 @@
 (expect
   (tt/with-temp* [Metric [metric {:table_id (data/id :venues)
                                   :definition {:aggregation [[:count]]}}]]
-    (with-rasta
+    (mt/with-test-user :rasta
       (with-dashboard-cleanup
         (test-automagic-analysis metric)))))
 
@@ -116,7 +117,7 @@
                                                                  :source-table (data/id :venues)}
                                                          :type :query
                                                          :database (data/id)}}]]
-      (with-rasta
+      (mt/with-test-user :rasta
         (with-dashboard-cleanup
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
           (-> card-id Card test-automagic-analysis))))))
@@ -131,7 +132,7 @@
                                                                  :source-table (data/id :venues)}
                                                          :type :query
                                                          :database (data/id)}}]]
-      (with-rasta
+      (mt/with-test-user :rasta
         (with-dashboard-cleanup
           (-> card-id Card test-automagic-analysis))))))
 
@@ -143,7 +144,7 @@
                                          :dataset_query {:native {:query "select * from users"}
                                                          :type :native
                                                          :database (data/id)}}]]
-      (with-rasta
+      (mt/with-test-user :rasta
         (with-dashboard-cleanup
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
           (-> card-id Card test-automagic-analysis))))))
@@ -163,14 +164,14 @@
                       Card [{source-id :id} {:table_id      (data/id :venues)
                                              :collection_id   collection-id
                                              :dataset_query   source-query
-                                             :result_metadata (with-rasta (result-metadata-for-query source-query))}]
+                                             :result_metadata (mt/with-test-user :rasta (result-metadata-for-query source-query))}]
                       Card [{card-id :id} {:table_id      (data/id :venues)
                                            :collection_id collection-id
                                            :dataset_query {:query    {:filter       [:> [:field-literal "PRICE" "type/Number"] 10]
                                                                       :source-table (str "card__" source-id)}
                                                            :type     :query
                                                            :database mbql.s/saved-questions-virtual-database-id}}]]
-        (with-rasta
+        (mt/with-test-user :rasta
           (with-dashboard-cleanup
             (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
             (-> card-id Card test-automagic-analysis)))))))
@@ -184,7 +185,7 @@
                                                                     :source-table (data/id :venues)}
                                                          :type     :query
                                                          :database (data/id)}}]]
-      (with-rasta
+      (mt/with-test-user :rasta
         (with-dashboard-cleanup
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
           (-> card-id Card test-automagic-analysis))))))
@@ -198,14 +199,14 @@
                       Card [{source-id :id} {:table_id        nil
                                              :collection_id   collection-id
                                              :dataset_query   source-query
-                                             :result_metadata (with-rasta (result-metadata-for-query source-query))}]
+                                             :result_metadata (mt/with-test-user :rasta (result-metadata-for-query source-query))}]
                       Card [{card-id :id} {:table_id      nil
                                            :collection_id collection-id
                                            :dataset_query {:query    {:filter       [:> [:field-literal "PRICE" "type/Number"] 10]
                                                                       :source-table (str "card__" source-id)}
                                                            :type     :query
                                                            :database mbql.s/saved-questions-virtual-database-id}}]]
-        (with-rasta
+        (mt/with-test-user :rasta
           (with-dashboard-cleanup
             (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
             (-> card-id Card test-automagic-analysis)))))))
@@ -220,7 +221,7 @@
                                                                     :source-table (data/id :venues)}
                                                          :type     :query
                                                          :database (data/id)}}]]
-      (with-rasta
+      (mt/with-test-user :rasta
         (with-dashboard-cleanup
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
           (-> card-id Card test-automagic-analysis))))))
@@ -233,7 +234,7 @@
                                          :dataset_query {:native   {:query "select * from users"}
                                                          :type     :native
                                                          :database (data/id)}}]]
-      (with-rasta
+      (mt/with-test-user :rasta
         (with-dashboard-cleanup
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
           (-> card-id Card test-automagic-analysis))))))
@@ -246,7 +247,7 @@
                                          :dataset_query {:native   {:query "select * from users"}
                                                          :type     :native
                                                          :database (data/id)}}]]
-      (with-rasta
+      (mt/with-test-user :rasta
         (with-dashboard-cleanup
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
           (-> card-id Card test-automagic-analysis))))))
@@ -260,7 +261,7 @@
                                                                     :source-table (data/id :venues)}
                                                          :type     :query
                                                          :database (data/id)}}]]
-      (with-rasta
+      (mt/with-test-user :rasta
         (with-dashboard-cleanup
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
           (-> card-id
@@ -277,7 +278,7 @@
                                                                     :source-table (data/id :venues)}
                                                          :type     :query
                                                          :database (data/id)}}]]
-      (with-rasta
+      (mt/with-test-user :rasta
         (with-dashboard-cleanup
           (perms/grant-collection-readwrite-permissions! (perms-group/all-users) collection-id)
           (-> card-id
@@ -286,7 +287,7 @@
 
 
 (expect
-  (with-rasta
+  (mt/with-test-user :rasta
     (with-dashboard-cleanup
       (let [q (query/adhoc-query {:query {:filter [:> [:field-id (data/id :venues :price)] 10]
                                           :source-table (data/id :venues)}
@@ -295,7 +296,7 @@
         (test-automagic-analysis q)))))
 
 (expect
-  (with-rasta
+  (mt/with-test-user :rasta
     (with-dashboard-cleanup
       (let [q (query/adhoc-query {:query {:aggregation [[:count]]
                                           :breakout [[:field-id (data/id :venues :category_id)]]
@@ -305,7 +306,7 @@
         (test-automagic-analysis q)))))
 
 (expect
-  (with-rasta
+  (mt/with-test-user :rasta
     (with-dashboard-cleanup
       (let [q (query/adhoc-query {:query {:aggregation [[:count]]
                                           :breakout [[:fk-> (data/id :checkins) (data/id :venues :category_id)]]
@@ -315,7 +316,7 @@
         (test-automagic-analysis q)))))
 
 (expect
-  (with-rasta
+  (mt/with-test-user :rasta
     (with-dashboard-cleanup
       (let [q (query/adhoc-query {:query {:filter [:> [:field-id (data/id :venues :price)] 10]
                                           :source-table (data/id :venues)}
@@ -328,7 +329,7 @@
 
 (expect
   4
-  (with-rasta
+  (mt/with-test-user :rasta
     (->> (data/db) candidate-tables first :tables count)))
 
 ;; /candidates should work with unanalyzed tables
@@ -338,7 +339,7 @@
                   Table    [{table-id :id} {:db_id db-id}]
                   Field    [_ {:table_id table-id}]
                   Field    [_ {:table_id table-id}]]
-    (with-rasta
+    (mt/with-test-user :rasta
       (with-dashboard-cleanup
         (count (candidate-tables (Database db-id)))))))
 
@@ -348,26 +349,34 @@
                   Table    [{table-id :id} {:db_id db-id}]
                   Field    [_ {:table_id table-id}]
                   Field    [_ {:table_id table-id}]]
-    (with-rasta
+    (mt/with-test-user :rasta
       (with-dashboard-cleanup
         (let [database (Database db-id)]
           (db/with-call-counting [call-count]
             (candidate-tables database)
             (call-count)))))))
 
+(deftest empty-table-test
+  (testing "candidate-tables should work with an empty Table (no Fields)"
+    (mt/with-temp* [Database [db]
+                    Table    [_ {:db_id (:id db)}]]
+      (mt/with-test-user :rasta
+        (is (= []
+               (candidate-tables db)))))))
+
 (expect
-  {:list-like?  true
-   :link-table? false
-   :num-fields 2}
-  (tt/with-temp* [Database [{db-id :id}]
-                  Table    [{table-id :id} {:db_id db-id}]
-                  Field    [_ {:table_id table-id :special_type :type/PK}]
-                  Field    [_ {:table_id table-id}]]
-    (with-rasta
-      (with-dashboard-cleanup
-        (-> (#'magic/enhance-table-stats [(Table table-id)])
-            first
-            :stats)))))
+ {:list-like?  true
+  :link-table? false
+  :num-fields 2}
+ (tt/with-temp* [Database [{db-id :id}]
+                 Table    [{table-id :id} {:db_id db-id}]
+                 Field    [_ {:table_id table-id :special_type :type/PK}]
+                 Field    [_ {:table_id table-id}]]
+   (mt/with-test-user :rasta
+     (with-dashboard-cleanup
+       (-> (#'magic/enhance-table-stats [(Table table-id)])
+           first
+           :stats)))))
 
 (expect
   {:list-like?  false
@@ -378,7 +387,7 @@
                   Field    [_ {:table_id table-id :special_type :type/PK}]
                   Field    [_ {:table_id table-id :special_type :type/FK}]
                   Field    [_ {:table_id table-id :special_type :type/FK}]]
-    (with-rasta
+    (mt/with-test-user :rasta
       (with-dashboard-cleanup
         (-> (#'magic/enhance-table-stats [(Table table-id)])
             first

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -26,7 +26,7 @@
 (defn- do-with-rasta
   "Call `f` with Rasta as the current user."
   [f]
-  (users/with-test-user :rasta
+  (mt/with-test-user :rasta
     (f)))
 
 (defn- check-perms-for-rasta
@@ -35,7 +35,7 @@
   [query]
   (do-with-rasta (fn [] (check-perms query))))
 
-(def perms-error-msg #"^You do not have permissions to run this query\.")
+(def ^:private perms-error-msg #"^You do not have permissions to run this query\.")
 
 (deftest native-query-perms-test
   (testing "Make sure the NATIVE query fails to run if current user doesn't have perms"

--- a/test/metabase/test/automagic_dashboards.clj
+++ b/test/metabase/test/automagic_dashboards.clj
@@ -1,23 +1,11 @@
 (ns metabase.test.automagic-dashboards
   "Helper functions and macros for writing tests for automagic dashboards."
-  (:require [metabase.api.common :as api]
-            [metabase.mbql
+  (:require [metabase.mbql
              [normalize :as normalize]
              [schema :as mbql.s]]
-            [metabase.models.user :as user]
             [metabase.test.data.users :as test-users]
             [metabase.test.util :as tu]
             [schema.core :as s]))
-
-(defmacro with-rasta
-  "Execute body with rasta as the current user."
-  [& body]
-  `(binding [api/*current-user-id*              (test-users/user->id :rasta)
-             api/*current-user-permissions-set* (-> :rasta
-                                                    test-users/user->id
-                                                    user/permissions-set
-                                                    atom)]
-     ~@body))
 
 (defmacro with-dashboard-cleanup
   "Execute body and cleanup all dashboard elements created."


### PR DESCRIPTION
Previously, `GET /api/automagic-dashboards/database/:id/candidates` failed with a 500 response for Tables that contained no Fields with an error similar to the one below:

```json
{
  "message": "Syntax error in SQL statement \"SELECT \"\"TABLE_ID\"\", COUNT(*) AS \"\"COUNT\"\" FROM \"\"METABASE_FIELD\"\" WHERE ((\"\"TABLE_ID\"\" IN NULL[*]) AND \"\"ACTIVE\"\" = TRUE AND (\"\"SPECIAL_TYPE\"\" IN (?, ?))) GROUP BY \"\"TABLE_ID\"\" \"; expected \"(\"; SQL statement:\nSELECT \"TABLE_ID\", count(*) AS \"COUNT\" FROM \"METABASE_FIELD\" WHERE ((\"TABLE_ID\" in NULL) AND \"ACTIVE\" = TRUE AND (\"SPECIAL_TYPE\" in (?, ?))) GROUP BY \"TABLE_ID\" [42001-197]",
  "type": "class org.h2.jdbc.JdbcSQLException",
  "stacktrace": [
    "org.h2.message.DbException.getJdbcSQLException(DbException.java:357)",
    "org.h2.message.DbException.getSyntaxError(DbException.java:217)",
    "org.h2.command.Parser.getSyntaxError(Parser.java:555)",
    "org.h2.command.Parser.read(Parser.java:3518)",
    "org.h2.command.Parser.readCondition(Parser.java:2433)",
    "org.h2.command.Parser.readAnd(Parser.java:2342)",
    "org.h2.command.Parser.readExpression(Parser.java:2334)",
    "org.h2.command.Parser.readTerm(Parser.java:3252)",
    "org.h2.command.Parser.readFactor(Parser.java:2587)",
    "org.h2.command.Parser.readSum(Parser.java:2574)",
    "org.h2.command.Parser.readConcat(Parser.java:2544)",
    "org.h2.command.Parser.readCondition(Parser.java:2370)",
    "org.h2.command.Parser.readAnd(Parser.java:2342)",
    "org.h2.command.Parser.readExpression(Parser.java:2334)",
    "org.h2.command.Parser.readTerm(Parser.java:3252)",
    "org.h2.command.Parser.readFactor(Parser.java:2587)",
    "org.h2.command.Parser.readSum(Parser.java:2574)",
    "org.h2.command.Parser.readConcat(Parser.java:2544)",
    "org.h2.command.Parser.readCondition(Parser.java:2370)",
    "org.h2.command.Parser.readAnd(Parser.java:2342)",
    "org.h2.command.Parser.readExpression(Parser.java:2334)",
    "org.h2.command.Parser.parseSelectSimple(Parser.java:2291)",
    "org.h2.command.Parser.parseSelectSub(Parser.java:2133)",
    "org.h2.command.Parser.parseSelectUnion(Parser.java:1946)",
    "org.h2.command.Parser.parseSelect(Parser.java:1919)",
    "org.h2.command.Parser.parsePrepared(Parser.java:463)",
    "org.h2.command.Parser.parse(Parser.java:335)",
    "org.h2.command.Parser.parse(Parser.java:311)",
    "org.h2.command.Parser.prepareCommand(Parser.java:278)",
    "org.h2.engine.Session.prepareLocal(Session.java:611)",
    "org.h2.engine.Session.prepareCommand(Session.java:549)",
    "org.h2.jdbc.JdbcConnection.prepareCommand(JdbcConnection.java:1247)",
    "org.h2.jdbc.JdbcPreparedStatement.<init>(JdbcPreparedStatement.java:76)",
    "org.h2.jdbc.JdbcConnection.prepareStatement(JdbcConnection.java:304)",
    "com.mchange.v2.c3p0.impl.NewProxyConnection.prepareStatement(NewProxyConnection.java:387)",
    "clojure.java.jdbc$prepare_statement.invokeStatic(jdbc.clj:672)",
    "clojure.java.jdbc$prepare_statement.invoke(jdbc.clj:619)",
    "clojure.java.jdbc$db_query_with_resultset_STAR_.invokeStatic(jdbc.clj:1094)",
    "clojure.java.jdbc$db_query_with_resultset_STAR_.invoke(jdbc.clj:1075)",
    "clojure.java.jdbc$query.invokeStatic(jdbc.clj:1164)",
    "clojure.java.jdbc$query.invoke(jdbc.clj:1126)",
    "toucan.db$query.invokeStatic(db.clj:285)",
    "toucan.db$query.doInvoke(db.clj:281)",
    "clojure.lang.RestFn.invoke(RestFn.java:410)",
    "--> automagic_dashboards.core$enhance_table_stats.invokeStatic(core.clj:1243)",
    "automagic_dashboards.core$enhance_table_stats.invoke(core.clj:1220)",
    "automagic_dashboards.core$candidate_tables.invokeStatic(core.clj:1282)",
    "automagic_dashboards.core$candidate_tables.invoke(core.clj:1262)",
    "automagic_dashboards.core$candidate_tables.invokeStatic(core.clj:1272)",
    "automagic_dashboards.core$candidate_tables.invoke(core.clj:1262)",
    "api.automagic_dashboards$fn__60721.invokeStatic(automagic_dashboards.clj:63)",
    "api.automagic_dashboards$fn__60721.invoke(automagic_dashboards.clj:60)",
    "middleware.auth$enforce_authentication$fn__54955.invoke(auth.clj:14)",
    "routes$fn__73494$fn__73495.doInvoke(routes.clj:60)",
    "middleware.exceptions$catch_uncaught_exceptions$fn__72026.invoke(exceptions.clj:97)",
    "middleware.exceptions$catch_api_exceptions$fn__72023.invoke(exceptions.clj:85)",
    "middleware.log$log_api_call$fn__73917$fn__73918.invoke(log.clj:188)",
    "middleware.log$log_api_call$fn__73917.invoke(log.clj:182)",
    "middleware.security$add_security_headers$fn__71989.invoke(security.clj:143)",
    "middleware.json$wrap_json_body$fn__73575.invoke(json.clj:64)",
    "middleware.json$wrap_streamed_json_response$fn__73593.invoke(json.clj:100)",
    "middleware.misc$maybe_set_site_url$fn__57850.invoke(misc.clj:59)",
    "middleware.session$bind_current_user$fn__58107$fn__58108.invoke(session.clj:304)",
    "middleware.session$do_with_current_user.invokeStatic(session.clj:279)",
    "middleware.session$do_with_current_user.invoke(session.clj:272)",
    "middleware.session$bind_current_user$fn__58107.invoke(session.clj:303)",
    "middleware.session$wrap_current_user_id$fn__58092.invoke(session.clj:252)",
    "middleware.session$wrap_session_id$fn__58024.invoke(session.clj:170)",
    "middleware.auth$wrap_api_key$fn__54963.invoke(auth.clj:27)",
    "middleware.misc$bind_user_locale$fn__57855.invoke(misc.clj:78)",
    "middleware.misc$add_content_type$fn__57836.invoke(misc.clj:29)",
    "middleware.misc$disable_streaming_buffering$fn__57864.invoke(misc.clj:94)",
    "middleware.misc$bind_request$fn__57867.invoke(misc.clj:111)"
  ],
  "sql-exception-chain": [
    "JdbcSQLException:",
    "Message: Syntax error in SQL statement \"SELECT \"\"TABLE_ID\"\", COUNT(*) AS \"\"COUNT\"\" FROM \"\"METABASE_FIELD\"\" WHERE ((\"\"TABLE_ID\"\" IN NULL[*]) AND \"\"ACTIVE\"\" = TRUE AND (\"\"SPECIAL_TYPE\"\" IN (?, ?))) GROUP BY \"\"TABLE_ID\"\" \"; expected \"(\"; SQL statement:",
    "SELECT \"TABLE_ID\", count(*) AS \"COUNT\" FROM \"METABASE_FIELD\" WHERE ((\"TABLE_ID\" in NULL) AND \"ACTIVE\" = TRUE AND (\"SPECIAL_TYPE\" in (?, ?))) GROUP BY \"TABLE_ID\" [42001-197]",
    "SQLState: 42001",
    "Error Code: 42001"
  ]
}
```

This PR adds a test for this condition and handles it correctly.