### PR TITLE
Null datetime objects can blow up pulse rendering

### DIFF
--- a/src/metabase/pulse/render/datetime.clj
+++ b/src/metabase/pulse/render/datetime.clj
@@ -1,6 +1,7 @@
 (ns metabase.pulse.render.datetime
   "Logic for rendering datetimes inside Pulses."
-  (:require [clojure.tools.logging :as log]
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [java-time :as t]
             [metabase.util
              [date-2 :as u.date]
@@ -17,20 +18,22 @@
   "Reformat a temporal literal string `s` (i.e., an ISO-8601 string) with a human-friendly format based on the
   column `:unit`."
   [timezone-id s col]
-  (case (:unit col)
-    ;; these types have special formatting
-    :hour    (reformat-temporal-str timezone-id s "h a - MMM yyyy")
-    :week    (str "Week " (reformat-temporal-str timezone-id s "w - YYYY"))
-    :month   (reformat-temporal-str timezone-id s "MMMM yyyy")
-    :quarter (reformat-temporal-str timezone-id s "QQQ - yyyy")
+  (if (str/blank? s)
+    ""
+    (case (:unit col)
+      ;; these types have special formatting
+      :hour    (reformat-temporal-str timezone-id s "h a - MMM yyyy")
+      :week    (str "Week " (reformat-temporal-str timezone-id s "w - YYYY"))
+      :month   (reformat-temporal-str timezone-id s "MMMM yyyy")
+      :quarter (reformat-temporal-str timezone-id s "QQQ - yyyy")
 
-    ;; no special formatting here : return as ISO-8601
-    ;; TODO: probably shouldn't even be showing sparkline for x-of-y groupings?
-    (:year :hour-of-day :day-of-week :week-of-year :month-of-year)
-    s
+      ;; no special formatting here : return as ISO-8601
+      ;; TODO: probably shouldn't even be showing sparkline for x-of-y groupings?
+      (:year :hour-of-day :day-of-week :week-of-year :month-of-year)
+      s
 
-    ;; for everything else return in this format
-    (reformat-temporal-str timezone-id s "MMM d, yyyy")))
+      ;; for everything else return in this format
+      (reformat-temporal-str timezone-id s "MMM d, yyyy"))))
 
 (def ^:private RenderableInterval
   {:interval-start     Temporal

--- a/test/metabase/pulse/render/datetime_test.clj
+++ b/test/metabase/pulse/render/datetime_test.clj
@@ -44,3 +44,11 @@
     (testing "No special formatting for year? :shrug:"
       (is (= ["2018-07-16T18:04:00Z" "2021-07-16T18:04:00Z"]
              (format-temporal-string-pair :year "2018-07-16T18:04:00Z" "2021-07-16T18:04:00Z"))))))
+
+(deftest format-temporal-str-test
+  (testing "Null values do not blow up"
+    (is (= ""
+           (datetime/format-temporal-str "UTC" nil :now))))
+  (testing "Not-null values work"
+    (is (= "Jul 16, 2020"
+           (datetime/format-temporal-str "UTC" now :day)))))


### PR DESCRIPTION
A null datetime object passed in from a database can cause pulse
rendering to fail, because the string being parsed is null.

Handle this by returning "" for any null date.

Fixes metabase/metabase#11665