### PR TITLE
Update fingerprint schema to allow for empty result text fingerprints

### DIFF
--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -1,4 +1,9 @@
-import { signInAsNormalUser, restore, popover } from "__support__/cypress";
+import {
+  signInAsNormalUser,
+  restore,
+  popover,
+  modal,
+} from "__support__/cypress";
 
 describe("scenarios > question > native", () => {
   before(restore);
@@ -181,5 +186,23 @@ describe("scenarios > question > native", () => {
       cy.visit(`/question/${response.body.id}?created_at=2020-01`);
       cy.contains("580");
     });
+  });
+
+  it("can save a question with no rows", () => {
+    cy.visit("/question/new");
+    cy.contains("Native query").click();
+    cy.get(".ace_content").type("select * from people where false");
+    cy.get(".NativeQueryEditor .Icon-play").click();
+    cy.contains("No results!");
+    cy.get(".Icon-contract").click();
+    cy.contains("Save").click();
+
+    modal().within(() => {
+      cy.findByLabelText("Name").type("empty question");
+      cy.findByText("Save").click();
+    });
+
+    // confirm that the question saved and url updated
+    cy.location("pathname").should("match", /\/question\/\d+/);
   });
 });

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -112,7 +112,7 @@
   {(s/optional-key :percent-json)   (s/maybe Percent)
    (s/optional-key :percent-url)    (s/maybe Percent)
    (s/optional-key :percent-email)  (s/maybe Percent)
-   (s/optional-key :average-length) s/Num})
+   (s/optional-key :average-length) (s/maybe s/Num)})
 
 (def TemporalFingerprint
   "Schema for fingerprint information for Fields deriving from `:type/Temporal`."


### PR DESCRIPTION
Fixes #11256

The bug was caused by too strict a schema for `TextFingerprint`. When there are no results, the fingerprint in `result_metadata` was (I believe correctly) set to `null`. This broke on save because we validate the metadata that the client passes back.

This could probably do with a backend test, but I wasn't sure where to put it.