### PR TITLE
Add description icon to public/embed question/dashboard

### DIFF
--- a/frontend/src/metabase/components/TitleAndDescription.jsx
+++ b/frontend/src/metabase/components/TitleAndDescription.jsx
@@ -16,7 +16,7 @@ const TitleAndDescription = ({ title, description, className }: Attributes) => (
     <h2 className="h2 mr1 text-wrap">{title}</h2>
     {description && (
       <Tooltip tooltip={description} maxWidth={"22em"}>
-        <Icon name="info" style={{ marginTop: 3 }} />
+        <Icon name="info" className="mx1" />
       </Tooltip>
     )}
   </div>

--- a/frontend/src/metabase/public/components/EmbedFrame.jsx
+++ b/frontend/src/metabase/public/components/EmbedFrame.jsx
@@ -8,6 +8,7 @@ import { parseHashOptions } from "metabase/lib/browser";
 
 import MetabaseSettings from "metabase/lib/settings";
 
+import TitleAndDescription from "metabase/components/TitleAndDescription";
 import Parameters from "metabase/parameters/components/Parameters";
 import LogoBadge from "./LogoBadge";
 
@@ -53,6 +54,7 @@ export default class EmbedFrame extends Component {
     const {
       className,
       children,
+      description,
       actionButtons,
       location,
       parameters,
@@ -87,7 +89,9 @@ export default class EmbedFrame extends Component {
         >
           {name || (parameters && parameters.length > 0) ? (
             <div className="EmbedFrame-header flex align-center p1 sm-p2 lg-p3">
-              {name && <div className="h4 text-bold sm-h3 md-h2">{name}</div>}
+              {name && (
+                <TitleAndDescription title={name} description={description} />
+              )}
               {parameters && parameters.length > 0 ? (
                 <div className="flex ml-auto">
                   <Parameters


### PR DESCRIPTION
This re-uses the same component as used on regular dashboards, which is almost identical to how it looked on public/embed.
Fixes #8117
Fixes #12015