### PR TITLE
Adding option to force all traffic to HTTPS

### DIFF
--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -49,6 +49,12 @@ const SECTIONS = updateSectionsWithPlugins({
         type: "string",
       },
       {
+        key: "redirect-all-requests-to-https",
+        display_name: t`Redirect to HTTPS`,
+        type: "boolean",
+        note: t`This value only takes effect if Site URL is HTTPS`,
+      },
+      {
         key: "admin-email",
         display_name: t`Email Address for Help Requests`,
         type: "string",

--- a/project.clj
+++ b/project.clj
@@ -133,7 +133,6 @@
    [ring/ring-core "1.8.0"]
    [ring/ring-jetty-adapter "1.8.0"]                                  ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
    [ring/ring-json "0.4.0"]                                           ; Ring middleware for reading/writing JSON automatically
-   [ring/ring-ssl "0.3.0"]                                            ; Ring middleware for redirecting HTTP to HTTPS
    [stencil "0.5.0"]                                                  ; Mustache templates for Clojure
    [toucan "1.15.1" :exclusions [org.clojure/java.jdbc                ; Model layer, hydration, and DB utilities
                                  org.clojure/tools.logging

--- a/project.clj
+++ b/project.clj
@@ -133,6 +133,7 @@
    [ring/ring-core "1.8.0"]
    [ring/ring-jetty-adapter "1.8.0"]                                  ; Ring adapter using Jetty webserver (used to run a Ring server for unit tests)
    [ring/ring-json "0.4.0"]                                           ; Ring middleware for reading/writing JSON automatically
+   [ring/ring-ssl "0.3.0"]                                            ; Ring middleware for redirecting HTTP to HTTPS
    [stencil "0.5.0"]                                                  ; Mustache templates for Clojure
    [toucan "1.15.1" :exclusions [org.clojure/java.jdbc                ; Model layer, hydration, and DB utilities
                                  org.clojure/tools.logging

--- a/src/metabase/handler.clj
+++ b/src/metabase/handler.clj
@@ -10,7 +10,8 @@
              [log :as mw.log]
              [misc :as mw.misc]
              [security :as mw.security]
-             [session :as mw.session]]
+             [session :as mw.session]
+             [ssl :as mw.ssl]]
             [metabase.plugins.classloader :as classloader]
             [ring.middleware
              [cookies :refer [wrap-cookies]]
@@ -21,6 +22,7 @@
 ;; required here because this namespace is not actually used anywhere but we need it to be loaded because it adds
 ;; impls for handling `core.async` channels as web server responses
 (classloader/require 'metabase.async.api-response)
+
 
 (def app
   "The primary entry point to the Ring HTTP server."
@@ -49,5 +51,6 @@
    wrap-cookies                            ; Parses cookies in the request map and assocs as :cookies
    mw.misc/add-content-type                ; Adds a Content-Type header for any response that doesn't already have one
    mw.misc/disable-streaming-buffering     ; Add header to streaming (async) responses so ngnix doesn't buffer keepalive bytes
-   wrap-gzip))                             ; GZIP response if client can handle it
+   wrap-gzip                               ; GZIP response if client can handle it
+   mw.ssl/redirect-to-https-middleware))   ; Redirect to HTTPS if configured to do so
 ;; ▲▲▲ PRE-PROCESSING ▲▲▲ happens from BOTTOM-TO-TOP

--- a/src/metabase/middleware/session.clj
+++ b/src/metabase/middleware/session.clj
@@ -44,7 +44,7 @@
     response
     {:body response, :status 200}))
 
-(defn- https-request?
+(defn https-request?
   "True if the original request made by the frontend client (i.e., browser) was made over HTTPS.
 
   In many production instances, a reverse proxy such as an ELB or nginx will handle SSL termination, and the actual

--- a/src/metabase/middleware/ssl.clj
+++ b/src/metabase/middleware/ssl.clj
@@ -1,12 +1,30 @@
 (ns metabase.middleware.ssl
   "Middleware for redirecting users to HTTPS sessions"
-  (:require [metabase.middleware.session :as mw.session]
+  (:require [clojure.string :as str]
+            [metabase.middleware.session :as mw.session]
             [metabase.public-settings :as public-settings]
-            [ring.middleware.ssl :refer [ssl-redirect-response]]))
+            [ring.util
+             [request :as req]
+             [response :as resp]]))
 
 (def no-redirect-https-uris
   "The set of URLs that should not be forced to redirect to their HTTPS equivalents"
   #{"/api/health"})
+
+(defn- get-request? [{method :request-method}]
+  (or (= method :head)
+      (= method :get)))
+
+(defn- https-url [url-string]
+  (let [url (java.net.URL. url-string)
+        site-url (java.net.URL. (public-settings/site-url))]
+    (str (java.net.URL. "https" (.getHost site-url) (.getPort site-url) (.getFile url)))))
+
+(defn- ssl-redirect-response
+  "Given a HTTP request, return a redirect response to the equivalent HTTPS URL."
+  [request]
+  (-> (resp/redirect (https-url (req/request-url request)))
+      (resp/status   (if (get-request? request) 301 307))))
 
 (defn redirect-to-https-middleware
   "Redirect users to HTTPS sessions when certain conditions are met.
@@ -14,12 +32,18 @@
   [handler]
   (fn [request respond raise]
     (cond
+      (str/blank? (public-settings/site-url))
+      (handler request respond raise)
+
+      (not (str/starts-with? (public-settings/site-url) "https:"))
+      (handler request respond raise)
+
       (no-redirect-https-uris (:uri request))
       (handler request respond raise)
 
       (and
        (public-settings/redirect-all-requests-to-https)
        (not (mw.session/https-request? request)))
-      (respond (ssl-redirect-response request {:ssl-port (public-settings/https-port)}))
+      (respond (ssl-redirect-response request))
 
       :else (handler request respond raise))))

--- a/src/metabase/middleware/ssl.clj
+++ b/src/metabase/middleware/ssl.clj
@@ -1,0 +1,25 @@
+(ns metabase.middleware.ssl
+  "Middleware for redirecting users to HTTPS sessions"
+  (:require [metabase.middleware.session :as mw.session]
+            [metabase.public-settings :as public-settings]
+            [ring.middleware.ssl :refer [ssl-redirect-response]]))
+
+(def no-redirect-https-uris
+  "The set of URLs that should not be forced to redirect to their HTTPS equivalents"
+  #{"/api/health"})
+
+(defn redirect-to-https-middleware
+  "Redirect users to HTTPS sessions when certain conditions are met.
+   See `no-redirect-https-uris` for URIs excluded from https redirects."
+  [handler]
+  (fn [request respond raise]
+    (cond
+      (no-redirect-https-uris (:uri request))
+      (handler request respond raise)
+
+      (and
+       (public-settings/redirect-all-requests-to-https)
+       (not (mw.session/https-request? request)))
+      (respond (ssl-redirect-response request {:ssl-port (public-settings/https-port)}))
+
+      :else (handler request respond raise))))

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -275,3 +275,15 @@
   :visibility :public
   :setter     :none
   :getter     (constantly config/mb-version-info))
+
+(defsetting redirect-all-requests-to-https
+  (deferred-tru "Force all traffic to use HTTPS via a redirect")
+  :visibility :public
+  :type       :boolean
+  :default    false)
+
+(defsetting https-port
+  (deferred-tru "HTTPS port number for redirects")
+  :visibility :public
+  :type       :integer
+  :default    443)

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -277,13 +277,7 @@
   :getter     (constantly config/mb-version-info))
 
 (defsetting redirect-all-requests-to-https
-  (deferred-tru "Force all traffic to use HTTPS via a redirect")
+  (deferred-tru "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS")
   :visibility :public
   :type       :boolean
   :default    false)
-
-(defsetting https-port
-  (deferred-tru "HTTPS port number for redirects")
-  :visibility :public
-  :type       :integer
-  :default    443)

--- a/test/metabase/middleware/ssl_test.clj
+++ b/test/metabase/middleware/ssl_test.clj
@@ -1,0 +1,71 @@
+(ns metabase.middleware.ssl-test
+  (:require [clojure.test :refer :all]
+            [metabase.middleware.ssl :as mw.ssl]
+            [metabase.test.util :as tu]
+            [ring.mock.request :as mock]
+            [ring.util.response :as response]))
+
+(defn- handler [request]
+  ((mw.ssl/redirect-to-https-middleware
+    (fn [request respond _] (respond (response/response ""))))
+   request
+   identity
+   (fn [e] (throw e))))
+
+(deftest test-redirect-index
+  (testing "does not redirect when disabled"
+    (tu/with-temporary-setting-values [redirect-all-requests-to-https false]
+      (let [response (handler (mock/request :get "/"))]
+        (is (= 200 (:status response))))))
+  (testing "redirects when enabled"
+    (tu/with-temporary-setting-values [redirect-all-requests-to-https true]
+      (let [response (handler (mock/request :get "/"))]
+        (is (= 301 (:status response)))
+        (is (= "https://localhost:443/" (get-in response [:headers "Location"]))))))
+  (testing "redirects with custom SSL port"
+    (tu/with-temporary-setting-values [redirect-all-requests-to-https true
+                                       https-port 4444]
+      (let [response (handler (mock/request :get "/"))]
+        (is (= 301 (:status response)))
+        (is (= "https://localhost:4444/" (get-in response [:headers "Location"])))))))
+
+(deftest test-do-not-redirect-healthcheck
+  (testing "does not redirect when disabled"
+    (tu/with-temporary-setting-values [redirect-all-requests-to-https false]
+     (let [response (handler (mock/request :get "/api/health"))]
+       (is (= 200 (:status response))))))
+  (testing "does not redirect when enabled"
+    (tu/with-temporary-setting-values [redirect-all-requests-to-https true]
+     (let [response (handler (mock/request :get "/api/health"))]
+       (is (= 200 (:status response)))))))
+
+(deftest test-do-not-redirect-loadbalancer-sessions
+  (testing "does not redirect"
+    (tu/with-temporary-setting-values [redirect-all-requests-to-https true]
+      (let [response (handler (-> (mock/request :get "/foo")
+                                  (mock/header :X-Forwarded-Proto "https")))]
+        (is (= 200 (:status response))))
+      (let [response (handler (-> (mock/request :get "/foo")
+                                  (mock/header :X-URL-Scheme "https")))]
+        (is (= 200 (:status response))))
+
+      (let [response (handler (-> (mock/request :get "/foo")
+                                  (mock/header :X-Forwarded-SSL "on")))]
+        (is (= 200 (:status response))))
+      (let [response (handler (-> (mock/request :get "/foo")
+                                  (mock/header :Front-End-HTTPS "on")))]
+        (is (= 200 (:status response))))
+
+      (let [response (handler (-> (mock/request :get "/foo")
+                                  (mock/header :Origin "https://foo")))]
+        (is (= 200 (:status response)))))))
+
+(deftest test-does-not-redirect-https-sessions
+  (testing "does not redirect when disabled"
+    (tu/with-temporary-setting-values [redirect-all-requests-to-https false]
+     (let [response (handler (mock/request :get "https://localhost/foo"))]
+       (is (= 200 (:status response))))))
+  (testing "does not redirect when enabled"
+    (tu/with-temporary-setting-values [redirect-all-requests-to-https true]
+      (let [response (handler (mock/request :get "https://localhost/foo"))]
+        (is (= 200 (:status response)))))))

--- a/test/metabase/middleware/ssl_test.clj
+++ b/test/metabase/middleware/ssl_test.clj
@@ -14,17 +14,19 @@
 
 (deftest test-redirect-index
   (testing "does not redirect when disabled"
-    (tu/with-temporary-setting-values [redirect-all-requests-to-https false]
+    (tu/with-temporary-setting-values [site-url "https://localhost"
+                                       redirect-all-requests-to-https false]
       (let [response (handler (mock/request :get "/"))]
         (is (= 200 (:status response))))))
   (testing "redirects when enabled"
-    (tu/with-temporary-setting-values [redirect-all-requests-to-https true]
+    (tu/with-temporary-setting-values [site-url "https://localhost"
+                                       redirect-all-requests-to-https true]
       (let [response (handler (mock/request :get "/"))]
         (is (= 301 (:status response)))
-        (is (= "https://localhost:443/" (get-in response [:headers "Location"]))))))
+        (is (= "https://localhost/" (get-in response [:headers "Location"]))))))
   (testing "redirects with custom SSL port"
-    (tu/with-temporary-setting-values [redirect-all-requests-to-https true
-                                       https-port 4444]
+    (tu/with-temporary-setting-values [site-url "https://localhost:4444"
+                                       redirect-all-requests-to-https true]
       (let [response (handler (mock/request :get "/"))]
         (is (= 301 (:status response)))
         (is (= "https://localhost:4444/" (get-in response [:headers "Location"])))))))
@@ -35,13 +37,15 @@
      (let [response (handler (mock/request :get "/api/health"))]
        (is (= 200 (:status response))))))
   (testing "does not redirect when enabled"
-    (tu/with-temporary-setting-values [redirect-all-requests-to-https true]
+    (tu/with-temporary-setting-values [site-url "https://localhost"
+                                       redirect-all-requests-to-https true]
      (let [response (handler (mock/request :get "/api/health"))]
        (is (= 200 (:status response)))))))
 
 (deftest test-do-not-redirect-loadbalancer-sessions
   (testing "does not redirect"
-    (tu/with-temporary-setting-values [redirect-all-requests-to-https true]
+    (tu/with-temporary-setting-values [site-url "https://localhost"
+                                       redirect-all-requests-to-https true]
       (let [response (handler (-> (mock/request :get "/foo")
                                   (mock/header :X-Forwarded-Proto "https")))]
         (is (= 200 (:status response))))
@@ -62,10 +66,12 @@
 
 (deftest test-does-not-redirect-https-sessions
   (testing "does not redirect when disabled"
-    (tu/with-temporary-setting-values [redirect-all-requests-to-https false]
+    (tu/with-temporary-setting-values [site-url "https://localhost"
+                                       redirect-all-requests-to-https false]
      (let [response (handler (mock/request :get "https://localhost/foo"))]
        (is (= 200 (:status response))))))
   (testing "does not redirect when enabled"
-    (tu/with-temporary-setting-values [redirect-all-requests-to-https true]
+    (tu/with-temporary-setting-values [site-url "https://localhost"
+                                       redirect-all-requests-to-https true]
       (let [response (handler (mock/request :get "https://localhost/foo"))]
         (is (= 200 (:status response)))))))


### PR DESCRIPTION
Adds a boolean setting to force redirects to HTTPS (defaults to false)
and a integer setting for the SSL port number.

Resolves #4871