### PR TITLE
Add description to SQL Server database port

### DIFF
--- a/frontend/src/metabase/entities/databases/forms.js
+++ b/frontend/src/metabase/entities/databases/forms.js
@@ -221,6 +221,7 @@ function getFieldsForEngine(engine, details, id) {
         name: `details.${field.name}`,
         title: field["display-name"],
         type: field.type,
+        description: field.description,
         placeholder: field.placeholder || field.default,
         options: field.options,
         validate: value => (field.required && !value ? t`required` : null),

--- a/modules/drivers/sqlserver/resources/metabase-plugin.yaml
+++ b/modules/drivers/sqlserver/resources/metabase-plugin.yaml
@@ -11,7 +11,7 @@ driver:
     - host
     - merge:
         - port
-        - placeholder: 1433
+        - description: Leave empty to use Dynamic Ports, or input specific port. Standard port is 1433.
     - merge:
         - dbname
         - name: db


### PR DESCRIPTION
This might be a little different, but since the port input size is now smaller, then I don't see how to place a longer string like needed.
Fixes #9226
![Screenshot_2020-06-25 Databases · Admin · Metabase](https://user-images.githubusercontent.com/1447303/85856486-61268000-b7b8-11ea-9ae3-82d5c0e08cfa.png)