### PR TITLE
Avoid passing undefined in for slack channel value

### DIFF
--- a/frontend/src/metabase/pulse/components/PulseEditChannels.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditChannels.jsx
@@ -145,6 +145,10 @@ export default class PulseEditChannels extends Component {
   };
 
   renderFields(channel, index, channelSpec) {
+    const valueForField = field => {
+      const value = channel.details && channel.details[field.name];
+      return value != null ? value : null; // convert undefined to null so Uncontrollable doesn't ignore changes
+    };
     return (
       <div>
         {channelSpec.fields.map(field => (
@@ -153,7 +157,7 @@ export default class PulseEditChannels extends Component {
             {field.type === "select" ? (
               <Select
                 className="h4 text-bold bg-white inline-block"
-                value={channel.details && channel.details[field.name]}
+                value={valueForField(field)}
                 placeholder={t`Pick a user or channel...`}
                 searchProp="name"
                 // Address #5799 where `details` object is missing for some reason


### PR DESCRIPTION
Fixes #12174 

This was the same root cause as #11899. Now that `Select` is `Uncontrollable` passing an undefined value silently breaks `onChange`.

@tlrobinson I'm not sure where we need to use uncontrolled fields. Is there a better way to switch between controlled and uncontrolled than checking value?

---

It'd be nice to have some e2e testing around configuring slack/email pulses, so we can see if they totally break like this. Is it worth stubbing out Slack to list fake channels?

