### PR TITLE
Fixes night mode filters and a couple of other minor things

### DIFF
--- a/frontend/src/metabase/css/dashboard.css
+++ b/frontend/src/metabase/css/dashboard.css
@@ -55,9 +55,8 @@
   color: var(--color-text-white);
 }
 
-.Dashboard.Dashboard--night .Header-button,
-.Dashboard.Dashboard--night .Header-button svg {
-  color: color(var(--color-text-medium) alpha(-70%));
+.Dashboard.Dashboard--night .Header-button {
+  color: var(--color-text-medium);
 }
 
 .Dashboard.Dashboard--fullscreen .fullscreen-normal-text {

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.jsx
@@ -218,10 +218,7 @@ export default class DashboardHeader extends Component {
           ref="addQuestionModal"
           triggerElement={
             <Tooltip tooltip={t`Add a question`}>
-              <span
-                data-metabase-event="Dashboard;Add Card Modal"
-                title={t`Add a question to this dashboard`}
-              >
+              <span data-metabase-event="Dashboard;Add Card Modal">
                 <Icon
                   className={cx("text-brand-hover cursor-pointer", {
                     "Icon--pulse": isEmpty,
@@ -253,7 +250,6 @@ export default class DashboardHeader extends Component {
               className={cx("text-brand-hover", {
                 "text-brand": this.state.modal === "parameters",
               })}
-              title={t`Parameters`}
               onClick={() => this.setState({ modal: "parameters" })}
             >
               <Icon name="funnel_add" size={16} />
@@ -277,7 +273,6 @@ export default class DashboardHeader extends Component {
           <a
             data-metabase-event="Dashboard;Add Text Box"
             key="add-text"
-            title={t`Add a text box`}
             className="text-brand-hover cursor-pointer"
             onClick={() => this.onAddTextBox()}
           >
@@ -304,7 +299,6 @@ export default class DashboardHeader extends Component {
           <a
             data-metabase-event="Dashboard;Edit"
             key="edit"
-            title={t`Edit Dashboard Layout`}
             className="text-brand-hover cursor-pointer"
             onClick={() => this.handleEdit(dashboard)}
           >

--- a/frontend/src/metabase/parameters/components/ParameterWidget.css
+++ b/frontend/src/metabase/parameters/components/ParameterWidget.css
@@ -99,6 +99,11 @@
   color: var(--color-text-medium);
 }
 
+.Dashboard--night :local(.parameter.noPopover) input:focus,
+.Theme--night :local(.parameter.noPopover) input:focus {
+  color: var(--color-text-white);
+}
+
 :local(.input) {
 }
 

--- a/frontend/src/metabase/public/components/widgets/EmbedSelect.jsx
+++ b/frontend/src/metabase/public/components/widgets/EmbedSelect.jsx
@@ -18,10 +18,10 @@ const EmbedSelect = ({ className, value, onChange, options }: Props) => (
     {options.map(option => (
       <div
         className={cx(
-          "flex-full flex layout-centered mx1 p1 border-bottom border-medium border-dark-hover",
+          "flex-full flex layout-centered mx1 p1 border-bottom border-medium",
           {
-            "border-dark": value === option.value,
-            "cursor-pointer": value !== option.value,
+            "border-brand cursor-default": value === option.value,
+            "border-dark-hover cursor-pointer": value !== option.value,
           },
         )}
         onClick={() => onChange(option.value)}

--- a/frontend/src/metabase/setup/components/LanguageStep.jsx
+++ b/frontend/src/metabase/setup/components/LanguageStep.jsx
@@ -55,8 +55,8 @@ export default class LanguageStep extends React.Component {
           </p>
           <div className="overflow-hidden mb4">
             <ol
-              className="overflow-scroll text-dark text-bold bordered rounded px2 py1"
-              style={{ height: 280 }}
+              className="scroll-y text-dark text-bold bordered rounded px2 py1"
+              style={{ maxHeight: 280 }}
             >
               {_.sortBy(
                 MetabaseSettings.get("available-locales") || [


### PR DESCRIPTION
1. Fixes #9551 and adds `brand` color for the bottom border theme selector buttons
![Screenshot-20200627182242-702x401](https://user-images.githubusercontent.com/1447303/85927404-1aaf4f00-b8a6-11ea-8761-fd26fdc97e13.png)

2. Removes browser-style tooltips from dashboard action buttons
![Screenshot-20200627183613-442x278](https://user-images.githubusercontent.com/1447303/85927407-200c9980-b8a6-11ea-8fcd-1c807bf5178a.png)

3. Fixes dashboard nighttime fullscreen action buttons to have color, hover and timer present similar to public dashboard
![Screenshot-20200627183737-295x94](https://user-images.githubusercontent.com/1447303/85927453-7083f700-b8a6-11ea-8fad-ad14c75d48c1.png)

4. Removes x-scroll from setup language list
![Screenshot_2020-06-27 Metabase](https://user-images.githubusercontent.com/1447303/85927488-acb75780-b8a6-11ea-80c2-cc8b50f85e25.png)