### PR TITLE
Add FE support for count(Field)

### DIFF
--- a/frontend/src/metabase/lib/expressions/config.js
+++ b/frontend/src/metabase/lib/expressions/config.js
@@ -72,7 +72,7 @@ export const MBQL_CLAUSES = {
   count: {
     displayName: `Count`,
     type: "aggregation",
-    args: [],
+    args: ["expression"],
   },
   "cum-count": {
     displayName: `CumulativeCount`,


### PR DESCRIPTION
Exposes `count(expression)` on the FE. Solves #11558  