### PR TITLE
MBQL: fix expressions+joins+multiple columns with same name

### DIFF
--- a/backend/mbql/test/metabase/mbql/util_test.clj
+++ b/backend/mbql/test/metabase/mbql/util_test.clj
@@ -901,6 +901,17 @@
     [:sum [:field-id 1]]
     [:aggregation-options [:sum [:field-id 1]] {:name "sum_2", :display-name "Sum of Field 1"}]]))
 
+(deftest unique-name-generator-test
+  (testing "Can we get a simple unique name generator"
+    (is (= ["count" "sum" "count_2" "count_2_2"]
+           (map (mbql.u/unique-name-generator) ["count" "sum" "count" "count_2"]))))
+  (testing "Can we get an idempotent unique name generator"
+    (is (= ["count" "sum" "count" "count_2"]
+           (map (mbql.u/unique-name-generator) [:x :y :x :z] ["count" "sum" "count" "count_2"]))))
+  (testing "Can the same object have multiple aliases"
+    (is (= ["count" "sum" "count" "count_2"]
+           (map (mbql.u/unique-name-generator) [:x :y :x :x] ["count" "sum" "count" "count_2"])))))
+
 
 ;;; --------------------------------------------- query->max-rows-limit ----------------------------------------------
 

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -209,7 +209,7 @@
   schema + Table name. Used to implement things like `:joined-field`s."
   nil)
 
-(def ^:dynamic *name-aliasing-fn-for-source* {})
+(def ^:dynamic ^:private *name-aliasing-fn-for-source* {})
 
 (defmethod ->honeysql [:sql nil]    [_ _]    nil)
 (defmethod ->honeysql [:sql Object] [_ this] this)

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -844,7 +844,8 @@
                                  (mbql.u/replace expression-definition
                                    [:expression expr] (expressions (keyword expr)))])
                               (distinct
-                               (mbql.u/match query [(_ :guard #{:field-literal :field-id :joined-field}) & _])))))]
+                               (mbql.u/match (dissoc query :source-query)
+                                 [(_ :guard #{:field-literal :field-id :joined-field}) & _])))))]
     (-> query
         (mbql.u/replace [:joined-field alias field] field)
         (dissoc :source-table :joins :expressions :source-metadata)

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -225,7 +225,7 @@
 
 (defn- store-alias
   [field-id alias]
-  (some-> *name-store* deref (swap! assoc field-id alias)))
+  (some-> *name-store* (swap! assoc field-id alias)))
 
 (defmethod ->honeysql [:sql nil]    [_ _]    nil)
 (defmethod ->honeysql [:sql Object] [_ this] this)

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -863,7 +863,7 @@
                        (mbql.u/replace expression-definition
                          [:expression expr] (expressions (keyword expr)))])
                     (distinct
-                     (mbql.u/match (select-keys query [:aggregation :filter :breakout :fields :order-by])
+                     (mbql.u/match (select-keys query [:aggregation :filter :breakout :fields])
                        [(_ :guard #{:field-literal :field-id :joined-field}) & _]))))
         subselect (-> query
                       (select-keys [:joins :source-table :source-query :source-metadata])

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -224,8 +224,8 @@
   (some-> *name-store* deref (get field-id)))
 
 (defn- store-alias
-  [field-id alias]
-  (some-> *name-store* (swap! assoc field-id alias)))
+  [field-id field-alias]
+  (some-> *name-store* (swap! assoc field-id field-alias)))
 
 (defmethod ->honeysql [:sql nil]    [_ _]    nil)
 (defmethod ->honeysql [:sql Object] [_ this] this)

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -830,7 +830,7 @@
     (apply-top-level-clauses driver honeysql-form (dissoc inner-query :source-query))))
 
 
-;;; -------------------------------------------- putting it all togetrher --------------------------------------------
+;;; -------------------------------------------- putting it all together --------------------------------------------
 
 (defn- expressions->subselect
   [{:keys [expressions] :as query}]

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -863,7 +863,7 @@
                        (mbql.u/replace expression-definition
                          [:expression expr] (expressions (keyword expr)))])
                     (distinct
-                     (mbql.u/match (select-keys query [:aggregation :filters :breakout :fields :order-by])
+                     (mbql.u/match (select-keys query [:aggregation :filter :breakout :fields :order-by])
                        [(_ :guard #{:field-literal :field-id :joined-field}) & _]))))
         subselect (-> query
                       (select-keys [:joins :source-table :source-query :source-metadata])

--- a/test/metabase/query_processor_test/case_test.clj
+++ b/test/metabase/query_processor_test/case_test.clj
@@ -70,7 +70,7 @@
 (deftest test-case-normalization
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= 116.0 (test-case ["sum" ["case" [[["<" ["field-id" (mt/id :venues :price)] 2] 2]
-                                            [["<" ["field-id" (mt/id :venues :price)] 4] 1]] ]])))))
+                                            [["<" ["field-id" (mt/id :venues :price)] 4] 1]]]])))))
 
 (deftest test-case-expressions
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -266,7 +266,7 @@
                  mt/rows
                  ffirst))))
     (testing "Do joins where the same field name is present in multiple tables work with expression hoisting"
-      (is (= [1 2 5]
+      (is (= [1 5 6]
              (->> (mt/run-mbql-query checkins
                     {:expressions {:prev_month [:+ [:field-id (data/id :checkins :id)]
                                                 [:joined-field "users__via__user_id" [:field-id (data/id :users :id)]]]}
@@ -274,6 +274,7 @@
                                    [:joined-field "users__via__user_id" [:field-id (data/id :users :id)]]
                                    [:expression :prev_month]]
                      :limit       1
+                     :order-by    [[:asc [:field-id (data/id :checkins :id)]]]
                      :joins       [{:strategy :left-join
                                     :source-table (data/id :users)
                                     :alias        "users__via__user_id"

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -128,17 +128,15 @@
                 :fields       [[:expression :x]]
                 :source-query {:source-table (data/id :venues)
                                :aggregation  [[:count]]}}))))
-    ;; (is (= [[200]]
-    ;;        (mt/formatted-rows [int]
-    ;;          (mt/run-mbql-query venues
-    ;;            {:expressions  {:x [:* [:field-literal "count" :type/Integer] 2]}
-    ;;             :fields       [[:expression :x]]
-    ;;             :source-query {:source-table (data/id :venues)
-    ;;                            :aggregation  [[:count]]
-    ;;                            :breakout     [[:field-id (data/id :venues :name)]]}
-    ;;             :limit        1}))))
-
-    ))
+    (is (= [[2]]
+           (mt/formatted-rows [int]
+             (mt/run-mbql-query venues
+               {:expressions  {:x [:* [:field-literal "count" :type/Integer] 2]}
+                :fields       [[:expression :x]]
+                :source-query {:source-table (data/id :venues)
+                               :aggregation  [[:count]]
+                               :breakout     [[:field-id (data/id :venues :name)]]}
+                :limit        1}))))))
 
 (deftest expressions-should-include-type-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -264,4 +264,19 @@
                                    :condition    [:= $user_id
                                                   [:joined-field "users__via__user_id" [:field-id (data/id :users :id)]]]}]})
                  mt/rows
-                 ffirst))))))
+                 ffirst))))
+    (testing "Do joins where the same field name is present in multiple tables work with expression hoisting"
+      (is (= [1 2 5]
+             (->> (mt/run-mbql-query checkins
+                    {:expressions {:prev_month [:+ [:field-id (data/id :checkins :id)]
+                                                [:joined-field "users__via__user_id" [:field-id (data/id :users :id)]]]}
+                     :fields      [[:field-id (data/id :checkins :id)]
+                                   [:joined-field "users__via__user_id" [:field-id (data/id :users :id)]]
+                                   [:expression :prev_month]]
+                     :limit       1
+                     :joins       [{:strategy :left-join
+                                    :source-table (data/id :users)
+                                    :alias        "users__via__user_id"
+                                    :condition    [:= $user_id
+                                                   [:joined-field "users__via__user_id" [:field-id (data/id :users :id)]]]}]})
+                  (mt/formatted-rows [int int int])))))))

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -266,7 +266,7 @@
                  mt/rows
                  ffirst))))
     (testing "Do joins where the same field name is present in multiple tables work with expression hoisting"
-      (is (= [1 5 6]
+      (is (= [[1 5 6]]
              (->> (mt/run-mbql-query checkins
                     {:expressions {:prev_month [:+ [:field-id (data/id :checkins :id)]
                                                 [:joined-field "users__via__user_id" [:field-id (data/id :users :id)]]]}


### PR DESCRIPTION
Fixes a bug where nested queries didn't distinguish between fields with the same name but from different tables (eg. when joining 2 tables with the field `created_at` the results have the first `created_at` duplicated instead of two distinct fields with distinct values). Once we started lifting expressions to a subselect, the bug became more prominent.

Also fixes a bug where expressions subselect tried to lift fields from `:source-query`.

A potentially cleaner solution to a lot of machinations around lifting cols and tracking their names would be to use `:field-literal`s instead of `field-id`s in the outer query, this however would loose us some metadata and would be somewhat slower/more computationally expensive as we'd then have to needlessly recalculate fingerprints for the fields. Since custom expressions have the potential to be used quite heavily I opted for the more performant solution. 

Fixes #12252 (partially, other half is fixed in #12345) and #12243.