### PR TITLE
Add new env vars

### DIFF
--- a/src/metabase/async/streaming_response/thread_pool.clj
+++ b/src/metabase/async/streaming_response/thread_pool.clj
@@ -4,7 +4,9 @@
            org.apache.commons.lang3.concurrent.BasicThreadFactory$Builder))
 
 (def ^:private ^Long thread-pool-max-size
-  (or (config/config-int :mb-jetty-maxthreads) 50))
+  (or (config/config-int :mb-async-query-thread-pool-size)
+      (config/config-int :mb-jetty-maxthreads)
+      50))
 
 (defonce ^:private thread-pool*
   (delay

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -240,7 +240,12 @@
   we use separate options for data warehouse DBs. See
   https://www.mchange.com/projects/c3p0/#configuring_connection_testing for an overview of the options used
   below (jump to the 'Simple advice on Connection testing' section.)"
-  {"idleConnectionTestPeriod" 60})
+  (merge
+   {"idleConnectionTestPeriod" 60}
+   ;; only merge in `max-pool-size` if it's actually set, this way it doesn't override any things that may have been
+   ;; set in `c3p0.properties`
+   (when-let [max-pool-size (config/config-int :mb-application-db-max-connection-pool-size)]
+     {"maxPoolSize" max-pool-size})))
 
 (defn- create-connection-pool! [jdbc-spec]
   (db/set-default-quoting-style! (case (db-type)

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -4,6 +4,7 @@
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.tools.logging :as log]
             [metabase
+             [config :as config]
              [connection-pool :as connection-pool]
              [driver :as driver]
              [util :as u]]
@@ -44,14 +45,15 @@
 
 (defmethod data-warehouse-connection-pool-properties :default
   [_]
-  {;; only fetch one new connection at a time, rather than batching fetches (default = 3 at a time). This is done in
+  { ;; only fetch one new connection at a time, rather than batching fetches (default = 3 at a time). This is done in
    ;; interest of minimizing memory consumption
    "acquireIncrement"             1
    ;; [From dox] Seconds a Connection can remain pooled but unused before being discarded.
    "maxIdleTime"                  (* 3 60 60) ; 3 hours
    "minPoolSize"                  1
    "initialPoolSize"              1
-   "maxPoolSize"                  15
+   "maxPoolSize"                  (or (config/config-int :mb-jdbc-data-warehouse-max-connection-pool-size)
+                                      15)
    ;; [From dox] If true, an operation will be performed at every connection checkout to verify that the connection is
    ;; valid. [...] ;; Testing Connections in checkout is the simplest and most reliable form of Connection testing,
    ;; but for better performance, consider verifying connections periodically using `idleConnectionTestPeriod`. [...]


### PR DESCRIPTION
*  `MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE` or `java -Dmb.application.db.max.connection.pool.size`

   Previously the only way to configure this was with a custom `c3p0.properties` file. This env var is added to make configuration in the most common cases a little easier

*  `MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE` or `java -Dmb.jdbc.data.warehouse.max.connection.pool.size`

   AFAIK this was not actually configurable in recent releases.

*  `MB_ASYNC_QUERY_THREAD_POOL_SIZE` or `java -Dmb.async.query.thread.pool.size`

   The size of the threadpool that handles query API requests asynchronously. By default this uses the same thread pool size as the Jetty thread pool size but I added this if you wanted to configure this to something different now you can do so.