### PR TITLE
Avoid crash when PinMap is missing a warning handler

### DIFF
--- a/frontend/src/metabase/visualizations/components/PinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/PinMap.jsx
@@ -159,8 +159,9 @@ export default class PinMap extends Component {
         t`We filtered out ${filteredRows} row(s) containing null values.`,
       );
     }
-    // $FlowFixMe flow thinks warnings can be undefined
-    onUpdateWarnings(warnings);
+    if (onUpdateWarnings && warnings) {
+      onUpdateWarnings(warnings);
+    }
 
     const bounds = L.latLngBounds(points);
 


### PR DESCRIPTION
Fixes #12603

I think this started with #12159 since it added a warning when map rows are filtered out.

This PR fixes the direct cause of the crash by dropping warnings if there isn't handler.  Separately, I created an issue (#12606) to make sure we _do_ have a handler everywhere.