### PR TITLE
Set SelectButton min-width to 200 in FormSelectWidget

### DIFF
--- a/frontend/src/metabase/components/form/widgets/FormSelectWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormSelectWidget.jsx
@@ -8,6 +8,7 @@ const FormSelectWidget = ({ placeholder, options = [], field }) => (
     {...field}
     // react-redux expects to be raw value
     onChange={e => field.onChange(e.target.value)}
+    buttonProps={{ style: { minWidth: 200 } }}
   >
     {options.map(({ name, value }) => (
       <Option key={value} value={value}>


### PR DESCRIPTION
This PR adds the tweak that @mazameli called out in #12751.

Before

<img width="700" src="https://user-images.githubusercontent.com/691495/85415321-311e7900-b53b-11ea-9997-12646fe62cd3.png">

After

<img width="700" src="https://user-images.githubusercontent.com/691495/85415336-37acf080-b53b-11ea-8fc0-4a1effa956bd.png">

