### PR TITLE
Harden insights

### DIFF
--- a/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
+++ b/src/metabase/sync/analyze/fingerprint/fingerprinters.clj
@@ -108,7 +108,8 @@
        (reduced result#)
        result#)))
 
-(defn- with-error-handling
+(defn with-error-handling
+  "Wrap `rf` in an error-catching transducer."
   [rf msg]
   (fn
     ([] (with-reduced-error msg (rf)))

--- a/src/metabase/sync/analyze/query_results.clj
+++ b/src/metabase/sync/analyze/query_results.clj
@@ -90,4 +90,5 @@
                            (assoc metadata :fingerprint fingerprint)))
                        fingerprints
                        cols)
-        :insights insights}))))
+        :insights (when-not (instance? Throwable insights)
+                    insights)}))))

--- a/test/metabase/sync/analyze/query_results_test.clj
+++ b/test/metabase/sync/analyze/query_results_test.clj
@@ -13,11 +13,11 @@
              [fingerprinters :as fprint]
              [insights :as insights]]
             [metabase.sync.analyze.query-results :as qr]
-            [metabase.test.mock.util :as mock.u]
             [metabase.test
              [data :as data]
              [sync :as sync-test]
-             [util :as tu]]))
+             [util :as tu]]
+            [metabase.test.mock.util :as mock.u]))
 
 (defn- column->name-keyword [field-or-column-metadata]
   (-> field-or-column-metadata

--- a/test/metabase/sync/analyze/query_results_test.clj
+++ b/test/metabase/sync/analyze/query_results_test.clj
@@ -117,6 +117,5 @@
     (is (= 36 (with-redefs [fprint/earliest sync-test/crash-fn]
                 (-> (timeseries-dataset) :rows count)))))
   (testing "Data should come back even if there is an error when calculating insights"
-    (testing "Data should come back even if there is an error during fingerprinting"
-      (is (= 36 (with-redefs [insights/change sync-test/crash-fn]
-                  (-> (timeseries-dataset) :rows count)))))))
+    (is (= 36 (with-redefs [insights/change sync-test/crash-fn]
+                (-> (timeseries-dataset) :rows count))))))

--- a/test/metabase/sync/analyze/query_results_test.clj
+++ b/test/metabase/sync/analyze/query_results_test.clj
@@ -9,10 +9,15 @@
             [metabase.mbql.schema :as mbql.s]
             [metabase.models.card :refer [Card]]
             [metabase.query-processor.test-util :as qp.test-util]
-            [metabase.sync.analyze.fingerprint.fingerprinters :as fprint]
+            [metabase.sync.analyze.fingerprint
+             [fingerprinters :as fprint]
+             [insights :as insights]]
             [metabase.sync.analyze.query-results :as qr]
             [metabase.test.mock.util :as mock.u]
-            [metabase.test.util :as tu]))
+            [metabase.test
+             [data :as data]
+             [sync :as sync-test]
+             [util :as tu]]))
 
 (defn- column->name-keyword [field-or-column-metadata]
   (-> field-or-column-metadata
@@ -99,3 +104,19 @@
     (mt/with-temp Card [card {:dataset_query {:database (mt/id), :type :native, :native {:query "select longitude from venues"}}}]
       (is (= (select-keys mock.u/venue-fingerprints [:longitude])
              (name->fingerprints (query->result-metadata (query-for-card card))))))))
+
+(defn- timeseries-dataset
+  []
+  (->> {:aggregation [[:count]]
+        :breakout    [[:datetime-field [:field-id (data/id :checkins :date)] :month]]}
+       (mt/run-mbql-query checkins)
+       :data))
+
+(deftest error-resilience-test
+  (testing "Data should come back even if there is an error during fingerprinting"
+    (is (= 36 (with-redefs [fprint/earliest sync-test/crash-fn]
+                (-> (timeseries-dataset) :rows count)))))
+  (testing "Data should come back even if there is an error when calculating insights"
+    (testing "Data should come back even if there is an error during fingerprinting"
+      (is (= 36 (with-redefs [insights/change sync-test/crash-fn]
+                  (-> (timeseries-dataset) :rows count)))))))


### PR DESCRIPTION
Wraps insights transducer in an error handling rf, preventing the entire QP failing on error. Fixes #12251.