### PR TITLE
Fix include-drivers lein middleware

### DIFF
--- a/lein-plugins/include-drivers/project.clj
+++ b/lein-plugins/include-drivers/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/lein-include-drivers "1.0.8"
+(defproject metabase/lein-include-drivers "1.0.9"
   :min-lein-version "2.5.0"
   :eval-in-leiningen true
   :deploy-repositories [["clojars" {:sign-releases false}]]

--- a/project.clj
+++ b/project.clj
@@ -251,7 +251,7 @@
 
    :with-include-drivers-middleware
    {:plugins
-    [[metabase/lein-include-drivers "1.0.8"]]
+    [[metabase/lein-include-drivers "1.0.9"]]
 
     :middleware
     [leiningen.include-drivers/middleware]}

--- a/src/metabase/plugins/classloader.clj
+++ b/src/metabase/plugins/classloader.clj
@@ -12,7 +12,8 @@
 
   <3 Cam"
   (:refer-clojure :exclude [require])
-  (:require [clojure.tools.logging :as log]
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [dynapath.util :as dynapath]
             [metabase.util.i18n :refer [deferred-trs]])
   (:import [clojure.lang DynamicClassLoader RT]
@@ -126,8 +127,9 @@
         (apply clojure.core/require args)))
     (catch Throwable e
       (throw (ex-info (.getMessage e)
-                      {:classloader    (the-classloader)
-                       :classpath-urls (map str (dynapath/all-classpath-urls (the-classloader)))}
+                      {:classloader      (the-classloader)
+                       :classpath-urls   (map str (dynapath/all-classpath-urls (the-classloader)))
+                       :system-classpath (sort (str/split (System/getProperty "java.class.path") #"[:;]"))}
                       e)))))
 
 (defonce ^:private already-added (atom #{}))


### PR DESCRIPTION
@robdaemon helped diagnose a confusing issue where plugin namespaces such as `metabase.driver.redshift` weren't available in `lein with-profiles +include-all-drivers run`. This was because the plugin had logic to avoid infinite loops if Leiningen ran it more than once that ended up not modifying the profile if ran a second time