### PR TITLE
wrap lines in object detail json display

### DIFF
--- a/frontend/src/metabase/css/query_builder.css
+++ b/frontend/src/metabase/css/query_builder.css
@@ -588,6 +588,7 @@
   background-color: var(--color-bg-light);
   border: 1px solid var(--color-border);
   border-radius: 2px;
+  white-space: pre-wrap;
 }
 
 .PopoverBody.AddToDashboard {


### PR DESCRIPTION
Wraps long lines in the object detail JSON display to prevent it from breaking the layout. Closes #11887

