### PR TITLE
Attempt to infer better base type than type/* for native queries; fix H2 NPE

### DIFF
--- a/modules/drivers/druid/src/metabase/driver/druid/execute.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/execute.clj
@@ -132,7 +132,7 @@
                                   vec)
                              (-> result :results first keys))
         metadata           (result-metadata col-names)
-        annotate-col-names (map (comp keyword :name) (annotate/column-info* outer-query metadata))]
+        annotate-col-names (map (comp keyword :name) (annotate/merged-column-info outer-query metadata))]
     (respond metadata (result-rows result col-names annotate-col-names))))
 
 (defn execute-reducible-query

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -297,7 +297,8 @@
 ;; de-CLOB any CLOB values that come back
 (defmethod sql-jdbc.execute/read-column-thunk :h2
   [_ ^ResultSet rs ^ResultSetMetaData rsmeta ^Integer i]
-  (let [classname (Class/forName (.getColumnClassName rsmeta i) true (classloader/the-classloader))]
+  (let [classname (some-> (.getColumnClassName rsmeta i)
+                          (Class/forName true (classloader/the-classloader)))]
     (if (isa? classname Clob)
       (fn []
         (jdbc-protocols/clob->str (.getObject rs i)))

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -162,7 +162,7 @@
   (qp.store/with-store
     (let [preprocessed (query->preprocessed query)]
       (driver/with-driver (driver.u/database->driver (:database preprocessed))
-        (seq (annotate/column-info* preprocessed nil))))))
+        (seq (annotate/merged-column-info preprocessed nil))))))
 
 (defn query->native
   "Return the native form for `query` (e.g. for a MBQL query on Postgres this would return a map containing the compiled

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -544,7 +544,7 @@
          cols-returned-by-driver)
     cols))
 
-(s/defn column-info* :- ColsWithUniqueNames
+(s/defn merged-column-info :- ColsWithUniqueNames
   "Returns deduplicated and merged column metadata (`:cols`) for query results by combining (a) the initial results
   metadata returned by the driver's impl of `execute-reducible-query` and (b) column metadata inferred by logic in
   this namespace."
@@ -565,7 +565,7 @@
    (fn combine [result sampled-rows]
      (rf (cond-> result
            (map? result)
-           (assoc-in [:data :cols] (column-info* query (assoc metadata :rows sampled-rows))))))))
+           (assoc-in [:data :cols] (merged-column-info query (assoc metadata :rows sampled-rows))))))))
 
 (defn add-column-info
   "Middleware for adding type information about the columns in the query results (the `:cols` key)."
@@ -575,7 +575,7 @@
      query
      (fn [metadata]
        (if (= query-type :query)
-         (rff (assoc metadata :cols (column-info* query metadata)))
+         (rff (assoc metadata :cols (merged-column-info query metadata)))
          ;; rows sampling is only needed for native queries! TODO ­ not sure we really even need to do for native
          ;; queries...
          (add-column-info-xform query metadata (rff metadata))))

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -97,3 +97,13 @@
                    :field_ref    [:field-literal "NAME" :type/Text]
                    :name         "NAME"}]
                  (mt/cols results))))))))
+
+(deftest native-query-date-trunc-test
+  (mt/test-driver :h2
+    (testing "A native query that doesn't return a column class name metadata should work correctly (#12150)"
+      (is (= [{:display_name "D"
+               :base_type    :type/DateTime
+               :source       :native
+               :field_ref    [:field-literal "D" :type/DateTime]
+               :name         "D"}]
+             (mt/cols (qp/process-query (mt/native-query {:query "SELECT date_trunc('day', DATE) AS D FROM CHECKINS LIMIT 5;"}))))))))

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -38,9 +38,9 @@
                :rows [[nil]]}))))
 
     (testing "should attempt to infer better base type if driver returns :type/* (#12150)"
-      ;; `column-info*` handles merging info returned by driver & inferred by annotate
+      ;; `merged-column-info` handles merging info returned by driver & inferred by annotate
       (is (= [{:name "a", :display_name "a", :base_type :type/Integer, :source :native, :field_ref [:field-literal "a" :type/Integer]}]
-             (annotate/column-info*
+             (annotate/merged-column-info
               {:type :native}
               {:cols [{:name "a", :base_type :type/*}]
                :rows [[1] [2] [nil] [3]]}))))))


### PR DESCRIPTION
Fixes #12150

*  If a driver returns base type `:type/*` (i.e., unknown type) in column metadata for native query results, attempt to infer better type by scanning values sample
*  Fix NPE in H2 native query results for columns where JDBC metadata `.getColumnClassName` returned nil
*  Rename `annotate/column-info*` to `annotate/merged-column-info` (makes the purpose of the function clearer)