### PR TITLE
Fix small logos

### DIFF
--- a/frontend/src/metabase/auth/containers/LoginApp.jsx
+++ b/frontend/src/metabase/auth/containers/LoginApp.jsx
@@ -38,7 +38,7 @@ export default class LoginApp extends Component {
       <div className="flex flex-column flex-full md-layout-centered">
         <div className="Login-wrapper wrapper Grid Grid--full md-Grid--1of2 relative z2">
           <div className="Grid-cell flex layout-centered text-brand">
-            <LogoIcon className="Logo my4 sm-my0" height={85} />
+            <LogoIcon className="Logo my4 sm-my0" height={65} />
           </div>
           <div className="Login-content Grid-cell p4 bg-white bordered rounded shadowed">
             <h2 className="Login-header mb2">{t`Sign in to Metabase`}</h2>

--- a/frontend/src/metabase/components/LogoIcon.jsx
+++ b/frontend/src/metabase/components/LogoIcon.jsx
@@ -5,25 +5,20 @@ import cx from "classnames";
 import { PLUGIN_LOGO_ICON_COMPONENTS } from "metabase/plugins";
 
 class DefaultLogoIcon extends Component {
-  static defaultProps = {
-    size: 32,
-  };
-
   static propTypes = {
-    size: PropTypes.number,
     width: PropTypes.number,
     height: PropTypes.number,
     dark: PropTypes.bool,
   };
 
   render() {
-    const { dark, height, width, size } = this.props;
+    const { dark, height, width } = this.props;
     return (
       <svg
         className={cx("Icon", { "text-brand": !dark }, { "text-white": dark })}
         viewBox="0 0 66 85"
-        width={width || size}
-        height={height || size}
+        width={width}
+        height={height}
         fill="currentcolor"
       >
         <path

--- a/frontend/src/metabase/components/LogoIcon.jsx
+++ b/frontend/src/metabase/components/LogoIcon.jsx
@@ -35,7 +35,6 @@ class DefaultLogoIcon extends Component {
 }
 
 export default function LogoIcon(props) {
-  console.log("logo props?", props);
   const [Component = DefaultLogoIcon] = PLUGIN_LOGO_ICON_COMPONENTS;
   return <Component {...props} />;
 }

--- a/frontend/src/metabase/components/LogoIcon.jsx
+++ b/frontend/src/metabase/components/LogoIcon.jsx
@@ -5,6 +5,9 @@ import cx from "classnames";
 import { PLUGIN_LOGO_ICON_COMPONENTS } from "metabase/plugins";
 
 class DefaultLogoIcon extends Component {
+  static defaultProps = {
+    height: 32,
+  };
   static propTypes = {
     width: PropTypes.number,
     height: PropTypes.number,
@@ -32,6 +35,7 @@ class DefaultLogoIcon extends Component {
 }
 
 export default function LogoIcon(props) {
+  console.log("logo props?", props);
   const [Component = DefaultLogoIcon] = PLUGIN_LOGO_ICON_COMPONENTS;
   return <Component {...props} />;
 }


### PR DESCRIPTION
So this one is a little weird but I *think* the reason certain logos started getting smaller without any particularly obvious reason at the site of their use was the whole "DefaultIcon" switch to help plugin-ify things. I think the size prop ended up taking precedence due to the use of `||` and because it had a default value via `defaultProps.`

The addition of the size prop itself was probably never a great idea. We don't use it anywhere in the code and the logo also isn't quite square but regardless the idea of having two different size props is just kind of bad component api design. Mix that in with how width and size interact with the SVG viewBox and suddenly you end up with a lot of confusion about what the heck the size of the thing is going to be. Happily this is a case of the saner component API also fixing the bug.

I still don't love that the primary way we seem to tweak the size is via "height" based on a look through the codebase, but that's small potatoes in the grand scheme of things.

@paulrosenzweig / @tlrobinson would this introduce any potential issues with white label logos? I believe we just swap the entire component out right so internal prop changes shouldn't matter?

Closes #12441 