### PR TITLE
Attempt to fix flakiness w/chart drill test

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/chart_drill.cy.spec.js
@@ -53,6 +53,12 @@ describe("scenarios > visualizations > chart drill", () => {
   });
 
   it("should drill through a nested query", () => {
+    // There's a slight hiccup in the UI with nested questions when we Summarize by City below.
+    // Because there's only 5 rows, it automatically switches to the chart, but issues another
+    // dataset request. So we wait for the dataset to load.
+    cy.server();
+    cy.route("POST", "/api/dataset").as("dataset");
+
     // save a question of people in CA
     cy.request("POST", "/api/card", {
       name: "CA People",
@@ -79,6 +85,7 @@ describe("scenarios > visualizations > chart drill", () => {
       .click();
 
     // wait for chart to load
+    cy.wait("@dataset");
     cy.contains("Count by City");
     // drill into the first bar
     cy.get(".bar")


### PR DESCRIPTION
There's some odd UI behavior that makes this test fail occasionally.

This attempts to wait for the API request to finish before selecting the chart.