### PR TITLE
Fix expression 'replace' helper text

### DIFF
--- a/docs/users-guide/expressions.md
+++ b/docs/users-guide/expressions.md
@@ -76,7 +76,7 @@ This would return rows where `Created At` is between January 1, 2020 and March 3
 | Percentile         | `percentile(column, percentile-value)`         | Returns the value of the column at the percentile value.                                                                                                           | `percentile([Score], 0.9)`                                           |
 | Power              | `power(number, exponent)`                      | Raises a number to the power of the exponent value.                                                                                                                | `power([Length], 2)`                                                 |
 | Regex extract      | `regexextract(text, regular_expression)`       | Extracts matching substrings according to a regular expression.                                                                                                    | `regexextract( [Address], "[0-9]+" )`                                |
-| Replace            | `replace(text, position, length, new_text)`    | Replaces a part of the input text with new text.                                                                                                                   | `replace( [Order ID], 8, 3, [Updated Part of ID] )`                  |
+| Replace            | `replace(text, find, replace)`                 | Replaces a part of the input text with new text.                                                                                                                   | `replace( [Title], "Enormous", "Gigantic" )`                         |
 | Round              | `round(number)`                                | Rounds a decimal number either up or down to the nearest integer value.                                                                                            | `round([Temperature])`                                               |
 | Right trim         | `rtrim(text)`                                  | Removes trailing whitespace from a string of text.                                                                                                                 | `rtrim( [Comment] )`                                                 |
 | Share              | `share(condition)`                             | Returns the percent of rows in the data that match the condition, as a decimal.                                                                                    | `share( [Source] = "Goolge" )`                                       |
@@ -94,7 +94,7 @@ This would return rows where `Created At` is between January 1, 2020 and March 3
 
 Certain database types don't support some of the above functions:
 
-MySQL
+MySQL and SQL Server
 
 - median
 - percentile

--- a/frontend/src/metabase/lib/expressions/helper_text_strings.js
+++ b/frontend/src/metabase/lib/expressions/helper_text_strings.js
@@ -235,17 +235,9 @@ const helperTextStrings = [
   },
   {
     name: "replace",
-    structure:
-      "replace(" +
-      t`text` +
-      ", " +
-      t`find` +
-      ", " +
-      t`replace` +
-      ")",
+    structure: "replace(" + t`text` + ", " + t`find` + ", " + t`replace` + ")",
     description: t`Replaces a part of the input text with new text.`,
-    example:
-      "replace([" + t`Title` + '] , "Enormous", "Gigantic")',
+    example: "replace([" + t`Title` + '] , "Enormous", "Gigantic")',
     args: [
       {
         name: t`text`,

--- a/frontend/src/metabase/lib/expressions/helper_text_strings.js
+++ b/frontend/src/metabase/lib/expressions/helper_text_strings.js
@@ -239,31 +239,25 @@ const helperTextStrings = [
       "replace(" +
       t`text` +
       ", " +
-      t`position` +
+      t`find` +
       ", " +
-      t`length` +
-      ", " +
-      t`new_text` +
+      t`replace` +
       ")",
     description: t`Replaces a part of the input text with new text.`,
     example:
-      "replace([" + t`Order ID` + "] , 8, 3, [" + t`Updated Part of ID` + "] )",
+      "replace([" + t`Title` + '] , "Enormous", "Gigantic")',
     args: [
       {
         name: t`text`,
         description: t`The text that will be modified.`,
       },
       {
-        name: t`position`,
-        description: t`The position where the replacing will start.`,
+        name: t`find`,
+        description: t`The text to find.`,
       },
       {
-        name: t`length`,
-        description: t`The number of characters to replace.`,
-      },
-      {
-        name: t`new_text`,
-        description: t`The text to use in the replacement.`,
+        name: t`replace`,
+        description: t`The text to replace with.`,
       },
     ],
   },

--- a/frontend/src/metabase/lib/expressions/helper_text_strings.js
+++ b/frontend/src/metabase/lib/expressions/helper_text_strings.js
@@ -249,7 +249,7 @@ const helperTextStrings = [
       },
       {
         name: t`replace`,
-        description: t`The text to replace with.`,
+        description: t`The text to use as the replacement.`,
       },
     ],
   },


### PR DESCRIPTION
Fix `replace` expression helper and documentation text.
This will break some translations, but it's worth it, since the syntax was incorrect before.
Also closes #12222, since it seems like we forgot to mention the SQL Server limitation.