### PR TITLE
Use `include_sensitive_fields` when fetching table metadata in datamodel

### DIFF
--- a/frontend/src/metabase/admin/datamodel/withTableMetadataLoaded.js
+++ b/frontend/src/metabase/admin/datamodel/withTableMetadataLoaded.js
@@ -5,14 +5,18 @@ export default ComposedComponent => {
     componentDidMount() {
       const { table } = this.props;
       if (table) {
-        table.fetchMetadataAndForeignTables();
+        table.fetchMetadataAndForeignTables({
+          params: { include_sensitive_fields: true },
+        });
       }
     }
 
     componentDidUpdate(prevProps) {
       const { table } = this.props;
       if (table !== prevProps.table) {
-        table.fetchMetadataAndForeignTables();
+        table.fetchMetadataAndForeignTables({
+          params: { include_sensitive_fields: true },
+        });
       }
     }
 

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -75,9 +75,10 @@ const Tables = createEntity({
         ({ id }) => [...Tables.getObjectStatePath(id), "fetchMetadata"],
       ),
       withNormalize(TableSchema),
-    )(({ id }) => async (dispatch, getState) => {
+    )(({ id }, options = {}) => async (dispatch, getState) => {
       const table = await MetabaseApi.table_query_metadata({
         tableId: id,
+        ...options.params,
       });
       return addValidOperatorsToFields(table);
     }),

--- a/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
@@ -94,11 +94,26 @@ describe("scenarios > admin > datamodel > table", () => {
       cy.get(alias).contains(desiredOption);
     }
 
-    it("should allow hiding of columns", () => {
+    it("should allow hiding of columns outside of detail views", () => {
       cy.visit(ORDERS_URL);
 
       field("Created At").as("created_at");
       testSelect("@created_at", "Everywhere", "Only in detail views");
+    });
+
+    it("should allow hiding of columns entirely", () => {
+      cy.visit(ORDERS_URL);
+
+      field("Created At").as("created_at");
+      testSelect("@created_at", "Everywhere", "Do not include");
+
+      // click over to products and back so we refresh the columns
+      cy.contains("Products").click();
+      cy.url().should("include", "/admin/datamodel/database/1/table/1");
+      cy.contains("Orders").click();
+
+      // created at should still be there
+      field("Created At");
     });
 
     it("should allow changing of special type and currency", () => {


### PR DESCRIPTION
Fixes #10297