### PR TITLE
Improve how lists are indented in the ReactMarkdown component

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Text.css
+++ b/frontend/src/metabase/visualizations/visualizations/Text.css
@@ -68,24 +68,19 @@
 :local .text-card-markdown ul {
   font-size: 16px;
   margin: 0.5em 0 0.5em 0;
-  padding: 0 1.5em 0 1em;
+  padding: 0 1.5em;
   list-style-type: disc;
 }
 :local .text-card-markdown ol {
   font-size: 16px;
   margin: 0.5em 0 0.5em 0;
-  padding: 0 1.5em 0 1em;
+  padding: 0 1.5em;
   list-style-type: decimal;
 }
 
 :local .text-card-markdown li {
-  list-style-position: inside;
+  list-style-position: outside;
   padding: 0.25em 0 0 0;
-}
-:local .text-card-markdown ol li::before {
-  content: "";
-  width: 7px;
-  display: inline-block;
 }
 
 :local .text-card-markdown a {


### PR DESCRIPTION
Currently, the ReactMarkdown components does a poor job of indenting lists that contain items that wrap over multiple lines. This change moves the bullets/numbers to be positioned on the outside.

# Before

![image](https://user-images.githubusercontent.com/27211/78414065-13412680-7666-11ea-9c29-1e15324145a5.png)

# After

![image](https://user-images.githubusercontent.com/27211/78414117-5ac7b280-7666-11ea-8b86-97cbaeabf3d3.png)

---

###### Before submitting the PR, please make sure you do the following
- [ ] ~~If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.~~
### Tests
-  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [ ] ~~If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`~~

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).