### PR TITLE
Send credentials, i.e. cookies, with requests for the manifest

### DIFF
--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -10,7 +10,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/app/assets/img/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/app/assets/img/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/app/assets/img/favicon-16x16.png">
-    <link rel="manifest" href="/app/assets/img/site.webmanifest">
+    <link rel="manifest" crossorigin="use-credentials" href="/app/assets/img/site.webmanifest">
     <link rel="mask-icon" href="/app/assets/img/safari-pinned-tab.svg" color="#62a8e6">
     <link rel="shortcut icon" href="/app/assets/img/favicon.ico">
     <meta name="msapplication-TileColor" content="#2d89ef">


### PR DESCRIPTION
When running Metabase behind a proxy that adds a layer of
authentication/authorization, then requests for the manifest are blocked
by the proxy, because cookies are not sent along with the request.

See https://web.dev/add-manifest/#link-manifest for a brief explanation.


###### Before submitting the PR, please make sure you do the following

~- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.~ N/A
### Tests
-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)

~-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`~ N/A

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
