### PR TITLE
fix for RestfulRequest.reset()

### DIFF
--- a/frontend/src/metabase/lib/request.js
+++ b/frontend/src/metabase/lib/request.js
@@ -48,7 +48,7 @@ export class RestfulRequest {
     }
   };
 
-  reset = () => dispatch => dispatch(this.actions.reset);
+  reset = () => ({ type: this.actions.resetRequest });
 
   mergeToDictionary = (dict, result) => {
     dict = dict || {};


### PR DESCRIPTION
i can't tell if or how it was working prior to this fix. please let me
know if i missed something. here's what changed:

- `reset()` returns an action object vs a thunk function (noticed also
  it should have been `dispatch.action()` otherwise)

- `this.actions.resetRequest` vs `this.actions.reset`, as the latter
  does not exit

Ran the frontend tests with `yarn lint && yarn flow && yarn test` and got some warnings but i do not think it's from my changes, and i didn't see any failed tests.

###### Before submitting the PR, please make sure you do the following
- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
