### PR TITLE
Fix crash rendering choropleth maps

### DIFF
--- a/frontend/src/metabase/visualizations/components/CardRenderer.jsx
+++ b/frontend/src/metabase/visualizations/components/CardRenderer.jsx
@@ -108,7 +108,6 @@ export default class CardRenderer extends Component {
       });
     } catch (err) {
       console.error(err);
-      this.props.onRenderError(err.message || err);
     }
   }
 

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -330,6 +330,7 @@ export default class ChoroplethMap extends Component {
             onClickFeature={onClickFeature}
             projection={projection}
             projectionFrame={projectionFrame}
+            onRenderError={this.props.onRenderError}
           />
         ) : (
           <LeafletChoropleth
@@ -339,6 +340,7 @@ export default class ChoroplethMap extends Component {
             onHoverFeature={onHoverFeature}
             onClickFeature={onClickFeature}
             minimalBounds={minimalBounds}
+            onRenderError={this.props.onRenderError}
           />
         )}
       </ChartWithLegend>

--- a/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
@@ -17,6 +17,7 @@ const LeafletChoropleth = ({
   getColor = () => color("brand"),
   onHoverFeature = () => {},
   onClickFeature = () => {},
+  onRenderError,
 }) => (
   <CardRenderer
     series={series}
@@ -104,6 +105,7 @@ const LeafletChoropleth = ({
         map.remove();
       };
     }}
+    onRenderError={onRenderError}
   />
 );
 


### PR DESCRIPTION
Fixes #12249 

There were three issues causing this:
* We didn't pass in `onRenderError` to the choropleth maps. (That's the direct error in the issue)
* Some Google Analytics timing code called `onRenderError`. I think I did this. Really if tracking fails it should just drop the error.

