### PR TITLE
Fix extracting :minute-of-hour and :hour-of-day from BigQuery TIME

### DIFF
--- a/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
@@ -300,9 +300,6 @@
 
 (defn- extract [unit expr]
   (condp = (temporal-type expr)
-    :datetime
-    (recur unit (->temporal-type :timestamp expr))
-
     :time
     (do
       (assert (valid-time-extract-units unit)
@@ -322,7 +319,10 @@
       (assert (or (valid-date-extract-units unit)
                   (valid-time-extract-units unit))
               (tru "Cannot extract {0} from a DATETIME or TIMESTAMP" unit))
-      (with-temporal-type (hsql/call :extract unit expr) nil))))
+      (with-temporal-type (hsql/call :extract unit expr) nil))
+
+    ;; for datetimes or anything without a known temporal type, cast to timestamp and go from there
+    (recur unit (->temporal-type :timestamp expr))))
 
 (defmethod sql.qp/date [:bigquery :minute]          [_ _ expr] (trunc   :minute    expr))
 (defmethod sql.qp/date [:bigquery :minute-of-hour]  [_ _ expr] (extract :minute    expr))

--- a/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery/query_processor.clj
@@ -170,7 +170,7 @@
       [:field-id id]               (temporal-type (qp.store/field id))
       [:field-literal _ base-type] (base-type->temporal-type base-type))))
 
-(defn- with-temporal-type [x new-type]
+(defn- with-temporal-type {:style/indent 0} [x new-type]
   (if (= (temporal-type x) new-type)
     x
     (vary-meta x assoc :bigquery/temporal-type new-type)))
@@ -292,8 +292,37 @@
   [unit hsql-form]
   (TruncForm. hsql-form unit))
 
+(def ^:private valid-date-extract-units
+  #{:dayofweek :day :dayofyear :week :isoweek :month :quarter :year :isoyear})
+
+(def ^:private valid-time-extract-units
+  #{:microsecond :millisecond :second :minute :hour})
+
 (defn- extract [unit expr]
-  (with-temporal-type (hsql/call :extract unit (->temporal-type :timestamp expr)) nil))
+  (condp = (temporal-type expr)
+    :datetime
+    (recur unit (->temporal-type :timestamp expr))
+
+    :time
+    (do
+      (assert (valid-time-extract-units unit)
+              (tru "Cannot extract {0} from a TIME field" unit))
+      (recur unit (with-temporal-type (hsql/call :timestamp (hsql/call :datetime "1970-01-01" expr))
+                                      :timestamp)))
+
+    ;; timestamp and date both support extract()
+    :date
+    (do
+      (assert (valid-date-extract-units unit)
+              (tru "Cannot extract {0} from a DATE field" unit))
+      (with-temporal-type (hsql/call :extract unit expr) nil))
+
+    :timestamp
+    (do
+      (assert (or (valid-date-extract-units unit)
+                  (valid-time-extract-units unit))
+              (tru "Cannot extract {0} from a DATETIME or TIMESTAMP" unit))
+      (with-temporal-type (hsql/call :extract unit expr) nil))))
 
 (defmethod sql.qp/date [:bigquery :minute]          [_ _ expr] (trunc   :minute    expr))
 (defmethod sql.qp/date [:bigquery :minute-of-hour]  [_ _ expr] (extract :minute    expr))

--- a/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
+++ b/modules/drivers/bigquery/test/metabase/driver/bigquery/query_processor_test.clj
@@ -301,14 +301,17 @@
                                            (#'bigquery.qp/temporal-type filter-value))
                             (is (= expected-clause
                                    (sql.qp/->honeysql :bigquery filter-clause))))))))))))
+
           (testing "\ndate extraction filters"
             (doseq [[temporal-type field] fields
                     :let                  [identifier          (hx/identifier :field "ABC" (name temporal-type))
-                                           expected-identifier (if (= temporal-type :timestamp)
-                                                                 identifier
-                                                                 (hx/cast :timestamp identifier))]]
-              (is (= [:= (hsql/call :extract :dayofweek expected-identifier) 1]
-                     (sql.qp/->honeysql :bigquery [:= [:datetime-field [:field-id (:id field)] :day-of-week] 1]))))))))))
+                                           expected-identifier (case temporal-type
+                                                                 :date      identifier
+                                                                 :datetime  (hx/cast :timestamp identifier)
+                                                                 :timestamp identifier)]]
+              (testing (format "\ntemporal-type = %s" temporal-type)
+                (is (= [:= (hsql/call :extract :dayofweek expected-identifier) 1]
+                       (sql.qp/->honeysql :bigquery [:= [:datetime-field [:field-id (:id field)] :day-of-week] 1])))))))))))
 
 (deftest reconcile-relative-datetimes-test
   (testing "relative-datetime clauses on their own"
@@ -555,23 +558,49 @@
                                                                         [:datetime-field [:field-id (:id f)] unit]
                                                                         [:relative-datetime -1 unit]])}))))))))))
 
+(def ^:private filter-test-table
+  [[nil          :minute :hour :day  :week :month :quarter :year]
+   [:time        true    true  false false false  false    false]
+   [:datetime    true    true  true  true  true   true     true]
+   [:date        false   false true  true  true   true     true]
+   [:datetime_tz true    true  true  true  true   true     true]])
+
+(defn- test-table-with-fn [table f]
+  (let [units (rest (first table))]
+    (dorun (pmap (fn [[field & vs]]
+                   (testing (format "\nfield = %s" field)
+                     (dorun (pmap (fn [[unit expected]]
+                                    (testing (format "\nunit = %s" unit)
+                                      (is (= expected
+                                             (f field unit)))))
+                                  (zipmap units vs)))))
+                 (rest table)))))
+
 (deftest filter-by-relative-date-ranges-e2e-test
   (mt/test-driver :bigquery
     (testing (str "Make sure filtering against relative date ranges works correctly regardless of underlying column "
                   "type (#11725)")
       (mt/dataset attempted-murders
-        (is (= [[nil          :minute :hour :day  :week :month :quarter :year]
-                [:time        true    true  false false false  false    false]
-                [:datetime    true    true  true  true  true   true     true]
-                [:date        false   false true  true  true   true     true]
-                [:datetime_tz true    true  true  true  true   true     true]]
-               (let [units  [:minute :hour :day :week :month :quarter :year]
-                     fields [:time :datetime :date :datetime_tz]]
+        (test-table-with-fn filter-test-table can-we-filter-against-relative-datetime?)))))
 
-                 (into
-                  [(into [nil] units)]
-                  (pmap
-                   (fn [field]
-                     (into [field] (pmap (partial can-we-filter-against-relative-datetime? field)
-                                         units)))
-                   fields)))))))))
+(def ^:private breakout-test-table
+  [[nil          :default :minute :hour :day  :week :month :quarter :year :minute-of-hour :hour-of-day :day-of-week :day-of-month :day-of-year :week-of-year :month-of-year :quarter-of-year]
+   [:time        true     true    true  false false false  false    false true            true         false        false         false        false         false          false]
+   [:datetime    true     true    true  true  true  true   true     true  true            true         true         true          true         true          true           true]
+   [:date        true     false   false true  true  true   true     true  false           false        true         true          true         true          true           true]
+   [:datetime_tz true     true    true  true  true  true   true     true  true            true         true         true          true         true          true           true]])
+
+(defn- can-breakout? [field unit]
+  (try
+    (mt/run-mbql-query attempts
+      {:aggregation [[:count]]
+       :breakout [[:datetime-field (mt/id :attempts field) unit]]})
+    true
+    (catch Throwable _
+      false)))
+
+(deftest breakout-by-bucketed-datetimes-e2e-test
+  (mt/test-driver :bigquery
+    (testing "Make sure datetime breakouts like :minute-of-hour work correctly for different temporal types"
+      (mt/dataset attempted-murders
+        (test-table-with-fn breakout-test-table can-breakout?)))))


### PR DESCRIPTION
I just realized extracting `:minute-of-hour` and `:hour-of-day` from `TIME` columns in BigQuery doesn't work as expected. `extract()` is not directly supported by BigQuery `TIME` columns, but we can work around this by casting the column to a `TIMESTAMP` in order to extract the minutes or hours)