### PR TITLE
xrays: don't barf on names with % in them

### DIFF
--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -996,15 +996,15 @@
                                            ;; (no chunking).
                                            first))]
     (let [show (or show max-cards)]
-      (log/infof (trs "Applying heuristic {0} to {1}." (:rule rule) full-name))
-      (log/infof (trs "Dimensions bindings:\n{0}"
+      (log/info (trs "Applying heuristic {0} to {1}." (:rule rule) full-name))
+      (log/info (trs "Dimensions bindings:\n{0}"
                       (->> context
                            :dimensions
                            (m/map-vals #(update % :matches (partial map :name)))
                            u/pprint-to-str)))
-      (log/infof (trs "Using definitions:\nMetrics:\n{0}\nFilters:\n{1}"
-                      (->> context :metrics (m/map-vals :metric) u/pprint-to-str)
-                      (-> context :filters u/pprint-to-str)))
+      (log/info (trs "Using definitions:\nMetrics:\n{0}\nFilters:\n{1}"
+                     (->> context :metrics (m/map-vals :metric) u/pprint-to-str)
+                     (-> context :filters u/pprint-to-str)))
       (-> dashboard
           (populate/create-dashboard show)
           (assoc :related           (related context rule)

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -90,6 +90,13 @@
            count
            (= 1)))))
 
+(deftest wierd-characters-in-names-test
+  (mt/with-test-user :rasta
+    (with-dashboard-cleanup
+      (-> (Table (mt/id :venues))
+          (assoc :display_name "%Venues")
+          test-automagic-analysis))))
+
 (expect
   (mt/with-test-user :rasta
     (with-dashboard-cleanup

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -91,11 +91,12 @@
            (= 1)))))
 
 (deftest wierd-characters-in-names-test
-  (mt/with-test-user :rasta
-    (with-dashboard-cleanup
-      (-> (Table (mt/id :venues))
-          (assoc :display_name "%Venues")
-          test-automagic-analysis))))
+  (mt/with-log-level :info
+    (mt/with-test-user :rasta
+      (with-dashboard-cleanup
+        (-> (Table (mt/id :venues))
+            (assoc :display_name "%Venues")
+            test-automagic-analysis)))))
 
 (expect
   (mt/with-test-user :rasta


### PR DESCRIPTION
For no reason we were using `infof` for some of the logging in xrays which broke if names had % in them. I also grepe through the rest of the codebase if the pattern is used somewhere else, but it isn't.  

Fixes #12592