### PR TITLE
Replace XSSFWorkbook with SXSSFWorkbook (drastically reduce memory usage for streaming large XLSX files)

### DIFF
--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -10,7 +10,7 @@
              [i18n :refer [tru]]])
   (:import java.io.OutputStream
            org.apache.poi.ss.usermodel.Cell
-           org.apache.poi.xssf.usermodel.XSSFWorkbook))
+           org.apache.poi.xssf.streaming.SXSSFWorkbook))
 
 (defmethod i/stream-options :xlsx
   [_]
@@ -35,7 +35,7 @@
 ;; TODO -- this is obviously not streaming! SAD!
 (defmethod i/streaming-results-writer :xlsx
   [_ ^OutputStream os]
-  (let [workbook (XSSFWorkbook.)
+  (let [workbook (SXSSFWorkbook.)
         sheet    (spreadsheet/add-sheet! workbook (tru "Query result"))]
     (reify i/StreamingResultsWriter
       (begin! [_ {{:keys [cols]} :data}]
@@ -46,4 +46,5 @@
 
       (finish! [_ _]
         (spreadsheet/save-workbook-into-stream! os workbook)
+        (.dispose workbook)
         (.close os)))))


### PR DESCRIPTION
I got Gateway timeout when trying to export an large excel file ,I know the error is from proxy layer,
however , I notice machine's resources have not been released and got error in logs:

<details>
<summary>Logs</summary>
<pre><code>
05-13 16:06:30 ERROR middleware.catch-exceptions :: Error processing query: null
{:database_id 1,
 :started_at (t/zoned-date-time "2020-05-13T16:05:18.254+08:00[Asia/Shanghai]"),
 :via
 [{:status :failed,
   :class org.apache.poi.openxml4j.exceptions.OpenXML4JRuntimeException,
   :error
   "Fail to save: an error occurs while saving the package : The part /docProps/core.xml failed to be saved in the stream with marshaller org.apache.poi.openxml4j.opc.internal.marshallers.ZipPackagePropertiesMarshaller@b1fbf78",
   :stacktrace
   ["org.apache.poi.openxml4j.opc.ZipPackage.saveImpl(ZipPackage.java:595)"
    "org.apache.poi.openxml4j.opc.OPCPackage.save(OPCPackage.java:1539)"
    "org.apache.poi.POIXMLDocument.write(POIXMLDocument.java:227)"
    "dk.ative.docjure.spreadsheet$save_workbook_into_stream_BANG_.invokeStatic(spreadsheet.clj:96)"
    "dk.ative.docjure.spreadsheet$save_workbook_into_stream_BANG_.invoke(spreadsheet.clj:91)"
    "--> query_processor.streaming.xlsx$eval42146$fn$reify__42149.finish_BANG_(xlsx.clj:48)"
    "query_processor.streaming$streaming_reducedf$fn__42164.invoke(streaming.clj:40)"
    "query_processor.context$reducedf.invokeStatic(context.clj:77)"
    "query_processor.context$reducedf.invoke(context.clj:72)"
    "query_processor.context.default$default_reducef.invokeStatic(default.clj:65)"
    "query_processor.context.default$default_reducef.invoke(default.clj:49)"
    "query_processor.context$reducef.invokeStatic(context.clj:69)"
    "query_processor.context$reducef.invoke(context.clj:62)"
    "query_processor.context.default$default_runf$respond_STAR___26339.invoke(default.clj:70)"
    "driver.sql_jdbc.execute$execute_reducible_query.invokeStatic(execute.clj:392)"
    "driver.sql_jdbc.execute$execute_reducible_query.invoke(execute.clj:377)"
    "driver.sql_jdbc$eval58837$fn__58838.invoke(sql_jdbc.clj:50)"
    "driver.h2$eval83569$fn__83570.invoke(h2.clj:81)"
    "query_processor.context$executef.invokeStatic(context.clj:59)"
    "query_processor.context$executef.invoke(context.clj:48)"
    "query_processor.context.default$default_runf.invokeStatic(default.clj:69)"
    "query_processor.context.default$default_runf.invoke(default.clj:67)"
    "query_processor.context$runf.invokeStatic(context.clj:45)"
    "query_processor.context$runf.invoke(context.clj:39)"
    "query_processor.reducible$pivot.invokeStatic(reducible.clj:34)"
    "query_processor.reducible$pivot.invoke(reducible.clj:31)"
    "query_processor.middleware.mbql_to_native$mbql__GT_native$fn__53003.invoke(mbql_to_native.clj:26)"
    "query_processor.middleware.check_features$check_features$fn__52237.invoke(check_features.clj:42)"
    "query_processor.middleware.optimize_datetime_filters$optimize_datetime_filters$fn__53202.invoke(optimize_datetime_filters.clj:133)"
    "query_processor.middleware.wrap_value_literals$wrap_value_literals$fn__57584.invoke(wrap_value_literals.clj:137)"
    "query_processor.middleware.annotate$add_column_info$fn__47680.invoke(annotate.clj:577)"
    "query_processor.middleware.permissions$check_query_permissions$fn__52096.invoke(permissions.clj:64)"
    "query_processor.middleware.pre_alias_aggregations$pre_alias_aggregations$fn__53742.invoke(pre_alias_aggregations.clj:40)"
    "query_processor.middleware.cumulative_aggregations$handle_cumulative_aggregations$fn__52326.invoke(cumulative_aggregations.clj:61)"
    "query_processor.middleware.resolve_joins$resolve_joins$fn__54316.invoke(resolve_joins.clj:183)"
    "query_processor.middleware.add_implicit_joins$add_implicit_joins$fn__50563.invoke(add_implicit_joins.clj:245)"
    "query_processor.middleware.limit$limit$fn__52981.invoke(limit.clj:38)"
    "query_processor.middleware.format_rows$format_rows$fn__52954.invoke(format_rows.clj:81)"
    "query_processor.middleware.desugar$desugar$fn__52398.invoke(desugar.clj:22)"
    "query_processor.middleware.binning$update_binning_strategy$fn__51300.invoke(binning.clj:229)"
    "query_processor.middleware.resolve_fields$resolve_fields$fn__51890.invoke(resolve_fields.clj:24)"
    "query_processor.middleware.add_dimension_projections$add_remapping$fn__50087.invoke(add_dimension_projections.clj:270)"
    "query_processor.middleware.add_implicit_clauses$add_implicit_clauses$fn__50311.invoke(add_implicit_clauses.clj:147)"
    "query_processor.middleware.add_source_metadata$add_source_metadata_for_source_queries$fn__50726.invoke(add_source_metadata.clj:105)"
    "query_processor.middleware.reconcile_breakout_and_order_by_bucketing$reconcile_breakout_and_order_by_bucketing$fn__53967.invoke(reconcile_breakout_and_order_by_bucketing.clj:98)"
    "query_processor.middleware.auto_bucket_datetimes$auto_bucket_datetimes$fn__50933.invoke(auto_bucket_datetimes.clj:125)"
    "query_processor.middleware.resolve_source_table$resolve_source_tables$fn__51945.invoke(resolve_source_table.clj:46)"
    "query_processor.middleware.parameters$substitute_parameters$fn__53715.invoke(parameters.clj:104)"
    "query_processor.middleware.resolve_referenced$resolve_referenced_card_resources$fn__51999.invoke(resolve_referenced.clj:80)"
    "query_processor.middleware.expand_macros$expand_macros$fn__52662.invoke(expand_macros.clj:158)"
    "query_processor.middleware.add_timezone_info$add_timezone_info$fn__50741.invoke(add_timezone_info.clj:15)"
    "query_processor.middleware.splice_params_in_response$splice_params_in_response$fn__57416.invoke(splice_params_in_response.clj:32)"
    "query_processor.middleware.resolve_database_and_driver$resolve_database_and_driver$fn__53984$fn__53988.invoke(resolve_database_and_driver.clj:33)"
    "driver$do_with_driver.invokeStatic(driver.clj:61)"
    "driver$do_with_driver.invoke(driver.clj:57)"
    "query_processor.middleware.resolve_database_and_driver$resolve_database_and_driver$fn__53984.invoke(resolve_database_and_driver.clj:27)"
    "query_processor.middleware.fetch_source_query$resolve_card_id_source_tables$fn__52876.invoke(fetch_source_query.clj:243)"
    "query_processor.middleware.store$initialize_store$fn__57433$fn__57434.invoke(store.clj:11)"
    "query_processor.store$do_with_store.invokeStatic(store.clj:46)"
    "query_processor.store$do_with_store.invoke(store.clj:40)"
    "query_processor.middleware.store$initialize_store$fn__57433.invoke(store.clj:10)"
    "query_processor.middleware.cache$maybe_return_cached_results$fn__51842.invoke(cache.clj:209)"
    "query_processor.middleware.validate$validate_query$fn__57450.invoke(validate.clj:10)"
    "query_processor.middleware.normalize_query$normalize$fn__53024.invoke(normalize_query.clj:22)"
    "query_processor.middleware.add_rows_truncated$add_rows_truncated$fn__50589.invoke(add_rows_truncated.clj:36)"
    "query_processor.middleware.results_metadata$record_and_return_metadata_BANG_$fn__57395.invoke(results_metadata.clj:124)"
    "query_processor.middleware.constraints$add_default_userland_constraints$fn__52261.invoke(constraints.clj:42)"
    "query_processor.middleware.process_userland_query$process_userland_query$fn__53833.invoke(process_userland_query.clj:136)"
    "query_processor.middleware.catch_exceptions$catch_exceptions$fn__52190.invoke(catch_exceptions.clj:174)"
    "query_processor.reducible$async_qp$qp_STAR___46493$thunk__46494.invoke(reducible.clj:101)"
    "query_processor.reducible$async_qp$qp_STAR___46493$fn__46496.invoke(reducible.clj:106)"]}],
 :json_query
 {:type "native",
  :native
  {:query
   "select * from ORDERS \n    union all select * from ORDERS\n     union all select * from ORDERS\n      union all select * from ORDERS\n       union all select * from ORDERS\n        union all select * from ORDERS\n         union all select * from ORDERS\n          union all select * from ORDERS\n           union all select * from ORDERS\n            union all select * from ORDERS\n             union all select * from ORDERS\n              union all select * from ORDERS\n               union all select * from ORDERS\n                union all select * from ORDERS\n                 union all select * from ORDERS\n                  union all select * from ORDERS\n                   union all select * from ORDERS\n                    union all select * from ORDERS\n                     union all select * from ORDERS\n                      union all select * from ORDERS\n                       union all select * from ORDERS",
   :template-tags {}},
  :database 1,
  :middleware {:skip-results-metadata? true, :format-rows? false},
  :async? true},
 :status :failed,
 :class org.apache.poi.openxml4j.exceptions.OpenXML4JException,
 :stacktrace
 ["org.apache.poi.openxml4j.opc.ZipPackage.saveImpl(ZipPackage.java:582)"
  "org.apache.poi.openxml4j.opc.OPCPackage.save(OPCPackage.java:1539)"
  "org.apache.poi.POIXMLDocument.write(POIXMLDocument.java:227)"
  "dk.ative.docjure.spreadsheet$save_workbook_into_stream_BANG_.invokeStatic(spreadsheet.clj:96)"
  "dk.ative.docjure.spreadsheet$save_workbook_into_stream_BANG_.invoke(spreadsheet.clj:91)"
  "--> query_processor.streaming.xlsx$eval42146$fn$reify__42149.finish_BANG_(xlsx.clj:48)"
  "query_processor.streaming$streaming_reducedf$fn__42164.invoke(streaming.clj:40)"
  "query_processor.context$reducedf.invokeStatic(context.clj:77)"
  "query_processor.context$reducedf.invoke(context.clj:72)"
  "query_processor.context.default$default_reducef.invokeStatic(default.clj:65)"
  "query_processor.context.default$default_reducef.invoke(default.clj:49)"
  "query_processor.context$reducef.invokeStatic(context.clj:69)"
  "query_processor.context$reducef.invoke(context.clj:62)"
  "query_processor.context.default$default_runf$respond_STAR___26339.invoke(default.clj:70)"
  "driver.sql_jdbc.execute$execute_reducible_query.invokeStatic(execute.clj:392)"
  "driver.sql_jdbc.execute$execute_reducible_query.invoke(execute.clj:377)"
  "driver.sql_jdbc$eval58837$fn__58838.invoke(sql_jdbc.clj:50)"
  "driver.h2$eval83569$fn__83570.invoke(h2.clj:81)"
  "query_processor.context$executef.invokeStatic(context.clj:59)"
  "query_processor.context$executef.invoke(context.clj:48)"
  "query_processor.context.default$default_runf.invokeStatic(default.clj:69)"
  "query_processor.context.default$default_runf.invoke(default.clj:67)"
  "query_processor.context$runf.invokeStatic(context.clj:45)"
  "query_processor.context$runf.invoke(context.clj:39)"
  "query_processor.reducible$pivot.invokeStatic(reducible.clj:34)"
  "query_processor.reducible$pivot.invoke(reducible.clj:31)"
  "query_processor.middleware.mbql_to_native$mbql__GT_native$fn__53003.invoke(mbql_to_native.clj:26)"
  "query_processor.middleware.check_features$check_features$fn__52237.invoke(check_features.clj:42)"
  "query_processor.middleware.optimize_datetime_filters$optimize_datetime_filters$fn__53202.invoke(optimize_datetime_filters.clj:133)"
  "query_processor.middleware.wrap_value_literals$wrap_value_literals$fn__57584.invoke(wrap_value_literals.clj:137)"
  "query_processor.middleware.annotate$add_column_info$fn__47680.invoke(annotate.clj:577)"
  "query_processor.middleware.permissions$check_query_permissions$fn__52096.invoke(permissions.clj:64)"
  "query_processor.middleware.pre_alias_aggregations$pre_alias_aggregations$fn__53742.invoke(pre_alias_aggregations.clj:40)"
  "query_processor.middleware.cumulative_aggregations$handle_cumulative_aggregations$fn__52326.invoke(cumulative_aggregations.clj:61)"
  "query_processor.middleware.resolve_joins$resolve_joins$fn__54316.invoke(resolve_joins.clj:183)"
  "query_processor.middleware.add_implicit_joins$add_implicit_joins$fn__50563.invoke(add_implicit_joins.clj:245)"
  "query_processor.middleware.limit$limit$fn__52981.invoke(limit.clj:38)"
  "query_processor.middleware.format_rows$format_rows$fn__52954.invoke(format_rows.clj:81)"
  "query_processor.middleware.desugar$desugar$fn__52398.invoke(desugar.clj:22)"
  "query_processor.middleware.binning$update_binning_strategy$fn__51300.invoke(binning.clj:229)"
  "query_processor.middleware.resolve_fields$resolve_fields$fn__51890.invoke(resolve_fields.clj:24)"
  "query_processor.middleware.add_dimension_projections$add_remapping$fn__50087.invoke(add_dimension_projections.clj:270)"
  "query_processor.middleware.add_implicit_clauses$add_implicit_clauses$fn__50311.invoke(add_implicit_clauses.clj:147)"
  "query_processor.middleware.add_source_metadata$add_source_metadata_for_source_queries$fn__50726.invoke(add_source_metadata.clj:105)"
  "query_processor.middleware.reconcile_breakout_and_order_by_bucketing$reconcile_breakout_and_order_by_bucketing$fn__53967.invoke(reconcile_breakout_and_order_by_bucketing.clj:98)"
  "query_processor.middleware.auto_bucket_datetimes$auto_bucket_datetimes$fn__50933.invoke(auto_bucket_datetimes.clj:125)"
  "query_processor.middleware.resolve_source_table$resolve_source_tables$fn__51945.invoke(resolve_source_table.clj:46)"
  "query_processor.middleware.parameters$substitute_parameters$fn__53715.invoke(parameters.clj:104)"
  "query_processor.middleware.resolve_referenced$resolve_referenced_card_resources$fn__51999.invoke(resolve_referenced.clj:80)"
  "query_processor.middleware.expand_macros$expand_macros$fn__52662.invoke(expand_macros.clj:158)"
  "query_processor.middleware.add_timezone_info$add_timezone_info$fn__50741.invoke(add_timezone_info.clj:15)"
  "query_processor.middleware.splice_params_in_response$splice_params_in_response$fn__57416.invoke(splice_params_in_response.clj:32)"
  "query_processor.middleware.resolve_database_and_driver$resolve_database_and_driver$fn__53984$fn__53988.invoke(resolve_database_and_driver.clj:33)"
  "driver$do_with_driver.invokeStatic(driver.clj:61)"
  "driver$do_with_driver.invoke(driver.clj:57)"
  "query_processor.middleware.resolve_database_and_driver$resolve_database_and_driver$fn__53984.invoke(resolve_database_and_driver.clj:27)"
  "query_processor.middleware.fetch_source_query$resolve_card_id_source_tables$fn__52876.invoke(fetch_source_query.clj:243)"
  "query_processor.middleware.store$initialize_store$fn__57433$fn__57434.invoke(store.clj:11)"
  "query_processor.store$do_with_store.invokeStatic(store.clj:46)"
  "query_processor.store$do_with_store.invoke(store.clj:40)"
  "query_processor.middleware.store$initialize_store$fn__57433.invoke(store.clj:10)"
  "query_processor.middleware.cache$maybe_return_cached_results$fn__51842.invoke(cache.clj:209)"
  "query_processor.middleware.validate$validate_query$fn__57450.invoke(validate.clj:10)"
  "query_processor.middleware.normalize_query$normalize$fn__53024.invoke(normalize_query.clj:22)"
  "query_processor.middleware.add_rows_truncated$add_rows_truncated$fn__50589.invoke(add_rows_truncated.clj:36)"
  "query_processor.middleware.results_metadata$record_and_return_metadata_BANG_$fn__57395.invoke(results_metadata.clj:124)"
  "query_processor.middleware.constraints$add_default_userland_constraints$fn__52261.invoke(constraints.clj:42)"
  "query_processor.middleware.process_userland_query$process_userland_query$fn__53833.invoke(process_userland_query.clj:136)"
  "query_processor.middleware.catch_exceptions$catch_exceptions$fn__52190.invoke(catch_exceptions.clj:174)"
  "query_processor.reducible$async_qp$qp_STAR___46493$thunk__46494.invoke(reducible.clj:101)"
  "query_processor.reducible$async_qp$qp_STAR___46493$fn__46496.invoke(reducible.clj:106)"],
 :context :xlsx-download,
 :error "The part /docProps/core.xml failed to be saved in the stream with marshaller org.apache.poi.openxml4j.opc.internal.marshallers.ZipPackagePropertiesMarshaller@b1fbf78",
 :row_count 0,
 :running_time 0,
 :data {:rows [], :cols []}}
</code></pre></details>

So I try to replace `XSSFWorkbook` with `SXSSFWorkbook` in `src/metabase/query_processor/streaming/xlsx.clj`

> [SXSSFWorkbook allows to write very large files without running out of memory as only a configurable portion of the rows are kept in memory at any one time. ](http://poi.apache.org/apidocs/dev/org/apache/poi/xssf/streaming/SXSSFWorkbook.html)

This is still not streaming for HTTP Request.
but According to my test , This solved (maybe eased..) the problem of insufficient memory and Reduced a lot of time

Native query for test:
```sql
select * from ORDERS 
    union all select * from ORDERS
     union all select * from ORDERS
      union all select * from ORDERS
       union all select * from ORDERS
        union all select * from ORDERS
         union all select * from ORDERS
          union all select * from ORDERS
           union all select * from ORDERS
            union all select * from ORDERS
             union all select * from ORDERS
              union all select * from ORDERS
               union all select * from ORDERS
                union all select * from ORDERS
                 union all select * from ORDERS
                  union all select * from ORDERS
                   union all select * from ORDERS
                    union all select * from ORDERS
                     union all select * from ORDERS
                      union all select * from ORDERS
                       union all select * from ORDERS
```
This got 393961 rows data , I export xlsx for 3 times:

Before changing：
![image](https://user-images.githubusercontent.com/15194498/81789226-3fd64100-9536-11ea-9e13-356a3430abf8.png)

After：
![image](https://user-images.githubusercontent.com/15194498/81789589-c723b480-9536-11ea-923e-6a2cdded8ae8.png)