### PR TITLE
Fix selector scroll jankyness

### DIFF
--- a/frontend/src/metabase/components/AccordionList.jsx
+++ b/frontend/src/metabase/components/AccordionList.jsx
@@ -382,7 +382,7 @@ export default class AccordionList extends Component {
     const defaultListStyle = {
       // HACK - Ensure the component can scroll
       // This is a temporary fix to handle cases where the parent component doesn’t pass in the correct `maxHeight`
-      overflowY: "scroll",
+      overflowY: "auto",
     };
 
     return (

--- a/frontend/src/metabase/query_builder/components/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector.jsx
@@ -859,12 +859,14 @@ const TablePicker = ({
       },
     ];
     return (
-      <div>
+      <div style={{ width: 300, overflowY: "auto" }}>
         <AccordionList
           id="TablePicker"
           key="tablePicker"
           className="text-brand"
           sections={sections}
+          maxHeight={Infinity}
+          width={"100%"}
           searchable
           onChange={item => onChangeTable(item.table)}
           itemIsSelected={item =>
@@ -951,12 +953,14 @@ class FieldPicker extends Component {
     ];
 
     return (
-      <div style={{ width: 300 }}>
+      <div style={{ width: 300, overflowY: "auto" }}>
         <AccordionList
           id="FieldPicker"
           key="fieldPicker"
           className="text-brand"
           sections={sections}
+          maxHeight={Infinity}
+          width={"100%"}
           searchable
           onChange={item => onChangeField(item.field)}
           itemIsSelected={item =>

--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -22,7 +22,7 @@ export type AccordionListSection = {
 type Props = {
   className?: string,
   maxHeight?: number,
-  width?: ?number,
+  width?: ?number | ?string,
 
   dimension?: ?Dimension,
   dimensions?: Dimension[],

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover.jsx
@@ -154,7 +154,10 @@ export default class ViewFilterPopover extends Component {
     const dimension = filter && filter.dimension();
     if (choosingField || !dimension) {
       return (
-        <div className={className} style={{ minWidth: MIN_WIDTH, ...style }}>
+        <div
+          className={className}
+          style={{ minWidth: MIN_WIDTH, overflowY: "auto", ...style }}
+        >
           {fieldPickerTitle && (
             <SidebarHeader className="mx1 my2" title={fieldPickerTitle} />
           )}
@@ -177,7 +180,7 @@ export default class ViewFilterPopover extends Component {
               // special case for segments
               this.handleCommitFilter(item.filter, item.query);
             }}
-            width={isSidebar ? null : MIN_WIDTH}
+            width={isSidebar ? null : "100%"}
             alwaysExpanded={isTopLevel || isSidebar}
           />
           {showCustom && (


### PR DESCRIPTION
This feels a little hacky, but it is way less ugly than before and behaves more sane.
I could use an adult (Paul? :wink:) to validate that it's not causing some unforeseen problem.

And yes, Firefox also added a x-scroll, which made one of the y-scrollbars even more difficult to use.
I have manually scrolled to the right, so it shows both y-scrollbars.
**Before:**
![image](https://user-images.githubusercontent.com/1447303/85343632-a2373f80-b4ed-11ea-8293-d3ce91115aac.png)
![image](https://user-images.githubusercontent.com/1447303/85343609-90ee3300-b4ed-11ea-9b64-c6e9c95ae64b.png)

**After:**
![image](https://user-images.githubusercontent.com/1447303/85343285-bf1f4300-b4ec-11ea-8e0d-1a91b885fe29.png)
![image](https://user-images.githubusercontent.com/1447303/85343444-29d07e80-b4ed-11ea-878c-b7a705bad686.png)

Fixes #5829 - double-scrollbars
Fixes #6969 - weird scroll-to-top on scroll-up on table/field
And probably also fixes #8656, but I don't have Safari, so I could use a hand testing