### PR TITLE
Fix permissions for schema-less dbs

### DIFF
--- a/frontend/src/metabase/admin/permissions/routes.jsx
+++ b/frontend/src/metabase/admin/permissions/routes.jsx
@@ -31,7 +31,7 @@ const getRoutes = store => (
       </Route>
 
       {/* TABLES NO SCHEMA */}
-      {/* NOTE: this route is to support null schemas, inject the empty string as the schemaName */}
+      {/* NOTE: this route is to support null schemas */}
       <Route
         path=":databaseId/tables"
         component={(
@@ -39,7 +39,7 @@ const getRoutes = store => (
         ) => (
           <TablesPermissionsApp
             {...props}
-            params={{ ...props.params, schemaName: "" }}
+            params={{ ...props.params, schemaName: null }}
           />
         )}
       >

--- a/frontend/src/metabase/admin/permissions/selectors.js
+++ b/frontend/src/metabase/admin/permissions/selectors.js
@@ -662,7 +662,7 @@ export const getDatabasesPermissionsGrid = createSelector(
           },
           name: database.name,
           link:
-            schemas.length === 0 || (schemas.length === 1 && schemas[0] === "")
+            schemas.length === 0 || (schemas.length === 1 && schemas[0] == null)
               ? {
                   name: t`View tables`,
                   url: `/admin/permissions/databases/${database.id}/tables`,


### PR DESCRIPTION
fixes #12269

The permissions screen needed to be updated to use `null` for the schema name when a db doesn't support schemas.

It'd be great to add a test once #12292 is merged.