### PR TITLE
Bump flatland/ordered

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -114,7 +114,7 @@
    [org.apache.commons/commons-lang3 "3.9"]                           ; helper methods for working with java.lang stuff
    [org.clojars.pntblnk/clj-ldap "0.0.16"]                            ; LDAP client
    [org.eclipse.jetty/jetty-server "9.4.27.v20200227"]                ; We require JDK 8 which allows us to run Jetty 9.4, ring-jetty-adapter runs on 1.7 which forces an older version
-   [org.flatland/ordered "1.5.7"]                                     ; ordered maps & sets
+   [org.flatland/ordered "1.5.9"]                                     ; ordered maps & sets
    [org.liquibase/liquibase-core "3.6.3"                              ; migration management (Java lib)
     :exclusions [ch.qos.logback/logback-classic]]
    [org.mariadb.jdbc/mariadb-java-client "2.5.1"]                     ; MySQL/MariaDB driver


### PR DESCRIPTION
Bumps flatland/ordered to 1.5.9 as this version has no outside dependencies.

Edit: PR is intentionally against master as I don't think this is patch-release material. 