### PR TITLE
Add timeouts for both configurations

### DIFF
--- a/bin/aws-eb-docker/.ebextensions/metabase_config/metabase-setup.sh
+++ b/bin/aws-eb-docker/.ebextensions/metabase_config/metabase-setup.sh
@@ -127,6 +127,10 @@ server {
         proxy_set_header    Host                $host;
         proxy_set_header    X-Real-IP            $remote_addr;
         proxy_set_header    X-Forwarded-For        $proxy_add_x_forwarded_for;
+        proxy_connect_timeout 600;
+        proxy_send_timeout 600;
+        proxy_read_timeout 600;
+        send_timeout 600;
     }
 }
 EOF


### PR DESCRIPTION
We don't use `NGINX_FORCE_SSL` as we're in a VPC.
