### PR TITLE
Fix premium embedding token settings

### DIFF
--- a/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
+++ b/frontend/src/metabase/admin/settings/containers/SettingsEditorApp.jsx
@@ -109,6 +109,7 @@ export default class SettingsEditorApp extends Component {
     const { settings, updateSetting } = this.props;
     const setting = _.findWhere(settings, { key });
     if (!setting) {
+      console.error(`Attempted to change unknown setting ${key}`);
       throw new Error(t`Unknown setting ${key}`);
     }
     return updateSetting({ ...setting, value });

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -59,4 +59,84 @@ describe("scenarios > admin > settings", () => {
     openOrdersTable();
     cy.contains(/^February 11, 2019, 9:40 PM$/);
   });
+
+  it("should validate a premium embedding token has a valid format", () => {
+    cy.server();
+    cy.route("PUT", "/api/setting/premium-embedding-token").as("saveEmbeddingToken");
+
+    cy.visit("/admin/settings/embedding_in_other_applications");
+    cy.contains("Premium embedding");
+    cy.contains("Enter a token").click();
+
+    // Try an invalid token format
+    cy
+      .contains("Enter the token")
+      .next()
+      .type("Hi")
+      .blur();
+    cy.wait("@saveEmbeddingToken").then(({ response }) => {
+      expect(response.body).to.equal("Token format is invalid. Token should be 64 hexadecimal characters.");
+    });
+    cy.contains("Token format is invalid.");
+  });
+
+  it("should validate a premium embedding token exists", () => {
+    cy.server();
+    cy.route("PUT", "/api/setting/premium-embedding-token").as("saveEmbeddingToken");
+
+    cy.visit("/admin/settings/embedding_in_other_applications");
+    cy.contains("Premium embedding");
+    cy.contains("Enter a token").click();
+
+    // Try a valid format, but an invalid token
+    cy
+      .contains("Enter the token")
+      .next()
+      .type("11397b1e60cfb1372f2f33ac8af234a15faee492bbf5c04d0edbad76da3e614a")
+      .blur();
+    cy.wait("@saveEmbeddingToken").then(({ response }) => {
+      expect(response.body).to.equal("Unable to validate token: 404 not found.");
+    });
+    cy.contains("Unable to validate token: 404 not found.");
+  });
+
+  it("should be able to set a premium embedding token", () => {
+    // A random embedding token with valid format
+    let embeddingToken = "11397b1e60cfb1372f2f33ac8af234a15faee492bbf5c04d0edbad76da3e614a";
+
+    cy.server();
+    cy.route({
+      method: "PUT",
+      url: "/api/setting/premium-embedding-token",
+      response: embeddingToken
+    }).as("saveEmbeddingToken");
+
+    cy.visit("/admin/settings/embedding_in_other_applications");
+    cy.contains("Premium embedding");
+    cy.contains("Enter a token").click();
+
+    cy.route("GET","/api/session/properties").as("getSessionProperties");
+    cy.route({
+      method: "GET",
+      url: "/api/setting",
+      response: [
+        {"key": "enable-embedding", "value": true},
+        {"key": "embedding-secret-key", "value": embeddingToken},
+        {"key":"premium-embedding-token", "value": embeddingToken}
+      ],
+    }).as("getSettings");
+
+    cy
+      .contains("Enter the token")
+      .next()
+      .type(embeddingToken)
+      .blur();
+    cy.wait("@saveEmbeddingToken").then(({ response }) => {
+      expect(response.body).to.equal(embeddingToken);
+    });
+    cy.wait("@getSessionProperties");
+    cy.wait("@getSettings");
+    cy.contains("Premium embedding enabled");
+  })
+
 });

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -62,72 +62,78 @@ describe("scenarios > admin > settings", () => {
 
   it("should validate a premium embedding token has a valid format", () => {
     cy.server();
-    cy.route("PUT", "/api/setting/premium-embedding-token").as("saveEmbeddingToken");
+    cy.route("PUT", "/api/setting/premium-embedding-token").as(
+      "saveEmbeddingToken",
+    );
 
     cy.visit("/admin/settings/embedding_in_other_applications");
     cy.contains("Premium embedding");
     cy.contains("Enter a token").click();
 
     // Try an invalid token format
-    cy
-      .contains("Enter the token")
+    cy.contains("Enter the token")
       .next()
       .type("Hi")
       .blur();
     cy.wait("@saveEmbeddingToken").then(({ response }) => {
-      expect(response.body).to.equal("Token format is invalid. Token should be 64 hexadecimal characters.");
+      expect(response.body).to.equal(
+        "Token format is invalid. Token should be 64 hexadecimal characters.",
+      );
     });
     cy.contains("Token format is invalid.");
   });
 
   it("should validate a premium embedding token exists", () => {
     cy.server();
-    cy.route("PUT", "/api/setting/premium-embedding-token").as("saveEmbeddingToken");
+    cy.route("PUT", "/api/setting/premium-embedding-token").as(
+      "saveEmbeddingToken",
+    );
 
     cy.visit("/admin/settings/embedding_in_other_applications");
     cy.contains("Premium embedding");
     cy.contains("Enter a token").click();
 
     // Try a valid format, but an invalid token
-    cy
-      .contains("Enter the token")
+    cy.contains("Enter the token")
       .next()
       .type("11397b1e60cfb1372f2f33ac8af234a15faee492bbf5c04d0edbad76da3e614a")
       .blur();
     cy.wait("@saveEmbeddingToken").then(({ response }) => {
-      expect(response.body).to.equal("Unable to validate token: 404 not found.");
+      expect(response.body).to.equal(
+        "Unable to validate token: 404 not found.",
+      );
     });
     cy.contains("Unable to validate token: 404 not found.");
   });
 
   it("should be able to set a premium embedding token", () => {
     // A random embedding token with valid format
-    let embeddingToken = "11397b1e60cfb1372f2f33ac8af234a15faee492bbf5c04d0edbad76da3e614a";
+    let embeddingToken =
+      "11397b1e60cfb1372f2f33ac8af234a15faee492bbf5c04d0edbad76da3e614a";
 
     cy.server();
     cy.route({
       method: "PUT",
       url: "/api/setting/premium-embedding-token",
-      response: embeddingToken
+      response: embeddingToken,
     }).as("saveEmbeddingToken");
 
     cy.visit("/admin/settings/embedding_in_other_applications");
     cy.contains("Premium embedding");
     cy.contains("Enter a token").click();
 
-    cy.route("GET","/api/session/properties").as("getSessionProperties");
+    cy.route("GET", "/api/session/properties").as("getSessionProperties");
     cy.route({
       method: "GET",
       url: "/api/setting",
       response: [
-        {"key": "enable-embedding", "value": true},
-        {"key": "embedding-secret-key", "value": embeddingToken},
-        {"key":"premium-embedding-token", "value": embeddingToken}
+        { key: "enable-embedding", value: true },
+        { key: "embedding-secret-key", value: embeddingToken },
+        { key: "premium-embedding-token", value: embeddingToken },
       ],
     }).as("getSettings");
 
-    cy
-      .contains("Enter the token")
+    cy.contains("Enter the token")
       .next()
       .type(embeddingToken)
       .blur();
@@ -137,6 +143,5 @@ describe("scenarios > admin > settings", () => {
     cy.wait("@getSessionProperties");
     cy.wait("@getSettings");
     cy.contains("Premium embedding enabled");
-  })
-
+  });
 });

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -108,7 +108,7 @@ describe("scenarios > admin > settings", () => {
 
   it("should be able to set a premium embedding token", () => {
     // A random embedding token with valid format
-    let embeddingToken =
+    const embeddingToken =
       "11397b1e60cfb1372f2f33ac8af234a15faee492bbf5c04d0edbad76da3e614a";
 
     cy.server();

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -10,12 +10,15 @@
             [metabase.models
              [common :as common]
              [setting :as setting :refer [defsetting]]]
-            [metabase.public-settings.metastore]
+            metabase.public-settings.metastore
             [metabase.util
              [i18n :refer [available-locales-with-names deferred-tru set-locale trs tru]]
              [password :as password]]
             [toucan.db :as db])
   (:import java.util.UUID))
+
+;; These modules register settings but are otherwise unused. They still must be imported.
+(comment metabase.public-settings.metastore/keep-me)
 
 (defsetting check-for-updates
   (deferred-tru "Identify when new versions of Metabase are available.")

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -10,6 +10,7 @@
             [metabase.models
              [common :as common]
              [setting :as setting :refer [defsetting]]]
+            [metabase.public-settings.metastore]
             [metabase.util
              [i18n :refer [available-locales-with-names deferred-tru set-locale trs tru]]
              [password :as password]]


### PR DESCRIPTION
Resolves #12273

At some point we stopped importing the `metabase.public-settings.metastore` module which broke the settings defined there.

Currently `metabase.api.session-test` just checks that the endpoint returns the defined tests but maybe we should hard-code some expected (and unexpected) settings keys like these in a test?

Alternatively we could write a Cypress test but we'd need to include a token or test mode to bypass the token check, which we probably don't want to do.

```clojure
;; GET /session/properties

;; Unauthenticated
(expect
  (keys (setting/properties :public))
  (keys (client :get 200 "session/properties")))

;; Authenticated normal user
(expect
  (keys (merge
          (setting/properties :public)
          (setting/properties :authenticated)))
  (keys ((test-users/user->client :lucky) :get 200 "session/properties")))

;; Authenticated super user
(expect
  (keys (merge
          (setting/properties :public)
          (setting/properties :authenticated)
          (setting/properties :admin)))
  (keys ((test-users/user->client :crowberto) :get 200 "session/properties")))
```