### PR TITLE
cancel running queries in situations we missed

### DIFF
--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -131,6 +131,7 @@ export const POP_STATE = "metabase/qb/POP_STATE";
 export const popState = createThunkAction(
   POP_STATE,
   location => async (dispatch, getState) => {
+    dispatch(cancelQuery());
     const card = getCard(getState());
     if (location.state && location.state.card) {
       if (!Utils.equals(card, location.state.card)) {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -211,6 +211,7 @@ export default class NativeQueryEditor extends Component {
   }
 
   componentWillUnmount() {
+    this.props.cancelQuery();
     document.removeEventListener("keydown", this.handleKeyDown);
   }
 
@@ -233,6 +234,7 @@ export default class NativeQueryEditor extends Component {
   };
 
   runQuery = () => {
+    this.props.cancelQuery();
     const { query, runQuestionQuery } = this.props;
 
     // if any text is selected, just run that


### PR DESCRIPTION
Fixes #11240, Fixes #7849

This cancels running queries in three situations where we previously forgot to cancel:
1. You go back in the QueryBuilder
2. You leave the NativeQueryEditor
3. You rerun a native query with cmd-enter

I manually verified these cases, but I didn't see a good way to add automated tests. Postgres can simulate slow queries `pg_sleep()`. If H2 had a similar function it would make testing cancelation easier.

I only checked that queries canceled on Postgres, there might be other db-specific bugs.