### PR TITLE
Add basic functionality for multi-series chart values

### DIFF
--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -372,6 +372,7 @@
 
 .Dashboard text.value-label,
 .Dashboard text.value-label-outline,
+.Dashboard text.value-label-white,
 .Dashboard .LineAreaBarChart .dc-chart .axis text {
   font-size: 12px;
 }

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -169,6 +169,23 @@ class ChartSettings extends Component {
     }
 
     const sectionNames = Object.keys(sections);
+
+    // This sorts the section radio buttons.
+    const sectionSortOrder = [
+      "data",
+      "display",
+      "axes",
+      "labels",
+      // include all section names so any forgotten sections are sorted to the end
+      ...sectionNames.map(x => x.toLowerCase()),
+    ];
+    sectionNames.sort((a, b) => {
+      const [aIdx, bIdx] = [a, b].map(x =>
+        sectionSortOrder.indexOf(x.toLowerCase()),
+      );
+      return aIdx - bIdx;
+    });
+
     const currentSection =
       this.state.currentSection && sections[this.state.currentSection]
         ? this.state.currentSection

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -222,3 +222,8 @@ text.value-label {
   fill: var(--color-text-dark);
   font-weight: 800;
 }
+
+text.value-label-white {
+  fill: var(--color-text-white);
+  font-weight: 800;
+}

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -214,13 +214,17 @@ text.value-label {
 
 text.value-label-outline {
   font-weight: 800;
-  stroke-width: 4px;
+  font-size: 12px;
+  letter-spacing: 0.5px;
+  stroke-width: 3px;
   stroke: var(--color-text-white);
 }
 
 text.value-label {
   fill: var(--color-text-dark);
+  font-size: 12px;
   font-weight: 800;
+  letter-spacing: 0.5px;
 }
 
 text.value-label-white {

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeries.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeries.jsx
@@ -40,7 +40,7 @@ export default class ChartNestedSettingSeries extends React.Component {
             return (
               <div
                 key={key}
-                className="px4 pb2 mb2 border-bottom align-self-stretch"
+                className="px4 pt2 mt2 border-top align-self-stretch"
               >
                 <div className="flex align-center">
                   <ColorPicker

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -2,13 +2,11 @@
 
 import d3 from "d3";
 import _ from "underscore";
-import moment from "moment";
 
 import { color } from "metabase/lib/colors";
-import { clipPathReference } from "metabase/lib/dom";
-import { COMPACT_CURRENCY_OPTIONS } from "metabase/lib/formatting";
+import { clipPathReference, moveToFront } from "metabase/lib/dom";
 import { adjustYAxisTicksIfNeeded } from "./apply_axis";
-import { isHistogramBar } from "./renderer_utils";
+import { onRenderValueLabels } from "./chart_values";
 
 const X_LABEL_MIN_SPACING = 2; // minimum space we want to leave between labels
 const X_LABEL_ROTATE_90_THRESHOLD = 24; // tick width breakpoint for switching from 45° to 90°
@@ -19,13 +17,6 @@ const X_LABEL_DISABLED_SPACING = 6; // spacing to use if the x-axis is disabled 
 // +-------------------------------------------------------------------------------------------------------------------+
 // |                                                  HELPER FUNCTIONS                                                 |
 // +-------------------------------------------------------------------------------------------------------------------+
-
-// moves an element on top of all siblings
-function moveToTop(element) {
-  if (element) {
-    element.parentNode.appendChild(element);
-  }
-}
 
 // assumes elements are in order from left to right, skips those that aren't
 function getMinElementSpacing(elements) {
@@ -60,7 +51,7 @@ function onRenderRemoveClipPath(chart) {
 function onRenderMoveContentToTop(chart) {
   for (const element of chart.selectAll(".sub, .chart-body")[0]) {
     // move chart content on top of axis (z-index doesn't work on SVG):
-    moveToTop(element);
+    moveToFront(element);
   }
 }
 
@@ -73,13 +64,13 @@ function onRenderReorderCharts(chart) {
     // move area charts first
     for (const [index, display] of displayTypes.entries()) {
       if (display === "area") {
-        moveToTop(chart.select(`.sub._${index}`)[0][0]);
+        moveToFront(chart.select(`.sub._${index}`)[0][0]);
       }
     }
     // move line charts second
     for (const [index, display] of displayTypes.entries()) {
       if (display === "line") {
-        moveToTop(chart.select(`.sub._${index}`)[0][0]);
+        moveToFront(chart.select(`.sub._${index}`)[0][0]);
       }
     }
   }
@@ -246,299 +237,6 @@ function onRenderVoronoiHover(chart) {
       dispatchUIEvent(e, "click");
     })
     .order();
-}
-
-function onRenderValueLabels(
-  chart,
-  { formatYValue, xInterval, yAxisSplit, datas },
-) {
-  const seriesSettings = datas.map((_, seriesIndex) =>
-    chart.settings.series(chart.series[seriesIndex]),
-  );
-
-  // See if each series is enabled. Fall back to the chart-level setting if undefined.
-  let showSeries = seriesSettings.map(
-    ({ show_series_values = chart.settings["graph.show_values"] }) =>
-      show_series_values,
-  );
-
-  if (
-    showSeries.every(s => s === false) || // every series setting is off
-    chart.settings["stackable.stack_type"] === "normalized" // chart is normalized
-  ) {
-    return;
-  }
-
-  let displays = seriesSettings.map(settings => settings.display);
-  if (chart.settings["stackable.stack_type"] === "stacked") {
-    // When stacked, flatten datas into one series. We'll sum values on the same x point later.
-    datas = [datas.flat()];
-
-    // Individual series might have display set to something besides the actual stacked display.
-    displays = [chart.settings["stackable.stack_display"]];
-    showSeries = [true];
-  }
-  const showAll = chart.settings["graph.label_value_frequency"] === "all";
-
-  // Count max points in a single series to estimate when labels should be hidden
-  const maxSeriesLength = Math.max(...datas.map(d => d.length));
-
-  const barWidth = chart
-    .svg()
-    .select("rect")[0][0]
-    .getAttribute("width");
-  const barCount = displays.filter(d => d === "bar").length;
-
-  const xScale = chart.x();
-  const yScaleForSeries = index =>
-    yAxisSplit[0].includes(index) ? chart.y() : chart.rightY();
-
-  // Update datas to use named x/y and include `showLabelBelow`.
-  // We need to add `showLabelBelow` before data is filtered to show every nth value.
-  datas = datas.map((data, seriesIndex) => {
-    if (!showSeries[seriesIndex]) {
-      // We need to keep the series in `datas` to place the labels correctly over grouped bar charts.
-      // Instead, we remove all the data so no labels are displayed.
-      return [];
-    }
-    const display = displays[seriesIndex];
-
-    // Sum duplicate x values in the same series.
-    data = _.chain(data)
-      .groupBy(([x]) => xScale(x))
-      .values()
-      .map(data => {
-        const [[x]] = data;
-        const y = data.reduce((sum, [, y]) => sum + y, 0);
-        return [x, y];
-      })
-      .value();
-
-    return data
-      .map(([x, y], i) => {
-        const isLocalMin =
-          // first point or prior is greater than y
-          (i === 0 || data[i - 1][1] > y) &&
-          // last point point or next is greater than y
-          (i === data.length - 1 || data[i + 1][1] > y);
-        const showLabelBelow = isLocalMin && display === "line";
-        const rotated = barCount > 1 && display === "bar" && barWidth < 40;
-        const hidden =
-          !showAll && barCount > 1 && display === "bar" && barWidth < 20;
-        return { x, y, showLabelBelow, seriesIndex, rotated, hidden };
-      })
-      .filter(d => !(display === "bar" && d.y === 0));
-  });
-
-  const formattingSetting = chart.settings["graph.label_value_formatting"];
-  const compactForSeries = datas.map(data => {
-    if (formattingSetting === "compact") {
-      return true;
-    }
-    if (formattingSetting === "full") {
-      return false;
-    }
-    // for "auto" we use compact if it shortens avg label length by >3 chars
-    const getAvgLength = compact => {
-      const options = {
-        compact,
-        // We include compact currency options here for both compact and
-        // non-compact formatting. This prevents auto's logic from depending on
-        // those settings.
-        ...COMPACT_CURRENCY_OPTIONS,
-        // We need this to ensure the settings are used. Otherwise, a cached
-        // _numberFormatter would take precedence.
-        _numberFormatter: undefined,
-      };
-      const lengths = data.map(d => formatYValue(d.y, options).length);
-      return lengths.reduce((sum, l) => sum + l, 0) / lengths.length;
-    };
-    return getAvgLength(true) < getAvgLength(false) - 3;
-  });
-
-  // use the chart body so things line up properly
-  const parent = chart.svg().select(".chart-body");
-
-  // Ordinal bar charts and histograms need extra logic to center the label.
-  const xShifts = displays.map((display, index) => {
-    const thisChart = chart.children()[index];
-    const barIndex = displays.slice(0, index).filter(d => d === "bar").length;
-    let xShift = 0;
-
-    if (xScale.rangeBand) {
-      if (display === "bar") {
-        const xShiftForSeries = xScale.rangeBand() / barCount;
-        xShift += (barIndex + 0.5) * xShiftForSeries;
-      } else {
-        xShift += xScale.rangeBand() / 2;
-      }
-      if (displays.some(d => d === "bar") && displays.some(d => d !== "bar")) {
-        xShift += (chart._rangeBandPadding() * xScale.rangeBand()) / 2;
-      }
-    } else if (
-      // non-ordinal bar charts don't have rangeBand set, but still need xShifting if they're grouped.
-      thisChart.barPadding
-    ) {
-      // For these timeseries/quantitative scales, we look at the distance between two points one "interval" apart.
-      // We then scale to remove the padding and divide by the number of bars to get the per-bar shift from the center.
-      const startOfDomain = xScale.domain()[0];
-      const oneIntervalOver = moment.isMoment(startOfDomain)
-        ? startOfDomain.clone().add(xInterval.count, xInterval.interval)
-        : startOfDomain + xInterval;
-      const groupWidth =
-        (xScale(oneIntervalOver) - xScale(startOfDomain)) *
-        (1 - thisChart.barPadding());
-      xShift -= groupWidth / 2;
-      const xShiftForSeries = groupWidth / barCount;
-      xShift += (barIndex + 0.5) * xShiftForSeries;
-    }
-
-    if (
-      isHistogramBar({ settings: chart.settings, chartType: display }) &&
-      displays.length === 1
-    ) {
-      // this has to match the logic in `doHistogramBarStuff`
-      const [x1, x2] = chart
-        .svg()
-        .selectAll("rect")
-        .flat()
-        .map(r => parseFloat(r.getAttribute("x")));
-      const barWidth = x2 - x1;
-      xShift += barWidth / 2;
-    }
-    return xShift;
-  });
-
-  const xyPos = ({ x, y, showLabelBelow, seriesIndex }) => {
-    const yScale = yScaleForSeries(seriesIndex);
-    const xPos = xShifts[seriesIndex] + xScale(x);
-    let yPos = yScale(y) + (showLabelBelow ? 18 : -8);
-    // if the yPos is below the x axis, move it to be above the data point
-    const [yMax] = yScale.range();
-    if (yPos > yMax) {
-      yPos = yScale(y) - 8;
-    }
-    return { xPos, yPos, yHeight: yMax - yPos };
-  };
-
-  const MIN_ROTATED_HEIGHT = 50;
-  const addLabels = (data, compact = null) => {
-    // make sure we don't add .value-lables multiple times
-    parent.select(".value-labels").remove();
-    // Safari had an issue with rendering paint-order: stroke. To work around
-    // that, we create two text labels: one for the the black text and another
-    // for the white outline behind it.
-    const labelGroups = parent
-      .append("svg:g")
-      .classed("value-labels", true)
-      .selectAll("g")
-      .data(data)
-      .enter()
-      .append("g")
-      .attr("text-anchor", d =>
-        !d.rotated
-          ? "middle"
-          : xyPos(d).yHeight < MIN_ROTATED_HEIGHT
-          ? "start"
-          : "end",
-      )
-      .attr("transform", d => {
-        const { xPos, yPos, yHeight } = xyPos(d);
-        const transforms = [`translate(${xPos}, ${yPos})`];
-        if (d.rotated) {
-          transforms.push(
-            "rotate(-90)",
-            `translate(${yHeight < MIN_ROTATED_HEIGHT ? -3 : -15}, 4)`,
-          );
-        }
-        return transforms.join(" ");
-      });
-
-    ["value-label-outline", "value-label"].forEach(klass =>
-      labelGroups
-        .append("text")
-        .attr("class", klass)
-        .text(({ y, seriesIndex }) =>
-          formatYValue(y, {
-            compact: compact === null ? compactForSeries[seriesIndex] : compact,
-          }),
-        ),
-    );
-  };
-
-  const nthForSeries = datas.map((data, index) => {
-    if (showAll || (barCount > 1 && displays[index] === "bar")) {
-      // show all is turned on or this is a bar in a grouped bar chart
-      return 1;
-    }
-    // auto fit
-    // Render a sample of rows to estimate average label size.
-    // We use that estimate to compute the label interval.
-    const LABEL_PADDING = 6;
-    const MAX_SAMPLE_SIZE = 30;
-    const sampleStep = Math.ceil(maxSeriesLength / MAX_SAMPLE_SIZE);
-    const sample = data.filter((d, i) => i % sampleStep === 0);
-    addLabels(sample, compactForSeries[index]);
-    const totalWidth = chart
-      .svg()
-      .selectAll(".value-label-outline")
-      .flat()
-      .reduce((sum, label) => sum + label.getBoundingClientRect().width, 0);
-    const labelWidth = totalWidth / sample.length + LABEL_PADDING;
-
-    const { width: chartWidth } = chart
-      .svg()
-      .select(".axis.x")
-      .node()
-      .getBoundingClientRect();
-
-    return Math.ceil((labelWidth * maxSeriesLength) / chartWidth);
-  });
-
-  const MIN_SPACING = 20;
-  _.chain(datas)
-    .flatten()
-    .filter(d => displays[d.seriesIndex] === "line")
-    .map(d => ({ d, ...xyPos(d) }))
-    .groupBy(({ xPos }) => xPos)
-    .values()
-    .each(group => {
-      const sortedByY = _.sortBy(group, ({ yPos }) => yPos);
-      let prev;
-      for (const { d, yPos } of sortedByY) {
-        if (prev == null || yPos - prev > MIN_SPACING) {
-          // there's enough space between this label and the prev
-          prev = yPos;
-          continue;
-        }
-
-        if (!d.showLabelBelow) {
-          // try flipping the label below to get farther from previous label
-          const flippedYPos = xyPos({ ...d, showLabelBelow: true }).yPos;
-          if (flippedYPos - prev > MIN_SPACING) {
-            d.showLabelBelow = true;
-            prev = flippedYPos;
-            continue;
-          }
-        }
-
-        // hide this label and don't update prev so it isn't considered for collisions
-        d.hidden = true;
-      }
-    });
-
-  addLabels(
-    datas.flatMap(data =>
-      data.filter((d, i) => i % nthForSeries[d.seriesIndex] === 0 && !d.hidden),
-    ),
-  );
-
-  moveToTop(
-    chart
-      .svg()
-      .select(".value-labels")
-      .node().parentNode,
-  );
 }
 
 function onRenderCleanupGoalAndTrend(chart, onGoalHover, isSplitAxis) {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -270,9 +270,9 @@ function onRenderValueLabels(chart, formatYValue, datas) {
     (data, index) => chart.settings.series(chart.series[index]).display,
   );
 
-  // Update `data` to use named x/y and include `showLabelBelow`.
+  // Set `data` to flattened `datas` and use named x/y and include `showLabelBelow`.
   // We need to do that before data is filtered to show every nth value.
-  data = datas.flatMap((data, seriesIndex) => {
+  const data = datas.flatMap((data, seriesIndex) => {
     const display = displays[seriesIndex];
     return data
       .map(([x, y], i) => {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -262,7 +262,8 @@ function onRenderValueLabels(
   let displays = datas.map(
     (data, index) => chart.settings.series(chart.series[index]).display,
   );
-  if (chart.settings["stackable.stack_type"] === "stacked") {
+  const stacked = chart.settings["stackable.stack_type"] === "stacked";
+  if (stacked) {
     // When stacked, zip together the corresponding values and sum them.
     datas = [
       _.zip(...datas).map(datasForSeries =>
@@ -287,7 +288,7 @@ function onRenderValueLabels(
     const display = displays[seriesIndex];
     const settings = chart.settings.series(chart.series[seriesIndex]);
 
-    if (settings["show_series_values"] === false) {
+    if (settings["show_series_values"] === false && !stacked) {
       // We need to keep the series in `datas` to place the labels correctly over grouped bar charts.
       // Instead, we remove all the data so no labels are displayed.
       return [];

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -285,6 +285,13 @@ function onRenderValueLabels(
   // We need to add `showLabelBelow` before data is filtered to show every nth value.
   datas = datas.map((data, seriesIndex) => {
     const display = displays[seriesIndex];
+    const settings = chart.settings.series(chart.series[seriesIndex]);
+
+    if (settings["show_series_values"] === false) {
+      // We need to keep the series in `datas` to place the labels correctly over grouped bar charts.
+      // Instead, we remove all the data so no labels are displayed.
+      return [];
+    }
     return data
       .map(([x, y], i) => {
         const isLocalMin =

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarPostRender.js
@@ -247,7 +247,7 @@ function onRenderVoronoiHover(chart) {
     .order();
 }
 
-function onRenderValueLabels(chart, formatYValue, datas) {
+function onRenderValueLabels(chart, { formatYValue, yAxisSplit, datas }) {
   if (
     !chart.settings["graph.show_values"] || // setting is off
     chart.settings["stackable.stack_type"] === "normalized" // no normalized
@@ -323,7 +323,8 @@ function onRenderValueLabels(chart, formatYValue, datas) {
   const parent = chart.svg().select(".chart-body");
 
   const xScale = chart.x();
-  const yScale = chart.y();
+  const yScaleForSeries = index =>
+    yAxisSplit[0].includes(index) ? chart.y() : chart.rightY();
 
   // Ordinal bar charts and histograms need extra logic to center the label.
   const xShifts = displays.map((display, index) => {
@@ -388,6 +389,7 @@ function onRenderValueLabels(chart, formatYValue, datas) {
       .enter()
       .append("g")
       .attr("transform", ({ x, y, showLabelBelow, seriesIndex }) => {
+        const yScale = yScaleForSeries(seriesIndex);
         const xPos = xShifts[seriesIndex] + xScale(x);
         let yPos = yScale(y) + (showLabelBelow ? 18 : -8);
         // if the yPos is below the x axis, move it to be above the data point
@@ -581,7 +583,7 @@ function onRenderAddExtraClickHandlers(chart) {
 // the various steps that get called
 function onRender(
   chart,
-  { onGoalHover, isSplitAxis, isStacked, formatYValue, datas },
+  { onGoalHover, isSplitAxis, yAxisSplit, isStacked, formatYValue, datas },
 ) {
   onRenderRemoveClipPath(chart);
   onRenderMoveContentToTop(chart);
@@ -591,7 +593,7 @@ function onRender(
   onRenderEnableDots(chart);
   onRenderVoronoiHover(chart);
   onRenderCleanupGoalAndTrend(chart, onGoalHover, isSplitAxis); // do this before hiding x-axis
-  onRenderValueLabels(chart, formatYValue, datas);
+  onRenderValueLabels(chart, { formatYValue, yAxisSplit, datas });
   onRenderHideDisabledLabels(chart);
   onRenderHideDisabledAxis(chart);
   onRenderHideBadAxis(chart);

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -872,11 +872,13 @@ export default function lineAreaBar(
   }
 
   // HACK: compositeChart + ordinal X axis shenanigans. See https://github.com/dc-js/dc.js/issues/678 and https://github.com/dc-js/dc.js/issues/662
-  const hasBar = _.any(
-    series,
-    single => getSeriesDisplay(settings, single) === "bar",
-  );
-  parent._rangeBandPadding(hasBar ? BAR_PADDING_RATIO : 1);
+  if (!isHistogram(props.settings)) {
+    const hasBar = _.any(
+      series,
+      single => getSeriesDisplay(settings, single) === "bar",
+    );
+    parent._rangeBandPadding(hasBar ? BAR_PADDING_RATIO : 1);
+  }
 
   applyXAxisSettings(parent, props.series, xAxisProps);
 

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -890,6 +890,7 @@ export default function lineAreaBar(
   lineAndBarOnRender(parent, {
     onGoalHover,
     isSplitAxis: yAxisProps.isSplit,
+    yAxisSplit: yAxisProps.yAxisSplit,
     isStacked: isStacked(parent.settings, datas),
     formatYValue: getYValueFormatter(parent, series, yAxisProps.yExtent),
     datas,

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -891,6 +891,7 @@ export default function lineAreaBar(
     onGoalHover,
     isSplitAxis: yAxisProps.isSplit,
     yAxisSplit: yAxisProps.yAxisSplit,
+    xInterval: xAxisProps.xInterval,
     isStacked: isStacked(parent.settings, datas),
     formatYValue: getYValueFormatter(parent, series, yAxisProps.yExtent),
     datas,

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -132,6 +132,9 @@ export function onRenderValueLabels(
 
   // Ordinal bar charts and histograms need extra logic to center the label.
   const xShifts = displays.map((display, index) => {
+    if (display !== "bar") {
+      return 0;
+    }
     const barIndex = displays.slice(0, index).filter(d => d === "bar").length;
     let xShift = 0;
 
@@ -288,7 +291,8 @@ export function onRenderValueLabels(
           continue;
         }
 
-        if (!d.showLabelBelow) {
+        if (!d.showLabelBelow && displays[d.seriesIndex] === "line") {
+          // if we're a line label that's currently above the line
           // try flipping the label below to get farther from previous label
           const flippedYPos = xyPos({ ...d, showLabelBelow: true }).yPos;
           if (flippedYPos - prev > MIN_SPACING) {

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -47,9 +47,6 @@ export function onRenderValueLabels(
   }
   const showAll = chart.settings["graph.label_value_frequency"] === "all";
 
-  // Count max points in a single series to estimate when labels should be hidden
-  const maxSeriesLength = Math.max(...datas.map(d => d.length));
-
   let barWidth;
   const barCount = displays.filter(d => d === "bar").length;
   if (barCount > 0) {
@@ -99,6 +96,9 @@ export function onRenderValueLabels(
       })
       .filter(d => !(display === "bar" && d.y === 0));
   });
+
+  // Count max points in a single series to estimate when labels should be hidden
+  const maxSeriesLength = Math.max(...datas.map(d => d.length));
 
   const formattingSetting = chart.settings["graph.label_value_formatting"];
   const compactForSeries = datas.map(data => {

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -11,7 +11,7 @@ To do this it has to match the behavior in dc.js and our own hacks on top of tha
  - Hide labels to only show every nth label if there isn't enough horizontal space.
  - Rotate labels for tightly spaced grouped bar chart.
  - Switch label formatting to compact if it will save space.
- - Drop clustered labels for overlapping lines.
+ - Drop clustered labels for overlapping lines and bars.
 */
 
 export function onRenderValueLabels(
@@ -271,7 +271,10 @@ export function onRenderValueLabels(
   const MIN_SPACING = 20;
   _.chain(datas)
     .flatten()
-    .filter(d => displays[d.seriesIndex] === "line")
+    .filter(
+      d =>
+        displays[d.seriesIndex] === "line" || displays[d.seriesIndex] === "bar",
+    )
     .map(d => ({ d, ...xyPos(d) }))
     .groupBy(({ xPos }) => xPos)
     .values()

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -50,10 +50,12 @@ export function onRenderValueLabels(
   let barWidth;
   const barCount = displays.filter(d => d === "bar").length;
   if (barCount > 0) {
-    barWidth = chart
-      .svg()
-      .select("rect.bar")[0][0]
-      .getAttribute("width");
+    barWidth = parseFloat(
+      chart
+        .svg()
+        .select("rect.bar")[0][0]
+        .getAttribute("width"),
+    );
   }
 
   const xScale = chart.x();
@@ -147,7 +149,7 @@ export function onRenderValueLabels(
       }
     } else if (
       // non-ordinal bar charts don't have rangeBand set, but still need xShifting if they're grouped.
-      thisChart.barPadding
+      barWidth
     ) {
       // For these timeseries/quantitative scales, we look at the distance between two points one "interval" apart.
       // We then scale to remove the padding and divide by the number of bars to get the per-bar shift from the center.
@@ -155,9 +157,9 @@ export function onRenderValueLabels(
       const oneIntervalOver = moment.isMoment(startOfDomain)
         ? startOfDomain.clone().add(xInterval.count, xInterval.interval)
         : startOfDomain + xInterval;
-      const groupWidth =
-        (xScale(oneIntervalOver) - xScale(startOfDomain)) *
-        (1 - thisChart.barPadding());
+      const seriesPadding = barWidth < 4 ? 0 : barWidth < 8 ? 1 : 2;
+      const groupWidth = (barWidth + seriesPadding) * barCount;
+
       xShift -= groupWidth / 2;
       const xShiftForSeries = groupWidth / barCount;
       xShift += (barIndex + 0.5) * xShiftForSeries;

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -7,7 +7,7 @@ import { isHistogramBar } from "./renderer_utils";
 
 /*
 There's a lot of messy logic in this function. Its purpose is to place text labels at the appropriate place over a chart.
-To do this it has to match the behavior in dc.js and our own hacks on top of that. Here's a description of what it does:
+To do this it has to match the behavior in dc.js and our own hacks on top of that. Here are some things it does:
  - Show labels under (rather than over) local minima on line charts.
  - Hide labels to only show every nth label if there isn't enough horizontal space.
  - Rotate labels for tightly spaced grouped bar chart.
@@ -50,11 +50,14 @@ export function onRenderValueLabels(
   // Count max points in a single series to estimate when labels should be hidden
   const maxSeriesLength = Math.max(...datas.map(d => d.length));
 
-  const barWidth = chart
-    .svg()
-    .select("rect")[0][0]
-    .getAttribute("width");
+  let barWidth;
   const barCount = displays.filter(d => d === "bar").length;
+  if (barCount > 0) {
+    barWidth = chart
+      .svg()
+      .select("rect.bar")[0][0]
+      .getAttribute("width");
+  }
 
   const xScale = chart.x();
   const yScaleForSeries = index =>

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -1,0 +1,322 @@
+import _ from "underscore";
+import moment from "moment";
+
+import { COMPACT_CURRENCY_OPTIONS } from "metabase/lib/formatting";
+import { moveToFront } from "metabase/lib/dom";
+import { isHistogramBar } from "./renderer_utils";
+
+/*
+There's a lot of messy logic in this function. Its purpose is to place text labels at the appropriate place over a chart.
+To do this it has to match the behavior in dc.js and our own hacks on top of that. Here's a description of what it does:
+ - Show labels under (rather than over) local minima on line charts.
+ - Hide labels to only show every nth label if there isn't enough horizontal space.
+ - Rotate labels for tightly spaced grouped bar chart.
+ - Switch label formatting to compact if it will save space.
+ - Drop clustered labels for overlapping lines.
+*/
+
+export function onRenderValueLabels(
+  chart,
+  { formatYValue, xInterval, yAxisSplit, datas },
+) {
+  const seriesSettings = datas.map((_, seriesIndex) =>
+    chart.settings.series(chart.series[seriesIndex]),
+  );
+
+  // See if each series is enabled. Fall back to the chart-level setting if undefined.
+  let showSeries = seriesSettings.map(
+    ({ show_series_values = chart.settings["graph.show_values"] }) =>
+      show_series_values,
+  );
+
+  if (
+    showSeries.every(s => s === false) || // every series setting is off
+    chart.settings["stackable.stack_type"] === "normalized" // chart is normalized
+  ) {
+    return;
+  }
+
+  let displays = seriesSettings.map(settings => settings.display);
+  if (chart.settings["stackable.stack_type"] === "stacked") {
+    // When stacked, flatten datas into one series. We'll sum values on the same x point later.
+    datas = [datas.flat()];
+
+    // Individual series might have display set to something besides the actual stacked display.
+    displays = [chart.settings["stackable.stack_display"]];
+    showSeries = [true];
+  }
+  const showAll = chart.settings["graph.label_value_frequency"] === "all";
+
+  // Count max points in a single series to estimate when labels should be hidden
+  const maxSeriesLength = Math.max(...datas.map(d => d.length));
+
+  const barWidth = chart
+    .svg()
+    .select("rect")[0][0]
+    .getAttribute("width");
+  const barCount = displays.filter(d => d === "bar").length;
+
+  const xScale = chart.x();
+  const yScaleForSeries = index =>
+    yAxisSplit[0].includes(index) ? chart.y() : chart.rightY();
+
+  // Update datas to use named x/y and include `showLabelBelow`.
+  // We need to add `showLabelBelow` before data is filtered to show every nth value.
+  datas = datas.map((data, seriesIndex) => {
+    if (!showSeries[seriesIndex]) {
+      // We need to keep the series in `datas` to place the labels correctly over grouped bar charts.
+      // Instead, we remove all the data so no labels are displayed.
+      return [];
+    }
+    const display = displays[seriesIndex];
+
+    // Sum duplicate x values in the same series.
+    data = _.chain(data)
+      .groupBy(([x]) => xScale(x))
+      .values()
+      .map(data => {
+        const [[x]] = data;
+        const y = data.reduce((sum, [, y]) => sum + y, 0);
+        return [x, y];
+      })
+      .value();
+
+    return data
+      .map(([x, y], i) => {
+        const isLocalMin =
+          // first point or prior is greater than y
+          (i === 0 || data[i - 1][1] > y) &&
+          // last point point or next is greater than y
+          (i === data.length - 1 || data[i + 1][1] > y);
+        const showLabelBelow = isLocalMin && display === "line";
+        const rotated = barCount > 1 && display === "bar" && barWidth < 40;
+        const hidden =
+          !showAll && barCount > 1 && display === "bar" && barWidth < 20;
+        return { x, y, showLabelBelow, seriesIndex, rotated, hidden };
+      })
+      .filter(d => !(display === "bar" && d.y === 0));
+  });
+
+  const formattingSetting = chart.settings["graph.label_value_formatting"];
+  const compactForSeries = datas.map(data => {
+    if (formattingSetting === "compact") {
+      return true;
+    }
+    if (formattingSetting === "full") {
+      return false;
+    }
+    // for "auto" we use compact if it shortens avg label length by >3 chars
+    const getAvgLength = compact => {
+      const options = {
+        compact,
+        // We include compact currency options here for both compact and
+        // non-compact formatting. This prevents auto's logic from depending on
+        // those settings.
+        ...COMPACT_CURRENCY_OPTIONS,
+        // We need this to ensure the settings are used. Otherwise, a cached
+        // _numberFormatter would take precedence.
+        _numberFormatter: undefined,
+      };
+      const lengths = data.map(d => formatYValue(d.y, options).length);
+      return lengths.reduce((sum, l) => sum + l, 0) / lengths.length;
+    };
+    return getAvgLength(true) < getAvgLength(false) - 3;
+  });
+
+  // use the chart body so things line up properly
+  const parent = chart.svg().select(".chart-body");
+
+  // Ordinal bar charts and histograms need extra logic to center the label.
+  const xShifts = displays.map((display, index) => {
+    const thisChart = chart.children()[index];
+    const barIndex = displays.slice(0, index).filter(d => d === "bar").length;
+    let xShift = 0;
+
+    if (xScale.rangeBand) {
+      if (display === "bar") {
+        const xShiftForSeries = xScale.rangeBand() / barCount;
+        xShift += (barIndex + 0.5) * xShiftForSeries;
+      } else {
+        xShift += xScale.rangeBand() / 2;
+      }
+      if (displays.some(d => d === "bar") && displays.some(d => d !== "bar")) {
+        xShift += (chart._rangeBandPadding() * xScale.rangeBand()) / 2;
+      }
+    } else if (
+      // non-ordinal bar charts don't have rangeBand set, but still need xShifting if they're grouped.
+      thisChart.barPadding
+    ) {
+      // For these timeseries/quantitative scales, we look at the distance between two points one "interval" apart.
+      // We then scale to remove the padding and divide by the number of bars to get the per-bar shift from the center.
+      const startOfDomain = xScale.domain()[0];
+      const oneIntervalOver = moment.isMoment(startOfDomain)
+        ? startOfDomain.clone().add(xInterval.count, xInterval.interval)
+        : startOfDomain + xInterval;
+      const groupWidth =
+        (xScale(oneIntervalOver) - xScale(startOfDomain)) *
+        (1 - thisChart.barPadding());
+      xShift -= groupWidth / 2;
+      const xShiftForSeries = groupWidth / barCount;
+      xShift += (barIndex + 0.5) * xShiftForSeries;
+    }
+
+    if (
+      isHistogramBar({ settings: chart.settings, chartType: display }) &&
+      displays.length === 1
+    ) {
+      // this has to match the logic in `doHistogramBarStuff`
+      const [x1, x2] = chart
+        .svg()
+        .selectAll("rect")
+        .flat()
+        .map(r => parseFloat(r.getAttribute("x")));
+      const barWidth = x2 - x1;
+      xShift += barWidth / 2;
+    }
+    return xShift;
+  });
+
+  const xyPos = ({ x, y, showLabelBelow, seriesIndex }) => {
+    const yScale = yScaleForSeries(seriesIndex);
+    const xPos = xShifts[seriesIndex] + xScale(x);
+    let yPos = yScale(y) + (showLabelBelow ? 18 : -8);
+    // if the yPos is below the x axis, move it to be above the data point
+    const [yMax] = yScale.range();
+    if (yPos > yMax) {
+      yPos = yScale(y) - 8;
+    }
+    return {
+      xPos,
+      yPos,
+      // yHeight is the distance from the x axis
+      yHeight: yMax - yPos,
+    };
+  };
+
+  const MIN_ROTATED_HEIGHT = 50;
+  const addLabels = (data, compact = null) => {
+    // make sure we don't add .value-lables multiple times
+    parent.select(".value-labels").remove();
+    // Safari had an issue with rendering paint-order: stroke. To work around
+    // that, we create two text labels: one for the the black text and another
+    // for the white outline behind it.
+    const labelGroups = parent
+      .append("svg:g")
+      .classed("value-labels", true)
+      .selectAll("g")
+      .data(data)
+      .enter()
+      .append("g")
+      .attr("text-anchor", d =>
+        // Unrotated (horizontal) labels should be centered above the bar or point.
+        // Rotated labels should appear a fixed distance from the top of the bar.
+        // If the rotated label is above the bar, we anchor the start.
+        // When the label is inside the bar, we anchor the end.
+        !d.rotated
+          ? "middle"
+          : xyPos(d).yHeight < MIN_ROTATED_HEIGHT
+          ? "start"
+          : "end",
+      )
+      .attr("transform", d => {
+        const { xPos, yPos, yHeight } = xyPos(d);
+        const transforms = [`translate(${xPos}, ${yPos})`];
+        if (d.rotated) {
+          transforms.push(
+            "rotate(-90)",
+            `translate(${yHeight < MIN_ROTATED_HEIGHT ? -3 : -15}, 4)`,
+          );
+        }
+        return transforms.join(" ");
+      });
+
+    ["value-label-outline", "value-label"].forEach(klass =>
+      labelGroups
+        .append("text")
+        .attr("class", klass)
+        .text(({ y, seriesIndex }) =>
+          formatYValue(y, {
+            compact: compact === null ? compactForSeries[seriesIndex] : compact,
+          }),
+        ),
+    );
+  };
+
+  const nthForSeries = datas.map((data, index) => {
+    if (showAll || (barCount > 1 && displays[index] === "bar")) {
+      // show all is turned on or this is a bar in a grouped bar chart
+      return 1;
+    }
+    // auto fit
+    // Render a sample of rows to estimate average label size.
+    // We use that estimate to compute the label interval.
+    const LABEL_PADDING = 6;
+    const MAX_SAMPLE_SIZE = 30;
+    const sampleStep = Math.ceil(maxSeriesLength / MAX_SAMPLE_SIZE);
+    const sample = data.filter((d, i) => i % sampleStep === 0);
+    addLabels(sample, compactForSeries[index]);
+    const totalWidth = chart
+      .svg()
+      .selectAll(".value-label-outline")
+      .flat()
+      .reduce((sum, label) => sum + label.getBoundingClientRect().width, 0);
+    const labelWidth = totalWidth / sample.length + LABEL_PADDING;
+
+    const { width: chartWidth } = chart
+      .svg()
+      .select(".axis.x")
+      .node()
+      .getBoundingClientRect();
+
+    return Math.ceil((labelWidth * maxSeriesLength) / chartWidth);
+  });
+
+  // Hide labels when lines are clustered together.
+  // We group data points by x value, sort by y, and walk across them.
+  // If the label is too close to the previous one, we try flipping it to the other side.
+  // If that failed, we hide the label.
+  const MIN_SPACING = 20;
+  _.chain(datas)
+    .flatten()
+    .filter(d => displays[d.seriesIndex] === "line")
+    .map(d => ({ d, ...xyPos(d) }))
+    .groupBy(({ xPos }) => xPos)
+    .values()
+    .each(group => {
+      const sortedByY = _.sortBy(group, ({ yPos }) => yPos);
+      let prev;
+      for (const { d, yPos } of sortedByY) {
+        if (prev == null || yPos - prev > MIN_SPACING) {
+          // there's enough space between this label and the prev
+          prev = yPos;
+          continue;
+        }
+
+        if (!d.showLabelBelow) {
+          // try flipping the label below to get farther from previous label
+          const flippedYPos = xyPos({ ...d, showLabelBelow: true }).yPos;
+          if (flippedYPos - prev > MIN_SPACING) {
+            d.showLabelBelow = true;
+            prev = flippedYPos;
+            continue;
+          }
+        }
+
+        // hide this label and don't update prev so it isn't considered for collisions
+        d.hidden = true;
+      }
+    });
+
+  addLabels(
+    datas.flatMap(data =>
+      data.filter((d, i) => i % nthForSeries[d.seriesIndex] === 0 && !d.hidden),
+    ),
+  );
+
+  moveToFront(
+    chart
+      .svg()
+      .select(".value-labels")
+      .node().parentNode,
+  );
+}

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -311,9 +311,6 @@ export const GRAPH_GOAL_SETTINGS = {
   },
 };
 
-// with more than this many rows, don't display values on top of bars by default
-const AUTO_SHOW_VALUES_MAX_ROWS = 25;
-
 export const GRAPH_DISPLAY_VALUES_SETTINGS = {
   "graph.show_values": {
     section: t`Display`,
@@ -321,13 +318,7 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS = {
     widget: "toggle",
     getHidden: (series, vizSettings) =>
       vizSettings["stackable.stack_type"] === "normalized",
-    getDefault: ([{ card, data }]) =>
-      // small bar graphs should have this turned on by default,
-      // but bar graphs that were saved without this feature shouldn't
-      card.original_card_id == null &&
-      card.display === "bar" &&
-      data.rows.length < AUTO_SHOW_VALUES_MAX_ROWS,
-    persistDefault: true,
+    default: false,
   },
   "graph.label_value_frequency": {
     section: t`Display`,

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -320,7 +320,7 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS = {
     title: t`Show values on data points`,
     widget: "toggle",
     getHidden: (series, vizSettings) =>
-      series.length > 1 || vizSettings["stackable.stack_type"] === "normalized",
+      vizSettings["stackable.stack_type"] === "normalized",
     getDefault: ([{ card, data }]) =>
       // small bar graphs should have this turned on by default,
       // but bar graphs that were saved without this feature shouldn't
@@ -334,7 +334,6 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS = {
     title: t`Values to show`,
     widget: "radio",
     getHidden: (series, vizSettings) =>
-      series.length > 1 ||
       vizSettings["graph.show_values"] !== true ||
       vizSettings["stackable.stack_type"] === "normalized",
     props: {
@@ -351,7 +350,6 @@ export const GRAPH_DISPLAY_VALUES_SETTINGS = {
     title: t`Value formatting`,
     widget: "radio",
     getHidden: (series, vizSettings) =>
-      series.length > 1 ||
       vizSettings["graph.show_values"] !== true ||
       vizSettings["stackable.stack_type"] === "normalized",
     props: {

--- a/frontend/src/metabase/visualizations/lib/settings/series.js
+++ b/frontend/src/metabase/visualizations/lib/settings/series.js
@@ -133,7 +133,6 @@ export function seriesSetting({
       title: t`Show values for this series`,
       widget: "toggle",
       getHidden: (single, seriesSettings, { settings }) =>
-        !settings["graph.show_values"] ||
         settings["stackable.stack_type"] === "stacked",
       getDefault: (single, seriesSettings, { settings }) =>
         settings["graph.show_values"],

--- a/frontend/src/metabase/visualizations/lib/settings/series.js
+++ b/frontend/src/metabase/visualizations/lib/settings/series.js
@@ -132,8 +132,10 @@ export function seriesSetting({
     show_series_values: {
       title: t`Show values for this series`,
       widget: "toggle",
-      getHidden: (single, seriesSettings, { settings }) =>
-        settings["stackable.stack_type"] === "stacked",
+      getHidden: (single, seriesSettings, { settings, series }) =>
+        series.length <= 1 || // no need to show series-level control if there's only one series
+        !settings.hasOwnProperty("graph.show_values") || // don't show it unless this chart has a global setting
+        settings["stackable.stack_type"], // hide series controls if the chart is stacked
       getDefault: (single, seriesSettings, { settings }) =>
         settings["graph.show_values"],
       readDependencies: ["graph.show_values", "stackable.stack_type"],

--- a/frontend/src/metabase/visualizations/lib/settings/series.js
+++ b/frontend/src/metabase/visualizations/lib/settings/series.js
@@ -129,6 +129,15 @@ export function seriesSetting({
       },
       getHidden: (single, settings, { series }) => series.length < 2,
     },
+    show_series_values: {
+      title: t`Show values for this series`,
+      widget: "toggle",
+      getHidden: (single, seriesSettings, { settings }) =>
+        !settings["graph.show_values"],
+      getDefault: (single, seriesSettings, { settings }) =>
+        settings["graph.show_values"],
+      readDependencies: ["graph.show_values"],
+    },
   };
 
   function getSettingDefintionsForSingleSeries(series, object, settings) {

--- a/frontend/src/metabase/visualizations/lib/settings/series.js
+++ b/frontend/src/metabase/visualizations/lib/settings/series.js
@@ -133,10 +133,11 @@ export function seriesSetting({
       title: t`Show values for this series`,
       widget: "toggle",
       getHidden: (single, seriesSettings, { settings }) =>
-        !settings["graph.show_values"],
+        !settings["graph.show_values"] ||
+        settings["stackable.stack_type"] === "stacked",
       getDefault: (single, seriesSettings, { settings }) =>
         settings["graph.show_values"],
-      readDependencies: ["graph.show_values"],
+      readDependencies: ["graph.show_values", "stackable.stack_type"],
     },
   };
 

--- a/frontend/src/metabase/visualizations/visualizations/AreaChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/AreaChart.jsx
@@ -23,7 +23,6 @@ export default class AreaChart extends LineAreaBarChart {
   static noun = t`area chart`;
 
   static settings = {
-    ...GRAPH_DATA_SETTINGS,
     ...LINE_SETTINGS,
     ...STACKABLE_SETTINGS,
     ...GRAPH_GOAL_SETTINGS,
@@ -31,6 +30,7 @@ export default class AreaChart extends LineAreaBarChart {
     ...GRAPH_AXIS_SETTINGS,
     ...PLUGIN_CHART_SETTINGS,
     ...GRAPH_DISPLAY_VALUES_SETTINGS,
+    ...GRAPH_DATA_SETTINGS,
   };
 
   static renderer = areaRenderer;

--- a/frontend/src/metabase/visualizations/visualizations/BarChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/BarChart.jsx
@@ -22,13 +22,13 @@ export default class BarChart extends LineAreaBarChart {
   static noun = t`bar chart`;
 
   static settings = {
-    ...GRAPH_DATA_SETTINGS,
     ...STACKABLE_SETTINGS,
     ...GRAPH_GOAL_SETTINGS,
     ...GRAPH_COLORS_SETTINGS,
     ...GRAPH_AXIS_SETTINGS,
     ...PLUGIN_CHART_SETTINGS,
     ...GRAPH_DISPLAY_VALUES_SETTINGS,
+    ...GRAPH_DATA_SETTINGS,
   };
 
   static renderer = barRenderer;

--- a/frontend/src/metabase/visualizations/visualizations/ComboChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/ComboChart.jsx
@@ -21,13 +21,13 @@ export default class LineChart extends LineAreaBarChart {
   static noun = t`line and bar chart`;
 
   static settings = {
-    ...GRAPH_DATA_SETTINGS,
     ...LINE_SETTINGS,
     ...GRAPH_GOAL_SETTINGS,
     ...GRAPH_COLORS_SETTINGS,
     ...GRAPH_AXIS_SETTINGS,
     ...PLUGIN_CHART_SETTINGS,
     ...GRAPH_DISPLAY_VALUES_SETTINGS,
+    ...GRAPH_DATA_SETTINGS,
   };
 
   static renderer = comboRenderer;

--- a/frontend/src/metabase/visualizations/visualizations/ComboChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/ComboChart.jsx
@@ -10,6 +10,7 @@ import {
   GRAPH_GOAL_SETTINGS,
   GRAPH_COLORS_SETTINGS,
   GRAPH_AXIS_SETTINGS,
+  GRAPH_DISPLAY_VALUES_SETTINGS,
 } from "../lib/settings/graph";
 import { PLUGIN_CHART_SETTINGS } from "metabase/plugins";
 
@@ -26,6 +27,7 @@ export default class LineChart extends LineAreaBarChart {
     ...GRAPH_COLORS_SETTINGS,
     ...GRAPH_AXIS_SETTINGS,
     ...PLUGIN_CHART_SETTINGS,
+    ...GRAPH_DISPLAY_VALUES_SETTINGS,
   };
 
   static renderer = comboRenderer;

--- a/frontend/src/metabase/visualizations/visualizations/LineChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/LineChart.jsx
@@ -21,13 +21,13 @@ export default class LineChart extends LineAreaBarChart {
   static noun = t`line chart`;
 
   static settings = {
-    ...GRAPH_DATA_SETTINGS,
     ...LINE_SETTINGS,
     ...GRAPH_GOAL_SETTINGS,
     ...GRAPH_COLORS_SETTINGS,
     ...GRAPH_AXIS_SETTINGS,
     ...PLUGIN_CHART_SETTINGS,
     ...GRAPH_DISPLAY_VALUES_SETTINGS,
+    ...GRAPH_DATA_SETTINGS,
   };
 
   static renderer = lineRenderer;

--- a/frontend/src/metabase/visualizations/visualizations/RowChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart.jsx
@@ -21,9 +21,9 @@ export default class RowChart extends LineAreaBarChart {
   static renderer = rowRenderer;
 
   static settings = {
-    ...GRAPH_DATA_SETTINGS,
     ...GRAPH_COLORS_SETTINGS,
     ...PLUGIN_CHART_SETTINGS,
+    ...GRAPH_DATA_SETTINGS,
   };
 }
 

--- a/frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/ScatterPlot.jsx
@@ -22,11 +22,11 @@ export default class ScatterPlot extends LineAreaBarChart {
   static renderer = scatterRenderer;
 
   static settings = {
-    ...GRAPH_DATA_SETTINGS,
     ...GRAPH_BUBBLE_SETTINGS,
     ...GRAPH_GOAL_SETTINGS,
     ...GRAPH_COLORS_SETTINGS,
     ...GRAPH_AXIS_SETTINGS,
     ...PLUGIN_CHART_SETTINGS,
+    ...GRAPH_DATA_SETTINGS,
   };
 }

--- a/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/settings/visualization.unit.spec.js
@@ -124,21 +124,9 @@ describe("visualization_settings", () => {
       });
     });
     describe("graph.show_values", () => {
-      it("should show values on a bar chart with ten bars", () => {
+      it("should not show values on a bar chart by default", () => {
         const card = { visualization_settings: {}, display: "bar" };
         const data = { rows: new Array(10).fill([1]) };
-        const settings = getComputedSettingsForSeries([{ card, data }]);
-        expect(settings["graph.show_values"]).toBe(true);
-      });
-      it("should not show values on a line chart with ten value", () => {
-        const card = { visualization_settings: {}, display: "line" };
-        const data = { rows: new Array(10).fill([1]) };
-        const settings = getComputedSettingsForSeries([{ card, data }]);
-        expect(settings["graph.show_values"]).toBe(false);
-      });
-      it("should not show values on a bar chart with thirty bars", () => {
-        const card = { visualization_settings: {}, display: "bar" };
-        const data = { rows: new Array(30).fill([1]) };
         const settings = getComputedSettingsForSeries([{ card, data }]);
         expect(settings["graph.show_values"]).toBe(false);
       });


### PR DESCRIPTION
The first commit here adds basic labeling. It doesn't yet update how we drop labels to avoid crowding or add series-level settings.
# Examples
## Grouped Bar
![image](https://user-images.githubusercontent.com/691495/83678723-2f9d0900-a5ac-11ea-9ae6-247289f78693.png)
## Multiple Lines
Lots of crowding 😬 
![image](https://user-images.githubusercontent.com/691495/83678757-39bf0780-a5ac-11ea-9785-69c46c803bbf.png)
## Stacked Bar
![image](https://user-images.githubusercontent.com/691495/83678775-417eac00-a5ac-11ea-9d22-a81a0bb6d868.png)
## Stacked Histogram
![image](https://user-images.githubusercontent.com/691495/83678789-49d6e700-a5ac-11ea-839e-0afeb6d9e7f8.png)
## Stacked Area
![image](https://user-images.githubusercontent.com/691495/83678812-52c7b880-a5ac-11ea-869f-a7a0d7eee8d4.png)
## Combo Bar/Line
![image](https://user-images.githubusercontent.com/691495/83678850-61ae6b00-a5ac-11ea-82a2-89647fa10ba9.png)

