### PR TITLE
Check https before allowing https redirect setting

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx
@@ -61,7 +61,7 @@ export default class HttpsOnlyWidget extends Component {
         {status === VERIFIED ? (
           <SettingToggle {...this.props} />
         ) : status === CHECKING ? (
-          t`Checking HTTPS`
+          t`Checking HTTPS...`
         ) : status === FAILED ? (
           t`It looks like HTTPS is not properly configured`
         ) : null // NOT_CHECKED

--- a/frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/HttpsOnlyWidget.jsx
@@ -1,0 +1,72 @@
+/* @flow */
+
+import React, { Component } from "react";
+import { t } from "ttag";
+
+import SettingToggle from "./SettingToggle";
+
+type Props = {
+  onChange: (value: any) => void,
+  setting: {},
+  settingValues: { "site-url": string },
+};
+
+type State = {
+  status: string,
+};
+
+const VERIFIED = "verified";
+const CHECKING = "checking";
+const NOT_CHECKED = "not_checked";
+const FAILED = "failed";
+
+export default class HttpsOnlyWidget extends Component {
+  props: Props;
+  state: State;
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      status: NOT_CHECKED,
+    };
+  }
+
+  checkHttps() {
+    const req = new XMLHttpRequest();
+    req.timeout = 10000; // don't make the user wait >10s
+    req.addEventListener("load", () => this.setState({ status: VERIFIED }));
+    req.addEventListener("error", () => this.setState({ status: FAILED }));
+    req.open("GET", this.props.settingValues["site-url"] + "/api/health");
+    this.setState({ status: CHECKING });
+    req.send();
+  }
+
+  componentDidMount() {
+    this.checkHttps();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (
+      prevProps.settingValues["site-url"] !==
+      this.props.settingValues["site-url"]
+    ) {
+      this.checkHttps();
+    }
+  }
+
+  render() {
+    const { status } = this.state;
+    return (
+      <div>
+        {status === VERIFIED ? (
+          <SettingToggle {...this.props} />
+        ) : status === CHECKING ? (
+          t`Checking HTTPS`
+        ) : status === FAILED ? (
+          t`It looks like HTTPS is not properly configured`
+        ) : null // NOT_CHECKED
+        }
+      </div>
+    );
+  }
+}

--- a/frontend/src/metabase/admin/settings/components/widgets/SiteUrlWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SiteUrlWidget.jsx
@@ -1,0 +1,27 @@
+/* @flow */
+
+import React, { Component } from "react";
+
+import InputWithSelectPrefix from "metabase/components/InputWithSelectPrefix";
+
+type Props = {
+  onChange: (value: any) => void,
+  setting: { value: string },
+};
+
+export default class SiteUrlWidget extends Component {
+  props: Props;
+
+  render() {
+    const { setting, onChange } = this.props;
+    return (
+      <InputWithSelectPrefix
+        value={setting.value}
+        onChange={e => onChange(e.target.value)}
+        prefixes={["https://", "http://"]}
+        defaultPrefix="http://"
+        caseInsensitivePrefix={true}
+      />
+    );
+  }
+}

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -3,6 +3,8 @@ import { createSelector } from "reselect";
 import MetabaseSettings from "metabase/lib/settings";
 import { t } from "ttag";
 import CustomGeoJSONWidget from "./components/widgets/CustomGeoJSONWidget";
+import SiteUrlWidget from "./components/widgets/SiteUrlWidget";
+import HttpsOnlyWidget from "./components/widgets/HttpsOnlyWidget";
 import {
   PublicLinksDashboardListing,
   PublicLinksQuestionListing,
@@ -48,12 +50,14 @@ const SECTIONS = updateSectionsWithPlugins({
         key: "site-url",
         display_name: t`Site URL`,
         type: "string",
+        widget: SiteUrlWidget,
       },
       {
         key: "redirect-all-requests-to-https",
         display_name: t`Redirect to HTTPS`,
         type: "boolean",
-        note: t`This value only takes effect if Site URL is HTTPS`,
+        getHidden: ({ "site-url": url }) => !/^https:\/\//.test(url),
+        widget: HttpsOnlyWidget,
       },
       {
         key: "admin-email",

--- a/frontend/src/metabase/components/InputWithSelectPrefix.jsx
+++ b/frontend/src/metabase/components/InputWithSelectPrefix.jsx
@@ -1,0 +1,91 @@
+/* @flow */
+
+import React, { Component } from "react";
+
+import Select, { Option } from "./Select";
+import InputBlurChange from "./InputBlurChange";
+
+type Props = {
+  onChange: (value: any) => void,
+  value: string,
+  prefixes: string[],
+  defaultPrefix: string,
+  caseInsensitivePrefix?: boolean,
+};
+
+type State = {
+  prefix: string,
+  rest: string,
+};
+
+export default class InputWithSelectPrefix extends Component {
+  props: Props;
+  state: State;
+
+  constructor(props: Props) {
+    super(props);
+    this.state = { prefix: "", rest: "" };
+  }
+
+  componentDidMount() {
+    this.setPrefixAndRestFromValue();
+  }
+
+  setPrefixAndRestFromValue() {
+    const {
+      value,
+      prefixes,
+      defaultPrefix,
+      caseInsensitivePrefix = false,
+    } = this.props;
+    if (value) {
+      const prefix = prefixes.find(
+        caseInsensitivePrefix
+          ? p => value.toLowerCase().startsWith(p.toLowerCase())
+          : p => value.startsWith(p),
+      );
+      this.setState(
+        prefix
+          ? { prefix, rest: value.slice(prefix.length) }
+          : { prefix: defaultPrefix, rest: value },
+      );
+    }
+  }
+
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    const { prefix, rest } = this.state;
+    if (prevState.rest !== rest || prevState.prefix !== prefix) {
+      const value = prefix + rest;
+      this.props.onChange({ target: { value } });
+    }
+    if (prevProps.value !== this.props.value) {
+      this.setPrefixAndRestFromValue();
+    }
+  }
+
+  render() {
+    const { prefixes, defaultPrefix } = this.props;
+    const { prefix, rest } = this.state;
+    return (
+      <div className="flex align-stretch SettingsInput Form-input p0">
+        <Select
+          className="border-right"
+          value={prefix || defaultPrefix}
+          onChange={e => this.setState({ prefix: e.target.value })}
+          buttonProps={{ className: "borderless" }}
+        >
+          {prefixes.map(p => (
+            <Option value={p}>{p}</Option>
+          ))}
+        </Select>
+        <InputBlurChange
+          type="text"
+          className="Form-input flex-full borderless"
+          value={rest}
+          placeholder={"foo"}
+          onBlurChange={e => this.setState({ rest: e.target.value })}
+        />
+      </div>
+    );
+  }
+}

--- a/frontend/src/metabase/components/Select.jsx
+++ b/frontend/src/metabase/components/Select.jsx
@@ -36,6 +36,9 @@ export default class Select extends Component {
     // PopoverWithTrigger props
     isInitiallyOpen: PropTypes.bool,
 
+    // SelectButton props
+    buttonProps: PropTypes.object,
+
     // AccordianList props
     searchProp: PropTypes.string,
     searchCaseInsensitive: PropTypes.bool,
@@ -156,6 +159,7 @@ export default class Select extends Component {
 
   render() {
     const {
+      buttonProps,
       className,
       placeholder,
       searchProp,
@@ -179,6 +183,7 @@ export default class Select extends Component {
           <SelectButton
             className="full-width"
             hasValue={selectedNames.length > 0}
+            {...buttonProps}
           >
             {selectedNames.length > 0
               ? selectedNames.map((name, index) => (

--- a/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/settings.cy.spec.js
@@ -1,4 +1,9 @@
-import { signInAsAdmin, restore, openOrdersTable } from "__support__/cypress";
+import {
+  signInAsAdmin,
+  restore,
+  popover,
+  openOrdersTable,
+} from "__support__/cypress";
 
 describe("scenarios > admin > settings", () => {
   before(restore);
@@ -35,6 +40,57 @@ describe("scenarios > admin > settings", () => {
       .type("bob@metabase.com")
       .blur();
     cy.wait("@saveSettings");
+  });
+
+  it("should check for working https before enabling a redirect", () => {
+    cy.visit("/admin/settings/general");
+    cy.server();
+    cy.route("GET", "**/api/health", "ok").as("httpsCheck");
+
+    // settings have loaded, but there's no redirect setting visible
+    cy.contains("Site URL");
+    cy.contains("Redirect to HTTPS").should("not.exist");
+
+    // switch site url to use https
+    cy.contains("Site URL")
+      .parent()
+      .parent()
+      .find(".AdminSelect")
+      .click();
+    popover()
+      .contains("https://")
+      .click();
+
+    cy.wait("@httpsCheck");
+    cy.contains("Redirect to HTTPS")
+      .parent()
+      .parent()
+      .contains("Disabled");
+
+    restore(); // avoid leaving https site url
+  });
+
+  it("should display an error if the https redirect check fails", () => {
+    cy.visit("/admin/settings/general");
+    cy.server();
+    // return 500 on https check
+    cy.route({ method: "GET", url: "**/api/health", status: 500 }).as(
+      "httpsCheck",
+    );
+
+    // switch site url to use https
+    cy.contains("Site URL")
+      .parent()
+      .parent()
+      .find(".AdminSelect")
+      .click();
+    popover()
+      .contains("https://")
+      .click();
+
+    cy.wait("@httpsCheck");
+    cy.contains("It looks like HTTPS is not properly configured");
+    restore(); // avoid leaving https site url
   });
 
   it("should update the formatting", () => {

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -191,7 +191,9 @@
     (when (seq v)
       v)))
 
-(defn- string->boolean [string-value]
+(defn string->boolean
+  "Interpret a `string-value` of a Setting as a boolean."
+  [string-value]
   (when (seq string-value)
     (case (str/lower-case string-value)
       "true"  true
@@ -336,29 +338,29 @@
   such as `\"true\"` or `\"false\"` (these strings are case-insensitive)."
   [setting-definition-or-name new-value]
   (set-string! setting-definition-or-name (if (string? new-value)
-                                 (set-boolean! setting-definition-or-name (string->boolean new-value))
-                                 (case new-value
-                                   true  "true"
-                                   false "false"
-                                   nil   nil))))
+                                            (set-boolean! setting-definition-or-name (string->boolean new-value))
+                                            (case new-value
+                                              true  "true"
+                                              false "false"
+                                              nil   nil))))
 
 (defn set-integer!
   "Set the value of integer `setting-definition-or-name`."
   [setting-definition-or-name new-value]
   (set-string! setting-definition-or-name (when new-value
-                                 (assert (or (integer? new-value)
-                                             (and (string? new-value)
-                                                  (re-matches #"^\d+$" new-value))))
-                                 (str new-value))))
+                                            (assert (or (integer? new-value)
+                                                        (and (string? new-value)
+                                                             (re-matches #"^\d+$" new-value))))
+                                            (str new-value))))
 
 (defn set-double!
   "Set the value of double `setting-definition-or-name`."
   [setting-definition-or-name new-value]
   (set-string! setting-definition-or-name (when new-value
-                                 (assert (or (number? new-value)
-                                             (and (string? new-value)
-                                                  (re-matches #"[+-]?([0-9]*[.])?[0-9]+" new-value) )))
-                                 (str new-value))))
+                                            (assert (or (number? new-value)
+                                                        (and (string? new-value)
+                                                             (re-matches #"[+-]?([0-9]*[.])?[0-9]+" new-value) )))
+                                            (str new-value))))
 
 (defn set-json!
   "Serialize `new-value` for `setting-definition-or-name` as a JSON string and save it."
@@ -513,8 +515,8 @@
   (when-not (or (valid-trs-or-tru? desc)
                 (valid-str-of-trs-or-tru? desc))
     (throw (IllegalArgumentException.
-             (trs "defsetting descriptions strings must have `:visibilty` `:internal`, `:setter` `:none`, or internationalized, found: `{0}`"
-                  (pr-str desc)))))
+            (trs "defsetting descriptions strings must have `:visibilty` `:internal`, `:setter` `:none`, or internationalized, found: `{0}`"
+                 (pr-str desc)))))
   desc)
 
 (defmacro defsetting
@@ -565,8 +567,8 @@
                   description
                   (validate-description description))
          setting# (register-setting! (assoc ~options
-                                       :name ~(keyword setting-symb)
-                                       :description desc#))]
+                                            :name ~(keyword setting-symb)
+                                            :description desc#))]
      (-> (def ~setting-symb (setting-fn setting#))
          (alter-meta! merge (metadata-for-setting-fn setting#)))))
 
@@ -667,7 +669,7 @@
   "Returns settings values for a given :visibility"
   [visibility]
   (->> @registered-settings
-    (filter (fn [[_ options]] (and (not (:sensitive? options))
-                                   (= (:visibility options) visibility))))
-    (map (fn [[name]] [name (get name)]))
-    (into {})))
+       (filter (fn [[_ options]] (and (not (:sensitive? options))
+                                      (= (:visibility options) visibility))))
+       (map (fn [[name]] [name (get name)]))
+       (into {})))

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -58,8 +58,10 @@
     (assert (u/url? s) (tru "Invalid site URL: {0}" (pr-str s)))
     s))
 
+(declare redirect-all-requests-to-https)
+
 ;; This value is *guaranteed* to never have a trailing slash :D
-;; It will also prepend `http://` to the URL if there's not protocol when it comes in
+;; It will also prepend `http://` to the URL if there's no protocol when it comes in
 (defsetting site-url
   (deferred-tru "The base URL of this Metabase instance, e.g. \"http://metabase.my-company.com\".")
   :visibility :public
@@ -69,7 +71,12 @@
               (catch AssertionError e
                 (log/error e (trs "site-url is invalid; returning nil for now. Will be reset on next request.")))))
   :setter (fn [new-value]
-            (setting/set-string! :site-url (some-> new-value normalize-site-url))))
+            (let [new-value (some-> new-value normalize-site-url)
+                  https?    (some-> new-value (str/starts-with?  "https:" ))]
+              ;; if the site URL isn't HTTPS then disable force HTTPS redirects if set
+              (when-not https?
+                (redirect-all-requests-to-https false))
+              (setting/set-string! :site-url new-value))))
 
 (defsetting site-locale
   (str (deferred-tru "The language that should be used for Metabase's UI, system emails, pulses, and alerts.")
@@ -283,4 +290,12 @@
   (deferred-tru "Force all traffic to use HTTPS via a redirect, if the site URL is HTTPS")
   :visibility :public
   :type       :boolean
-  :default    false)
+  :default    false
+  :setter     (fn [new-value]
+                ;; if we're trying to enable this setting, make sure `site-url` is actually an HTTPS URL.
+                (when (if (string? new-value)
+                        (setting/string->boolean new-value)
+                        new-value)
+                  (assert (some-> (site-url) (str/starts-with? "https:"))
+                          (tru "Cannot redirect requests to HTTPS unless `site-url` is HTTPS.")))
+                (setting/set-boolean! :redirect-all-requests-to-https new-value)))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -287,10 +287,10 @@
   (assert (even? (count bindings)) "mismatched setting/value pairs: is each setting name followed by a value?")
   (if (empty? bindings)
     `(do ~@body)
-    (let [body `(do-with-temporary-setting-value ~(keyword setting-k) ~value (fn [] ~@body))]
-      (if (seq more)
-        `(with-temporary-setting-values ~more ~body)
-        body))))
+    `(do-with-temporary-setting-value ~(keyword setting-k) ~value
+       (fn []
+         (with-temporary-setting-values ~more
+           ~@body)))))
 
 (defn do-with-discarded-setting-changes [settings thunk]
   (initialize/initialize-if-needed! :db :plugins)


### PR DESCRIPTION
Fixes #12540 

I implemented a slightly modified version of @kdoh's designs. The "Redirect to HTTPS" setting is hidden unless the current site url is HTTPS. It also checks SITE_URL + "/api/health" before allowing you to enable the redirect.

![image](https://user-images.githubusercontent.com/691495/83445673-642d8b00-a41b-11ea-93e5-8c8a20f1e771.png)

(The fonts are weird because of how I set up my local https proxy)

---

Remaining BE change:
- [ ] Changing the site URL to a non-https URL should turn off the redirect if enabled.