### PR TITLE
MBQL: make `concat` work with any number of args

### DIFF
--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -142,6 +142,12 @@
     (hsql/call :substr (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver start) (sql.qp/->honeysql driver length))
     (hsql/call :substr (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver start))))
 
+(defmethod sql.qp/->honeysql [:oracle :concat]
+  [driver [_ & args]]
+  (->> args
+       (map (partial sql.qp/->honeysql driver))
+       (reduce (partial hsql/call :concat))))
+
 (defmethod sql.qp/->honeysql [:oracle :regex-match-first]
   [driver [_ arg pattern]]
   (hsql/call :regexp_substr (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver pattern)))

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -139,6 +139,12 @@
   (hsql/call :replace (sql.qp/->honeysql driver arg) (splice-raw-string-value driver pattern)
              (splice-raw-string-value driver replacement)))
 
+(defmethod sql.qp/->honeysql [:redshift :concat]
+  [driver [_ & args]]
+  (->> args
+       (map (partial sql.qp/->honeysql driver))
+       (reduce (partial hsql/call :concat))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         metabase.driver.sql-jdbc impls                                         |
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -100,6 +100,12 @@
                                 one-day))
         one-day))
 
+(defmethod sql.qp/->honeysql [:vertica :concat]
+  [driver [_ & args]]
+  (->> args
+       (map (partial sql.qp/->honeysql driver))
+       (reduce (partial hsql/call :concat))))
+
 (defmethod sql.qp/->honeysql [:vertica :regex-match-first]
   [driver [_ arg pattern]]
   (hsql/call :regexp_substr (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver pattern)))

--- a/test/metabase/query_processor_test/string_extracts_test.clj
+++ b/test/metabase/query_processor_test/string_extracts_test.clj
@@ -57,7 +57,9 @@
 
 (deftest test-concat
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
-    (is (= "foobar" (test-string-extract [:concat "foo" "bar"])))))
+    (is (= "foobar" (test-string-extract [:concat "foo" "bar"])))
+    (testing "Does concat work with >2 args"
+      (is (= "foobar" (test-string-extract [:concat "f" "o" "o" "b" "a" "r"]))))))
 
 (deftest test-regex-match-first
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions :regex)


### PR DESCRIPTION
Redshift, Oracle & Vertica support only 2 arg concat. This compiles concat with > 2 args into nested concats (which according to the docs is the idiomatic way of doing it).

Fixes #12544