### PR TITLE
The log written by syslog user into metabase.log

### DIFF
--- a/docs/operations-guide/running-metabase-on-debian.md
+++ b/docs/operations-guide/running-metabase-on-debian.md
@@ -21,7 +21,7 @@ For security reasons we want to have Metabase run as an unprivileged user. We wi
     $ sudo useradd -r -s /bin/false -g metabase metabase
     $ sudo chown -R metabase:metabase </your/path/to/metabase/directory>
     $ sudo touch /var/log/metabase.log
-    $ sudo chown metabase:metabase /var/log/metabase.log
+    $ sudo chown syslog:adm /var/log/metabase.log
     $ sudo touch /etc/default/metabase
     $ sudo chmod 640 /etc/default/metabase
 


### PR DESCRIPTION
The file is always written by syslog user, and not by metabase user. Verified multiple times. When syslog user is the owner of the file /var/log/metabase.log, then the logs can be seen in that file. Please re verify and update.



###### Before submitting the PR, please make sure you do the following
- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
