### PR TITLE
Check field filter special type for UNIX timestamp [WIP]

### DIFF
--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -240,7 +240,8 @@
   (:replacement-snippet
    (honeysql->replacement-snippet-info
     driver
-    (let [identifier (sql.qp/->honeysql driver (sql.qp/field->identifier driver field))]
+    (let [identifier (cond->> (sql.qp/->honeysql driver (sql.qp/field->identifier driver field))
+                       (isa? (:special_type field) :type/UNIXTimestamp) (hsql/call :from_unixtime))]
       (if (date-params/date-type? param-type)
         (sql.qp/date driver :day identifier)
         identifier)))))


### PR DESCRIPTION
This is an _incomplete_ fix to #11934. It should be seen of more as a PoC for what's wrong.

The issue is caused by `parse-value-for-field-base-type` not taking fields' special types into account, and assuming that a `Number` field means that the parameter value for it will always be numeric. This doesn't hold in cases such as when UNIX timestamps are stored in integer fields, with the field configured in Metabase (_Data Model_) as timestamps.

The case in #11934 has a date range value (e.g. `2020-03-01~2020-03-31`) interpreted as a number (`2020`), which causes parameter substitution to fail when a string is expected to interpret as the date range. Even with that fixed, the resulting query has the field filter's field rendered in SQL as ```date(`users`.`signup_time`)```, where ```date(from_unixtime(`users`.`signup_time`))``` (`from_unixtime` call added) is necessary. The former doesn't return any results due to [`date` requiring](https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date) a date or datetime input, not an integer.

This fix is incomplete, because it feels slapped on in a way that it could cause issues in other parts of the code. I also suspect that this kind of duality of the nature values will apply to a number of other base/special type combinations.

At this point I think we need some feedback on the approach taken here. I suspect that a better/more general approach is possible.