### PR TITLE
Have datamodel include hidden tables that are excluded by default

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTablePicker.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTablePicker.jsx
@@ -9,7 +9,7 @@ import Tables from "metabase/entities/tables";
 import _ from "underscore";
 
 @Tables.loadList({
-  query: (state, { databaseId }) => ({ dbId: databaseId }),
+  query: (state, { databaseId }) => ({ dbId: databaseId, includeHidden: true }),
 })
 export default class MetadataTablePicker extends Component {
   constructor(props, context) {

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -26,18 +26,18 @@ import { addValidOperatorsToFields } from "metabase/lib/schema_metadata";
 import { getMetadata } from "metabase/selectors/metadata";
 
 const listTables = GET("/api/table");
-const listTablesForDatabase = async (...args) =>
+const listTablesForDatabase = async (params, ...args) =>
   // HACK: no /api/database/:dbId/tables endpoint
-  (await GET("/api/database/:dbId/metadata")(...args)).tables.filter(
-    /*
-     * HACK: Right now the endpoint returns all tables regardless of
-     * whether they're hidden. make sure table lists only use non hidden tables
-     * Ideally this should live in the API?
-     */
+  (await GET("/api/database/:dbId/metadata")(params, ...args)).tables.filter(
+    /* HACK: Right now the endpoint returns all tables regardless of whether
+       they're hidden. make sure table lists only use non hidden tables Ideally
+       this should live in the API? The `includeHidden` exception is used in the
+       admin panel where hidden tables are listed separately. */
     t =>
-      t.visibility_type !== "hidden" &&
-      t.visibility_type !== "technical" &&
-      t.visibility_type !== "cruft",
+      params.includeHidden ||
+      (t.visibility_type !== "hidden" &&
+        t.visibility_type !== "technical" &&
+        t.visibility_type !== "cruft"),
   );
 const listTablesForSchema = GET("/api/database/:dbId/schema/:schemaName");
 

--- a/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
@@ -1,6 +1,7 @@
 import { signInAsAdmin, restore } from "__support__/cypress";
 
-const ORDERS_URL = "/admin/datamodel/database/1/table/2";
+const SAMPLE_DB_URL = "/admin/datamodel/database/1";
+const ORDERS_URL = `${SAMPLE_DB_URL}/table/2`;
 
 describe("scenarios > admin > datamodel > table", () => {
   beforeEach(() => {
@@ -64,6 +65,11 @@ describe("scenarios > admin > datamodel > table", () => {
 
       cy.reload();
       cy.contains("Technical Data").should("have.class", "text-brand");
+
+      // check that it still appears in the sidebar on the db page
+      cy.visit(SAMPLE_DB_URL);
+      cy.contains("1 Hidden Table");
+      cy.contains("Orders");
     });
 
     function field(name) {


### PR DESCRIPTION
Fixes #12344

This PR adds a `includeHidden` flag so the datamodel can explicitly request hidden tables.

There was a Cypress test that _almost_ caught this issue. I updated it so that it would have.