### PR TITLE
Include dashboard name in browser title on public links

### DIFF
--- a/frontend/src/metabase/public/containers/PublicDashboard.jsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard.jsx
@@ -12,6 +12,7 @@ import DashboardGrid from "metabase/dashboard/components/DashboardGrid";
 import DashboardControls from "metabase/dashboard/hoc/DashboardControls";
 import { getDashboardActions } from "metabase/dashboard/components/DashboardActions";
 import EmbedFrame from "../components/EmbedFrame";
+import title from "metabase/hoc/Title";
 
 import { fetchDatabaseMetadata } from "metabase/redux/metadata";
 import { setErrorPage } from "metabase/redux/app";
@@ -88,6 +89,7 @@ type Props = {
   mapStateToProps,
   mapDispatchToProps,
 )
+@title(({ dashboard }) => dashboard && dashboard.name)
 @DashboardControls
 // NOTE: this should use DashboardData HoC
 export default class PublicDashboard extends Component {

--- a/frontend/src/metabase/public/containers/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion.jsx
@@ -8,6 +8,7 @@ import QueryDownloadWidget from "metabase/query_builder/components/QueryDownload
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import EmbedFrame from "../components/EmbedFrame";
+import title from "metabase/hoc/Title";
 
 import type { Card } from "metabase/meta/types/Card";
 import type { Dataset } from "metabase/meta/types/Dataset";
@@ -65,6 +66,7 @@ const mapDispatchToProps = {
   mapStateToProps,
   mapDispatchToProps,
 )
+@title(({ card }) => card && card.name)
 @ExplicitSize()
 export default class PublicQuestion extends Component {
   props: Props;

--- a/frontend/src/metabase/routes-public.jsx
+++ b/frontend/src/metabase/routes-public.jsx
@@ -2,7 +2,8 @@
 
 import React from "react";
 
-import { Route } from "react-router";
+import { Route } from "metabase/hoc/Title";
+import { t } from "ttag";
 
 import PublicNotFound from "metabase/public/components/PublicNotFound";
 
@@ -11,7 +12,7 @@ import PublicQuestion from "metabase/public/containers/PublicQuestion";
 import PublicDashboard from "metabase/public/containers/PublicDashboard";
 
 export const getRoutes = store => (
-  <Route>
+  <Route title={t`Metabase`}>
     <Route path="public" component={PublicApp}>
       <Route path="question/:uuid" component={PublicQuestion} />
       <Route path="dashboard/:uuid" component={PublicDashboard} />


### PR DESCRIPTION
Fixes #12227, but only for dashboards, which was also the original request.
For question, the code looks very different from dashboard - several tries, but couldn't make it work.
If someone has a quick hint, then I'll try to make it work, otherwise I'll edit the issue to only include dashboard and open another issue specific for public question browser title.