### PR TITLE
Docs: Environment variables

### DIFF
--- a/docs/operations-guide/environment-variables.md
+++ b/docs/operations-guide/environment-variables.md
@@ -5,15 +5,20 @@ Many settings in Metabase can viewed and modified in the Admin Panel, or set via
 Setting environment variables can be done in various ways depending on how Metabase is being run.
 
 JAR (Note that on Windows, use `set` instead of `export`):
+
 ```
 export MB_SITE_NAME="Awesome Company"
 java -jar metabase.jar
 ```
+
 JAR alternative (declared with `-D` prepending the variable):
+
 ```
 java -DMB_SITE_NAME="Awesome Company" -jar metabase.jar
 ```
+
 Docker:
+
 ```
 docker run -d -p 3000:3000 -e 'MB_SITE_NAME=Awesome Company' --name metabase metabase/metabase
 ```
@@ -543,14 +548,14 @@ Search base for users. (Will be searched recursively)
 #### `MB_LDAP_USER_FILTER`
 
 Type: string<br>
-Default: ```"(&(objectClass=inetOrgPerson)(|(uid={login})(mail={login})))"```
+Default: `"(&(objectClass=inetOrgPerson)(|(uid={login})(mail={login})))"`
 
 User lookup filter, the placeholder `{login}` will be replaced by the user supplied login.
 
 #### `MB_MAP_TILE_SERVER_URL`
 
 Type: string<br>
-Default: ```"http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"```
+Default: `"http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"`
 
 The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox.
 
@@ -727,4 +732,3 @@ Type: string<br>
 Default: `"http://static.metabase.com/version-info.json"`
 
 The address used to check for newer versions of Metabase.
-

--- a/docs/operations-guide/environment-variables.md
+++ b/docs/operations-guide/environment-variables.md
@@ -1,6 +1,6 @@
 # Environment variables
 
-Many settings in Metabase can viewed and modified in the Admin Panel, or set via environment variables. The environment variables always take precedence.
+Many settings in Metabase can be viewed and modified in the Admin Panel, or set via environment variables. The environment variables always take precedence.
 
 Setting environment variables can be done in various ways depending on how Metabase is being run.
 
@@ -30,7 +30,7 @@ docker run -d -p 3000:3000 -e 'MB_SITE_NAME=Awesome Company' --name metabase met
 Type: integer<br>
 Default: `20160`
 
-Session expiration, defined in seconds (default is 2 weeks), which will logout users after the defined period and require re-authentication.
+Session expiration, defined in seconds (default is 2 weeks), which will log out users after the defined period and require re-authentication.
 
 Note: This setting is not an idle/inactivity timeout. If you set this to 15 minutes, your users have to login (or re-authenticate) again every 15 minutes.
 
@@ -55,7 +55,7 @@ Enable the collection of anonymous usage data in order to help Metabase improve.
 Type: string<br>
 Default: `null`
 
-Middleware that enforces validation of the client via the request header `X-Metabase-Apikey`. If the header is available, then it’s validated against `MB_API_KEY`. When it matches, the request continues otherwise it’s blocked with a 403 Forbidden response.
+Middleware that enforces validation of the client via the request header `X-Metabase-Apikey`. If the header is available, then it’s validated against `MB_API_KEY`. When it matches, the request continues; otherwise it’s blocked with a 403 Forbidden response.
 
 #### `MB_APPLICATION_COLORS`
 
@@ -73,11 +73,11 @@ Since: 0.35.0
 
 Maximum number of connections to the Metabase application database.
 
-Change this to a higher value, if you notice that regular usage consumes close to or all connections. When all connections are in use, then Metabase might feel slow or unresponsive, when clicking around in the interface.
+Change this to a higher value if you notice that regular usage consumes all or close to all connections. When all connections are in use, Metabase might feel slow or unresponsive when clicking around the interface.
 
-Check the Metabase log, look for lines that contains the following `… App DB connections: 12/15 …`, where that example would indicate you’re using 12 out of 15 available connections.
+To see how many connections are being used, check the Metabase logs and look for lines that contains the following: `… App DB connections: 12/15 …`. In this example, 12 out of 15 available connections are being used.
 
-See [MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE](#MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE) for setting maximum connections to the databases setup in Metabase.
+See [MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE](#MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE) for setting maximum connections to the databases connected to Metabase.
 
 #### `MB_APPLICATION_FAVICON_URL`
 
@@ -144,14 +144,14 @@ Used to recognize the Mac App client, which then defaults to `"OSX"`.
 Type: boolean<br>
 Default: `true`
 
-Color log lines. When set to `false` it will disable log line colors. This is disabled on Windows. Related to [MB_EMOJI_IN_LOGS](#MB_EMOJI_IN_LOGS)
+Color log lines. When set to `false` it will disable log line colors. This is disabled on Windows. Related to [MB_EMOJI_IN_LOGS](#MB_EMOJI_IN_LOGS).
 
 #### `MB_CUSTOM_FORMATTING`
 
 Type: string<br>
 Default: `"{}"`
 
-JSON object keyed by type, containing formatting settings
+JSON object keyed by type, containing formatting settings.
 
 #### `MB_CUSTOM_GEOJSON`
 
@@ -165,7 +165,7 @@ JSON object containing information about custom GeoJSON files for use in map vis
 Type: boolean<br>
 Default: `true`
 
-When set to `false`, Metabase will print migrations needed to done in the application database and exit. Those migrations needs to applied manually. When `true`, Metabase will automatically make changes to the application database. This is not related to migrating away from H2.
+When set to `false`, Metabase will print migrations needed to be done in the application database and exit. Those migrations need to be applied manually. When `true`, Metabase will automatically make changes to the application database. This is not related to migrating away from H2.
 
 #### `MB_DB_CONNECTION_TIMEOUT_MS`
 
@@ -179,7 +179,7 @@ Timeout in milliseconds for connecting to the application database.
 Type: string<br>
 Default: `null`
 
-A JDBC style connection URI that can be used instead of most of `MB_DB_*` like [MB_DB_HOST](#MB_DB_HOST). Also used, when certain Connection String parameters are required for the connection. The connection type requirement is the same as [MB_DB_TYPE](#MB_DB_TYPE).
+A JDBC-style connection URI that can be used instead of most of `MB_DB_*` like [MB_DB_HOST](#MB_DB_HOST). Also used when certain Connection String parameters are required for the connection. The connection type requirement is the same as [MB_DB_TYPE](#MB_DB_TYPE).
 
 Example: `postgres://dbuser:dbpassword@db.example.com:port/mydb?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactorydbpassword@db.example.com`
 
@@ -197,7 +197,7 @@ Default: `"metabase.db"`
 
 Location of H2 database file. Should not include the `.mv.db` (or `.h2.db`) file extension. Used when [MB_DB_TYPE](#MB_DB_TYPE) is set to`"h2"`.
 
-Can also be used, when migrating away from H2, to specify where the existing data should be read from.
+Can also be used when migrating away from H2 to specify where the existing data should be read from.
 
 #### `MB_DB_HOST`
 
@@ -255,7 +255,7 @@ Use [MB_SOURCE_ADDRESS_HEADER](#MB_SOURCE_ADDRESS_HEADER) to set the IP address 
 Type: string<br>
 Default: `null`
 
-Email address you want to use as the sender of Metabase.
+Address you want to use as the sender of emails generated by Metabase, such as pulses or account invitations.
 
 #### `MB_EMAIL_SMTP_HOST`
 
@@ -312,7 +312,7 @@ Emojis on log lines. When set to `false` it will disable log line emojis. This i
 Type: boolean<br>
 Default: `false`
 
-Allow admins to securely embed questions and dashboards within other applications?
+Allow admins to securely embed questions and dashboards within other applications.
 
 #### `MB_ENABLE_NESTED_QUERIES`
 
@@ -327,7 +327,7 @@ Only available in Enterprise Edition<br>
 Type: boolean<br>
 Default: `true`
 
-Allow logging in by email and password, when SSO login options are enabled.
+Still allow logging in by email and password when SSO login options are enabled.
 
 #### `MB_ENABLE_PUBLIC_SHARING`
 
@@ -355,7 +355,7 @@ When `true`, this will enable `/api/testing` endpoint. **Warning:** This should 
 Type: boolean<br>
 Default: `true`
 
-Allow users to explore data using X-rays
+Allow users to explore data using X-rays.
 
 #### `MB_ENCRYPTION_SECRET_KEY`
 
@@ -371,7 +371,7 @@ Also see documentation page [Encrypting database details at rest](encrypting-dat
 Type: string<br>
 Default: `null`
 
-When set, allow users to sign up on their own if their Google account email address is from this domain.
+When set, allows users to automatically create their Metabase account by logging in if their Google account email address is from this domain.
 
 #### `MB_GOOGLE_AUTH_CLIENT_ID`
 
@@ -388,7 +388,7 @@ Since: 0.35.0
 
 Maximum number of connections to the data source databases. The maximum is for each database setup in Admin Panel > Databases, not a total for all databases.
 
-Change this to a higher value, if you notice that regular usage consumes close to or all connections. When all connections are in use, then Metabase will be slower to return results for queries, since it would have to wait for an available connection before processing the next query in the queue.
+Change this to a higher value if you notice that regular usage consumes all or close to all connections. When all connections are in use then Metabase will be slower to return results for queries, since it would have to wait for an available connection before processing the next query in the queue.
 
 See [MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE](#MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE) for setting maximum connections to the Metabase application database.
 
@@ -398,7 +398,7 @@ Type: integer<br>
 Default: `600000`<br>
 Since: 0.35.0
 
-Timeout of Jetty async threads, defined in milliseconds. The default is 10 minutes. Very few things might reach the timeout, since they return some type of data before, but things like CSV might.
+Timeout of Jetty async threads, defined in milliseconds. The default is 10 minutes. Very few things might reach that timeout, since they return some type of data before, but things like CSV downloads might.
 
 #### `MB_JETTY_DAEMON`
 
@@ -426,12 +426,12 @@ Blocks the thread until server ends.
 Type: integer<br>
 Default: `200000`
 
-Maximum idle time in milliseconds for a connection, defined in milliseconds.
+Maximum idle time for a connection, in milliseconds.
 
 #### `MB_JETTY_MAXQUEUED`
 
 Type: integer<br>
-Default: ???
+Default: _"FIX ME"_
 
 Maximum number of requests to be queued, when all threads are busy.
 
@@ -442,9 +442,9 @@ Default: `50`
 
 Maximum number of threads.
 
-Change this to a higher value, if you notice that regular usage consumes close to or all threads. When all threads are in use, then Metabase might feel slow or unresponsive, when clicking around in the interface.
+Change this to a higher value if you notice that regular usage consumes all or close to all threads. When all threads are in use Metabase might feel slow or unresponsive when clicking around the interface.
 
-Check the Metabase log, look for lines that contains the following `… Jetty threads: 45/50 …`, where that example would indicate you’re using 45 out of 50 available threads.
+To see how many threads are being used, check the Metabase logs and look for lines that contain the following: `… Jetty threads: 45/50 …`, which in this case would indicate 45 out of 50 available threads are being used.
 
 Related [MB_ASYNC_QUERY_THREAD_POOL_SIZE](#MB_ASYNC_QUERY_THREAD_POOL_SIZE).
 
@@ -469,7 +469,7 @@ Default: `null`
 
 When set to `true`, will enable HTTPS with the options configured in the `MB_JETTY_SSL_*` variables.
 
-Also see documentation page [Customizing Jetty webserver](customizing-jetty-webserver.md)
+Also see the [Customizing Jetty web server](customizing-jetty-webserver.md) documentation page. 
 
 #### `MB_JETTY_SSL_KEYSTORE`
 
@@ -519,7 +519,7 @@ Default page to show the user.
 Type: string<br>
 Default: `"mail"`
 
-Attribute to use for the users email. (usually 'mail', 'email' or 'userPrincipalName')
+Attribute to use for the user's email. (usually 'mail', 'email' or 'userPrincipalName')
 
 #### `MB_LDAP_ATTRIBUTE_FIRSTNAME`
 
@@ -540,7 +540,7 @@ Attribute to use for the user's last name. (usually 'sn')
 Type: string<br>
 Default: `null`
 
-The Distinguished Name to bind as (if any), this user will be used to lookup information about other users.
+The Distinguished Name to bind as (if any). This user will be used to lookup information about other users.
 
 #### `MB_LDAP_ENABLED`
 
@@ -554,7 +554,7 @@ Enable LDAP authentication.
 Type: string<br>
 Default: `null`
 
-Search base for groups, not required if your LDAP directory provides a 'memberOf' overlay. (Will be searched recursively)
+Search base for groups. Not required if your LDAP directory provides a 'memberOf' overlay. (Will be searched recursively.)
 
 #### `MB_LDAP_GROUP_MAPPINGS`
 
@@ -619,14 +619,14 @@ Comma-separated list of user attributes to skip syncing for LDAP users.
 Type: string<br>
 Default: `null`
 
-Search base for users. (Will be searched recursively)
+Search base for users. (Will be searched recursively.)
 
 #### `MB_LDAP_USER_FILTER`
 
 Type: string<br>
 Default: `"(&(objectClass=inetOrgPerson)(|(uid={login})(mail={login})))"`
 
-User lookup filter, the placeholder `{login}` will be replaced by the user supplied login.
+User lookup filter. The placeholder `{login}` will be replaced by the user supplied login.
 
 #### `MB_MAP_TILE_SERVER_URL`
 
@@ -672,7 +672,7 @@ Set a minimum password length to increase security for regular logins. This only
 Type: string<br>
 Default: `"plugins"`
 
-Path of the “plugins" directory, which is used for the Metabase database drivers. The path should be to a writable directory. When using JAR, the default directory is `plugins`, created in the same location as the JAR file. When using Docker, the default directory is `/plugins`
+Path of the “plugins" directory, which is used for the Metabase database drivers. The path should be to a writable directory. When using JAR, the default directory is `plugins`, created in the same location as the JAR file. When using Docker, the default directory is `/plugins`.
 
 The location is where custom third-party drivers should be added. Then Metabase will load the driver on startup, which can be verified in the log.
 
@@ -681,14 +681,14 @@ The location is where custom third-party drivers should be added. Then Metabase 
 Type: string<br>
 Default: `null`
 
-Token for premium features. Go to the https://store.metabase.com/ to get yours!
+Token for premium features.
 
 #### `MB_QP_CACHE_BACKEND`
 
 Type: string<br>
 Default: `"db"`
 
-Current cache backend. Dynamically rebindable primary for test purposes.
+Current cache backend. Dynamically rebindable primarily for test purposes.
 
 #### `MB_QUERY_CACHING_MAX_KB`
 
@@ -751,7 +751,7 @@ Hide the “Our data" section from the homepage by setting it to `false`. Show t
 Type: boolean<br>
 Default: `null`
 
-Hide the X-rays section from the homepage by setting it to `false`. Show the section with `true`, in case it was manually removed.
+Hide the X-rays section from the homepage by setting it to `false`. Show the section with `true`, in case it was manually removed. Even if set to `true`, these will be hidden if any dashboards have been pinned in the "Our Analytics" collection.
 
 #### `MB_SITE_LOCALE`
 
@@ -793,7 +793,7 @@ Slack API bearer token obtained from https://api.slack.com/web#authentication
 Type: string<br>
 Default: `X-Forwarded-For`
 
-Identify the source of HTTP requests by this headers value, instead of its remote address. Related to [MB_DISABLE_SESSION_THROTTLE](#MB_DISABLE_SESSION_THROTTLE)
+Identify the source of HTTP requests by this header's value, instead of its remote address. Related to [MB_DISABLE_SESSION_THROTTLE](#MB_DISABLE_SESSION_THROTTLE).
 
 #### `MB_SSL_CERTIFICATE_PUBLIC_KEY`
 

--- a/docs/operations-guide/environment-variables.md
+++ b/docs/operations-guide/environment-variables.md
@@ -181,7 +181,7 @@ Default: `null`
 
 A JDBC-style connection URI that can be used instead of most of `MB_DB_*` like [MB_DB_HOST](#MB_DB_HOST). Also used when certain Connection String parameters are required for the connection. The connection type requirement is the same as [MB_DB_TYPE](#MB_DB_TYPE).
 
-Example: `postgres://dbuser:dbpassword@db.example.com:port/mydb?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactorydbpassword@db.example.com`
+Example: `postgres://dbuser:dbpassword@db.example.com:port/mydb?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory`
 
 #### `MB_DB_DBNAME`
 

--- a/docs/operations-guide/environment-variables.md
+++ b/docs/operations-guide/environment-variables.md
@@ -1,61 +1,730 @@
 # Environment variables
 
-Most settings in Metabase can viewed and modified in the Admin Panel, or set via environment variables. The environment variables always take precedence.
+Many settings in Metabase can viewed and modified in the Admin Panel, or set via environment variables. The environment variables always take precedence.
 
-| Environment Variable                       | Type                                     | Default at install                                             | Description                                                                                                                                                                                                                                                                                                |
-| ------------------------------------------ | ---------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| MB_ABANDONMENT_EMAIL_SENT                  | boolean                                  | `false`                                                        | Have we sent an abandonment email to the instance admin?                                                                                                                                                                                                                                                   |
-| MB_ADMIN_EMAIL                             | string                                   | `null`                                                         | The email address users should be referred to if they encounter a problem.                                                                                                                                                                                                                                 |
-| MB_ANON_TRACKING_ENABLED                   | boolean                                  | `true`                                                         | Enable the collection of anonymous usage data in order to help Metabase improve.                                                                                                                                                                                                                           |
-| MB_BREAKOUT_BIN_WIDTH                      | double                                   | `10.0`                                                         | When using the default binning strategy for a field of type Coordinate (such as Latitude and Longitude), this number will be used as the default bin width (in degrees).                                                                                                                                   |
-| MB_BREAKOUT_BINS_NUM                       | integer                                  | `8`                                                            | When using the default binning strategy and a number of bins is not provided, this number will be used as the default.                                                                                                                                                                                     |
-| MB_CHECK_FOR_UPDATES                       | boolean                                  | `true`                                                         | Identify when new versions of Metabase are available.                                                                                                                                                                                                                                                      |
-| MB_CUSTOM_FORMATTING                       | JSON                                     | `{}`                                                           | Object keyed by type, containing formatting settings                                                                                                                                                                                                                                                       |
-| MB_CUSTOM_GEOJSON                          | JSON                                     | `{}`                                                           | JSON containing information about custom GeoJSON files for use in map visualizations instead of the default US State or World GeoJSON.                                                                                                                                                                     |
-| MB_EMAIL_FROM_ADDRESS                      | string                                   | `null`                                                         | Email address you want to use as the sender of Metabase.                                                                                                                                                                                                                                                   |
-| MB_EMAIL_SMTP_HOST                         | string                                   | `null`                                                         | The address of the SMTP server that handles your emails.                                                                                                                                                                                                                                                   |
-| MB_EMAIL_SMTP_PASSWORD                     | string                                   | `null`                                                         | SMTP password.                                                                                                                                                                                                                                                                                             |
-| MB_EMAIL_SMTP_PORT                         | int                                      | `25`                                                           | The port your SMTP server uses for outgoing emails.                                                                                                                                                                                                                                                        |
-| MB_EMAIL_SMTP_SECURITY                     | string                                   | `null`                                                         | SMTP secure connection protocol. (tls, ssl, starttls, or none)                                                                                                                                                                                                                                             |
-| MB_EMAIL_SMTP_USERNAME                     | string                                   | `null`                                                         | SMTP username.                                                                                                                                                                                                                                                                                             |
-| MB_EMBEDDING_SECRET_KEY                    | string                                   | `null`                                                         | Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints.                                                                                                                                                                                                                            |
-| MB_ENABLE_EMBEDDING                        | boolean                                  | `false`                                                        | Allow admins to securely embed questions and dashboards within other applications?                                                                                                                                                                                                                         |
-| MB_ENABLE_NESTED_QUERIES                   | boolean                                  | `true`                                                         | Allow using a saved question as the source for other queries?                                                                                                                                                                                                                                              |
-| MB_ENABLE_PUBLIC_SHARING                   | boolean                                  | `false`                                                        | Enable admins to create publicly viewable links (and embeddable iframes) for Questions and Dashboards?                                                                                                                                                                                                     |
-| MB_ENABLE_QUERY_CACHING                    | boolean                                  | `false`                                                        | Enabling caching will save the results of queries that take a long time to run.                                                                                                                                                                                                                            |
-| MB_ENABLE_XRAYS                            | boolean                                  | `true`                                                         | Allow users to explore data using X-rays                                                                                                                                                                                                                                                                   |
-| MB_FOLLOW_UP_EMAIL_SENT                    | boolean                                  | `false`                                                        | Have we sent a follow up email to the instance admin?                                                                                                                                                                                                                                                      |
-| MB_GOOGLE_AUTH_AUTO_CREATE_ACCOUNTS_DOMAIN | string                                   | `null`                                                         | When set, allow users to sign up on their own if their Google account email address is from this domain.                                                                                                                                                                                                   |
-| MB_GOOGLE_AUTH_CLIENT_ID                   | string                                   | `null`                                                         | Client ID for Google Auth SSO. If this is set, Google Auth is considered to be enabled.                                                                                                                                                                                                                    |
-| MB_HUMANIZATION_STRATEGY                   | string (`advanced`, `simple`, or `none`) | `"advanced"`                                                   | Metabase can attempt to transform your table and field names into more sensible, human-readable versions, e.g. "somehorriblename" becomes "Some Horrible Name". This doesn’t work all that well if the names are in a language other than English, however. Do you want us to take a guess?                |
-| MB_LDAP_ATTRIBUTE_EMAIL                    | string                                   | `"mail"`                                                       | Attribute to use for the users email. (usually 'mail', 'email' or 'userPrincipalName')                                                                                                                                                                                                                     |
-| MB_LDAP_ATTRIBUTE_FIRSTNAME                | string                                   | `"givenName"`                                                  | Attribute to use for the user's first name. (usually 'givenName')                                                                                                                                                                                                                                          |
-| MB_LDAP_ATTRIBUTE_LASTNAME                 | string                                   | `"sn"`                                                         | Attribute to use for the user's last name. (usually 'sn')                                                                                                                                                                                                                                                  |
-| MB_LDAP_BIND_DN                            | string                                   | `null`                                                         | The Distinguished Name to bind as (if any), this user will be used to lookup information about other users.                                                                                                                                                                                                |
-| MB_LDAP_ENABLED                            | boolean                                  | `false`                                                        | Enable LDAP authentication.                                                                                                                                                                                                                                                                                |
-| MB_LDAP_GROUP_BASE                         | string                                   | `null`                                                         | Search base for groups, not required if your LDAP directory provides a 'memberOf' overlay. (Will be searched recursively)                                                                                                                                                                                  |
-| MB_LDAP_GROUP_MAPPINGS                     | JSON                                     | `{}`                                                           | JSON containing LDAP to Metabase group mappings.                                                                                                                                                                                                                                                           |
-| MB_LDAP_GROUP_SYNC                         | boolean                                  | `false`                                                        | Enable group membership synchronization with LDAP.                                                                                                                                                                                                                                                         |
-| MB_LDAP_HOST                               | string                                   | `null`                                                         | Server hostname.                                                                                                                                                                                                                                                                                           |
-| MB_LDAP_PASSWORD                           | string                                   | `null`                                                         | The password to bind with for the lookup user.                                                                                                                                                                                                                                                             |
-| MB_LDAP_PORT                               | string                                   | `"389"`                                                        | Server port, usually 389 or 636 if SSL is used.                                                                                                                                                                                                                                                            |
-| MB_LDAP_SECURITY                           | string                                   | `"none"`                                                       | Use SSL, TLS or plain text.                                                                                                                                                                                                                                                                                |
-| MB_LDAP_USER_BASE                          | string                                   | `null`                                                         | Search base for users. (Will be searched recursively)                                                                                                                                                                                                                                                      |
-| MB_LDAP_USER_FILTER                        | string                                   | `(&(objectClass=inetOrgPerson)(|(uid={login})(mail={login})))` | User lookup filter, the placeholder {login} will be replaced by the user supplied login.                                                                                                                                                                                                                   |
-| MB_MAP_TILE_SERVER_URL                     | string                                   | `http://{s}.tile.openstreetmap.org/` `{z}/{x}/{y}.png`         | The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox.                                                                                                                                                                                                    |
-| MB_MAX_SIMULTANEOUS_QUERIES_PER_DB         | integer                                  | `15`                                                           | Maximum number of simultaneous queries to allow per connected Database.                                                                                                                                                                                                                                    |
-| MB_METABOT_ENABLED                         | boolean                                  | `false`                                                        | Enable MetaBot, which lets you search for and view your saved questions directly via Slack.                                                                                                                                                                                                                |
-| MB_METABOT_INSTANCE_LAST_CHECKIN           | string                                   | `null`                                                         | Timestamp of the last time the active MetaBot instance checked in.                                                                                                                                                                                                                                         |
-| MB_METABOT_INSTANCE_UUID                   | string                                   | `null`                                                         | UUID of the active MetaBot instance (the Metabase process currently handling MetaBot duties.)                                                                                                                                                                                                              |
-| MB_PREMIUM_EMBEDDING_TOKEN                 | string                                   | `null`                                                         | Token for premium features. Go to the MetaStore to get yours!                                                                                                                                                                                                                                              |
-| MB_QUERY_CACHING_MAX_KB                    | integer                                  | `1000`                                                         | The maximum size of the cache, per saved question, in kilobytes:                                                                                                                                                                                                                                           |
-| MB_QUERY_CACHING_MAX_TTL                   | integer                                  | `8640000` (100 days, in seconds)                               | The absolute maximum time to keep any cached query results, in seconds.                                                                                                                                                                                                                                    |
-| MB_QUERY_CACHING_MIN_TTL                   | integer                                  | `60`                                                           | Metabase will cache all saved questions with an average query execution time longer than this many seconds:                                                                                                                                                                                                |
-| MB_QUERY_CACHING_TTL_RATIO                 | integer                                  | `10`                                                           | To determine how long each saved question's cached result should stick around, we take the query's average execution time and multiply that by whatever you input here.So if a query takes on average 2 minutes to run, and you input 10 for your multiplier, its cache entry will persist for 20 minutes. |
-| MB_REPORT_TIMEZONE                         | string                                   | `null`                                                         | Connection timezone to use when executing queries. Defaults to system timezone.                                                                                                                                                                                                                            |
-| MB_SITE_LOCALE                             | string                                   | `"en"`                                                         | The default language for this Metabase instance. This only applies to emails, Pulses, etc. Users' browsers will specify the language used in the user interface.                                                                                                                                           |
-| MB_SITE_NAME                               | string                                   | `"Metabase"`                                                   | The name used for this instance of Metabase.                                                                                                                                                                                                                                                               |
-| MB_SITE_URL                                | string                                   | `null`                                                         | The base URL of this Metabase instance, e.g. "http://metabase.my-company.com".                                                                                                                                                                                                                             |
-| MB_SLACK_TOKEN                             | string                                   | `null`                                                         | Slack API bearer token obtained from https://api.slack.com/web#authentication                                                                                                                                                                                                                              |
-| MB_SOURCE_ADDRESS_HEADER                   | string                                   | `X-Forwarded-For`                                              | Identify the source of HTTP requests by this headers value, instead of its remote address.                                                                                                                                                                                                                 |
-| MB_SSL_CERTIFICATE_PUBLIC_KEY              | string                                   | `null`                                                         | Base-64 encoded public key for this sites SSL certificate.Specify this to enable HTTP Public Key Pinning.See http://mzl.la/1EnfqBf for more information.                                                                                                                                                   |
+Setting environment variables can be done in various ways depending on how Metabase is being run.
+
+JAR (Note that on Windows, use `set` instead of `export`):
+```
+export MB_SITE_NAME="Awesome Company"
+java -jar metabase.jar
+```
+JAR alternative (declared with `-D` prepending the variable):
+```
+java -DMB_SITE_NAME="Awesome Company" -jar metabase.jar
+```
+Docker:
+```
+docker run -d -p 3000:3000 -e 'MB_SITE_NAME=Awesome Company' --name metabase metabase/metabase
+```
+
+---
+
+#### `MAX_SESSION_AGE`
+
+Type: integer<br>
+Default: `20160`
+
+Session expiration, defined in seconds (default is 2 weeks), which will logout users after the defined period and require re-authentication.
+
+Note: This setting is not an idle/inactivity timeout. If you set this to 15 minutes, your users have to login (or re-authenticate) again every 15 minutes.
+
+Use [MB_SESSION_COOKIES](#MB_SESSION_COOKIES) to only expire sessions, when browser is closed.
+
+#### `MB_ADMIN_EMAIL`
+
+Type: string<br>
+Default: `null`
+
+The email address users should be referred to if they encounter a problem.
+
+#### `MB_ANON_TRACKING_ENABLED`
+
+Type: boolean<br>
+Default: `true`
+
+Enable the collection of anonymous usage data in order to help Metabase improve.
+
+#### `MB_API_KEY`
+
+Type: string<br>
+Default: `null`
+
+Middleware that enforces validation of the client via the request header `X-Metabase-Apikey`. If the header is available, then it’s validated against `MB_API_KEY`. When it matches, the request continues otherwise it’s blocked with a 403 Forbidden response.
+
+#### `MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE`
+
+Type: integer<br>
+Default: `15`
+
+Maximum number of connections to the Metabase application database.
+
+Change this to a higher value, if you notice that regular usage consumes close to or all connections. When all connections are in use, then Metabase might feel slow or unresponsive, when clicking around in the interface.
+
+Check the Metabase log, look for lines that contains the following `… App DB connections: 12/15 …`, where that example would indicate you’re using 12 out of 15 available connections.
+
+See [MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE](#MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE) for setting maximum connections to the databases setup in Metabase.
+
+#### `MB_ASYNC_QUERY_THREAD_POOL_SIZE`
+
+Type: integer<br>
+Default: `50`
+
+Maximum number of async Jetty threads. If not set, then [MB_JETTY_MAXTHREADS](#MB_JETTY_MAXTHREADS) will be used, otherwise it will use the default.
+
+#### `MB_BREAKOUT_BIN_WIDTH`
+
+Type: double<br>
+Default: `10.0`
+
+When using the default binning strategy for a field of type Coordinate (such as Latitude and Longitude), this number will be used as the default bin width (in degrees).
+
+#### `MB_BREAKOUT_BINS_NUM`
+
+Type: integer<br>
+Default: `8`
+
+When using the default binning strategy and a number of bins is not provided, this number will be used as the default.
+
+#### `MB_CHECK_FOR_UPDATES`
+
+Type: boolean<br>
+Default: `true`
+
+Identify when new versions of Metabase are available.
+
+#### `MB_CLIENT`
+
+Type: string<br>
+Default: `null`
+
+Used to recognize the Mac App client, which then defaults to `"OSX"`.
+
+#### `MB_COLORIZE_LOGS`
+
+Type: boolean<br>
+Default: `true`
+
+Color log lines. When set to `false` it will disable log line colors. This is disabled on Windows. Related to [MB_EMOJI_IN_LOGS](#MB_EMOJI_IN_LOGS)
+
+#### `MB_CUSTOM_FORMATTING`
+
+Type: string<br>
+Default: `"{}"`
+
+JSON object keyed by type, containing formatting settings
+
+#### `MB_CUSTOM_GEOJSON`
+
+Type: string<br>
+Default: `"{}"`
+
+JSON object containing information about custom GeoJSON files for use in map visualizations instead of the default US State or World GeoJSON.
+
+#### `MB_DB_AUTOMIGRATE`
+
+Type: boolean<br>
+Default: `true`
+
+When set to `false`, Metabase will print migrations needed to done in the application database and exit. Those migrations needs to applied manually. When `true`, Metabase will automatically make changes to the application database. This is not related to migrating away from H2.
+
+#### `MB_DB_CONNECTION_TIMEOUT_MS`
+
+Type: integer<br>
+Default: `5000`
+
+Timeout in milliseconds for connecting to the application database.
+
+#### `MB_DB_CONNECTION_URI`
+
+Type: string<br>
+Default: `null`
+
+A JDBC style connection URI that can be used instead of most of `MB_DB_*` like [MB_DB_HOST](#MB_DB_HOST). Also used, when certain Connection String parameters are required for the connection. The connection type requirement is the same as [MB_DB_TYPE](#MB_DB_TYPE).
+
+Example: `postgres://dbuser:dbpassword@db.example.com:port/mydb?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactorydbpassword@db.example.com`
+
+#### `MB_DB_DBNAME`
+
+Type: string<br>
+Default: `null`
+
+The database name of the application database used with [MB_DB_HOST](#MB_DB_HOST)
+
+#### `MB_DB_FILE`
+
+Type: string<br>
+Default: `"metabase.db"`
+
+Location of H2 database file. Should not include the `.mv.db` (or `.h2.db`) file extension. Used when [MB_DB_TYPE](#MB_DB_TYPE) is set to`"h2"`.
+
+Can also be used, when migrating away from H2, to specify where the existing data should be read from.
+
+#### `MB_DB_HOST`
+
+Type: string<br>
+Default: `null`
+
+The host name or IP address of the application database. Used when [MB_DB_TYPE](#MB_DB_TYPE) is different than `"h2"`.
+
+#### `MB_DB_IN_MEMORY`
+
+Type: boolean<br>
+Default: `null`
+
+Used for testing with [MB_DB_FILE](#MB_DB_FILE).
+
+#### `MB_DB_PASS`
+
+Type: string<br>
+Default: `null`
+
+The password for [MB_DB_HOST](#MB_DB_HOST).
+
+#### `MB_DB_PORT`
+
+Type: integer<br>
+Default: `null`
+
+The port for [MB_DB_HOST](#MB_DB_HOST).
+
+#### `MB_DB_TYPE`
+
+Type: string<br>
+Default: `"h2"`
+
+When `"h2"`, the application database is loaded from [MB_DB_FILE](#MB_DB_FILE), otherwise [MB_DB_HOST](#MB_DB_HOST) will be used to define application database.
+
+#### `MB_DB_USER`
+
+Type: string<br>
+Default: `null`
+
+The username for [MB_DB_HOST](#MB_DB_HOST).
+
+#### `MB_DISABLE_SESSION_THROTTLE`
+
+Type: boolean<br>
+Default: `false`
+
+When `true`, this will disable session throttling. **Warning:** It is not recommended to disable throttling, since it is a protective measure against brute-force attacks.
+
+Use [MB_SOURCE_ADDRESS_HEADER](#MB_SOURCE_ADDRESS_HEADER) to set the IP address of the remote client from e.g. a reverse-proxy.
+
+#### `MB_EMAIL_FROM_ADDRESS`
+
+Type: string<br>
+Default: `null`
+
+Email address you want to use as the sender of Metabase.
+
+#### `MB_EMAIL_SMTP_HOST`
+
+Type: string<br>
+Default: `null`
+
+The address of the SMTP server that handles your emails.
+
+#### `MB_EMAIL_SMTP_PASSWORD`
+
+Type: string<br>
+Default: `null`
+
+SMTP password.
+
+#### `MB_EMAIL_SMTP_PORT`
+
+Type: integer<br>
+Default: `null`
+
+The port your SMTP server uses for outgoing emails.
+
+#### `MB_EMAIL_SMTP_SECURITY`
+
+Type: string<br>
+Default: `"none"`
+
+SMTP secure connection protocol.
+
+#### `MB_EMAIL_SMTP_USERNAME`
+
+Type: string<br>
+Default: `null`
+
+SMTP username.
+
+#### `MB_EMOJI_IN_LOGS`
+
+Type: boolean<br>
+Default: `true`
+
+Emojis on log lines. When set to `false` it will disable log line emojis. This is disabled on Windows. Related to [MB_COLORIZE_LOGS](#MB_COLORIZE_LOGS).
+
+#### `MB_ENABLE_EMBEDDING`
+
+Type: boolean<br>
+Default: `false`
+
+Allow admins to securely embed questions and dashboards within other applications?
+
+#### `MB_ENABLE_NESTED_QUERIES`
+
+Type: boolean<br>
+Default: `true`
+
+Allow using a saved question as the source for other queries?
+
+#### `MB_ENABLE_PUBLIC_SHARING`
+
+Type: boolean<br>
+Default: `false`
+
+Enable admins to create publicly viewable links (and embedded iframes) for Questions and Dashboards?
+
+#### `MB_ENABLE_QUERY_CACHING`
+
+Type: boolean<br>
+Default: `false`
+
+Enabling caching will save the results of queries that take a long time to run.
+
+#### `MB_ENABLE_TEST_ENDPOINTS`
+
+Type: boolean<br>
+Default: `null`
+
+When `true`, this will enable `/api/testing` endpoint. **Warning:** This should never be enabled in production system.
+
+#### `MB_ENABLE_XRAYS`
+
+Type: boolean<br>
+Default: `true`
+
+Allow users to explore data using X-rays
+
+#### `MB_ENCRYPTION_SECRET_KEY`
+
+Type: string<br>
+Default: `null`
+
+When set, this will encrypt database credentials stored in the application database. Requirement: minimum 16 characters base64-encoded string.
+
+Also see documentation page [Encrypting database details at rest](encrypting-database-details-at-rest.md).
+
+#### `MB_GOOGLE_AUTH_AUTO_CREATE_ACCOUNTS_DOMAIN`
+
+Type: string<br>
+Default: `null`
+
+When set, allow users to sign up on their own if their Google account email address is from this domain.
+
+#### `MB_GOOGLE_AUTH_CLIENT_ID`
+
+Type: string<br>
+Default: `null`
+
+Client ID for Google Auth SSO. If this is set, Google Auth is considered to be enabled.
+
+#### `MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE`
+
+Type: integer<br>
+Default: `15`
+
+Maximum number of connections to the data source databases. The maximum is for each database setup in Admin Panel > Databases, not a total for all databases.
+
+Change this to a higher value, if you notice that regular usage consumes close to or all connections. When all connections are in use, then Metabase will be slower to return results for queries, since it would have to wait for an available connection before processing the next query in the queue.
+
+See [MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE](#MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE) for setting maximum connections to the Metabase application database.
+
+#### `MB_JETTY_ASYNC_RESPONSE_TIMEOUT`
+
+Type: integer<br>
+Default: `600000`
+
+Timeout of Jetty async threads, defined in milliseconds. The default is 10 minutes. Very few things might reach the timeout, since they return some type of data before, but things like CSV might.
+
+#### `MB_JETTY_DAEMON`
+
+Type: boolean<br>
+Default: `false`
+
+Use daemon threads.
+
+#### `MB_JETTY_HOST`
+
+Type: string<br>
+Default: `null`
+
+Configure a host either as a host name or IP address to identify a specific network interface on which to listen. If not set or set to `"0.0.0.0"`, Metabase listens on all network interfaces. It will listen on the port specified in [MB_JETTY_PORT](#MB_JETTY_PORT).
+
+#### `MB_JETTY_JOIN`
+
+Type: boolean<br>
+Default: `true`
+
+Blocks the thread until server ends.
+
+#### `MB_JETTY_MAXIDLETIME`
+
+Type: integer<br>
+Default: `200000`
+
+Maximum idle time in milliseconds for a connection, defined in milliseconds.
+
+#### `MB_JETTY_MAXQUEUED`
+
+Type: integer<br>
+Default: ???
+
+Maximum number of requests to be queued, when all threads are busy.
+
+#### `MB_JETTY_MAXTHREADS`
+
+Type: integer<br>
+Default: `50`
+
+Maximum number of threads.
+
+Change this to a higher value, if you notice that regular usage consumes close to or all threads. When all threads are in use, then Metabase might feel slow or unresponsive, when clicking around in the interface.
+
+Check the Metabase log, look for lines that contains the following `… Jetty threads: 45/50 …`, where that example would indicate you’re using 45 out of 50 available threads.
+
+Related [MB_ASYNC_QUERY_THREAD_POOL_SIZE](#MB_ASYNC_QUERY_THREAD_POOL_SIZE).
+
+#### `MB_JETTY_MINTHREADS`
+
+Type: integer<br>
+Default: `8`
+
+Minimum number of threads.
+
+#### `MB_JETTY_PORT`
+
+Type: integer<br>
+Default: `3000`
+
+Configure which port to use for HTTP. It will listen on the interface specified in [MB_JETTY_HOST](#MB_JETTY_HOST).
+
+#### `MB_JETTY_SSL`
+
+Type: boolean<br>
+Default: `null`
+
+When set to `true`, will enable HTTPS with the options configured in the `MB_JETTY_SSL_*` variables.
+
+Also see documentation page [Customizing Jetty webserver](customizing-jetty-webserver.md)
+
+#### `MB_JETTY_SSL_KEYSTORE`
+
+Type: string<br>
+Default: `null`
+
+Path to Java KeyStore file.
+
+#### `MB_JETTY_SSL_KEYSTORE_PASSWORD`
+
+Type: string<br>
+Default: `null`
+
+Password for Java KeyStore file.
+
+#### `MB_JETTY_SSL_PORT`
+
+Type: integer<br>
+Default: `null`
+
+Configure which port to use for HTTPS. It will listen on the interface specified in [MB_JETTY_HOST](#MB_JETTY_HOST).
+
+#### `MB_JETTY_SSL_TRUSTSTORE`
+
+Type: string<br>
+Default: `null`
+
+Path to Java TrustStore file.
+
+#### `MB_JETTY_SSL_TRUSTSTORE_PASSWORD`
+
+Type: string<br>
+Default: `null`
+
+Password for Java TrustStore file.
+
+#### `MB_LDAP_ATTRIBUTE_EMAIL`
+
+Type: string<br>
+Default: `"mail"`
+
+Attribute to use for the users email. (usually 'mail', 'email' or 'userPrincipalName')
+
+#### `MB_LDAP_ATTRIBUTE_FIRSTNAME`
+
+Type: string<br>
+Default: `"givenName"`
+
+Attribute to use for the user's first name. (usually 'givenName')
+
+#### `MB_LDAP_ATTRIBUTE_LASTNAME`
+
+Type: string<br>
+Default: `"sn"`
+
+Attribute to use for the user's last name. (usually 'sn')
+
+#### `MB_LDAP_BIND_DN`
+
+Type: string<br>
+Default: `null`
+
+The Distinguished Name to bind as (if any), this user will be used to lookup information about other users.
+
+#### `MB_LDAP_ENABLED`
+
+Type: boolean<br>
+Default: `false`
+
+Enable LDAP authentication.
+
+#### `MB_LDAP_GROUP_BASE`
+
+Type: string<br>
+Default: `null`
+
+Search base for groups, not required if your LDAP directory provides a 'memberOf' overlay. (Will be searched recursively)
+
+#### `MB_LDAP_GROUP_MAPPINGS`
+
+Type: string<br>
+Default: `"{}"`
+
+JSON object containing LDAP to Metabase group mappings.
+
+#### `MB_LDAP_GROUP_SYNC`
+
+Type: boolean<br>
+Default: `false`
+
+Enable group membership synchronization with LDAP.
+
+#### `MB_LDAP_HOST`
+
+Type: string<br>
+Default: `null`
+
+Server hostname.
+
+#### `MB_LDAP_PASSWORD`
+
+Type: string<br>
+Default: `null`
+
+The password to bind with for the lookup user.
+
+#### `MB_LDAP_PORT`
+
+Type: string<br>
+Default: `"389"`
+
+Server port, usually 389 or 636 if SSL is used.
+
+#### `MB_LDAP_SECURITY`
+
+Type: string<br>
+Default: `"none"`
+
+Use SSL, TLS or plain text.
+
+#### `MB_LDAP_USER_BASE`
+
+Type: string<br>
+Default: `null`
+
+Search base for users. (Will be searched recursively)
+
+#### `MB_LDAP_USER_FILTER`
+
+Type: string<br>
+Default: ```"(&(objectClass=inetOrgPerson)(|(uid={login})(mail={login})))"```
+
+User lookup filter, the placeholder `{login}` will be replaced by the user supplied login.
+
+#### `MB_MAP_TILE_SERVER_URL`
+
+Type: string<br>
+Default: ```"http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"```
+
+The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox.
+
+#### `MB_METABOT_ENABLED`
+
+Type: boolean<br>
+Default: `false`
+
+Enable MetaBot, which lets you search for and view your saved questions directly via Slack.
+
+#### `MB_NS_TRACE`
+
+Type: string<br>
+Default: `""`
+
+Comma-separated namespaces to trace. **WARNING:** Could log sensitive information like database passwords.
+
+#### `MB_PASSWORD_COMPLEXITY`
+
+Type: string<br>
+Default: `"normal"`
+
+Enforce a password complexity rule to increase security for regular logins. This only applies to new users or users that are changing their password. Related [MB_PASSWORD_LENGTH](#MB_PASSWORD_LENGTH)
+
+- `weak` requires length of 6 characters
+- `normal` requires at least 1 digit and length of 6 characters
+- `strong` requires at least 2 lowercase and 2 uppercase and 1 digit and 1 symbol and length of 8 characters.
+
+#### `MB_PASSWORD_LENGTH`
+
+Type: integer<br>
+Default: `6`
+
+Set a minimum password length to increase security for regular logins. This only applies to new users or users that are changing their password. Uses the length of [MB_PASSWORD_COMPLEXITY](#MB_PASSWORD_COMPLEXITY) if not set.
+
+#### `MB_PLUGINS_DIR`
+
+Type: string<br>
+Default: `"plugins"`
+
+Path of the “plugins" directory, which is used for the Metabase database drivers. The path should be to a writable directory. When using JAR, the default directory is `plugins`, created in the same location as the JAR file. When using Docker, the default directory is `/plugins`
+
+The location is where custom third-party drivers should be added. Then Metabase will load the driver on startup, which can be verified in the log.
+
+#### `MB_PREMIUM_EMBEDDING_TOKEN`
+
+Type: string<br>
+Default: `null`
+
+Token for premium features. Go to the https://store.metabase.com/ to get yours!
+
+#### `MB_QP_CACHE_BACKEND`
+
+Type: string<br>
+Default: `"db"`
+
+Current cache backend. Dynamically rebindable primary for test purposes.
+
+#### `MB_QUERY_CACHING_MAX_KB`
+
+Type: integer<br>
+Default: `1000`
+
+The maximum size of the cache, per saved question, in kilobytes.
+
+#### `MB_QUERY_CACHING_MAX_TTL`
+
+Type: integer<br>
+Default: `8640000`
+
+The absolute maximum time to keep any cached query results, in seconds. The default value is 100 days in seconds.
+
+#### `MB_QUERY_CACHING_MIN_TTL`
+
+Type: integer<br>
+Default: `60`
+
+Metabase will cache all saved questions with an average query execution time longer than this many seconds.
+
+#### `MB_QUERY_CACHING_TTL_RATIO`
+
+Type: integer<br>
+Default: `10`
+
+To determine how long each saved question's cached result should stick around, we take the query's average execution time and multiply that by whatever you input here. So if a query takes on average 2 minutes to run, and you input 10 for your multiplier, its cache entry will persist for 20 minutes.
+
+#### `MB_REPORT_TIMEZONE`
+
+Type: string<br>
+Default: `null`
+
+Connection timezone to use when executing queries. Defaults to system timezone.
+
+#### `MB_SESSION_COOKIES`
+
+Type: boolean<br>
+Default: `null`
+
+When set to `true`, the user login sessions will not expire until the browser is closed. When not set, or set to `false`, the user login sessions will expire after the amount of seconds defined in [MAX_SESSION_AGE](#MAX_SESSION_AGE) (by default 2 weeks).
+
+#### `MB_SETUP_TOKEN`
+
+Type: string<br>
+Default: `null`
+
+An UUID token used to signify that an instance has permissions to create the initial User. This is created upon the first launch of Metabase, by the first instance; once used, it is cleared out, never to be used again.
+
+#### `MB_SHOW_HOMEPAGE_DATA`
+
+Type: boolean<br>
+Default: `null`
+
+Hide the “Our data" section from the homepage by setting it to `false`. Show the section with `true`, in case it was manually removed.
+
+#### `MB_SHOW_HOMEPAGE_XRAYS`
+
+Type: boolean<br>
+Default: `null`
+
+Hide the X-rays section from the homepage by setting it to `false`. Show the section with `true`, in case it was manually removed.
+
+#### `MB_SITE_LOCALE`
+
+Type: string<br>
+Default: `"en"`
+
+The default language for this Metabase instance. This only applies to emails, Pulses, etc. Users' browsers will specify the language used in the user interface.
+
+#### `MB_SITE_NAME`
+
+Type: string<br>
+Default: `"Metabase"`
+
+The name used for this instance of Metabase.
+
+#### `MB_SITE_URL`
+
+Type: string<br>
+Default: `null`
+
+The base URL where users access Metabase, e.g. `https://metabase.example.com` or `https://example.com/metabase`.
+
+#### `MB_SITE_UUID`
+
+Type: string<br>
+Default: `null`
+
+An UUID token used for this instance of Metabase.
+
+#### `MB_SLACK_TOKEN`
+
+Type: string<br>
+Default: `null`
+
+Slack API bearer token obtained from https://api.slack.com/web#authentication
+
+#### `MB_SOURCE_ADDRESS_HEADER`
+
+Type: string<br>
+Default: `X-Forwarded-For`
+
+Identify the source of HTTP requests by this headers value, instead of its remote address. Related to [MB_DISABLE_SESSION_THROTTLE](#MB_DISABLE_SESSION_THROTTLE)
+
+#### `MB_SSL_CERTIFICATE_PUBLIC_KEY`
+
+Type: string<br>
+Default: `null`
+
+Base-64 encoded public key for this sites SSL certificate. Specify this to enable HTTP Public Key Pinning. Using HPKP is no longer recommended. See http://mzl.la/1EnfqBf for more information.
+
+#### `MB_VERSION_INFO_URL`
+
+Type: string<br>
+Default: `"http://static.metabase.com/version-info.json"`
+
+The address used to check for newer versions of Metabase.
+

--- a/docs/operations-guide/environment-variables.md
+++ b/docs/operations-guide/environment-variables.md
@@ -57,10 +57,19 @@ Default: `null`
 
 Middleware that enforces validation of the client via the request header `X-Metabase-Apikey`. If the header is available, then it’s validated against `MB_API_KEY`. When it matches, the request continues otherwise it’s blocked with a 403 Forbidden response.
 
+#### `MB_APPLICATION_COLORS`
+
+Only available in Enterprise Edition<br>
+Type: string<br>
+Default: `"{}"`
+
+JSON object of primary colors used in charts and throughout Metabase.
+
 #### `MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE`
 
 Type: integer<br>
-Default: `15`
+Default: `15`<br>
+Since: 0.35.0
 
 Maximum number of connections to the Metabase application database.
 
@@ -70,10 +79,35 @@ Check the Metabase log, look for lines that contains the following `… App DB c
 
 See [MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE](#MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE) for setting maximum connections to the databases setup in Metabase.
 
+#### `MB_APPLICATION_FAVICON_URL`
+
+Only available in Enterprise Edition<br>
+Type: string<br>
+Default: `"frontend_client/favicon.ico"`
+
+Path or URL to favicon file.
+
+#### `MB_APPLICATION_LOGO_URL`
+
+Only available in Enterprise Edition<br>
+Type: string<br>
+Default: `"app/assets/img/logo.svg"`
+
+Path or URL to logo file. For best results use SVG format.
+
+#### `MB_APPLICATION_NAME`
+
+Only available in Enterprise Edition<br>
+Type: string<br>
+Default: `"Metabase"`
+
+Replace the word `Metabase` wherever it appears with the defined string.
+
 #### `MB_ASYNC_QUERY_THREAD_POOL_SIZE`
 
 Type: integer<br>
-Default: `50`
+Default: `50`<br>
+Since: 0.35.0
 
 Maximum number of async Jetty threads. If not set, then [MB_JETTY_MAXTHREADS](#MB_JETTY_MAXTHREADS) will be used, otherwise it will use the default.
 
@@ -195,7 +229,7 @@ The port for [MB_DB_HOST](#MB_DB_HOST).
 
 #### `MB_DB_TYPE`
 
-Type: string<br>
+Type: string (`"h2"`, `"postgres"`, `"mysql"`)<br>
 Default: `"h2"`
 
 When `"h2"`, the application database is loaded from [MB_DB_FILE](#MB_DB_FILE), otherwise [MB_DB_HOST](#MB_DB_HOST) will be used to define application database.
@@ -246,7 +280,7 @@ The port your SMTP server uses for outgoing emails.
 
 #### `MB_EMAIL_SMTP_SECURITY`
 
-Type: string<br>
+Type: string (`"tls"`, `"ssl"`, `"starttls"`, `"none"`)<br>
 Default: `"none"`
 
 SMTP secure connection protocol.
@@ -257,6 +291,14 @@ Type: string<br>
 Default: `null`
 
 SMTP username.
+
+#### `MB_EMBEDDING_APP_ORIGIN`
+
+Only available in Enterprise Edition<br>
+Type: string<br>
+Default: `null`
+
+URL of origin allowed to embed the full Metabase application.
 
 #### `MB_EMOJI_IN_LOGS`
 
@@ -278,6 +320,14 @@ Type: boolean<br>
 Default: `true`
 
 Allow using a saved question as the source for other queries?
+
+#### `MB_ENABLE_PASSWORD_LOGIN`
+
+Only available in Enterprise Edition<br>
+Type: boolean<br>
+Default: `true`
+
+Allow logging in by email and password, when SSO login options are enabled.
 
 #### `MB_ENABLE_PUBLIC_SHARING`
 
@@ -333,7 +383,8 @@ Client ID for Google Auth SSO. If this is set, Google Auth is considered to be e
 #### `MB_JDBC_DATA_WAREHOUSE_MAX_CONNECTION_POOL_SIZE`
 
 Type: integer<br>
-Default: `15`
+Default: `15`<br>
+Since: 0.35.0
 
 Maximum number of connections to the data source databases. The maximum is for each database setup in Admin Panel > Databases, not a total for all databases.
 
@@ -344,7 +395,8 @@ See [MB_APPLICATION_DB_MAX_CONNECTION_POOL_SIZE](#MB_APPLICATION_DB_MAX_CONNECTI
 #### `MB_JETTY_ASYNC_RESPONSE_TIMEOUT`
 
 Type: integer<br>
-Default: `600000`
+Default: `600000`<br>
+Since: 0.35.0
 
 Timeout of Jetty async threads, defined in milliseconds. The default is 10 minutes. Very few things might reach the timeout, since they return some type of data before, but things like CSV might.
 
@@ -454,6 +506,14 @@ Default: `null`
 
 Password for Java TrustStore file.
 
+#### `MB_LANDING_PAGE`
+
+Only available in Enterprise Edition<br>
+Type: string<br>
+Default: `""`
+
+Default page to show the user.
+
 #### `MB_LDAP_ATTRIBUTE_EMAIL`
 
 Type: string<br>
@@ -538,6 +598,22 @@ Default: `"none"`
 
 Use SSL, TLS or plain text.
 
+#### `MB_LDAP_SYNC_USER_ATTRIBUTES`
+
+Only available in Enterprise Edition<br>
+Type: boolean<br>
+Default: `true`
+
+Should user attributes be synced when someone logs in via LDAP?
+
+#### `MB_LDAP_SYNC_USER_ATTRIBUTES_BLACKLIST`
+
+Only available in Enterprise Edition<br>
+Type: string<br>
+Default: `"userPassword,dn,distinguishedName"`
+
+Comma-separated list of user attributes to skip syncing for LDAP users.
+
 #### `MB_LDAP_USER_BASE`
 
 Type: string<br>
@@ -575,7 +651,7 @@ Comma-separated namespaces to trace. **WARNING:** Could log sensitive informatio
 
 #### `MB_PASSWORD_COMPLEXITY`
 
-Type: string<br>
+Type: string (`"weak"`, `"normal"`, `"strong"`)<br>
 Default: `"normal"`
 
 Enforce a password complexity rule to increase security for regular logins. This only applies to new users or users that are changing their password. Related [MB_PASSWORD_LENGTH](#MB_PASSWORD_LENGTH)

--- a/docs/operations-guide/environment-variables.md
+++ b/docs/operations-guide/environment-variables.md
@@ -188,7 +188,7 @@ Example: `postgres://dbuser:dbpassword@db.example.com:port/mydb?ssl=true&sslfact
 Type: string<br>
 Default: `null`
 
-The database name of the application database used with [MB_DB_HOST](#MB_DB_HOST)
+The database name of the application database used with [MB_DB_HOST](#MB_DB_HOST).
 
 #### `MB_DB_FILE`
 
@@ -319,7 +319,7 @@ Allow admins to securely embed questions and dashboards within other application
 Type: boolean<br>
 Default: `true`
 
-Allow using a saved question as the source for other queries?
+Allow using a saved question as the source for other queries.
 
 #### `MB_ENABLE_PASSWORD_LOGIN`
 
@@ -334,7 +334,7 @@ Still allow logging in by email and password when SSO login options are enabled.
 Type: boolean<br>
 Default: `false`
 
-Enable admins to create publicly viewable links (and embedded iframes) for Questions and Dashboards?
+Enable admins to create publicly viewable links (and embedded iframes) for questions and dashboards.
 
 #### `MB_ENABLE_QUERY_CACHING`
 
@@ -433,7 +433,7 @@ Maximum idle time for a connection, in milliseconds.
 Type: integer<br>
 Default: _"FIX ME"_
 
-Maximum number of requests to be queued, when all threads are busy.
+Maximum number of requests to be queued when all threads are busy.
 
 #### `MB_JETTY_MAXTHREADS`
 
@@ -469,7 +469,7 @@ Default: `null`
 
 When set to `true`, will enable HTTPS with the options configured in the `MB_JETTY_SSL_*` variables.
 
-Also see the [Customizing Jetty web server](customizing-jetty-webserver.md) documentation page. 
+Also see the [Customizing Jetty web server](customizing-jetty-webserver.md) documentation page.
 
 #### `MB_JETTY_SSL_KEYSTORE`
 
@@ -519,21 +519,21 @@ Default page to show the user.
 Type: string<br>
 Default: `"mail"`
 
-Attribute to use for the user's email. (usually 'mail', 'email' or 'userPrincipalName')
+Attribute to use for the user's email. Usually 'mail', 'email' or 'userPrincipalName'.
 
 #### `MB_LDAP_ATTRIBUTE_FIRSTNAME`
 
 Type: string<br>
 Default: `"givenName"`
 
-Attribute to use for the user's first name. (usually 'givenName')
+Attribute to use for the user's first name. Usually 'givenName'.
 
 #### `MB_LDAP_ATTRIBUTE_LASTNAME`
 
 Type: string<br>
 Default: `"sn"`
 
-Attribute to use for the user's last name. (usually 'sn')
+Attribute to use for the user's last name. Usually 'sn'.
 
 #### `MB_LDAP_BIND_DN`
 
@@ -604,7 +604,7 @@ Only available in Enterprise Edition<br>
 Type: boolean<br>
 Default: `true`
 
-Should user attributes be synced when someone logs in via LDAP?
+Sync user attributes when someone logs in via LDAP.
 
 #### `MB_LDAP_SYNC_USER_ATTRIBUTES_BLACKLIST`
 
@@ -672,7 +672,7 @@ Set a minimum password length to increase security for regular logins. This only
 Type: string<br>
 Default: `"plugins"`
 
-Path of the “plugins" directory, which is used for the Metabase database drivers. The path should be to a writable directory. When using JAR, the default directory is `plugins`, created in the same location as the JAR file. When using Docker, the default directory is `/plugins`.
+Path of the "plugins" directory, which is used for the Metabase database drivers. The path should be to a writable directory. When using JAR, the default directory is `plugins`, created in the same location as the JAR file. When using Docker, the default directory is `/plugins`.
 
 The location is where custom third-party drivers should be added. Then Metabase will load the driver on startup, which can be verified in the log.
 
@@ -744,7 +744,7 @@ An UUID token used to signify that an instance has permissions to create the ini
 Type: boolean<br>
 Default: `null`
 
-Hide the “Our data" section from the homepage by setting it to `false`. Show the section with `true`, in case it was manually removed.
+Hide the "Our data" section from the homepage by setting it to `false`. Show the section with `true`, in case it was manually removed.
 
 #### `MB_SHOW_HOMEPAGE_XRAYS`
 


### PR DESCRIPTION
Extends the newly envvars docs:
- Add the rest of the variables, including EE, that are writable (that's a tricky thing to figure out).
- Changed format away from table, since it didn't work very well on Github.
- And made variables linkable, so we can refer to them from other docs or issues.

Is it a bad format? Yes. Should we have something better? Yes. Is it better than nothing right now? Yes.

Fixes #12110