### PR TITLE
Allow a driver to customize the query remarks

### DIFF
--- a/backend/mbql/src/metabase/mbql/schema.clj
+++ b/backend/mbql/src/metabase/mbql/schema.clj
@@ -159,7 +159,8 @@
   {(s/optional-key :database_type) (s/maybe su/NonBlankString)
    (s/optional-key :base_type)     (s/maybe su/FieldType)
    (s/optional-key :special_type)  (s/maybe su/FieldType)
-   (s/optional-key :unit)          (s/maybe DatetimeFieldUnit)})
+   (s/optional-key :unit)          (s/maybe DatetimeFieldUnit)
+   (s/optional-key :name)          (s/maybe su/NonBlankString)})
 
 ;; Arguments to filter clauses are automatically replaced with [:value <value> <type-info>] clauses by the
 ;; `wrap-value-literals` middleware. This is done to make it easier to implement query processors, because most driver

--- a/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
@@ -229,8 +229,8 @@
     (binding [bigquery.common/*bigquery-timezone-id* (effective-query-timezone-id database)]
       (log/tracef "Running BigQuery query in %s timezone" bigquery.common/*bigquery-timezone-id*)
       (let [sql (str "-- " (qputil/query->remark :bigquery outer-query) "\n" (if (seq params)
-                                                                     (unprepare/unprepare driver (cons sql params))
-                                                                     sql))]
+                                                                               (unprepare/unprepare driver (cons sql params))
+                                                                               sql))]
         (process-native* respond database sql)))))
 
 

--- a/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
@@ -228,7 +228,7 @@
   (let [database (qp.store/database)]
     (binding [bigquery.common/*bigquery-timezone-id* (effective-query-timezone-id database)]
       (log/tracef "Running BigQuery query in %s timezone" bigquery.common/*bigquery-timezone-id*)
-      (let [sql (str "-- " (qputil/query->remark outer-query) "\n" (if (seq params)
+      (let [sql (str "-- " (qputil/query->remark :bigquery outer-query) "\n" (if (seq params)
                                                                      (unprepare/unprepare driver (cons sql params))
                                                                      sql))]
         (process-native* respond database sql)))))

--- a/modules/drivers/presto/src/metabase/driver/presto.clj
+++ b/modules/drivers/presto/src/metabase/driver/presto.clj
@@ -305,7 +305,7 @@
    context
    respond]
   (let [sql     (str "-- "
-                     (qputil/query->remark outer-query) "\n"
+                     (qputil/query->remark :presto outer-query) "\n"
                      (unprepare/unprepare driver (cons sql params)))
         details (merge (:details (qp.store/database))
                        settings)]

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -158,8 +158,38 @@
  [::legacy/use-legacy-classes-for-read-and-set OffsetTime]
  [:postgres OffsetTime])
 
+
+;; example query:
+;; {:database 2
+;; :query
+;; {:source-table 86
+;;  :filter
+;;  [:and
+;;   [:= [:field-id 46] [:value "MOROCCO" {:base_type :type/Text, :special_type :type/Category, :database_type "varchar", :name "c_nation"}]]
+;;   [:= [:field-id 47] [:value "AFRICA" {:base_type :type/Text, :special_type :type/Category, :database_type "varchar", :name "c_region"}]]]
+;;  :fields [[:field-id 48] [:field-id 41] [:field-id 43] [:field-id 44] [:field-id 42] [:field-id 46] [:field-id 45] [:field-id 47]]
+;;  :limit 2000}
+;; :type :query
+;; :middleware {:add-default-userland-constraints? true}
+;; :info
+;; {:executed-by 1
+;;  :context :ad-hoc
+;;  :nested? false
+;;  :query-hash [-98, -79, -69, 52, -33, -66, 92, -59, -30, -96, -90, 105, 14, -8, -50, -37, -69, -84, -84, -6, -106, 126, -8, -36, -52, -128, -58, -65, -8, 111, 14, 12]}
+;; :constraints {:max-results 10000, :max-results-bare-rows 2000}
+;; :native
+;; {:query
+;;  "SELECT \"public\".\"customer\".\"c_address\" AS \"c_address\", \"public\".\"customer\".\"c_city\" AS \"c_city\",
+;;  \"public\".\"customer\".\"c_custkey\" AS \"c_custkey\", \"public\".\"customer\".\"c_mktsegment\" AS \"c_mktsegment\",
+;;  \"public\".\"customer\".\"c_name\" AS \"c_name\", \"public\".\"customer\".\"c_nation\" AS \"c_nation\",
+;;  \"public\".\"customer\".\"c_phone\" AS \"c_phone\", \"public\".\"customer\".\"c_region\" AS \"c_region\"
+;;  FROM \"public\".\"customer\" WHERE (\"public\".\"customer\".\"c_nation\" = ? AND
+;;  \"public\".\"customer\".\"c_region\" = ?) LIMIT 2000"
+;;  :params ("MOROCCO" "AFRICA")}}
+
 (defmethod qputil/query->remark :redshift
   [_ {{:keys [executed-by query-hash card-id], :as info} :info, query-type :type :as params}]
+  (log/spy :error params)
   (str "/* partner: \"metabase\", "
        (json/generate-string {:dashboard_id nil ;; requires metabase/metabase#11909
                               :chart_id card-id

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -162,7 +162,12 @@
 (defn query->field-values
   "Convert a MBQL query to a map of field->value"
   [query]
-  (into {} (map (fn [v] [(:name (nth v 2)) (second v)]) (mbqlu/match query :value))))
+  (let [values (mbqlu/match query :value)]
+    (into {} (map (fn [[column values]]
+                    [column (if (> (count values) 1)
+                              (map #(get % 1) values)
+                              (get (first values) 1))])
+                  (group-by #(:name (get % 2)) values)))))
 
 (defmethod qputil/query->remark :redshift
   [_ {{:keys [executed-by query-hash card-id], :as info} :info, query-type :type :as params}]

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -5,7 +5,9 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [honeysql.core :as hsql]
-            [metabase.driver :as driver]
+            [metabase
+             [driver :as driver]
+             [public-settings :as pubset]]
             [metabase.driver.common :as driver.common]
             [metabase.driver.sql-jdbc
              [connection :as sql-jdbc.conn]
@@ -176,7 +178,7 @@
        (json/generate-string {:dashboard_id nil ;; requires metabase/metabase#11909
                               :chart_id card-id
                               :optional_user_id executed-by
-                              :optional_account_id nil
+                              :optional_account_id (pubset/site-uuid)
                               :filter_values (query->field-values params)})
        " */ "
        (qputil/default-query->remark params)))

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -1,10 +1,15 @@
 (ns metabase.driver.redshift-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
+            [metabase.driver.sql-jdbc.execute :as execute]
             [metabase.plugins.jdbc-proxy :as jdbc-proxy]
-            [metabase.test
-             [fixtures :as fixtures]
-             [util :as tu]]
-            [metabase.test.data.datasets :refer [expect-with-driver]]))
+            [metabase.query-processor :as qp]
+            [metabase.test :as mt]
+            [metabase.test.data.datasets :refer [expect-with-driver]]
+            [metabase.test.data.redshift :as rstest]
+            [metabase.test.fixtures :as fixtures]
+            [metabase.test.util :as tu]
+            [metabase.util :as u]))
 
 (use-fixtures :once (fixtures/initialize :plugins))
 
@@ -16,3 +21,44 @@
   (is (= "com.amazon.redshift.jdbc.Driver"
          (.getName (class (jdbc-proxy/wrapped-driver (java.sql.DriverManager/getDriver "jdbc:redshift://host:5432/testdb")))))
       "Make sure we're using the correct driver for Redshift"))
+
+(defn- query->native [query]
+  (let [native-query (atom nil)]
+    (with-redefs [execute/prepared-statement (fn [_ _ sql _]
+                                               (reset! native-query sql)
+                                               (throw (Exception. "done")))]
+      (u/ignore-exceptions
+       (qp/process-query {:database (mt/id)
+                          :type     :query
+                          :query    {:source-table (mt/id :venues)
+                                     :limit        1}
+                          :info     {:executed-by 1000
+                                     :query-hash  (byte-array [1 2 3 4])}}))
+      @native-query)))
+
+;; TODO: Add executed-by and card-id and such to this
+(deftest remark-test
+  (let [expected (str/replace
+                  (str
+                   "-- /* partner: \"metabase\", {\"dashboard_id\":null,\"chart_id\":null,\"optional_user_id\":1000,\"filter_values\":{}} */"
+                   " Metabase:: userID: 1000 queryType: MBQL queryHash: 01020304\n"
+                   "SELECT \"%schema%\".\"test_data_venues\".\"id\" AS \"id\","
+                   " \"%schema%\".\"test_data_venues\".\"name\" AS \"name\","
+                   " \"%schema%\".\"test_data_venues\".\"category_id\" AS \"category_id\","
+                   " \"%schema%\".\"test_data_venues\".\"latitude\" AS \"latitude\","
+                   " \"%schema%\".\"test_data_venues\".\"longitude\" AS \"longitude\","
+                   " \"%schema%\".\"test_data_venues\".\"price\" AS \"price\""
+                   " FROM \"%schema%\".\"test_data_venues\""
+                   " LIMIT 1")
+                  "%schema%" rstest/session-schema-name)]
+   (mt/test-driver
+    :redshift
+    (is (= expected
+           (query->native
+            {:database (mt/id)
+             :type     :query
+             :query    {:source-table (mt/id :venues)
+                        :limit        1}
+             :info     {:executed-by 1000
+                        :query-hash  (byte-array [1 2 3 4])}}))
+        "if I run a Redshift query, does it get a remark added to it?"))))

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -1,26 +1,26 @@
 (ns metabase.driver.redshift-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer :all]
+  (:require [clojure
+             [string :as str]
+             [test :refer :all]]
+            [metabase
+             [public-settings :as pubset]
+             [query-processor :as qp]
+             [test :as mt]
+             [util :as u]]
             [metabase.driver.sql-jdbc.execute :as execute]
             [metabase.plugins.jdbc-proxy :as jdbc-proxy]
-            [metabase.query-processor :as qp]
-            [metabase.test :as mt]
-            [metabase.test.data.datasets :refer [expect-with-driver]]
             [metabase.test.data.redshift :as rstest]
-            [metabase.test.fixtures :as fixtures]
-            [metabase.test.util :as tu]
-            [metabase.util :as u]))
+            [metabase.test.fixtures :as fixtures]))
 
 (use-fixtures :once (fixtures/initialize :plugins))
-
-(expect-with-driver :redshift
-  "UTC"
-  (tu/db-timezone-id))
+(use-fixtures :once (fixtures/initialize :db))
 
 (deftest correct-driver-test
-  (is (= "com.amazon.redshift.jdbc.Driver"
-         (.getName (class (jdbc-proxy/wrapped-driver (java.sql.DriverManager/getDriver "jdbc:redshift://host:5432/testdb")))))
-      "Make sure we're using the correct driver for Redshift"))
+  (mt/test-driver
+    :redshift
+    (is (= "com.amazon.redshift.jdbc.Driver"
+           (.getName (class (jdbc-proxy/wrapped-driver (java.sql.DriverManager/getDriver "jdbc:redshift://host:5432/testdb")))))
+        "Make sure we're using the correct driver for Redshift")))
 
 (defn- query->native [query]
   (let [native-query (atom nil)]
@@ -28,14 +28,15 @@
                                                (reset! native-query sql)
                                                (throw (Exception. "done")))]
       (u/ignore-exceptions
-       (qp/process-query query))
+        (qp/process-query query))
       @native-query)))
 
 ;; TODO: Add executed-by and card-id and such to this
 (deftest remark-test
   (let [expected (str/replace
                   (str
-                   "-- /* partner: \"metabase\", {\"dashboard_id\":null,\"chart_id\":null,\"optional_user_id\":1000,\"optional_account_id\":null,"
+                   "-- /* partner: \"metabase\", {\"dashboard_id\":null,\"chart_id\":null,\"optional_user_id\":1000,"
+                   "\"optional_account_id\":\"" (pubset/site-uuid) "\","
                    "\"filter_values\":{\"userid\":1,\"firstname\":[\"Rafael\",\"Robert\"]}} */"
                    " Metabase:: userID: 1000 queryType: MBQL queryHash: cb83d4f6eedc250edb0f2c16f8d9a21e5d42f322ccece1494c8ef3d634581fe2\n"
                    "SELECT \"%schema%\".\"test_data_users\".\"id\" AS \"id\","

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -36,13 +36,14 @@
   (let [expected (str/replace
                   (str
                    "-- /* partner: \"metabase\", {\"dashboard_id\":null,\"chart_id\":null,\"optional_user_id\":1000,\"optional_account_id\":null,"
-                   "\"filter_values\":{\"userid\":1,\"firstname\":\"Rafael\"}} */"
+                   "\"filter_values\":{\"userid\":1,\"firstname\":[\"Rafael\",\"Robert\"]}} */"
                    " Metabase:: userID: 1000 queryType: MBQL queryHash: cb83d4f6eedc250edb0f2c16f8d9a21e5d42f322ccece1494c8ef3d634581fe2\n"
                    "SELECT \"%schema%\".\"test_data_users\".\"id\" AS \"id\","
                    " \"%schema%\".\"test_data_users\".\"name\" AS \"name\","
                    " \"%schema%\".\"test_data_users\".\"last_login\" AS \"last_login\""
                    " FROM \"%schema%\".\"test_data_users\""
-                   " WHERE (\"%schema%\".\"test_data_users\".\"id\" = 1 AND \"%schema%\".\"test_data_users\".\"name\" = ?)"
+                   " WHERE (\"%schema%\".\"test_data_users\".\"id\" = 1 OR \"%schema%\".\"test_data_users\".\"name\" = ?"
+                   " OR \"schema_170\".\"test_data_users\".\"name\" = ?)"
                    " LIMIT 2000")
                   "%schema%" rstest/session-schema-name)]
    (mt/test-driver
@@ -53,9 +54,10 @@
              :query
              {:source-table (mt/id :users)
               :filter
-              [:and
+              [:or
                [:= [:field-id (mt/id :users :id)] [:value 1 {:name "userid"}]]
-               [:= [:field-id (mt/id :users :name)] [:value "Rafael" {:name "firstname"}]]]
+               [:= [:field-id (mt/id :users :name)] [:value "Rafael" {:name "firstname"}]]
+               [:= [:field-id (mt/id :users :name)] [:value "Robert" {:name "firstname"}]]]
               :limit 2000}
              :type :query
              :info {:executed-by 1000

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -43,25 +43,22 @@
                    " \"%schema%\".\"test_data_users\".\"last_login\" AS \"last_login\""
                    " FROM \"%schema%\".\"test_data_users\""
                    " WHERE (\"%schema%\".\"test_data_users\".\"id\" = 1 OR \"%schema%\".\"test_data_users\".\"name\" = ?"
-                   " OR \"schema_170\".\"test_data_users\".\"name\" = ?)"
+                   " OR \"%schema%\".\"test_data_users\".\"name\" = ?)"
                    " LIMIT 2000")
                   "%schema%" rstest/session-schema-name)]
    (mt/test-driver
     :redshift
     (is (= expected
            (query->native
-            {:database (mt/id)
-             :query
-             {:source-table (mt/id :users)
-              :filter
-              [:or
-               [:= [:field-id (mt/id :users :id)] [:value 1 {:name "userid"}]]
-               [:= [:field-id (mt/id :users :name)] [:value "Rafael" {:name "firstname"}]]
-               [:= [:field-id (mt/id :users :name)] [:value "Robert" {:name "firstname"}]]]
-              :limit 2000}
-             :type :query
+            (assoc
+             (mt/mbql-query users
+               {:filter [:or
+                         [:= $id [:value 1 {:name "userid"}]]
+                         [:= $name [:value "Rafael" {:name "firstname"}]]
+                         [:= $name [:value "Robert" {:name "firstname"}]]]
+                :limit 2000})
              :info {:executed-by 1000
                     :context :ad-hoc
                     :nested? false
-                    :query-hash (byte-array [-53, -125, -44, -10, -18, -36, 37, 14, -37, 15, 44, 22, -8, -39, -94, 30, 93, 66, -13, 34, -52, -20, -31, 73, 76, -114, -13, -42, 52, 88, 31, -30])}}))
+                    :query-hash (byte-array [-53, -125, -44, -10, -18, -36, 37, 14, -37, 15, 44, 22, -8, -39, -94, 30, 93, 66, -13, 34, -52, -20, -31, 73, 76, -114, -13, -42, 52, 88, 31, -30])})))
         "if I run a Redshift query, does it get a remark added to it?"))))

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -28,37 +28,38 @@
                                                (reset! native-query sql)
                                                (throw (Exception. "done")))]
       (u/ignore-exceptions
-       (qp/process-query {:database (mt/id)
-                          :type     :query
-                          :query    {:source-table (mt/id :venues)
-                                     :limit        1}
-                          :info     {:executed-by 1000
-                                     :query-hash  (byte-array [1 2 3 4])}}))
+       (qp/process-query query))
       @native-query)))
 
 ;; TODO: Add executed-by and card-id and such to this
 (deftest remark-test
   (let [expected (str/replace
                   (str
-                   "-- /* partner: \"metabase\", {\"dashboard_id\":null,\"chart_id\":null,\"optional_user_id\":1000,\"filter_values\":{}} */"
-                   " Metabase:: userID: 1000 queryType: MBQL queryHash: 01020304\n"
-                   "SELECT \"%schema%\".\"test_data_venues\".\"id\" AS \"id\","
-                   " \"%schema%\".\"test_data_venues\".\"name\" AS \"name\","
-                   " \"%schema%\".\"test_data_venues\".\"category_id\" AS \"category_id\","
-                   " \"%schema%\".\"test_data_venues\".\"latitude\" AS \"latitude\","
-                   " \"%schema%\".\"test_data_venues\".\"longitude\" AS \"longitude\","
-                   " \"%schema%\".\"test_data_venues\".\"price\" AS \"price\""
-                   " FROM \"%schema%\".\"test_data_venues\""
-                   " LIMIT 1")
+                   "-- /* partner: \"metabase\", {\"dashboard_id\":null,\"chart_id\":null,\"optional_user_id\":1000,\"optional_account_id\":null,"
+                   "\"filter_values\":{\"userid\":1,\"firstname\":\"Rafael\"}} */"
+                   " Metabase:: userID: 1000 queryType: MBQL queryHash: cb83d4f6eedc250edb0f2c16f8d9a21e5d42f322ccece1494c8ef3d634581fe2\n"
+                   "SELECT \"%schema%\".\"test_data_users\".\"id\" AS \"id\","
+                   " \"%schema%\".\"test_data_users\".\"name\" AS \"name\","
+                   " \"%schema%\".\"test_data_users\".\"last_login\" AS \"last_login\""
+                   " FROM \"%schema%\".\"test_data_users\""
+                   " WHERE (\"%schema%\".\"test_data_users\".\"id\" = 1 AND \"%schema%\".\"test_data_users\".\"name\" = ?)"
+                   " LIMIT 2000")
                   "%schema%" rstest/session-schema-name)]
    (mt/test-driver
     :redshift
     (is (= expected
            (query->native
             {:database (mt/id)
-             :type     :query
-             :query    {:source-table (mt/id :venues)
-                        :limit        1}
-             :info     {:executed-by 1000
-                        :query-hash  (byte-array [1 2 3 4])}}))
+             :query
+             {:source-table (mt/id :users)
+              :filter
+              [:and
+               [:= [:field-id (mt/id :users :id)] [:value 1 {:name "userid"}]]
+               [:= [:field-id (mt/id :users :name)] [:value "Rafael" {:name "firstname"}]]]
+              :limit 2000}
+             :type :query
+             :info {:executed-by 1000
+                    :context :ad-hoc
+                    :nested? false
+                    :query-hash (byte-array [-53, -125, -44, -10, -18, -36, 37, 14, -37, 15, 44, 22, -8, -39, -94, 30, 93, 66, -13, 34, -52, -20, -31, 73, 76, -114, -13, -42, 52, 88, 31, -30])}}))
         "if I run a Redshift query, does it get a remark added to it?"))))

--- a/modules/drivers/redshift/test/metabase/test/data/redshift.clj
+++ b/modules/drivers/redshift/test/metabase/test/data/redshift.clj
@@ -46,7 +46,7 @@
 (defonce ^:private session-schema-number
   (rand-int 240)) ; there's a maximum of 256 schemas per DB so make sure we don't go over that limit
 
-(defonce ^:private session-schema-name
+(defonce session-schema-name
   (str "schema_" session-schema-number))
 
 ;; When we test against Redshift we use a session-unique schema so we can run simultaneous tests

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -128,7 +128,7 @@
 (defmethod driver/execute-reducible-query :sparksql
   [driver {:keys [database settings], {sql :query, :keys [params], :as inner-query} :native, :as outer-query} context respond]
   (let [inner-query (-> (assoc inner-query
-                               :remark (qputil/query->remark outer-query)
+                               :remark (qputil/query->remark :sparksql outer-query)
                                :query  (if (seq params)
                                          (unprepare/unprepare driver (cons sql params))
                                          sql)

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -379,7 +379,7 @@
   {:added "0.35.0", :arglists '([driver query context respond])}
   [driver {{sql :query, params :params} :native, :as outer-query} context respond]
   {:pre [(string? sql) (seq sql)]}
-  (let [remark   (qputil/query->remark outer-query)
+  (let [remark   (qputil/query->remark driver outer-query)
         sql      (str "-- " remark "\n" sql)
         max-rows (or (mbql.u/query->max-rows-limit outer-query)
                      qp.i/absolute-max-results)]

--- a/src/metabase/query_processor/middleware/parameters.clj
+++ b/src/metabase/query_processor/middleware/parameters.clj
@@ -1,6 +1,8 @@
 (ns metabase.query-processor.middleware.parameters
   "Middleware for substituting parameters in queries."
-  (:require [clojure.data :as data]
+  (:require [clojure
+             [data :as data]
+             [set :as set]]
             [clojure.tools.logging :as log]
             [metabase.mbql
              [normalize :as normalize]
@@ -66,7 +68,7 @@
   "Move any top-level parameters to the same level (i.e., 'inner query') as the query the affect."
   [{:keys [parameters], query-type :type, :as outer-query}]
   {:pre [(#{:query :native} query-type)]}
-  (cond-> (dissoc outer-query :parameters)
+  (cond-> (set/rename-keys outer-query {:parameters :user-parameters})
     (seq parameters)
     (assoc-in [query-type :parameters] parameters)))
 

--- a/src/metabase/query_processor/middleware/wrap_value_literals.clj
+++ b/src/metabase/query_processor/middleware/wrap_value_literals.clj
@@ -24,7 +24,7 @@
 (defmethod type-info :default [_] nil)
 
 (defmethod type-info (class Field) [this]
-  (let [field-info (select-keys this [:base_type :special_type :database_type])]
+  (let [field-info (select-keys this [:base_type :special_type :database_type :name])]
     (merge
      field-info
      ;; add in a default unit for this Field so we know to wrap datetime strings in `absolute-datetime` below based on

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -38,8 +38,8 @@
                             (codecs/bytes->hex query-hash)))))
 
 (defmulti query->remark
-  "Generate an appropriate REMARK to be prepended to a query to give DBAs additional information about the query being
-  executed. See documentation for `mbql->native` and [issue #2386](https://github.com/metabase/metabase/issues/2386)
+  "Generate an appropriate remark `^String` to be prepended to a query to give DBAs additional information about the query
+  being executed. See documentation for `mbql->native` and [issue #2386](https://github.com/metabase/metabase/issues/2386)
   for more information."
   {:arglists '(^String [driver data])}
   driver/dispatch-on-initialized-driver

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -5,6 +5,7 @@
              [hash :as hash]]
             [cheshire.core :as json]
             [clojure.string :as str]
+            [metabase.driver :as driver]
             [metabase.util.schema :as su]
             [schema.core :as s]))
 
@@ -23,11 +24,8 @@
        (not page)
        (nil? aggregations)))
 
-(defn query->remark
-  "Generate an approparite REMARK to be prepended to a query to give DBAs additional information about the query being
-  executed. See documentation for `mbql->native` and [issue #2386](https://github.com/metabase/metabase/issues/2386)
-  for more information."
-  ^String [{{:keys [executed-by query-hash], :as info} :info, query-type :type}]
+(defn default-query->remark
+  [{{:keys [executed-by query-hash], :as info} :info, query-type :type}]
   (str "Metabase" (when executed-by
                     (assert (instance? (Class/forName "[B") query-hash))
                     (format ":: userID: %s queryType: %s queryHash: %s"
@@ -36,6 +34,18 @@
                               :query  "MBQL"
                               :native "native")
                             (codecs/bytes->hex query-hash)))))
+
+(defmulti query->remark
+  "Generate an appropriate REMARK to be prepended to a query to give DBAs additional information about the query being
+  executed. See documentation for `mbql->native` and [issue #2386](https://github.com/metabase/metabase/issues/2386)
+  for more information."
+  {:arglists '(^String [driver data])}
+  driver/dispatch-on-initialized-driver
+  :hierarchy #'driver/hierarchy)
+
+(defmethod query->remark :default
+  [_ params]
+  (default-query->remark params))
 
 
 ;;; ------------------------------------------------- Normalization --------------------------------------------------

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -25,6 +25,8 @@
        (nil? aggregations)))
 
 (defn default-query->remark
+  "Generates the default query remark. Exists as a separate function so that overrides of the query->remark multimethod
+   can access the default value."
   [{{:keys [executed-by query-hash], :as info} :info, query-type :type}]
   (str "Metabase" (when executed-by
                     (assert (instance? (Class/forName "[B") query-hash))

--- a/test/metabase/query_processor/middleware/parameters_test.clj
+++ b/test/metabase/query_processor/middleware/parameters_test.clj
@@ -14,7 +14,8 @@
 
 (deftest move-top-level-params-to-inner-query-test
   (is (= {:type   :native
-          :native {:query "WOW", :parameters ["My Param"]}}
+          :native {:query "WOW", :parameters ["My Param"]}
+          :user-parameters ["My Param"]}
          (#'parameters/move-top-level-params-to-inner-query
           {:type :native, :native {:query "WOW"}, :parameters ["My Param"]}))))
 
@@ -36,7 +37,8 @@
   (testing "can we expand native params if they are specified at the top level?"
     (is (= (data/query nil
              {:type   :native
-              :native {:query "SELECT * FROM venues WHERE price = 1;", :params []}})
+              :native {:query "SELECT * FROM venues WHERE price = 1;", :params []}
+              :user-parameters [{:type :category, :target [:variable [:template-tag "price"]], :value "1"}]})
            (substitute-params
             (data/query nil
               {:type       :native

--- a/test/metabase/query_processor/middleware/wrap_value_literals_test.clj
+++ b/test/metabase/query_processor/middleware/wrap_value_literals_test.clj
@@ -27,7 +27,8 @@
                      $id
                      [:value 50 {:base_type     :type/BigInteger
                                  :special_type  :type/PK
-                                 :database_type "BIGINT"}]]})
+                                 :database_type "BIGINT"
+                                 :name "ID"}]]})
          (wrap-value-literals
            (mt/mbql-query venues
              {:filter [:> $id 50]}))))
@@ -35,10 +36,12 @@
            {:filter [:and
                      [:> $id [:value 50 {:base_type     :type/BigInteger
                                          :special_type  :type/PK
-                                         :database_type "BIGINT"}]]
+                                         :database_type "BIGINT"
+                                         :name "ID"}]]
                      [:< $price [:value 5 {:base_type     :type/Integer
                                            :special_type  :type/Category
-                                           :database_type "INTEGER"}]]]})
+                                           :database_type "INTEGER"
+                                           :name "PRICE"}]]]})
          (wrap-value-literals
            (mt/mbql-query venues
              {:filter [:and
@@ -137,7 +140,8 @@
                        [:value "2018-10-01" {:base_type     :type/Date
                                              :special_type  nil
                                              :database_type "DATE"
-                                             :unit          :month}]]})
+                                             :unit          :month
+                                             :name          "DATE"}]]})
            (wrap-value-literals
              (mt/mbql-query checkins
                {:filter [:starts-with !month.date "2018-10-01"]}))))))


### PR DESCRIPTION
 This allows driver-specific metadata to be added to each query. If the
driver can apply the default metadata, it should call
default-query->remark