### PR TITLE
User-friendly message when server requires SSL

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -80,6 +80,9 @@
     #".*javax.net.ssl.SSLHandshakeException: PKIX path building failed.*"
     (driver.common/connection-error-messages :certificate-not-trusted)
 
+    #".*MongoSocketReadException: Prematurely reached end of stream.*"
+    (driver.common/connection-error-messages :requires-ssl)
+
     #".*"                               ; default
     message))
 

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -54,7 +54,10 @@
    (deferred-tru "Looks like the username or password is incorrect.")
 
    :certificate-not-trusted
-   (deferred-tru "Server certificate not trusted - did you specify the correct SSL certificate chain?")})
+   (deferred-tru "Server certificate not trusted - did you specify the correct SSL certificate chain?")
+
+   :requires-ssl
+   (deferred-tru "Server appears to require SSL - please enable SSL above")})
 
 ;; TODO - we should rename these from `default-*-details` to `default-*-connection-property`
 


### PR DESCRIPTION
When the server (likely) requires SSL, you get an error message like:

    Caused by: com.mongodb.MongoTimeoutException: Timed out after 3000 ms while waiting to connect. Client view of cluster state is {type=UNKNOWN, servers=[{address=127.0.0.1:27017, type=UNKNOWN, state=CONNECTING, exception={com.mongodb.MongoSocketReadException: Prematurely reached end of stream}}]

When this is found, suggest that the user enable SSL.

Resolves #12605

[ci mongo]