### PR TITLE
Fixing Google Analytics failures on new instances

### DIFF
--- a/modules/drivers/googleanalytics/src/metabase/driver/googleanalytics.clj
+++ b/modules/drivers/googleanalytics/src/metabase/driver/googleanalytics.clj
@@ -114,6 +114,8 @@
                  (json/parse-string query keyword)
                  query)
         client (client/database->client database)]
+    (assert (not (str/blank? (:metrics query)))
+            ":metrics is required in a Google Analytics query")
     ;; `end-date` is inclusive!!!
     (u/prog1 (.get (.ga (.data client))
                    (:ids query)


### PR DESCRIPTION
This stops a failure during fingerprinting of a table from causing the
entire sync to fail.

Fingerprinting is now skipped for Google Analytics datasources, as they
do not support this (all queries against GA require a `metrics`
parameter)

Add an assert to ensure that `:metrics` is present in a GA query. The
Google library will fail with a NPE when it's not.

Resolves #12411

[ci googleanalytics]