### PR TITLE
Increase mac app build step timeout [ci skip]

### DIFF
--- a/OSX/macos_release/common.clj
+++ b/OSX/macos_release/common.clj
@@ -122,7 +122,7 @@
       (throw (ex-info (format "Timed out after %d ms." timeout-ms) {})))
     result))
 
-(def ^:private command-timeout-ms (* 5 60 1000)) ; 5 minutes
+(def ^:private command-timeout-ms (* 15 60 1000)) ; 15 minutes
 
 (defn sh*
   "Run a shell command. Like `clojure.java.shell/sh`, but prints output to stdout/stderr and returns results as a vector


### PR DESCRIPTION
Sometimes uploading 500 MB of stuff to S3 takes more than 5 minutes on slow internet