### PR TITLE
Fix bug with getting sum over time in nested question.

### DIFF
--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -542,21 +542,6 @@ export class FieldLiteralDimension extends FieldDimension {
       },
     });
   }
-
-  defaultDimension(): ?Dimension {
-    if (this.field().isDate()) {
-      return new DatetimeFieldDimension(
-        this,
-        // Field literals don't have the fingerprint data we use to pick this, so let's just arbitrarily go with "day".
-        // We need some value to ensure that the date unit picker UI appears.
-        ["day"],
-        this._metadata,
-        this._query,
-      );
-    }
-    // TODO: Is there anything better to have here?
-    return null;
-  }
 }
 
 /**
@@ -640,7 +625,9 @@ import { DATETIME_UNITS, formatBucketing } from "metabase/lib/query_time";
 import type Aggregation from "./queries/structured/Aggregation";
 
 const isFieldDimension = dimension =>
-  dimension instanceof FieldIDDimension || dimension instanceof FKDimension;
+  dimension instanceof FieldIDDimension ||
+  dimension instanceof FKDimension ||
+  dimension instanceof FieldLiteralDimension;
 
 /**
  * DatetimeField dimension, `["datetime-field", field-reference, datetime-unit]`

--- a/frontend/src/metabase-lib/lib/Dimension.js
+++ b/frontend/src/metabase-lib/lib/Dimension.js
@@ -542,6 +542,21 @@ export class FieldLiteralDimension extends FieldDimension {
       },
     });
   }
+
+  defaultDimension(): ?Dimension {
+    if (this.field().isDate()) {
+      return new DatetimeFieldDimension(
+        this,
+        // Field literals don't have the fingerprint data we use to pick this, so let's just arbitrarily go with "day".
+        // We need some value to ensure that the date unit picker UI appears.
+        ["day"],
+        this._metadata,
+        this._query,
+      );
+    }
+    // TODO: Is there anything better to have here?
+    return null;
+  }
 }
 
 /**

--- a/frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js
+++ b/frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js
@@ -50,6 +50,6 @@ export default ({
               ? [aggregator.short, fieldRefForColumn(column)]
               : [aggregator.short],
           )
-          .pivot([dateDimension.defaultDimension().mbql()]),
+          .pivot([dateDimension.defaultBreakout()]),
     }));
 };

--- a/frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js
+++ b/frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js
@@ -3,6 +3,7 @@
 import React from "react";
 import { t } from "ttag";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
+import { DatetimeFieldDimension } from "metabase-lib/lib/Dimension";
 import { fieldRefForColumn } from "metabase/lib/dataset";
 import {
   getAggregationOperator,
@@ -50,6 +51,8 @@ export default ({
               ? [aggregator.short, fieldRefForColumn(column)]
               : [aggregator.short],
           )
-          .pivot([dateDimension.defaultBreakout()]),
+          .pivot([
+            DatetimeFieldDimension.defaultDimension(dateDimension).mbql(),
+          ]),
     }));
 };

--- a/frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js
+++ b/frontend/src/metabase/modes/components/drill/SummarizeColumnByTimeDrill.js
@@ -3,7 +3,6 @@
 import React from "react";
 import { t } from "ttag";
 import StructuredQuery from "metabase-lib/lib/queries/StructuredQuery";
-import { DatetimeFieldDimension } from "metabase-lib/lib/Dimension";
 import { fieldRefForColumn } from "metabase/lib/dataset";
 import {
   getAggregationOperator,
@@ -51,8 +50,6 @@ export default ({
               ? [aggregator.short, fieldRefForColumn(column)]
               : [aggregator.short],
           )
-          .pivot([
-            DatetimeFieldDimension.defaultDimension(dateDimension).mbql(),
-          ]),
+          .pivot([dateDimension.defaultBreakout()]),
     }));
 };

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -499,32 +499,6 @@ describe("Dimension", () => {
     });
   });
 
-  describe("FieldLiteralDimension", () => {
-    describe("INSTANCE METHODS", () => {
-      describe("defaultDimension()", () => {
-        it("should group date types by day", () => {
-          const dimension = Dimension.parseMBQL(
-            ["field-literal", "Created At", "type/Date"],
-            metadata,
-          );
-          expect(dimension.defaultDimension().mbql()).toEqual([
-            "datetime-field",
-            ["field-literal", "Created At", "type/Date"],
-            "day",
-          ]);
-        });
-
-        it("should return null otherwise", () => {
-          const dimension = Dimension.parseMBQL(
-            ["field-literal", "Total", "type/Float"],
-            metadata,
-          );
-          expect(dimension.defaultDimension()).toEqual(null);
-        });
-      });
-    });
-  });
-
   describe("AggregationDimension", () => {
     const dimension = Dimension.parseMBQL(["aggregation", 1], metadata);
 

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -499,7 +499,7 @@ describe("Dimension", () => {
     });
   });
 
-  describe.only("FieldLiteralDimension", () => {
+  describe("FieldLiteralDimension", () => {
     describe("INSTANCE METHODS", () => {
       describe("defaultDimension()", () => {
         it("should group date types by day", () => {

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -499,6 +499,32 @@ describe("Dimension", () => {
     });
   });
 
+  describe.only("FieldLiteralDimension", () => {
+    describe("INSTANCE METHODS", () => {
+      describe("defaultDimension()", () => {
+        it("should group date types by day", () => {
+          const dimension = Dimension.parseMBQL(
+            ["field-literal", "Created At", "type/Date"],
+            metadata,
+          );
+          expect(dimension.defaultDimension().mbql()).toEqual([
+            "datetime-field",
+            ["field-literal", "Created At", "type/Date"],
+            "day",
+          ]);
+        });
+
+        it("should return null otherwise", () => {
+          const dimension = Dimension.parseMBQL(
+            ["field-literal", "Total", "type/Float"],
+            metadata,
+          );
+          expect(dimension.defaultDimension()).toEqual(null);
+        });
+      });
+    });
+  });
+
   describe("AggregationDimension", () => {
     const dimension = Dimension.parseMBQL(["aggregation", 1], metadata);
 


### PR DESCRIPTION
Addresses part of #12568

Trying to get "Sum over time" on a nested question was crashing because the `defaultDimension` was null. The direct fix was to swap `.defaultDimension().mbql()` for `.defaultBreakout()` which has logic to check for a null `defaultDimension` and avoid calling `.mbql()`.

While I was in there, I refined things slightly to pick an arbitrary date unit if the field literal is a date type. That allows the user to use the date unit picking UI in the summarize sidebar.