### PR TITLE
Clean up DB form styling

### DIFF
--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -140,7 +140,7 @@ export default class DatabaseEditApp extends Component {
     const showTabs = editingExistingDatabase && letUserControlSchedulingSaved;
 
     return (
-      <div className="wrapper">
+      <Box px={[3, 4, 5]} mt={[1, 2, 3]}>
         <Breadcrumbs
           className="py4"
           crumbs={[
@@ -149,7 +149,7 @@ export default class DatabaseEditApp extends Component {
           ]}
         />
         <Flex pb={2}>
-          <Box style={{ maxWidth: 720 }}>
+          <Box w={620}>
             <div className="pt0">
               {showTabs && (
                 <div className="border-bottom mb2">
@@ -271,7 +271,7 @@ export default class DatabaseEditApp extends Component {
             </Box>
           )}
         </Flex>
-      </div>
+      </Box>
     );
   }
 }

--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -59,20 +59,27 @@ export default class FormField extends Component {
       <div
         className={cx("Form-field", className, {
           "Form--fieldError": !!error,
+          flex: horizontal,
         })}
         id={`formField-${name.replace(/\./g, "-")}`}
       >
         {(title || description) && (
-          <div className={cx({ ml2: horizontal })}>
+          <div>
             {title && (
-              <label className="Form-label" htmlFor={name} id={`${name}-label`}>
+              <label
+                className={cx("Form-label", { "mr-auto": horizontal })}
+                htmlFor={name}
+                id={`${name}-label`}
+              >
                 {title} {error && <span className="text-error">: {error}</span>}
               </label>
             )}
-            {description && <div>{description}</div>}
+            {description && <div className="mb1">{description}</div>}
           </div>
         )}
-        <div className="flex-no-shrink">{children}</div>
+        <div className={cx("flex-no-shrink", { "ml-auto": horizontal })}>
+          {children}
+        </div>
       </div>
     );
   }

--- a/frontend/src/metabase/components/form/FormField.jsx
+++ b/frontend/src/metabase/components/form/FormField.jsx
@@ -59,8 +59,8 @@ export default class FormField extends Component {
       <div
         className={cx("Form-field", className, {
           "Form--fieldError": !!error,
-          "flex flex-reverse justify-end": horizontal,
         })}
+        id={`formField-${name.replace(/\./g, "-")}`}
       >
         {(title || description) && (
           <div className={cx({ ml2: horizontal })}>
@@ -69,7 +69,7 @@ export default class FormField extends Component {
                 {title} {error && <span className="text-error">: {error}</span>}
               </label>
             )}
-            {description && <div className="mb1">{description}</div>}
+            {description && <div>{description}</div>}
           </div>
         )}
         <div className="flex-no-shrink">{children}</div>

--- a/frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx
@@ -3,9 +3,7 @@ import React from "react";
 import Toggle from "metabase/components/Toggle";
 
 const FormToggleWidget = ({ field }) => (
-  <div>
-    <Toggle aria-labelledby={`${field.name}-label`} {...field} />
-  </div>
+  <Toggle aria-labelledby={`${field.name}-label`} {...field} />
 );
 
 export default FormToggleWidget;

--- a/frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx
@@ -1,22 +1,10 @@
 import React from "react";
-import { t } from "ttag";
 
 import Toggle from "metabase/components/Toggle";
 
-const HIDDEN_STYLE = { height: 0, overflow: "hidden" };
-
-const FormToggleWidget = ({
-  field,
-  horizontal = false,
-  showEnabledLabel = !horizontal,
-}) => (
-  <div className="flex align-center">
+const FormToggleWidget = ({ field }) => (
+  <div>
     <Toggle aria-labelledby={`${field.name}-label`} {...field} />
-    {showEnabledLabel && (
-      <span className="text-bold mx1">
-        {/* HACK: ensure a consistent width by always rendering both labels */}
-      </span>
-    )}
   </div>
 );
 

--- a/frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormToggleWidget.jsx
@@ -15,8 +15,6 @@ const FormToggleWidget = ({
     {showEnabledLabel && (
       <span className="text-bold mx1">
         {/* HACK: ensure a consistent width by always rendering both labels */}
-        <div style={field.value ? {} : HIDDEN_STYLE}>{t`Enabled`}</div>
-        <div style={field.value ? HIDDEN_STYLE : {}}>{t`Disabled`}</div>
       </span>
     )}
   </div>

--- a/frontend/src/metabase/css/admin.css
+++ b/frontend/src/metabase/css/admin.css
@@ -193,9 +193,8 @@
   border: 1px solid var(--color-border);
   background-color: var(--color-bg-white);
   border-radius: var(--default-border-radius);
-  font-size: 14px;
   font-weight: 700;
-  min-width: 90px;
+  min-width: 200px;
 }
 
 .AdminSelect:hover {
@@ -326,4 +325,13 @@
 
 .AdminLink:hover {
   opacity: 1;
+}
+
+#formField-details-port .Form-input,
+#formField-details-tunnel-port .Form-input {
+  max-width: 200px !important;
+}
+
+#formField-details-password .Form-input {
+  margin-bottom: 2em;
 }

--- a/frontend/src/metabase/css/components/form.css
+++ b/frontend/src/metabase/css/components/form.css
@@ -35,7 +35,6 @@
   color: var(--color-text-dark);
   background-color: var(--color-bg-white);
   padding: 0.75em;
-  line-height: 1;
 }
 
 .Form-input,

--- a/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/add.cy.spec.js
@@ -34,7 +34,7 @@ describe("scenarios > admin > databases > add", () => {
 
     typeField("Name", "Test db name");
     typeField("Database name", "test_postgres_db");
-    typeField("Database username", "uberadmin");
+    typeField("Username", "uberadmin");
 
     cy.findByText("Save")
       .should("not.be.disabled")
@@ -50,7 +50,7 @@ describe("scenarios > admin > databases > add", () => {
 
     typeField("Name", "Test db name");
     typeField("Database name", "test_postgres_db");
-    typeField("Database username", "uberadmin");
+    typeField("Username", "uberadmin");
 
     cy.findByText("Save").should("not.be.disabled");
 
@@ -73,7 +73,7 @@ describe("scenarios > admin > databases > add", () => {
 
     typeField("Name", "Test db name");
     typeField("Database name", "test_postgres_db");
-    typeField("Database username", "uberadmin");
+    typeField("Username", "uberadmin");
 
     cy.findByText("Save").should("not.be.disabled");
 
@@ -111,7 +111,7 @@ describe("scenarios > admin > databases > add", () => {
 
     typeField("Name", "Test db name");
     typeField("Database name", "test_postgres_db");
-    typeField("Database username", "uberadmin");
+    typeField("Username", "uberadmin");
 
     cy.findByText("Save").click();
 

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -74,16 +74,16 @@
 (def default-user-details
   "Map of the db user details field, useful for `connection-properties` implementations"
   {:name         "user"
-   :display-name (deferred-tru "Database username")
+   :display-name (deferred-tru "Username")
    :placeholder  (deferred-tru "What username do you use to login to the database?")
    :required     true})
 
 (def default-password-details
   "Map of the db password details field, useful for `connection-properties` implementations"
   {:name         "password"
-   :display-name (deferred-tru "Database password")
+   :display-name (deferred-tru "Password")
    :type         :password
-   :placeholder  "*******"})
+   :placeholder  "••••••••"})
 
 (def default-dbname-details
   "Map of the db name details field, useful for `connection-properties` implementations"


### PR DESCRIPTION
Some small tweaks to help with legibility and make the database add / edit forms in admin land a (slightly) nicer place to be.

<img width="1792" alt="Screen Shot 2020-06-15 at 5 29 45 PM" src="https://user-images.githubusercontent.com/5248953/84708118-e5157800-af2d-11ea-9261-9f1a7d4964a5.png">

- Pad things out to better match different breakpoints
- Reduce the width of port inputs to make the forms a little easier to scan.
- Remove redundant "Enabled/Disabled" text on toggles and move them to the right so we have a nice even left edge.