### PR TITLE
Add scroll to Notebook column popover

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FieldsPicker.jsx
@@ -19,7 +19,11 @@ export default function FieldsPicker({
 }) {
   const selected = new Set(selectedDimensions.map(d => d.key()));
   return (
-    <PopoverWithTrigger triggerElement={t`Columns`} triggerClasses={className}>
+    <PopoverWithTrigger
+      triggerElement={t`Columns`}
+      triggerClasses={className}
+      sizeToFit
+    >
       <ul className="pt1">
         {(onSelectAll || onSelectNone) && (
           <li


### PR DESCRIPTION
This adds scroll to the Notebook column popover selector.
Fixes #11202. It will probably also help a lot of the people who upvoted #10460.

**Before:**
![image](https://user-images.githubusercontent.com/1447303/85294341-cae41880-b49e-11ea-95dc-755fe448eaa3.png)

![image](https://user-images.githubusercontent.com/1447303/85294367-d20b2680-b49e-11ea-9b9c-3ab32bac14b0.png)

**After:**
![image](https://user-images.githubusercontent.com/1447303/85294165-9a9c7a00-b49e-11ea-8bb6-85f19593377d.png)

![image](https://user-images.githubusercontent.com/1447303/85294200-a4be7880-b49e-11ea-8452-8df62c89a5f7.png)

I'm not sure if changing `sizeToFit`'s default to `true` would be better - Popover is used so many places that I decided against it, since it would be a big task to check consequences from that.
https://github.com/metabase/metabase/blob/3687548211c22b4107397e0d036cd5925f4825d9/frontend/src/metabase/components/Popover.jsx#L70