### PR TITLE
Fix deadlocks!

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -579,8 +579,8 @@
     (let [ttl-seconds (Math/round (float (/ (* average-duration (public-settings/query-caching-ttl-ratio))
                                             1000.0)))]
       (when-not (zero? ttl-seconds)
-        (log/info (format "Question's average execution duration is %d ms; using 'magic' TTL of %d seconds"
-                          average-duration ttl-seconds)
+        (log/info (trs "Question''s average execution duration is {0}; using ''magic'' TTL of {1}"
+                       (u/format-milliseconds average-duration) (u/format-seconds ttl-seconds))
                   (u/emoji "💾"))
         ttl-seconds))))
 

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -20,7 +20,8 @@
             [ring.util.codec :as codec]
             [schema.core :as s]
             [toucan.db :as db])
-  (:import liquibase.exception.LockException))
+  (:import com.mchange.v2.c3p0.PoolBackedDataSource
+           liquibase.exception.LockException))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          DB FILE & CONNECTION DETAILS                                          |
@@ -247,11 +248,19 @@
    (when-let [max-pool-size (config/config-int :mb-application-db-max-connection-pool-size)]
      {"maxPoolSize" max-pool-size})))
 
-(defn- create-connection-pool! [jdbc-spec]
+(defn- create-connection-pool!
+  "Create a connection pool for the application DB and set it as the default Toucan connection. This is normally called
+  once during start up; calling it a second time (e.g. from the REPL) will "
+  [jdbc-spec]
   (db/set-default-quoting-style! (case (db-type)
                                    :postgres :ansi
                                    :h2       :h2
                                    :mysql    :mysql))
+  ;; REPL usage only: kill the old pool if one exists
+  (u/ignore-exceptions
+    (when-let [^PoolBackedDataSource pool (:datasource (db/connection))]
+      (log/trace "Closing old application DB connection pool")
+      (.close pool)))
   (log/debug (trs "Set default db connection with connection pool..."))
   (db/set-default-db-connection! (connection-pool/connection-pool-spec jdbc-spec application-db-connection-pool-props))
   (db/set-default-jdbc-options! {:read-columns db.jdbc-protocols/read-columns})

--- a/src/metabase/query_processor/context/default.clj
+++ b/src/metabase/query_processor/context/default.clj
@@ -78,7 +78,7 @@
 (defn- default-resultf [result context]
   (if (nil? result)
     (do
-      (log/error (ex-info (trs "Unexpected nil result") {}) (trs "Unexpected nil result"))
+      (log/error (ex-info (trs "Unexpected nil result") {}))
       (recur false context))
     (let [out-chan (context/out-chan context)]
       (a/>!! out-chan result)
@@ -87,7 +87,7 @@
 (defn- default-timeoutf
   [context]
   (let [timeout (context/timeout context)]
-    (log/debug (trs "Query timed out after {0} ms, raising timeout exception." timeout))
+    (log/debug (trs "Query timed out after {0}, raising timeout exception." (u/format-milliseconds timeout)))
     (context/raisef (ex-info (tru "Timed out after {0}." (u/format-milliseconds timeout))
                       {:status :timed-out
                        :type   error-type/timed-out})

--- a/src/metabase/query_processor/middleware/cache_backend/interface.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/interface.clj
@@ -21,7 +21,7 @@
       (with-open [is (...)]
         (respond is)))
 
-  `max-age-seconds` may be floating-point.")
+  `max-age-seconds` may be floating-point. This method *must* return the result of `respond`.")
 
   (save-results! [this ^bytes query-hash ^bytes results]
     "Add a cache entry with the `results` of running query with byte array `query-hash`. This should replace any prior
@@ -30,6 +30,18 @@
   (purge-old-entries! [this max-age-seconds]
     "Purge all cache entires older than `max-age-seconds`. Will be called periodically when this backend is in use.
   `max-age-seconds` may be floating-point."))
+
+(defmacro with-cached-results
+  "Macro version for consuming `cached-results` from a `backend`.
+
+    (with-cached-results backend query-hash max-age-seconds [is]
+      ...)
+
+  InputStream `is` will be `nil` if no cached results were available."
+  {:style/indent 4}
+  [backend query-hash max-age-seconds [is-binding] & body]
+  `(cached-results ~backend ~query-hash ~max-age-seconds (fn [~(vary-meta is-binding assoc :tag 'java.io.InputStream)]
+                                                           ~@body)))
 
 (defmulti cache-backend
   "Return an instance of a cache backend, which is any object that implements `QueryProcessorCacheBackend`.

--- a/src/metabase/query_processor/reducible.clj
+++ b/src/metabase/query_processor/reducible.clj
@@ -3,7 +3,8 @@
             [clojure.tools.logging :as log]
             [metabase.async.util :as async.u]
             [metabase.query-processor.context :as context]
-            [metabase.query-processor.context.default :as context.default]))
+            [metabase.query-processor.context.default :as context.default]
+            [metabase.util :as u]))
 
 (defn- wire-up-context-channels!
   "Wire up the core.async channels in a QP `context`."
@@ -17,7 +18,7 @@
     (a/go
       (let [[val port] (a/alts! [out-chan (a/timeout timeout)] :priority true)]
         (log/tracef "Port %s got %s"
-                    (if (= port out-chan) "out-chan" (format "[timeout after %d ms]" timeout))
+                    (if (= port out-chan) "out-chan" (format "[timeout after %s]" (u/format-milliseconds timeout)))
                     val)
         (cond
           (not= port out-chan) (context/timeoutf context)

--- a/test/metabase/query_processor/middleware/cache/impl_test.clj
+++ b/test/metabase/query_processor/middleware/cache/impl_test.clj
@@ -21,12 +21,10 @@
 
   ([^bytes bytea rff]
    (with-open [bis (ByteArrayInputStream. bytea)]
-     (impl/reducible-deserialized-results bis (fn respond
-                                                ([_] nil)
-
-                                                ([metadata rows]
-                                                 (let [rf (rff metadata)]
-                                                   (reduce rf (rf) rows))))))))
+     (impl/with-reducible-deserialized-results [[metadata rows] bis]
+       (when rows
+         (let [rf (rff metadata)]
+           (reduce rf (rf) rows)))))))
 
 (deftest e2e-test
   (let [{:keys [in-chan out-chan]} (impl/serialize-async)]


### PR DESCRIPTION
When streaming cached results from the DB we could run into a situation where the MB instance would deadlock because all application DB connections would be tied up. Resolves the issue by a) reusing the bound connection for other app DB requests that may need to be executed when reducing cached results and b) saving QueryExecutions asynchronously.