### PR TITLE
Fix login redirect to unsaved question

### DIFF
--- a/frontend/src/metabase/auth/auth.js
+++ b/frontend/src/metabase/auth/auth.js
@@ -23,7 +23,6 @@ export const login = createThunkAction(
     await SessionApi.create(credentials);
 
     MetabaseAnalytics.trackEvent("Auth", "Login");
-    // TODO: redirect after login (carry user to intended destination)
     await Promise.all([
       dispatch(refreshCurrentUser()),
       dispatch(refreshSiteSettings()),
@@ -47,7 +46,6 @@ export const loginGoogle = createThunkAction(LOGIN_GOOGLE, function(
 
       MetabaseAnalytics.trackEvent("Auth", "Google Auth Login");
 
-      // TODO: redirect after login (carry user to intended destination)
       await Promise.all([
         dispatch(refreshCurrentUser()),
         dispatch(refreshSiteSettings()),

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -104,16 +104,7 @@ const UserIsAuthenticated = UserAuthWrapper({
   failureRedirectPath: "/auth/login",
   authSelector: state => state.currentUser,
   wrapperDisplayName: "UserIsAuthenticated",
-  redirectAction: location =>
-    // HACK: workaround for redux-auth-wrapper not including hash
-    // https://github.com/mjrussell/redux-auth-wrapper/issues/121
-    routerActions.replace({
-      ...location,
-      query: {
-        ...location.query,
-        redirect: location.query.redirect + (window.location.hash || ""),
-      },
-    }),
+  redirectAction: routerActions.replace,
 });
 
 const UserIsAdmin = UserAuthWrapper({

--- a/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, signOut, USERS } from "__support__/cypress";
+import { restore, signIn, signOut, USERS } from "__support__/cypress";
 
 describe("scenarios > auth > signin", () => {
   before(restore);
@@ -31,5 +31,26 @@ describe("scenarios > auth > signin", () => {
     cy.findByLabelText("Password").type(USERS.admin.password);
     cy.findByText("Sign in").click();
     cy.contains(/[a-z ]+, Bob/i);
+  });
+
+  it("should redirect to a unsaved question after login", () => {
+    signIn();
+    cy.visit("/");
+    cy.contains("Browse Data").click();
+    cy.contains("Sample Dataset").click();
+    cy.contains("Orders").click();
+    cy.contains("37.65");
+
+    // signout and reload page with question hash in url
+    signOut();
+    cy.reload();
+
+    cy.contains("Sign in to Metabase");
+    cy.findByLabelText("Email address").type(USERS.admin.username);
+    cy.findByLabelText("Password").type(USERS.admin.password);
+    cy.findByText("Sign in").click();
+
+    // order table should load after login
+    cy.contains("37.65");
   });
 });


### PR DESCRIPTION
Fixes #6317

The PR removes a workaround that added the hash to the redirect url. The external library that was being worked around fixed the issue, which broken things for us. I guess semver doesn't cover "breaking changes" due to workarounds on your end 😄.