### PR TITLE
Fix incorrect Content-Type "applicaton/json"

### DIFF
--- a/src/metabase/async/api_response.clj
+++ b/src/metabase/async/api_response.clj
@@ -195,7 +195,7 @@
   ManyToManyChannel
   (send* [input-chan _ respond _]
     (respond (assoc (response/response input-chan)
-                    :content-type "applicaton/json; charset=utf-8"
+                    :content-type "application/json; charset=utf-8"
                     :status 202))))
 
 ;; everthing in this namespace is deprecated!

--- a/src/metabase/async/streaming_response.clj
+++ b/src/metabase/async/streaming_response.clj
@@ -257,7 +257,7 @@
 
   Minimal example:
 
-    (streaming-response {:content-type \"applicaton/json; charset=utf-8\"} [os canceled-chan]
+    (streaming-response {:content-type \"application/json; charset=utf-8\"} [os canceled-chan]
       (write-something-to-stream! os))
 
   `f` should block until it is completely finished writing to the stream, which will be closed thereafter.

--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -12,7 +12,7 @@
 
 (defmethod i/stream-options :json
   [_]
-  {:content-type "applicaton/json; charset=utf-8"
+  {:content-type "application/json; charset=utf-8"
    :headers      {"Content-Disposition" (format "attachment; filename=\"query_result_%s.json\""
                                                 (u.date/format (t/zoned-date-time)))}})
 
@@ -40,7 +40,7 @@
 
 (defmethod i/stream-options :api
   [stream-type]
-  {:content-type "applicaton/json; charset=utf-8"})
+  {:content-type "application/json; charset=utf-8"})
 
 (defn- map->serialized-json-kvs
   "{:a 100, :b 200} ; -> \"a\":100,\"b\":200"

--- a/test/metabase/async/api_response_test.clj
+++ b/test/metabase/async/api_response_test.clj
@@ -31,7 +31,7 @@
               response    {:status       200
                            :headers      {}
                            :body         input-chan
-                           :content-type "applicaton/json; charset=utf-8"}]
+                           :content-type "application/json; charset=utf-8"}]
           ;; and keep it from getting [re]created.
           (with-redefs [async-response/async-keepalive-channel identity]
             (ring.protocols/write-body-to-stream output-chan response os))


### PR DESCRIPTION
This short PR fixes the incorrect value of the `Content-Type` HTTP header `applicaton/json` for `application/json`. I noticed this value when using the `/api/dataset` endpoint, on version `0.35.3`.

###### Before submitting the PR, please make sure you do the following
- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
