### PR TITLE
Change Map Tile Server URL to https

### DIFF
--- a/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
@@ -42,10 +42,6 @@ const LeafletChoropleth = ({
         keyboard: false,
       });
 
-      // L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-      //     attribution: 'Map data © <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors'
-      // }).addTo(map);
-
       const style = feature => ({
         fillColor: getColor(feature),
         weight: 1,

--- a/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
@@ -42,8 +42,8 @@ const LeafletChoropleth = ({
         keyboard: false,
       });
 
-      // L.tileLayer("http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-      //     attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
+      // L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      //     attribution: 'Map data © <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors'
       // }).addTo(map);
 
       const style = feature => ({

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -97,7 +97,7 @@
 
 (defsetting map-tile-server-url
   (deferred-tru "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox.")
-  :default    "http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+  :default    "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
   :visibility :public)
 
 (defsetting enable-public-sharing


### PR DESCRIPTION
Seems like browsers are getting more aggressive about mixed-content.
This changes the OpenStreetMap to https.