### PR TITLE
/api/database: Don't include virtual DB if nested queries are off

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -164,7 +164,7 @@
   (let [virtual-db-metadata (apply saved-cards-virtual-db-metadata options)]
     ;; only add the 'Saved Questions' DB if there are Cards that can be used
     (cond-> dbs
-      (source-query-cards-exist?) (concat [virtual-db-metadata]))))
+      (and (source-query-cards-exist?) virtual-db-metadata) (concat [virtual-db-metadata]))))
 
 (defn- dbs-list [& {:keys [include-tables? include-saved-questions-db? include-saved-questions-tables?]}]
   (when-let [dbs (seq (filter mi/can-read? (db/select Database {:order-by [:%lower.name :%lower.engine]})))]

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -19,7 +19,9 @@
              [analyze :as analyze]
              [field-values :as field-values]
              [sync-metadata :as sync-metadata]]
-            [metabase.test.fixtures :as fixtures]
+            [metabase.test
+             [fixtures :as fixtures]
+             [util :as tu]]
             [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan
@@ -372,7 +374,10 @@
     (testing "We should not include the saved questions virtual DB if there aren't any cards"
       (not-any?
        :is_saved_questions
-       ((mt/user->client :lucky) :get 200 "database?saved=true")))))
+       ((mt/user->client :lucky) :get 200 "database?saved=true")))
+    (testing "Ommit virtual DB if nested queries are disabled"
+      (tu/with-temporary-setting-values [enable-nested-queries false]
+        (every? some? ((mt/user->client :lucky) :get 200 "database?saved=true"))))))
 
 (deftest databases-list-include-saved-questions-tables-test
   ;; `?saved=true&include=tables` and `?include_cards=true` mean the same thing, so test them both


### PR DESCRIPTION
Part 2/2 of fix for #12323

If nested queries were disabled, there was a nil in the list of returned DBs (instead of the virtual DB) which tripped up the FE. 