### PR TITLE
Allow connection URIs for Mongo

### DIFF
--- a/frontend/src/metabase/components/form/widgets/FormInputWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormInputWidget.jsx
@@ -2,12 +2,13 @@ import React from "react";
 
 import { formDomOnlyProps } from "metabase/lib/redux";
 
-const FormInputWidget = ({ type = "text", placeholder, field }) => (
+const FormInputWidget = ({ type = "text", placeholder, field, readOnly }) => (
   <input
     className="Form-input full"
     type={type}
     placeholder={placeholder}
     aria-labelledby={`${field.name}-label`}
+    readOnly={readOnly}
     {...formDomOnlyProps(field)}
   />
 );

--- a/frontend/src/metabase/containers/Form.jsx
+++ b/frontend/src/metabase/containers/Form.jsx
@@ -46,6 +46,7 @@ export type FormFieldDefinition = {
   initial?: FormValue | (() => FormValue),
   normalize?: (value: FormValue) => FormValue,
   validate?: (value: FormValue, props: FormProps) => ?FormError | boolean,
+  readOnly?: boolean,
 };
 
 export type FormDefinition = {

--- a/frontend/src/metabase/entities/databases/forms.js
+++ b/frontend/src/metabase/entities/databases/forms.js
@@ -171,7 +171,7 @@ function getAuthCodeEnableAPILink(engine, details) {
   }
 }
 
-function getFieldsForEngine(engine, details) {
+function getFieldsForEngine(engine, details, id) {
   let info = (MetabaseSettings.get("engines") || {})[engine];
   if (engine === "bigquery") {
     // BigQuery has special logic to switch out forms depending on what style of authenication we use.
@@ -179,7 +179,7 @@ function getFieldsForEngine(engine, details) {
   }
   if (engine === "mongo") {
     // Mongo has special logic to switch between a connection URI and broken out fields
-    info = getFieldsForMongo(details, info);
+    info = getFieldsForMongo(details, info, id);
   }
   if (info) {
     const fields = [];
@@ -232,6 +232,7 @@ function getFieldsForEngine(engine, details) {
             : value,
         horizontal: field.type === "boolean",
         initial: field.default,
+        readOnly: field.readOnly || false,
         ...(overrides && overrides(engine, details)),
       });
     }
@@ -250,7 +251,7 @@ const ENGINE_OPTIONS = Object.entries(MetabaseSettings.get("engines") || {})
 
 const forms = {
   details: {
-    fields: ({ engine, details = {} } = {}) => [
+    fields: ({ id, engine, details = {} } = {}) => [
       {
         name: "engine",
         title: t`Database type`,
@@ -265,7 +266,7 @@ const forms = {
         validate: value => !value && t`required`,
         hidden: !engine,
       },
-      ...(getFieldsForEngine(engine, details) || []),
+      ...(getFieldsForEngine(engine, details, id) || []),
       {
         name: "auto_run_queries",
         type: "boolean",

--- a/frontend/src/metabase/entities/databases/forms.js
+++ b/frontend/src/metabase/entities/databases/forms.js
@@ -4,6 +4,7 @@ import { t, jt } from "ttag";
 import MetabaseSettings from "metabase/lib/settings";
 import ExternalLink from "metabase/components/ExternalLink";
 import getFieldsForBigQuery from "./big-query-fields";
+import getFieldsForMongo from "./mongo-fields";
 
 import MetadataSyncScheduleWidget from "metabase/admin/databases/components/widgets/MetadataSyncScheduleWidget";
 import CacheFieldValuesScheduleWidget from "metabase/admin/databases/components/widgets/CacheFieldValuesScheduleWidget";
@@ -175,6 +176,10 @@ function getFieldsForEngine(engine, details) {
   if (engine === "bigquery") {
     // BigQuery has special logic to switch out forms depending on what style of authenication we use.
     info = getFieldsForBigQuery(details);
+  }
+  if (engine === "mongo") {
+    // Mongo has special logic to switch between a connection URI and broken out fields
+    info = getFieldsForMongo(details, info);
   }
   if (info) {
     const fields = [];

--- a/frontend/src/metabase/entities/databases/mongo-fields.js
+++ b/frontend/src/metabase/entities/databases/mongo-fields.js
@@ -1,0 +1,69 @@
+import React from "react";
+import { t } from "ttag";
+
+import Link from "metabase/components/Link";
+
+function MongoConnectionStringToggle({
+  field: { value, onChange },
+  values: { details },
+}) {
+  return value === false ? (
+    <div>
+      <Link className="link" onClick={() => onChange(true)}>
+        {t`Paste a connection string`}
+      </Link>
+    </div>
+  ) : (
+    <div>
+      <Link className="link" onClick={() => onChange(false)}>
+        {t`Fill out individual fields`}
+      </Link>
+    </div>
+  );
+}
+
+export default function getFieldsForMongo(details, defaults) {
+  const useConnectionString =
+    details["use-connection-uri"] == null || details["use-connection-uri"];
+
+  const manualFields = [
+    "host",
+    "dbname",
+    "port",
+    "user",
+    "pass",
+    "authdb",
+    "additional-options",
+    "use-srv",
+    "ssl",
+  ];
+
+  const fields = [];
+  for (const field of defaults["details-fields"]) {
+    if (
+      (useConnectionString && manualFields.includes(field["name"])) ||
+      (!useConnectionString && field["name"] === "conn-uri")
+    ) {
+      continue;
+    } else {
+      // in the case that we're adding the conn-uri field, it becomes required
+      if (field["name"] === "conn-uri") {
+        field.required = true;
+      }
+
+      fields.push(field);
+    }
+  }
+
+  return {
+    "details-fields": [
+      {
+        name: "use-connection-uri",
+        type: MongoConnectionStringToggle,
+        hidden: true,
+        default: false,
+      },
+      ...fields,
+    ],
+  };
+}

--- a/frontend/src/metabase/entities/databases/mongo-fields.js
+++ b/frontend/src/metabase/entities/databases/mongo-fields.js
@@ -3,14 +3,6 @@ import { t } from "ttag";
 
 import Link from "metabase/components/Link";
 
-function WhyReadonly() {
-  return (
-    <div>
-      <p>{t`Once the connection string has been entered and saved, you cannot edit it, since a connection string can contain a password. To update the connection string, delete and re-add the database.`}</p>
-    </div>
-  );
-}
-
 function MongoConnectionStringToggle({ field: { value, onChange } }) {
   return (
     <div>
@@ -49,9 +41,6 @@ export default function getFieldsForMongo(details, defaults, id) {
     )
     .map(function(field) {
       if (field["name"] === "conn-uri" && id) {
-        // this has been previously saved, so you cannot edit it now
-        // to avoid leaking a password
-        field.readOnly = true;
         field.type = "password";
       }
       return field;
@@ -65,14 +54,6 @@ export default function getFieldsForMongo(details, defaults, id) {
         hidden: true,
         default: false,
       },
-      ...(id != null && useConnectionString
-        ? [
-            {
-              name: "readonly-info",
-              type: WhyReadonly,
-            },
-          ]
-        : []),
       ...fields,
     ],
   };

--- a/frontend/src/metabase/entities/databases/mongo-fields.js
+++ b/frontend/src/metabase/entities/databases/mongo-fields.js
@@ -3,20 +3,13 @@ import { t } from "ttag";
 
 import Link from "metabase/components/Link";
 
-function MongoConnectionStringToggle({
-  field: { value, onChange },
-  values: { details },
-}) {
-  return value === false ? (
+function MongoConnectionStringToggle({ field: { value, onChange } }) {
+  return (
     <div>
-      <Link className="link" onClick={() => onChange(true)}>
-        {t`Paste a connection string`}
-      </Link>
-    </div>
-  ) : (
-    <div>
-      <Link className="link" onClick={() => onChange(false)}>
-        {t`Fill out individual fields`}
+      <Link className="link" onClick={() => onChange(!value)}>
+        {value === false
+          ? t`Paste a connection string`
+          : t`Fill out individual fields`}
       </Link>
     </div>
   );
@@ -38,22 +31,13 @@ export default function getFieldsForMongo(details, defaults) {
     "ssl",
   ];
 
-  const fields = [];
-  for (const field of defaults["details-fields"]) {
-    if (
-      (useConnectionString && manualFields.includes(field["name"])) ||
-      (!useConnectionString && field["name"] === "conn-uri")
-    ) {
-      continue;
-    } else {
-      // in the case that we're adding the conn-uri field, it becomes required
-      if (field["name"] === "conn-uri") {
-        field.required = true;
-      }
-
-      fields.push(field);
-    }
-  }
+  const fields = defaults["details-fields"].filter(
+    field =>
+      !(
+        (useConnectionString && manualFields.includes(field["name"])) ||
+        (!useConnectionString && field["name"] === "conn-uri")
+      ),
+  );
 
   return {
     "details-fields": [

--- a/frontend/src/metabase/entities/databases/mongo-fields.js
+++ b/frontend/src/metabase/entities/databases/mongo-fields.js
@@ -51,8 +51,8 @@ export default function getFieldsForMongo(details, defaults, id) {
       if (field["name"] === "conn-uri" && id) {
         // this has been previously saved, so you cannot edit it now
         // to avoid leaking a password
-        // TODO: make the field value something like 'mongodb://************' in this case
         field.readOnly = true;
+        field.type = "password";
       }
       return field;
     });

--- a/modules/drivers/mongo/resources/metabase-plugin.yaml
+++ b/modules/drivers/mongo/resources/metabase-plugin.yaml
@@ -9,6 +9,10 @@ driver:
   connection-properties:
     - host
     - dbname
+    - name: conn-uri
+      type: string
+      display-name: Paste your connection string
+      placeholder: 'mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]'
     - merge:
         - port
         - default: 27017

--- a/modules/drivers/mongo/resources/metabase-plugin.yaml
+++ b/modules/drivers/mongo/resources/metabase-plugin.yaml
@@ -13,6 +13,7 @@ driver:
       type: string
       display-name: Paste your connection string
       placeholder: 'mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]'
+      required: true
     - merge:
         - port
         - default: 27017

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -31,32 +31,37 @@
 
 ;; ## Tests for connection functions
 (deftest can-connect-test?
-  (mt/test-driver :mongo
-    (doseq [{:keys [details expected message]} [{:details  {:host   "localhost"
-                                                            :port   3000
-                                                            :dbname "bad-db-name"}
-                                                 :expected false}
-                                                {:details  {}
-                                                 :expected false}
-                                                {:details  {:host   "localhost"
-                                                            :port   27017
-                                                            :dbname "metabase-test"}
-                                                 :expected true}
-                                                {:details  {:host   "localhost"
-                                                            :dbname "metabase-test"}
-                                                 :expected true
-                                                 :message  "should use default port 27017 if not specified"}
-                                                {:details  {:host   "123.4.5.6"
-                                                            :dbname "bad-db-name?connectTimeoutMS=50"}
-                                                 :expected false}
-                                                {:details  {:host   "localhost"
-                                                            :port   3000
-                                                            :dbname "bad-db-name?connectTimeoutMS=50"}
-                                                 :expected false}]]
-
-      (is (= expected
-             (driver.u/can-connect-with-details? :mongo details))
-          message))))
+  (mt/test-driver
+   :mongo
+   (doseq [{:keys [details expected message]} [{:details  {:host   "localhost"
+                                                           :port   3000
+                                                           :dbname "bad-db-name"}
+                                                :expected false}
+                                               {:details  {}
+                                                :expected false}
+                                               {:details  {:host   "localhost"
+                                                           :port   27017
+                                                           :dbname "metabase-test"}
+                                                :expected true}
+                                               {:details  {:host   "localhost"
+                                                           :dbname "metabase-test"}
+                                                :expected true
+                                                :message  "should use default port 27017 if not specified"}
+                                               {:details  {:host   "123.4.5.6"
+                                                           :dbname "bad-db-name?connectTimeoutMS=50"}
+                                                :expected false}
+                                               {:details  {:host   "localhost"
+                                                           :port   3000
+                                                           :dbname "bad-db-name?connectTimeoutMS=50"}
+                                                :expected false}
+                                               {:details  {:conn-uri "mongodb://localhost:27017/metabase-test"}
+                                                :expected true}
+                                               {:details  {:conn-uri "mongodb://localhost:3000/bad-db-name?connectTimeoutMS=50"}
+                                                :expected false}]]
+      (testing (str "connect with " details)
+        (is (= expected
+               (driver.u/can-connect-with-details? :mongo details))
+            message)))))
 
 (def ^:private native-query
   "[{\"$project\": {\"_id\": \"$_id\"}},


### PR DESCRIPTION
Allows a connection URI string to be used for connecting to Mongo. When
using a connection UR you cannot provide the SSL certificate in a field on
settings page. This is a limitation of the underlying driver.

Resolves #5084

[ci mongo]