### PR TITLE
Disambiguate duplicate native cols

### DIFF
--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -43,7 +43,15 @@
              (annotate/merged-column-info
               {:type :native}
               {:cols [{:name "a", :base_type :type/*}]
-               :rows [[1] [2] [nil] [3]]}))))))
+               :rows [[1] [2] [nil] [3]]}))))
+
+    (testing "should disambiguate duplicate names"
+      (is (= [{:name "a", :display_name "a", :base_type :type/Integer, :source :native, :field_ref [:field-literal "a" :type/Integer]}
+              {:name "a", :display_name "a", :base_type :type/Integer, :source :native, :field_ref [:field-literal "a_2" :type/Integer]}]
+             (annotate/column-info
+              {:type :native}
+              {:cols [{:name "a"} {:name "a"}]
+               :rows [[1 nil] [2 nil] [3 nil] [4 5] [6 7]]}))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Fixes the second part of #12252 where we didn't properly distinguish between two __native__ columns named the same. The `:field_ref`s are now unique, however this is very much a partial fix that solves the frontend issue at best. The problem is that we can make up a unique name, but the [native] query is as it is, if we use this `field_ref` in any followup MBQL queries, we will generate an invalid query as the now unique name does not exist in that query. The difference is that before the result would be wrong/incomplete, now followup queries break.

Solving this comprehensively would entail either parsing & rewriting the SQL; or introducing positional col referencing (same as we do for `:aggregation`. So you could do something like `[:field-literal 1 :type/Integer]`).

A less ambitious followup partial solution would be that if/when we generate an invalid followup query due to name clash we give you a nice error message/explanation. 

Another (potential) alternative is that we change the referencing logic on the FE if that's possible+sane+sensible. 