### PR TITLE
Allow a driver to customize the query remarks

### DIFF
--- a/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
@@ -228,7 +228,7 @@
   (let [database (qp.store/database)]
     (binding [bigquery.common/*bigquery-timezone-id* (effective-query-timezone-id database)]
       (log/tracef "Running BigQuery query in %s timezone" bigquery.common/*bigquery-timezone-id*)
-      (let [sql (str "-- " (qputil/query->remark outer-query) "\n" (if (seq params)
+      (let [sql (str "-- " (qputil/query->remark :bigquery outer-query) "\n" (if (seq params)
                                                                      (unprepare/unprepare driver (cons sql params))
                                                                      sql))]
         (process-native* respond database sql)))))

--- a/modules/drivers/presto/src/metabase/driver/presto.clj
+++ b/modules/drivers/presto/src/metabase/driver/presto.clj
@@ -305,7 +305,7 @@
    context
    respond]
   (let [sql     (str "-- "
-                     (qputil/query->remark outer-query) "\n"
+                     (qputil/query->remark :presto outer-query) "\n"
                      (unprepare/unprepare driver (cons sql params)))
         details (merge (:details (qp.store/database))
                        settings)]

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -128,7 +128,7 @@
 (defmethod driver/execute-reducible-query :sparksql
   [driver {:keys [database settings], {sql :query, :keys [params], :as inner-query} :native, :as outer-query} context respond]
   (let [inner-query (-> (assoc inner-query
-                               :remark (qputil/query->remark outer-query)
+                               :remark (qputil/query->remark :sparksql outer-query)
                                :query  (if (seq params)
                                          (unprepare/unprepare driver (cons sql params))
                                          sql)

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -379,7 +379,7 @@
   {:added "0.35.0", :arglists '([driver query context respond])}
   [driver {{sql :query, params :params} :native, :as outer-query} context respond]
   {:pre [(string? sql) (seq sql)]}
-  (let [remark   (qputil/query->remark outer-query)
+  (let [remark   (qputil/query->remark driver outer-query)
         sql      (str "-- " remark "\n" sql)
         max-rows (or (mbql.u/query->max-rows-limit outer-query)
                      qp.i/absolute-max-results)]

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -5,6 +5,7 @@
              [hash :as hash]]
             [cheshire.core :as json]
             [clojure.string :as str]
+            [metabase.driver :as driver]
             [metabase.util.schema :as su]
             [schema.core :as s]))
 
@@ -23,11 +24,8 @@
        (not page)
        (nil? aggregations)))
 
-(defn query->remark
-  "Generate an approparite REMARK to be prepended to a query to give DBAs additional information about the query being
-  executed. See documentation for `mbql->native` and [issue #2386](https://github.com/metabase/metabase/issues/2386)
-  for more information."
-  ^String [{{:keys [executed-by query-hash], :as info} :info, query-type :type}]
+(defn default-query->remark
+  [{{:keys [executed-by query-hash], :as info} :info, query-type :type}]
   (str "Metabase" (when executed-by
                     (assert (instance? (Class/forName "[B") query-hash))
                     (format ":: userID: %s queryType: %s queryHash: %s"
@@ -36,6 +34,18 @@
                               :query  "MBQL"
                               :native "native")
                             (codecs/bytes->hex query-hash)))))
+
+(defmulti query->remark
+  "Generate an appropriate REMARK to be prepended to a query to give DBAs additional information about the query being
+  executed. See documentation for `mbql->native` and [issue #2386](https://github.com/metabase/metabase/issues/2386)
+  for more information."
+  {:arglists '(^String [driver data])}
+  driver/dispatch-on-initialized-driver
+  :hierarchy #'driver/hierarchy)
+
+(defmethod query->remark :default
+  [_ params]
+  (default-query->remark params))
 
 
 ;;; ------------------------------------------------- Normalization --------------------------------------------------

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -25,6 +25,8 @@
        (nil? aggregations)))
 
 (defn default-query->remark
+  "Generates the default query remark. Exists as a separate function so that overrides of the query->remark multimethod
+   can access the default value."
   [{{:keys [executed-by query-hash], :as info} :info, query-type :type}]
   (str "Metabase" (when executed-by
                     (assert (instance? (Class/forName "[B") query-hash))


### PR DESCRIPTION
This allows driver-specific metadata to be added to each query. If the
driver can apply the default metadata, it should call
default-query->remark