### PR TITLE
Fix extra popover scrollbars

### DIFF
--- a/frontend/src/metabase/components/Popover.css
+++ b/frontend/src/metabase/components/Popover.css
@@ -20,7 +20,7 @@
   box-shadow: 0 4px 10px var(--color-shadow);
   background-color: var(--color-bg-white);
   border-radius: 6px;
-  overflow: scroll;
+  overflow: auto;
 }
 
 /* remove the max-width in cases where the popover content needs to expand


### PR DESCRIPTION
It looks like #12149 caused some unnecessary scrollbars on small popovers.

Screenshot from @walterl:

![image](https://user-images.githubusercontent.com/691495/77354182-be71e780-6d18-11ea-84f0-1f4674b905d4.png)

Changing `scroll` to `auto` seems to fix that and preserve behavior in the notebook popovers that prompted the original change.
