### PR TITLE
Add file.encoding to Diagnostic Info

### DIFF
--- a/src/metabase/troubleshooting.clj
+++ b/src/metabase/troubleshooting.clj
@@ -21,7 +21,8 @@
                                              "os.name"
                                              "os.version"
                                              "user.language"
-                                             "user.timezone"])))
+                                             "user.timezone"
+                                             "file.encoding"])))
 
 (defn metabase-info
   "Make it easy for the user to tell us what they're using"


### PR DESCRIPTION
Get Java `file.encoding` in diagnostic info - to help figure out problems in issues like #11924
There might be other issues, which has been caused by wrong encoding, so think it's worth the add - unless we want/can force Metabase to always use `file.encoding=UTF-8` (without consequences)