### PR TITLE
Refresh site settings after logging in with Google

### DIFF
--- a/frontend/src/metabase/auth/auth.js
+++ b/frontend/src/metabase/auth/auth.js
@@ -48,7 +48,10 @@ export const loginGoogle = createThunkAction(LOGIN_GOOGLE, function(
       MetabaseAnalytics.trackEvent("Auth", "Google Auth Login");
 
       // TODO: redirect after login (carry user to intended destination)
-      await dispatch(refreshCurrentUser());
+      await Promise.all([
+        dispatch(refreshCurrentUser()),
+        dispatch(refreshSiteSettings()),
+      ]);
       dispatch(push(redirectUrl || "/"));
     } catch (error) {
       await clearGoogleAuthCredentials();


### PR DESCRIPTION
Fixes #12359 

This copies over the same change from #12132 to the parallel code path for Google log in. This probably indicates that those could be consolidated, but they're pretty simple and rarely touched so 🤷.

I didn't test this locally since I don't have google auth credentials. @flamber do you have any? If not, it seems obvious enough (famous last words) that I'm good merging and verifying on stats after release is merged in.