### PR TITLE
Settings email form fixes

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsBatchForm.jsx
@@ -33,6 +33,8 @@ const SAVE_SETTINGS_BUTTONS_STATES = {
 @connect(
   null,
   { updateSettings },
+  null,
+  { withRef: true }, // HACK: needed so consuming components can call methods on the component :-/
 )
 export default class SettingsBatchForm extends Component {
   constructor(props, context) {

--- a/frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsEmailForm.jsx
@@ -69,7 +69,7 @@ export default class SettingsEmailForm extends Component {
     const { sendingEmail } = this.state;
     return (
       <SettingsBatchForm
-        ref={form => (this._form = form)}
+        ref={form => (this._form = form && form.getWrappedInstance())}
         {...this.props}
         updateSettings={this.props.updateEmailSettings}
         disable={sendingEmail !== "default"}

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -59,4 +59,37 @@ describe("scenarios > admin > settings", () => {
     openOrdersTable();
     cy.contains(/^February 11, 2019, 9:40 PM$/);
   });
+
+  describe(" > email settings", () => {
+    it("should be able to save email settings", () => {
+      cy.visit("/admin/settings/email");
+      cy.findByPlaceholderText("smtp.yourservice.com")
+        .type("localhost")
+        .blur();
+      cy.findByPlaceholderText("587")
+        .type("1234")
+        .blur();
+      cy.findByPlaceholderText("metabase@yourcompany.com")
+        .type("admin@metabase.com")
+        .blur();
+      cy.findByText("Save changes").click();
+
+      cy.findByText("Changes saved!");
+    });
+    it("should show an error if test email fails", () => {
+      cy.visit("/admin/settings/email");
+      cy.findByText("Send test email").click();
+      cy.findByText("Sorry, something went wrong. Please try again.");
+    });
+    it("should be able to clear email settings", () => {
+      cy.visit("/admin/settings/email");
+      cy.findByText("Clear").click();
+      cy.findByPlaceholderText("smtp.yourservice.com").should("have.value", "");
+      cy.findByPlaceholderText("587").should("have.value", "");
+      cy.findByPlaceholderText("metabase@yourcompany.com").should(
+        "have.value",
+        "",
+      );
+    });
+  });
 });


### PR DESCRIPTION
When we `connect`ed `SettingsBatchForm` it broke `SettingsEmailForm`.

Resolves #12274 
Resolves #12275 

A Cypress test would be nice but we'd need to spin up a test SMTP server.