### PR TITLE
Update visualization auto-selection logic

### DIFF
--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -80,6 +80,7 @@ export function serializeCardForUrl(card) {
     description: card.description,
     dataset_query: dataset_query,
     display: card.display,
+    displayIsLocked: card.displayIsLocked,
     parameters: card.parameters,
     visualization_settings: card.visualization_settings,
     original_card_id: card.original_card_id,

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -885,8 +885,6 @@ export const runQuestionQuery = ({
       ? question.isDirtyComparedTo(originalQuestion)
       : true;
 
-    // const cardIsDirty = getIsQuestionDirtyFromOriginal(getState(), question)
-    //
     if (shouldUpdateUrl) {
       dispatch(updateUrl(question.card(), { dirty: cardIsDirty }));
     }

--- a/frontend/src/metabase/query_builder/actions.js
+++ b/frontend/src/metabase/query_builder/actions.js
@@ -442,7 +442,7 @@ export const initializeQB = (location, params) => {
     let question = card && new Question(card, getMetadata(getState()));
     if (params.cardId) {
       // loading a saved question prevents auto-viz selection
-      question = question && question.setSelectedDisplay(question.display());
+      question = question && question.lockDisplay();
     }
 
     card = question && question.card();
@@ -541,9 +541,11 @@ export const updateCardVisualizationSettings = settings => async (
 ) => {
   const question = getQuestion(getState());
   await dispatch(
-    updateQuestion(question.updateSettings(settings), { run: "auto" }),
+    updateQuestion(question.updateSettings(settings), {
+      run: "auto",
+      shouldUpdateUrl: true,
+    }),
   );
-  dispatch(updateUrl(null, { dirty: true }));
 };
 
 export const replaceAllCardVisualizationSettings = settings => async (
@@ -552,9 +554,11 @@ export const replaceAllCardVisualizationSettings = settings => async (
 ) => {
   const question = getQuestion(getState());
   await dispatch(
-    updateQuestion(question.setSettings(settings), { run: "auto" }),
+    updateQuestion(question.setSettings(settings), {
+      run: "auto",
+      shouldUpdateUrl: true,
+    }),
   );
-  dispatch(updateUrl(null, { dirty: true }));
 };
 
 export const UPDATE_TEMPLATE_TAG = "metabase/qb/UPDATE_TEMPLATE_TAG";
@@ -697,7 +701,7 @@ export const navigateToNewCardInsideQB = createThunkAction(
 export const UPDATE_QUESTION = "metabase/qb/UPDATE_QUESTION";
 export const updateQuestion = (
   newQuestion,
-  { doNotClearNameAndId = false, run = false } = {},
+  { doNotClearNameAndId = false, run = false, shouldUpdateUrl = false } = {},
 ) => {
   return async (dispatch, getState) => {
     const oldQuestion = getQuestion(getState());
@@ -725,6 +729,10 @@ export const updateQuestion = (
 
     // Replace the current question with a new one
     await dispatch.action(UPDATE_QUESTION, { card: newQuestion.card() });
+
+    if (shouldUpdateUrl) {
+      dispatch(updateUrl(null, { dirty: true }));
+    }
 
     // See if the template tags editor should be shown/hidden
     const oldTagCount = getTemplateTagCount(oldQuestion);
@@ -805,12 +813,8 @@ export const apiCreateQuestion = question => {
     );
 
     // Saving a card, locks in the current display as though it had been
-    // selected in the UI. We also copy over `sensibleDisplays` since those were
-    // not persisted onto `createdQuestion`.
-    const card = createdQuestion
-      .setSensibleDisplays(question.sensibleDisplays())
-      .setSelectedDisplay(question.display())
-      .card();
+    // selected in the UI.
+    const card = createdQuestion.lockDisplay().card();
 
     dispatch.action(API_CREATE_QUESTION, card);
   };
@@ -881,6 +885,8 @@ export const runQuestionQuery = ({
       ? question.isDirtyComparedTo(originalQuestion)
       : true;
 
+    // const cardIsDirty = getIsQuestionDirtyFromOriginal(getState(), question)
+    //
     if (shouldUpdateUrl) {
       dispatch(updateUrl(question.card(), { dirty: cardIsDirty }));
     }
@@ -936,12 +942,20 @@ export const QUERY_COMPLETED = "metabase/qb/QUERY_COMPLETED";
 export const queryCompleted = (question, queryResults) => {
   return async (dispatch, getState) => {
     const [{ data }] = queryResults;
-    const card = question
-      .setSensibleDisplays(getSensibleDisplays(data))
-      .setDefaultDisplay()
-      .switchTableScalar(data)
-      .card();
-    dispatch.action(QUERY_COMPLETED, { card, queryResults });
+    const originalQuestion = getOriginalQuestion(getState());
+    const dirty =
+      !originalQuestion ||
+      (originalQuestion && question.isDirtyComparedTo(originalQuestion));
+    if (dirty) {
+      // Only update the display if the question is new or has been changed.
+      // Otherwise, trust that the question was saved with the correct display.
+      question = question
+        // if we are going to trigger autoselection logic, check if the locked display no longer is "sensible".
+        .maybeUnlockDisplay(getSensibleDisplays(data))
+        .setDefaultDisplay()
+        .switchTableScalar(data);
+    }
+    dispatch.action(QUERY_COMPLETED, { card: question.card(), queryResults });
   };
 };
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.jsx
@@ -61,8 +61,9 @@ const ChartTypeSidebar = ({
                   }
                   onClick={() => {
                     question
-                      .setSelectedDisplay(type)
-                      .update(null, { reload: false });
+                      .setDisplay(type)
+                      .lockDisplay(true) // prevent viz auto-selection
+                      .update(null, { reload: false, shouldUpdateUrl: true });
                     onOpenChartSettings({ section: t`Data` });
                     setUIControls({ isShowingRawTable: false });
                   }}

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -199,8 +199,6 @@ export const card = handleActions(
     [QUERY_COMPLETED]: {
       next: (state, { payload }) => ({
         ...state,
-        sensibleDisplays: payload.card.sensibleDisplays,
-        selectedDisplay: payload.card.selectedDisplay,
         display: payload.card.display,
       }),
     },

--- a/frontend/src/metabase/visualizations/index.js
+++ b/frontend/src/metabase/visualizations/index.js
@@ -21,7 +21,7 @@ export function getSensibleDisplays(data) {
     .filter(
       ([, viz]) =>
         // don't rule out displays if there's no data
-        data.rows.length === 0 || (viz.isSensible && viz.isSensible(data)),
+        data.rows.length <= 1 || (viz.isSensible && viz.isSensible(data)),
     )
     .map(([display]) => display);
 }

--- a/frontend/src/metabase/visualizations/index.js
+++ b/frontend/src/metabase/visualizations/index.js
@@ -18,7 +18,11 @@ visualizations.get = function(key) {
 
 export function getSensibleDisplays(data) {
   return Array.from(visualizations)
-    .filter(([, viz]) => viz.isSensible && viz.isSensible(data))
+    .filter(
+      ([, viz]) =>
+        // don't rule out displays if there's no data
+        data.rows.length === 0 || (viz.isSensible && viz.isSensible(data)),
+    )
     .map(([display]) => display);
 }
 

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -279,11 +279,22 @@ describe("Question", () => {
 
       it("should not set the display to scalar table was selected", () => {
         const question = new Question(orders_count_card, metadata)
-          .setSelectedDisplay("table")
-          .setSensibleDisplays(["table", "scalar"])
+          .setDisplay("table")
+          .lockDisplay()
+          .maybeUnlockDisplay(["table", "scalar"])
           .setDefaultDisplay();
 
         expect(question.display()).toBe("table");
+      });
+
+      it("should set the display to scalar if funnel was selected", () => {
+        const question = new Question(orders_count_card, metadata)
+          .setDisplay("funnel")
+          .lockDisplay()
+          .maybeUnlockDisplay(["table", "scalar"])
+          .setDefaultDisplay();
+
+        expect(question.display()).toBe("scalar");
       });
     });
   });


### PR DESCRIPTION
This PR tweaks the auto-selection behavior in a few ways:
1. The "locked" status is persisted in the URL, so you can send an unsaved question link without the recipient reverting to the default viz type. (Fixes #12361)
2. Don't run auto-selection unless the card is dirty. (Fixes #11675)
3. Don't unlock display when a (presumably temporary) dataset is returned with zero rows. (Fixes #11960)

## How it works now
(This is mostly unchanged from before, but just for posterity.)

When you create a new question and start editing it, we auto select the right display type based on the query and the data. If you explicitly choose a type in the left sidebar, we lock in that choice as you update the query. We only override it if the visualization is no longer "sensible" for the new data (e.g. a Gauge chart when there are multiple rows).

Saved questions are locked to a display type as though you selected it. Additionally, we _won't_ override even if the type isn't sensible until you edit the question. Saving a question shows that you want to preserve how it currently appears.

Here's the same info in bullets: 
* editing a new question -> we take the display from auto-selection
* editing a question after picking vis type -> use the display if sensible
* viewing an unchanged saved question ->  always use the display
* editing a saved question -> use the display if sensible

---

Separately from those fixes. I refactored how we lock display on a card. I previously left a comment that the data was "essentially a boolean flag". I changed it so it actually is a boolean. (No idea why I didn't before)