### PR TITLE
Forcing the run profile to include all drivers

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -216,7 +216,8 @@
    {:test-paths ^:replace []}
 
    :run
-   [:exclude-tests {}]
+   [:include-all-drivers
+    :exclude-tests {}]
 
    :run-with-repl
    [:exclude-tests


### PR DESCRIPTION
This alias was overriding any with-profiles from the command line. This
will force all the drivers to be loaded when doing lein run, which will
let local development against drivers work with lein run.