### PR TITLE
MBQL: add nil comparison tests

### DIFF
--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -49,53 +49,41 @@
     nil false
     x))
 
-;;; filter = true
-(qp.test/expect-with-non-timeseries-dbs
-  [[1 "Tempest" true]
-   [2 "Bullit"  true]]
-  (qp.test/formatted-rows [int str ->bool] :format-nil-values
-    (data/dataset places-cam-likes
-      (data/run-mbql-query places
-        {:filter   [:= $liked true]
-         :order-by [[:asc $id]]}))))
-
-;;; filter != false
-(qp.test/expect-with-non-timeseries-dbs
-  [[1 "Tempest" true]
-   [2 "Bullit"  true]]
-  (qp.test/formatted-rows [int str ->bool] :format-nil-values
-    (data/dataset places-cam-likes
-      (data/run-mbql-query places
-        {:filter   [:!= $liked false]
-         :order-by [[:asc $id]]}))))
-
-;;; filter != true
-(qp.test/expect-with-non-timeseries-dbs
-  [[3 "The Dentist" false]]
-  (qp.test/formatted-rows [int str ->bool] :format-nil-values
-    (data/dataset places-cam-likes
-      (data/run-mbql-query places
-        {:filter   [:!= $liked true]
-         :order-by [[:asc $id]]}))))
-
-;;; filter != nil
-(qp.test/expect-with-non-timeseries-dbs
-  [[12]]
-  (qp.test/formatted-rows [int str ->bool] :format-nil-values
-    (data/dataset bird-flocks
-      (data/run-mbql-query bird
-        {:filter      [:!= $flock_id nil]
-         :aggregation [[:count]]}))))
-
-;;; filter = nil
-(qp.test/expect-with-non-timeseries-dbs
-  [[6]]
-  (qp.test/formatted-rows [int str ->bool] :format-nil-values
-    (data/dataset bird-flocks
-      (data/run-mbql-query bird
-        {:filter      [:= $flock_id nil]
-         :aggregation [[:count]]}))))
-
+(deftest comparison-test
+  (datasets/test-drivers (qp.test/normal-drivers)
+    (testing "Can we use true literal in comparisons"
+      (is (= [[1 "Tempest" true]
+              [2 "Bullit"  true]]
+             (->> {:filter   [:= $liked true]
+                   :order-by [[:asc $id]]}
+                  (data/run-mbql-query places)
+                  (data/dataset places-cam-likes)
+                  (qp.test/formatted-rows [int str ->bool] :format-nil-values))))
+      (is (= [[3 "The Dentist" false]]
+             (->> {:filter   [:!= $liked true]
+                   :order-by [[:asc $id]]}
+                  (data/run-mbql-query places)
+                  (data/dataset places-cam-likes)
+                  (qp.test/formatted-rows [int str ->bool] :format-nil-values))))
+    (testing "Can we use false literal in comparisons"
+      (is (= [[1 "Tempest" true]
+              [2 "Bullit"  true]]
+             (->> {:filter   [:!= $liked false]
+                   :order-by [[:asc $id]]}
+                  (data/run-mbql-query places)
+                  (data/dataset places-cam-likes)
+                  (qp.test/formatted-rows [int str ->bool] :format-nil-values))))
+    (testing "Can we use nil literal in comparisons"
+      (is (= [[12]] (->> {:filter      [:!= $flock_id nil]
+                          :aggregation [[:count]]}
+                         (data/run-mbql-query bird)
+                         (data/dataset bird-flocks)
+                         qp.test/rows)))
+      (is (= [[6]] (->> {:filter       [:= $flock_id nil]
+                          :aggregation [[:count]]}
+                         (data/run-mbql-query bird)
+                         (data/dataset bird-flocks)
+                         qp.test/rows))))))
 
 (deftest between-test
   (datasets/test-drivers (qp.test/normal-drivers)

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -78,6 +78,24 @@
         {:filter   [:!= $liked true]
          :order-by [[:asc $id]]}))))
 
+;;; filter != nil
+(qp.test/expect-with-non-timeseries-dbs
+  [[12]]
+  (qp.test/formatted-rows [int str ->bool] :format-nil-values
+    (data/dataset bird-flocks
+      (data/run-mbql-query bird
+        {:filter      [:!= $flock_id nil]
+         :aggregation [[:count]]}))))
+
+;;; filter = nil
+(qp.test/expect-with-non-timeseries-dbs
+  [[6]]
+  (qp.test/formatted-rows [int str ->bool] :format-nil-values
+    (data/dataset bird-flocks
+      (data/run-mbql-query bird
+        {:filter      [:= $flock_id nil]
+         :aggregation [[:count]]}))))
+
 
 (deftest between-test
   (datasets/test-drivers (qp.test/normal-drivers)

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -83,7 +83,7 @@
                           :aggregation [[:count]]}
                          (data/run-mbql-query bird)
                          (data/dataset bird-flocks)
-                         qp.test/rows))))))
+                         qp.test/rows))))))))
 
 (deftest between-test
   (datasets/test-drivers (qp.test/normal-drivers)


### PR DESCRIPTION
Adds tests for MBQL filter expressions testing against nils (as there was some confusion in #12225 if we support that). 