### PR TITLE
Popover overflow scrolls rather than hides

### DIFF
--- a/frontend/src/metabase/components/Popover.css
+++ b/frontend/src/metabase/components/Popover.css
@@ -20,7 +20,7 @@
   box-shadow: 0 4px 10px var(--color-shadow);
   background-color: var(--color-bg-white);
   border-radius: 6px;
-  overflow: hidden;
+  overflow: scroll;
 }
 
 /* remove the max-width in cases where the popover content needs to expand


### PR DESCRIPTION
Fixes #12139

The reason I uncommented `overflow: hidden` was to avoid overflowing the popover's border radius. `overflow: scroll` does that too. The default of `overflow: visible` is the only problematic one.