### PR TITLE
Allow / in expression names

### DIFF
--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -859,11 +859,11 @@
 
 (defn- expressions->subselect
   [{:keys [expressions] :as query}]
-  (let [fields    (vec ; lazyness does not play well with dynamic binding
+  (let [fields    (vec ; laziness does not play well with dynamic binding
                    (concat
                     (for [[expression-name expression-definition] expressions]
                       [:expression-definition
-                       (name expression-name)
+                       (mbql.u/qualified-name expression-name)
                        (mbql.u/replace expression-definition
                          [:expression expr] (expressions (keyword expr)))])
                     (distinct

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -351,3 +351,16 @@
                                             [:field-id (data/id :lots_of_fields (keyword field))]))})
                   (mt/formatted-rows [int])
                   ffirst))))))
+
+;; Test for https://github.com/metabase/metabase/issues/12305
+(deftest expression-with-slashes
+  (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
+    (is (= [[1 "Red Medicine"           4 10.0646 -165.374 3 4.0]
+            [2 "Stout Burgers & Beers" 11 34.0996 -118.329 2 3.0]
+            [3 "The Apple Pan"         11 34.0406 -118.428 2 3.0]]
+           (mt/formatted-rows [int str int 4.0 4.0 int float]
+             (mt/run-mbql-query venues
+               {:expressions {:TEST/my-cool-new-field [:+ $price 1]}
+                :limit       3
+                :order-by    [[:asc $id]]})))
+        "Make sure an expression with a / in its name works")))


### PR DESCRIPTION
Fixes metabase/metabase#12305. Using (name) will drop the namespace of a
Clojure keyword. During JSON parsing, a key like "test/foo" will end up
in the Clojure namespace of `test` with a keyword name of `foo`. In
these cases, we need to use the `qualified-name` function to properly
output the expression name.