### PR TITLE
Reduce min-width of selects

### DIFF
--- a/frontend/src/metabase/css/admin.css
+++ b/frontend/src/metabase/css/admin.css
@@ -194,7 +194,7 @@
   background-color: var(--color-bg-white);
   border-radius: var(--default-border-radius);
   font-weight: 700;
-  min-width: 200px;
+  min-width: 104px;
 }
 
 .AdminSelect:hover {


### PR DESCRIPTION
Fixes #12750.

I tried to see if there was a quick fix to preserve what @kdoh was trying to do in the DB forms to make the selects the same width as the smallest input box. I think that'd require a bit more of a refactor, and I just want to make sure we have a fix for #12750 first.

Maybe @paulrosenzweig could let me know if there's a way to pass down the `min-width: 200px` down to `SelectButton` just in `FormSelectWidget`?

## Before: simple mode sidebar

![image](https://user-images.githubusercontent.com/2223916/85181092-f2867700-b239-11ea-8bbe-cb466e8bddf5.png)

## After: simple mode sidebar

<img width="350" alt="Screen Shot 2020-06-19 at 2 26 13 PM" src="https://user-images.githubusercontent.com/2223916/85180953-96bbee00-b239-11ea-9e46-5b5253d8124d.png">

## Before: notebook

![image](https://user-images.githubusercontent.com/2223916/85181066-e5698800-b239-11ea-86fe-fc76ffb0b646.png)


## After: notebook

![image](https://user-images.githubusercontent.com/2223916/85180972-aaffeb00-b239-11ea-89f3-3e243316c1d2.png)

## Before: add DB form

![image](https://user-images.githubusercontent.com/2223916/85181034-d4b91200-b239-11ea-92b4-ab804e75ea20.png)

## After: add DB form

![image](https://user-images.githubusercontent.com/2223916/85181010-c539c900-b239-11ea-8110-3508a31ebf2d.png)
