### PR TITLE
First time sync BigQuery data w/ Service Account

### DIFF
--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -16,12 +16,18 @@
             [metabase.query-processor.timezone :as qp.timezone]
             [metabase.test.data.impl :as data.impl]))
 
+(def initialized?
+  (atom nil))
+
 (defn init!
   []
-  (mbc/init!))
+  (mbc/init!)
+  (reset! initialized? true))
 
 (defn start!
   []
+  (when-not @initialized?
+    (init!))
   (metabase.server/start-web-server! #'metabase.handler/app)
   (metabase.db/setup-db!)
   (metabase.plugins/load-plugins!)

--- a/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
+++ b/modules/drivers/bigquery/src/metabase/driver/bigquery.clj
@@ -103,7 +103,7 @@
 
 (s/defn get-table :- Table
   ([{{:keys [project-id dataset-id]} :details, :as database} table-id]
-   (get-table (database->client database) project-id dataset-id table-id))
+   (get-table (database->client database) (find-project-id project-id (database->credential database)) dataset-id table-id))
 
   ([client :- Bigquery, project-id :- su/NonBlankString, dataset-id :- su/NonBlankString, table-id :- su/NonBlankString]
    (google/execute (.get (.tables client) project-id dataset-id table-id))))
@@ -205,7 +205,7 @@
 
 (defn- ^QueryResponse execute-bigquery
   ([{{:keys [project-id]} :details, :as database} sql parameters]
-   (execute-bigquery (database->client database) project-id sql parameters))
+   (execute-bigquery (database->client database) (find-project-id project-id (database->credential database)) sql parameters))
 
   ([^Bigquery client ^String project-id ^String sql parameters]
    {:pre [client (seq project-id) (seq sql)]}


### PR DESCRIPTION
When using a service account, the project-id isn't provided by the user,
but instead comes from the credentials for the service account. Handle
this case by looking for a project-id if one is provided explicitly,
otherwise defer to the credential object.

Additional change - during development, if (dev/init!) isn't called, the
event listeners are never setup, meaning that the initial syncs don't
occur.

Resolves #12648

[ci bigquery]