### PR TITLE
New HTTP request cancellation implementation

### DIFF
--- a/src/metabase/async/streaming_response.clj
+++ b/src/metabase/async/streaming_response.clj
@@ -141,6 +141,8 @@
           status (.read channel buf)]
       (log/tracef "Check cancelation status: .read returned %d" status)
       (neg? status))
+    (catch InterruptedException _
+      false)
     (catch ClosedChannelException _
       true)
     (catch Throwable e

--- a/src/metabase/async/streaming_response.clj
+++ b/src/metabase/async/streaming_response.clj
@@ -4,6 +4,7 @@
             [clojure.tools.logging :as log]
             compojure.response
             [metabase.async.streaming-response.thread-pool :as thread-pool]
+            [metabase.async.util :as async.u]
             [metabase.server.protocols :as server.protocols]
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs]]
@@ -14,7 +15,7 @@
              [servlet :as ring.servlet]])
   (:import [java.io BufferedWriter OutputStream OutputStreamWriter]
            java.nio.ByteBuffer
-           java.nio.channels.SocketChannel
+           [java.nio.channels ClosedChannelException SocketChannel]
            java.nio.charset.StandardCharsets
            java.util.zip.GZIPOutputStream
            javax.servlet.AsyncContext
@@ -140,6 +141,8 @@
           status (.read channel buf)]
       (log/tracef "Check cancelation status: .read returned %d" status)
       (neg? status))
+    (catch ClosedChannelException _
+      true)
     (catch Throwable e
       (log/error e (trs "Error determining whether HTTP request was canceled"))
       false)))

--- a/src/metabase/async/streaming_response.clj
+++ b/src/metabase/async/streaming_response.clj
@@ -13,11 +13,14 @@
              [response :as ring.response]
              [servlet :as ring.servlet]])
   (:import [java.io BufferedWriter OutputStream OutputStreamWriter]
+           java.nio.ByteBuffer
+           java.nio.channels.SocketChannel
            java.nio.charset.StandardCharsets
            java.util.zip.GZIPOutputStream
            javax.servlet.AsyncContext
            javax.servlet.http.HttpServletResponse
-           org.eclipse.jetty.io.EofException))
+           org.eclipse.jetty.io.EofException
+           org.eclipse.jetty.server.Request))
 
 (defn- write-to-output-stream!
   ([^OutputStream os x]
@@ -71,22 +74,24 @@
       (write-error! os e)
       nil)))
 
-(defn- do-f-async [^AsyncContext async-context f ^OutputStream os finished-chan]
+(defn- do-f-async
+  "Runs `f` asynchronously on the streaming response `thread-pool`, returning immediately. When `f` finishes, completes (i.e., closes) Jetty
+  `async-context`."
+  [^AsyncContext async-context f ^OutputStream os finished-chan canceled-chan]
   {:pre [(some? os)]}
-  (let [canceled-chan (a/promise-chan)
-        task          (bound-fn []
-                        (try
-                          (do-f* f os finished-chan canceled-chan)
-                          (catch Throwable e
-                            (log/error e (trs "bound-fn caught unexpected Exception"))
-                            (a/>!! finished-chan :unexpected-error))
-                          (finally
-                            (a/>!! finished-chan (if (a/poll! canceled-chan)
-                                                   :canceled
-                                                   :completed))
-                            (a/close! finished-chan)
-                            (a/close! canceled-chan)
-                            (.complete async-context))))]
+  (let [task (bound-fn []
+               (try
+                 (do-f* f os finished-chan canceled-chan)
+                 (catch Throwable e
+                   (log/error e (trs "bound-fn caught unexpected Exception"))
+                   (a/>!! finished-chan :unexpected-error))
+                 (finally
+                   (a/>!! finished-chan (if (a/poll! canceled-chan)
+                                          :canceled
+                                          :completed))
+                   (a/close! finished-chan)
+                   (a/close! canceled-chan)
+                   (.complete async-context))))]
     (.submit (thread-pool/thread-pool) ^Runnable task)
     nil))
 
@@ -118,27 +123,79 @@
       ([ba offset length]
        (write-to-output-stream! @dlay ba offset length)))))
 
-(defn- respond
-  [{:keys [^HttpServletResponse response ^AsyncContext async-context request-map response-map]}
-   f {:keys [content-type], :as options} finished-chan]
+(def ^:private async-cancellation-poll-interval-ms
+  "How often to check whether the request was canceled by the client."
+  1000)
+
+(defn- canceled?
+  "Check whether the HTTP request has been canceled by the client.
+
+  This function attempts to read a single byte from the underlying TCP socket; if the request is canceled, `.read`
+  will return `-1`. Otherwise, since the entire request has already been read, `.read` *should* probably complete
+  immediately, returning `0`."
+  [^Request request]
   (try
-    (.setStatus response 202)
-    (let [gzip?   (should-gzip-response? request-map)
-          headers (cond-> (assoc (:headers response-map) "Content-Type" content-type)
-                    gzip? (assoc "Content-Encoding" "gzip"))]
-      (#'ring.servlet/set-headers response headers)
-      (let [output-stream-delay (output-stream-delay gzip? response)
-            delay-os            (delay-output-stream output-stream-delay)]
-        (do-f-async async-context f delay-os finished-chan)))
+    (let [^SocketChannel channel (.. request getHttpChannel getEndPoint getTransport)
+          buf    (ByteBuffer/allocate 1)
+          status (.read channel buf)]
+      (log/tracef "Check cancelation status: .read returned %d" status)
+      (neg? status))
     (catch Throwable e
-      (log/error e (trs "Unexpected exception in do-f-async"))
-      (try
-        (.sendError response 500 (.getMessage e))
-        (catch Throwable e
-          (log/error e (trs "Unexpected exception writing error response"))))
-      (a/>!! finished-chan :unexpected-error)
-      (a/close! finished-chan)
-      (.complete async-context))))
+      (log/error e (trs "Error determining whether HTTP request was canceled"))
+      false)))
+
+(def ^:private async-cancellation-poll-timeout-ms
+  "How long to wait for the cancelation check to complete (it should usually complete immediately -- see above -- but if
+  it doesn't, we don't want to block forever)."
+  1000)
+
+(defn- start-async-cancel-loop!
+  "Starts an async loop that checks whether the client has canceled HTTP `request` at some interval. If the client has
+  canceled the request, this sends a message to `canceled-chan`."
+  [request finished-chan canceled-chan]
+  (a/go-loop []
+    (let [poll-timeout-chan (a/timeout async-cancellation-poll-interval-ms)
+          [_ port]          (a/alts! [poll-timeout-chan finished-chan])]
+      (when (= port poll-timeout-chan)
+        (log/tracef "Checking cancelation status after waiting %s")
+        (let [canceled-status-chan (async.u/cancelable-thread (canceled? request))
+              status-timeout-chan  (a/timeout async-cancellation-poll-timeout-ms)
+              [canceled? port]     (a/alts! [finished-chan canceled-status-chan status-timeout-chan])]
+          ;; if `canceled-status-chan` *wasn't* the first channel to return (i.e., we either timed out or the request
+          ;; was completed) then close `canceled-status-chan` which will kill the underlying thread
+          (a/close! canceled-status-chan)
+          (when (= port status-timeout-chan)
+            (log/debug (trs "Check cancelation status timed out after {0}"
+                            (u/format-milliseconds async-cancellation-poll-timeout-ms))))
+          (when (not= port finished-chan)
+            (if canceled?
+              (a/>! canceled-chan ::request-canceled)
+              (recur))))))))
+
+(defn- respond
+  [{:keys [^HttpServletResponse response ^AsyncContext async-context request-map response-map request]}
+   f {:keys [content-type], :as options} finished-chan]
+  (let [canceled-chan (a/promise-chan)]
+    (try
+      (.setStatus response 202)
+      (let [gzip?   (should-gzip-response? request-map)
+            headers (cond-> (assoc (:headers response-map) "Content-Type" content-type)
+                      gzip? (assoc "Content-Encoding" "gzip"))]
+        (#'ring.servlet/set-headers response headers)
+        (let [output-stream-delay (output-stream-delay gzip? response)
+              delay-os            (delay-output-stream output-stream-delay)]
+          (start-async-cancel-loop! request finished-chan canceled-chan)
+          (do-f-async async-context f delay-os finished-chan canceled-chan)))
+      (catch Throwable e
+        (log/error e (trs "Unexpected exception in do-f-async"))
+        (try
+          (.sendError response 500 (.getMessage e))
+          (catch Throwable e
+            (log/error e (trs "Unexpected exception writing error response"))))
+        (a/>!! finished-chan :unexpected-error)
+        (a/close! finished-chan)
+        (a/close! canceled-chan)
+        (.complete async-context)))))
 
 (declare render)
 
@@ -159,7 +216,13 @@
   ;; async responses only
   compojure.response/Sendable
   (send* [this request respond* _]
-    (respond* (compojure.response/render this request))))
+    (respond* (compojure.response/render this request)))
+
+  ;; TODO -- if we want this to work when running via `lein ring server` we need to add an impl for
+  ;; `ring.core.protocols/StreamableResponseBody`. Not sure if we want to do that because it would result in different
+  ;; behavior when running via `lein ring server` vs `lein run`/uberjar. Maybe better just to take `lein ring server`
+  ;; out and replace it with an auto-reload version of `lein run`
+  )
 
 ;; TODO -- don't think any of this is needed any mo
 (defn- render [^StreamingResponse streaming-response gzip?]
@@ -185,7 +248,7 @@
   (->StreamingResponse f options (a/promise-chan)))
 
 (defmacro streaming-response
-  "Return an streaming response that writes keepalive newline bytes.
+  "Create an API response that streams results to an `OutputStream`.
 
   Minimal example:
 
@@ -198,9 +261,7 @@
   Current options:
 
   *  `:content-type` -- string content type to return in the results. This is required!
-  *  `:headers` -- other headers to include in the API response.
-  *  `:write-keepalive-newlines?` -- whether we should write keepalive newlines every `keepalive-interval-ms`. Default
-      `true`; you can disable this for formats where it wouldn't work, such as CSV."
+  *  `:headers` -- other headers to include in the API response."
   {:style/indent 2, :arglists '([options [os-binding canceled-chan-binding] & body])}
   [options [os-binding canceled-chan-binding :as bindings] & body]
   {:pre [(= (count bindings) 2)]}

--- a/test/metabase/async/util_test.clj
+++ b/test/metabase/async/util_test.clj
@@ -64,26 +64,25 @@
       (is (= ::value
              (first (a/alts!! [out-chan-2 (a/timeout 1000)])))))))
 
-(deftest do-on-separate-thread-test
-  (testing "Make sure `do-on-separate-thread` can actually run a function correctly"
-    (tu.async/with-open-channels [result-chan (async.u/do-on-separate-thread (fn []
-                                                                               (Thread/sleep 100)
-                                                                               ::success))]
+(deftest cancelable-thread-test
+  (testing "Make sure `cancelable-thread` can actually run a function correctly"
+    (tu.async/with-open-channels [result-chan (async.u/cancelable-thread
+                                                (Thread/sleep 10)
+                                                ::success)]
       (is (= ::success
              (first (a/alts!! [result-chan (a/timeout 500)]))))))
 
-  (testing (str "when you close the result channel of `do-on-separate-thread,` it should cancel the future that's "
-                "running it. This will produce an InterruptedException")
+  (testing (str "when you close the result channel of `cancelable-thread`, it should cancel the future that's running "
+                "it. This will produce an InterruptedException")
     (tu.async/with-open-channels [started-chan  (a/chan 1)
                                   finished-chan (a/chan 1)]
-      (let [f           (fn []
+      (let [result-chan (async.u/cancelable-thread
                           (try
                             (a/>!! started-chan ::started)
                             (Thread/sleep 5000)
                             (a/>!! finished-chan ::finished)
                             (catch Throwable e
-                              (a/>!! finished-chan e))))
-            result-chan (async.u/do-on-separate-thread f)]
+                              (a/>!! finished-chan e))))]
         ;; wait for `f` to actually start running before we kill it. Otherwise it may not get started at all
         (a/go
           (a/alts!! [started-chan (a/timeout 1000)])
@@ -92,11 +91,11 @@
              InterruptedException
              (first (a/alts!! [finished-chan (a/timeout 1000)])))))))
 
-  (testing "We should be able to combine the `promise-pipe` and `do-on-separate-thread` and get results"
+  (testing "We should be able to combine the `promise-pipe` and `cancelable-thread` and get results"
     (letfn [(f []
-              (Thread/sleep 100)
+              (Thread/sleep 10)
               ::success)]
       (tu.async/with-open-channels [result-chan (a/promise-chan)]
-        (async.u/promise-pipe (async.u/do-on-separate-thread f) result-chan)
+        (async.u/promise-pipe (async.u/cancelable-thread-call f) result-chan)
         (is (= ::success
                (first (a/alts!! [result-chan (a/timeout 500)]))))))))


### PR DESCRIPTION
Only applies to streaming responses (i.e., results of query requests).

Start an async loop that checks every second whether the client has closed their end of the TCP connection (this is done by getting the underlying TCP [SocketChannel](https://docs.oracle.com/javase/8/docs/api/java/nio/channels/SocketChannel.html) and attempting to `.read()` a byte from the socket. `.read()` returns the number of bytes it was able to read -- since this is NIO it returns immediately -- `0` (because we've already read the full request) if the connection is still open or `-1` if closed. So if we get `-1` we know the query can be canceled.