### PR TITLE
Bump ring/ring-jetty-adapter 1.7.1 -> 1.8.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -129,7 +129,7 @@
    [puppetlabs/i18n "0.8.0"]                                          ; Internationalization library
    [redux "0.1.4"]                                                    ; Utility functions for building and composing transducers
    [ring/ring-core "1.8.0"]
-   [ring/ring-jetty-adapter "1.7.1"]                                  ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
+   [ring/ring-jetty-adapter "1.8.0"]                                  ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
    [ring/ring-json "0.4.0"]                                           ; Ring middleware for reading/writing JSON automatically
    [stencil "0.5.0"]                                                  ; Mustache templates for Clojure
    [toucan "1.15.1" :exclusions [org.clojure/java.jdbc honeysql]]     ; Model layer, hydration, and DB utilities


### PR DESCRIPTION
Fixes #12071 (this was fixed upstream in https://github.com/ring-clojure/ring/pull/380)