### PR TITLE
Fixing Google Analytics failures on new instances

### DIFF
--- a/modules/drivers/googleanalytics/src/metabase/driver/googleanalytics.clj
+++ b/modules/drivers/googleanalytics/src/metabase/driver/googleanalytics.clj
@@ -114,6 +114,8 @@
                  (json/parse-string query keyword)
                  query)
         client (client/database->client database)]
+    (assert (not (str/blank? (:metrics query)))
+            ":metrics is required in a Google Analytics query")
     ;; `end-date` is inclusive!!!
     (u/prog1 (.get (.ga (.data client))
                    (:ids query)

--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -32,7 +32,9 @@
     :fingerprint_version i/latest-fingerprint-version
     :last_analyzed       nil))
 
-(defn- empty-stats-map [fields-count]
+(defn empty-stats-map
+  "The default stats before any fingerprints happen"
+  [fields-count]
   {:no-data-fingerprints   0
    :failed-fingerprints    0
    :updated-fingerprints   0
@@ -159,7 +161,12 @@
   "Generate and save fingerprints for all the Fields in TABLE that have not been previously analyzed."
   [table :- i/TableInstance]
   (if-let [fields (fields-to-fingerprint table)]
-    (fingerprint-table! table fields)
+    (let [stats (sync-util/with-error-handling
+                    (format "Error fingerprinting %s" (sync-util/name-for-logging table))
+                  (fingerprint-table! table fields))]
+      (if (instance? Exception stats)
+        (empty-stats-map 0)
+        stats))
     (empty-stats-map 0)))
 
 (s/defn fingerprint-fields-for-db!

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.sync.analyze.fingerprint-test
   "Basic tests to make sure the fingerprint generatation code is doing something that makes sense."
-  (:require [expectations :refer :all]
+  (:require [clojure.test :refer :all]
+            [expectations :refer :all]
             [metabase
              [db :as mdb]
              [util :as u]]
@@ -224,3 +225,9 @@
                   fingerprinters/fingerprinter       (constantly (fingerprinters/constant-fingerprinter {:experimental {:fake-fingerprint? true}}))]
       [(#'fingerprint/fingerprint-table! (Table (data/id :venues)) [field])
        (into {} (db/select-one [Field :fingerprint :fingerprint_version :last_analyzed] :id (u/get-id field)))])))
+
+(deftest test-fingerprint-failure
+  (testing "if fingerprinting fails, the exception should not propagate"
+    (with-redefs [fingerprint/fingerprint-table! (fn [_ _] (throw (Exception. "expected")))]
+      (is (= (fingerprint/empty-stats-map 0)
+             (fingerprint/fingerprint-fields! (Table (data/id :venues))))))))


### PR DESCRIPTION
This handles the case where a table cannot be fingerprinted, for
example, Google Analytics. If an error is thrown during fingerprinting,
log that error and carry on with the sync. Previously this would have
aborted the sync entirely.

Add an assert to ensure that `:metrics` is present in a GA query. The
Google library will fail with a NPE when it's not.

Resolves #12411 

[ci googleanalytics]