### PR TITLE
Fix field values drop-down for fields added via joined tables

### DIFF
--- a/frontend/src/metabase/lib/query/field_ref.js
+++ b/frontend/src/metabase/lib/query/field_ref.js
@@ -94,6 +94,9 @@ export function getFieldTargetId(field: FieldReference): ?FieldId {
     return getFieldTargetId(field[1]);
   } else if (isFieldLiteral(field)) {
     return field;
+  } else if (isJoinedField(field)) {
+    // $FlowFixMe
+    return getFieldTargetId(field[2]);
   }
   console.warn("Unknown field type: ", field);
 }

--- a/frontend/test/metabase/scenarios/question/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/native.cy.spec.js
@@ -178,13 +178,8 @@ describe("scenarios > question > native", () => {
       .contains("Save")
       .click();
 
-    // update the query to use that snippet
-    cy.get("@ace")
-      // delete existing selection before selecting all
-      .type("{backspace}{selectAll}{backspace}")
-      .type("select {{snippet: stuff-snippet}}", {
-        parseSpecialCharSequences: false,
-      });
+    // SQL editor should get updated automatically
+    cy.get("@ace").contains("select {{snippet: stuff-snippet}}");
 
     // run the query and check the displayed scalar
     cy.get(".NativeQueryEditor .Icon-play").click();


### PR DESCRIPTION
This was a simple FE bug where there was code to handle `joined-field` Fields but it wasn't being used in the `getFieldTargetId` function (was being used elsewhere). Fixes #12250.