### PR TITLE
[wip] Add admin checklist item about migrating off of H2

### DIFF
--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -183,7 +183,7 @@
   [_]
   {:title       (tru "Switch to a production-ready app database")
    :group       (tru "Get connected")
-   :description (tru "Migrate off of the default H2 application database to something like PostgreSQL or MySQL.")
+   :description (tru "Migrate off of the default H2 application database to PostgreSQL or MySQL.")
    :link        "https://www.metabase.com/docs/latest/operations-guide/migrating-from-h2.html"
    :completed   (> (db/count User) 1)
    :triggered   (or (db/exists? Dashboard)

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -179,6 +179,17 @@
                     (db/exists? Pulse)
                     (>= (db/count Card) 5))})
 
+(defmethod admin-checklist-entry :migrate-app-db
+  [_]
+  {:title       (tru "Switch to a production-ready app database")
+   :group       (tru "Get connected")
+   :description (tru "Migrate off of the default H2 application database to something like PostgreSQL or MySQL.")
+   :link        "https://www.metabase.com/docs/latest/operations-guide/migrating-from-h2.html"
+   :completed   (> (db/count User) 1)
+   :triggered   (or (db/exists? Dashboard)
+                    (db/exists? Pulse)
+                    (>= (db/count Card) 5))})
+
 (defmethod admin-checklist-entry :hide-irrelevant-tables
   [_]
   {:title       (tru "Hide irrelevant tables")
@@ -219,8 +230,8 @@
 (defn- admin-checklist-values []
   (map
    admin-checklist-entry
-   [:add-a-database :set-up-email :set-slack-credentials :invite-team-members :hide-irrelevant-tables
-    :organize-questions :create-metrics :create-segments]))
+   [:add-a-database :set-up-email :set-slack-credentials :invite-team-members :migrate-app-db
+    :hide-irrelevant-tables :organize-questions :create-metrics :create-segments]))
 
 (defn- add-next-step-info
   "Add `is_next_step` key to all the `steps` from `admin-checklist`.


### PR DESCRIPTION
Implements https://github.com/metabase/metabase/issues/12695

Need help with these items:
- [ ] No idea how to add detection to see if the app DB is currently H2 or not
- [ ] The link to the docs works when you command/ctrl-click this new item, but if you regular-click it, it tries to send you to the docs within the app directory. Not sure how to override that behavior.
- [ ] I presume we'd need to hide this on Cloud instances (because they don't run H2, right?)

## Here's how it looks:

![image](https://user-images.githubusercontent.com/2223916/84554515-0af01200-accd-11ea-96af-a447fcfa3804.png)
