### PR TITLE
remove myself as a CODEOWNER for all of frontend/src

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 /src/metabase/sync/ @camsaul @sbelak
 /test/metabase/sync/ @camsaul @sbelak
 *.css @kdoh
-/frontend/src @tlrobinson @kdoh
+/frontend/src @tlrobinson
 /frontend/src/metabase/components/ @kdoh
 /frontend/src/metabase/admin/datamodel/ @tlrobinson @paulrosenzweig
 /frontend/src/metabase/entities/ @tlrobinson @paulrosenzweig


### PR DESCRIPTION
When we first set this up this scope made more sense, but I get automatically tagged for review on a fair number of frontend PRs that I don't have a ton of domain knowledge in these days.