### PR TITLE
Fixes (maybe) a flaky Cypress test

### DIFF
--- a/frontend/test/metabase/scenarios/public/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/public/public.cy.spec.js
@@ -38,13 +38,13 @@ describe("scenarios > public", () => {
     // Note: Test suite is sequential, so individual test cases can't be run individually
     it("should allow users to create parameterized SQL questions", () => {
       cy.visit(`/question/new?type=native&database=${SAMPLE_DATASET.id}`);
-      cy.get(".ace_text-input").type(
-        "select count(*) from products where {{c}}",
-        {
+      cy.get(".ace_text-input")
+        .wait(500)
+        .type("select count(*) from products where {{c}}", {
           force: true,
           parseSpecialCharSequences: false,
-        },
-      );
+        })
+        .should("have.value", "select count(*) from products where {{c}}\n\n");
 
       // HACK: disable the editor due to weirdness with `.type()` on other elements typing into editor
       cy.window().then(win => {
@@ -176,7 +176,7 @@ describe("scenarios > public", () => {
       cy.contains("Public link")
         .parent()
         .find("input")
-        .then($input => {
+        .should($input => {
           expect($input[0].value).to.match(PUBLIC_URL_REGEX);
           questionPublicLink = $input[0].value.match(PUBLIC_URL_REGEX)[0];
         });


### PR DESCRIPTION
This commit makes two changes to a single test:
1. Adds a wait to the SQL editor as I was having issues locally with the first 's' getting swallowed.
1.a Adds a 'should' to that same place to ensure the text is typed correctly.
2. Changes `then` to `should` in a test so it gets retried.

Relevant (open) Cypress issues:
- https://github.com/cypress-io/cypress/issues/5480
- https://github.com/cypress-io/cypress/issues/5626
- https://github.com/cypress-io/cypress/issues/3817

And Cypress note about retryability: https://docs.cypress.io/guides/core-concepts/retry-ability.html#Correctly-waiting-for-values