### PR TITLE
Minor Cypress fix

### DIFF
--- a/frontend/test/metabase/scenarios/public/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/public/public.cy.spec.js
@@ -143,6 +143,11 @@ describe("scenarios > public", () => {
       cy.contains("Save").click();
 
       cy.contains(COUNT_ALL);
+      cy.contains("Category")
+        .parent()
+        .parent()
+        .find("fieldset")
+        .should("not.exist");
 
       cy.contains("Category").click();
       cy.focused().type("Doohickey");


### PR DESCRIPTION
This is a minor fix, but we have a [Cypress test that can fail](https://dashboard.cypress.io/projects/a394u1/runs/186/failures?utm_source=github) leading to cascading downstream failures.

It looks like this is due to the XHR request not completing before we call `click` in the `should allow users to create parameterized dashboards` test resulting in a noop. So this small patch waits for the Edit/Remove buttons to not exist.