### PR TITLE
Fix parsing commit messages in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,7 @@ jobs:
             done;
       - run:
           name: Save last git commit message
-          command: git log -1 --oneline > commit.txt
+          command: git log -1 > commit.txt
       - run:
           name: Remove .git directory (not needed for tests)
           command: rm -rf /home/circleci/metabase/metabase/.git

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+codecov:
+    bot: "codecov-io"
+    require_ci_to_pass: no
+
+coverage:
+    round: down
+    range: 69..100


### PR DESCRIPTION
Parse more than just the first line of the commit message when looking for tags like `[ci drivers]` or `[ci all]`