### PR TITLE
Generate correct query when no DB supports nested queries

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -123,19 +123,20 @@
 (defn- source-query-cards
   "Fetch the Cards that can be used as source queries (e.g. presented as virtual tables)."
   [& {:keys [additional-constraints xform], :or {xform identity}}]
-  (transduce
-   (comp (filter card-can-be-used-as-source-query?) xform)
-   (completing conj #(hydrate % :collection))
-   []
-   (db/select-reducible [Card :name :description :database_id :dataset_query :id :collection_id :result_metadata]
-     {:where    (into [:and
-                       [:not= :result_metadata nil]
-                       [:= :archived false]
-                       [:in :database_id (ids-of-dbs-that-support-source-queries)]
-                       (collection/visible-collection-ids->honeysql-filter-clause
-                        (collection/permissions-set->visible-collection-ids @api/*current-user-permissions-set*))]
-                      additional-constraints)
-      :order-by [[:%lower.name :asc]]})))
+  (when-let [ids-of-dbs-that-support-source-queries (not-empty (ids-of-dbs-that-support-source-queries))]
+    (transduce
+     (comp (filter card-can-be-used-as-source-query?) xform)
+     (completing conj #(hydrate % :collection))
+     []
+     (db/select-reducible [Card :name :description :database_id :dataset_query :id :collection_id :result_metadata]
+       {:where    (into [:and
+                         [:not= :result_metadata nil]
+                         [:= :archived false]
+                         [:in :database_id ids-of-dbs-that-support-source-queries]
+                         (collection/visible-collection-ids->honeysql-filter-clause
+                          (collection/permissions-set->visible-collection-ids @api/*current-user-permissions-set*))]
+                        additional-constraints)
+       :order-by [[:%lower.name :asc]]}))))
 
 (defn- source-query-cards-exist?
   "Truthy if a single Card that can be used as a source query exists."

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -441,14 +441,8 @@
                        saved-questions-virtual-db)
                    (fetch-virtual-database)))))
 
-        (testing "Should work when there are no DBs that support nested queries"
-          (mt/with-temp* [Database [bad-db   {:engine ::no-nested-query-support, :details {}}]
-                          Card     [bad-card {:name            "Bad Card"
-                                              :dataset_query   {:database (u/get-id bad-db)
-                                                                :type     :native
-                                                                :native   {:query "[QUERY GOES HERE]"}}
-                                              :result_metadata [{:name "sparrows"}]
-                                              :database_id     (u/get-id bad-db)}]]
+        (testing "should work when there are no DBs that support nested queries"
+          (with-redefs [metabase.driver/supports? (constantly false)]
             (is (nil? (fetch-virtual-database)))))
 
         (testing "should remove Cards that use cumulative-sum and cumulative-count aggregations"
@@ -464,7 +458,7 @@
                        virtual-table-for-card
                        saved-questions-virtual-db)
                    (fetch-virtual-database)))))))))
-(databases-list-include-saved-questions-tables-test)
+
 (deftest db-metadata-saved-questions-db-test
   (testing "GET /api/database/:id/metadata works for the Saved Questions 'virtual' database"
     (mt/with-temp* [Card [card (assoc (card-with-native-query "Birthday Card")

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -441,6 +441,16 @@
                        saved-questions-virtual-db)
                    (fetch-virtual-database)))))
 
+        (testing "Should work when there are no DBs that support nested queries"
+          (mt/with-temp* [Database [bad-db   {:engine ::no-nested-query-support, :details {}}]
+                          Card     [bad-card {:name            "Bad Card"
+                                              :dataset_query   {:database (u/get-id bad-db)
+                                                                :type     :native
+                                                                :native   {:query "[QUERY GOES HERE]"}}
+                                              :result_metadata [{:name "sparrows"}]
+                                              :database_id     (u/get-id bad-db)}]]
+            (is (nil? (fetch-virtual-database)))))
+
         (testing "should remove Cards that use cumulative-sum and cumulative-count aggregations"
           (mt/with-temp* [Card [ok-card (ok-mbql-card)]
                           Card [_ (merge
@@ -454,7 +464,7 @@
                        virtual-table-for-card
                        saved-questions-virtual-db)
                    (fetch-virtual-database)))))))))
-
+(databases-list-include-saved-questions-tables-test)
 (deftest db-metadata-saved-questions-db-test
   (testing "GET /api/database/:id/metadata works for the Saved Questions 'virtual' database"
     (mt/with-temp* [Card [card (assoc (card-with-native-query "Birthday Card")


### PR DESCRIPTION
Fixes #12323. We had a bug where we generated invalid query if no DBs support nested queries. 

Not sure if `with-redefs` is the best way to mock this.