### PR TITLE
Wait for network requests to avoid race condition in bulk table test

### DIFF
--- a/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/datamodel/table.cy.spec.js
@@ -187,7 +187,10 @@ describe("scenarios > admin > datamodel > table", () => {
     });
 
     it("should allow bulk hiding tables", () => {
+      cy.route("GET", `**/api/table/*/query_metadata*`).as("tableMetadata");
       cy.visit(ORDERS_URL);
+      cy.wait(["@tableMetadata", "@tableMetadata", "@tableMetadata"]); // wait for these api calls to finish to avoid them overwriting later PUT calls
+
       cy.contains("4 Queryable Tables");
       cy.get(".AdminList-section .Icon-eye_crossed_out").click();
       cy.contains("4 Hidden Tables");


### PR DESCRIPTION
This add a `cy.wait` to avoid racing conflicting network requests against eachother.

Here's an example of the failure: `https://dashboard.cypress.io/projects/a394u1/runs/238/test-results/71949edb-86c0-4b44-8f17-59200cacbb66`

It doesn't fix the underlying issue. To do that we'd want to hide the UI until these requests complete. I don't think a real user would be able to interact quickly enough, so it shouldn't come up in real usage.