### PR TITLE
fix test flake by setting up question with API rather than UI

### DIFF
--- a/frontend/test/metabase/scenarios/public/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/public/public.cy.spec.js
@@ -127,7 +127,7 @@ describe("scenarios > public", () => {
       cy.contains("Public link")
         .parent()
         .find("input")
-        .then($input => {
+        .should($input => {
           expect($input[0].value).to.match(PUBLIC_URL_REGEX);
           questionPublicLink = $input[0].value.match(PUBLIC_URL_REGEX)[0];
         });
@@ -171,7 +171,7 @@ describe("scenarios > public", () => {
       cy.contains("Public link")
         .parent()
         .find("input")
-        .then($input => {
+        .should($input => {
           expect($input[0].value).to.match(PUBLIC_URL_REGEX);
           dashboardPublicLink = $input[0].value.match(PUBLIC_URL_REGEX)[0];
         });


### PR DESCRIPTION
This PR attempts to fix the flake in `public.cy.spec.js`. The initial setup was done in the UI but wasn't really important to the test. I deleted that and use the API instead, which should avoid the typing issues that were causing the failures.