### PR TITLE
EE Native Query Snippet Permissions Preliminary Work [WIP]

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -6392,3 +6392,45 @@ databaseChangeLog:
         - dropColumn:
             tableName: metabase_table
             columnName: rows
+
+# In EE, NativeQuerySnippets have a permissions system based on "snippet
+# folders" which are just implemented as collections under the hood.
+
+  - changeSet:
+      id: 170
+      author: camsaul
+      comment: Added 1.36.0
+      changes:
+        - addColumn:
+            tableName: native_query_snippet
+            columns:
+              - column:
+                  name: collection_id
+                  type: int
+                  remarks: 'ID of the Snippet Folder (Collection) this Snippet is in, if any'
+                  constraints:
+                    nullable: true
+                    references: collection(id)
+                    foreignKeyName: fk_snippet_collection_id
+                    deleteCascade: true
+        - createIndex:
+            tableName: native_query_snippet
+            indexName: idx_snippet_collection_id
+            columns:
+              - column:
+                  name: collection_id
+
+  - changeSet:
+      id: 171
+      author: camsaul
+      comment: Added 1.36.0
+      changes:
+        - addColumn:
+            tableName: collection
+            columns:
+              - column:
+                  name: type
+                  type: varchar(254)
+                  remarks: 'Type of this collection if not a normal collection, e.g. "snippet" for snippet "folders"'
+                  constraints:
+                    nullable: true

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -6380,9 +6380,8 @@ databaseChangeLog:
             columnName: started_at
             newDataType: ${timestamp_type}
 
-# Remove `Table.rows`, which hasn't been used for years now. Older versions of
-# Metabase used to store the row count in this column but we disabled it a long
-# time ago for performance reasons. Now it's time to remove it entirely.
+# Remove `Table.rows`, which hasn't been used for years now. Older versions of Metabase used to store the row count in
+# this column but we disabled it a long time ago for performance reasons. Now it's time to remove it entirely.
 
   - changeSet:
       id: 169
@@ -6393,8 +6392,8 @@ databaseChangeLog:
             tableName: metabase_table
             columnName: rows
 
-# In EE, NativeQuerySnippets have a permissions system based on "snippet
-# folders" which are just implemented as collections under the hood.
+# In EE, NativeQuerySnippets have a permissions system based on "snippet folders" which are Collections under the
+# hood. However, these Collections live in a separate "namespace" -- a completely separate hierarchy of Collections.
 
   - changeSet:
       id: 171
@@ -6429,8 +6428,8 @@ databaseChangeLog:
             tableName: collection
             columns:
               - column:
-                  name: type
+                  name: namespace
                   type: varchar(254)
-                  remarks: 'Type of this collection if not a normal collection, e.g. "snippet" for snippet "folders"'
+                  remarks: 'The namespace (hierachy) this Collection belongs to. NULL means the Collection is in the default namespace.'
                   constraints:
                     nullable: true

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -6397,7 +6397,7 @@ databaseChangeLog:
 # folders" which are just implemented as collections under the hood.
 
   - changeSet:
-      id: 170
+      id: 171
       author: camsaul
       comment: Added 1.36.0
       changes:
@@ -6421,7 +6421,7 @@ databaseChangeLog:
                   name: collection_id
 
   - changeSet:
-      id: 171
+      id: 172
       author: camsaul
       comment: Added 1.36.0
       changes:

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -286,9 +286,10 @@
 
 (api/defendpoint GET "/graph"
   "Fetch a graph of all Collection Permissions."
-  []
+  [namespace]
+  {namespace (s/maybe su/NonBlankString)}
   (api/check-superuser)
-  (collection.graph/graph))
+  (collection.graph/graph namespace))
 
 (defn- ->int [id] (Integer/parseInt (name id)))
 
@@ -311,11 +312,12 @@
 
 (api/defendpoint PUT "/graph"
   "Do a batch update of Collections Permissions by passing in a modified graph."
-  [:as {body :body}]
-  {body su/Map}
+  [namespace :as {body :body}]
+  {body      su/Map
+   namespace (s/maybe su/NonBlankString)}
   (api/check-superuser)
-  (collection.graph/update-graph! (dejsonify-graph body))
-  (collection.graph/graph))
+  (collection.graph/update-graph! namespace (dejsonify-graph body))
+  (collection.graph/graph namespace))
 
 
 (api/define-routes)

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -16,6 +16,9 @@
              [interface :as mi]
              [permissions :as perms]
              [pulse :as pulse :refer [Pulse]]]
+            [metabase.models.collection
+             [graph :as collection.graph]
+             [root :as collection.root]]
             [metabase.util :as u]
             [metabase.util.schema :as su]
             [schema.core :as s]
@@ -45,9 +48,9 @@
         collections
         (cons (root-collection) collections))
       (hydrate collections :can_write)
-      ;; remove the :metabase.models.collection/is-root? tag since FE doesn't need it
+      ;; remove the :metabase.models.collection.root/is-root? tag since FE doesn't need it
       (for [collection collections]
-        (dissoc collection ::collection/is-root?)))))
+        (dissoc collection ::collection.root/is-root?)))))
 
 
 ;;; --------------------------------- Fetching a single Collection & its 'children' ----------------------------------
@@ -148,7 +151,7 @@
 (api/defendpoint GET "/root"
   "Return the 'Root' Collection object with standard details added"
   []
-  (dissoc (root-collection) ::collection/is-root?))
+  (dissoc (root-collection) ::collection.root/is-root?))
 
 (api/defendpoint GET "/root/items"
   "Fetch objects that the current user should see at their root level. As mentioned elsewhere, the 'Root' Collection
@@ -282,8 +285,7 @@
   "Fetch a graph of all Collection Permissions."
   []
   (api/check-superuser)
-  (collection/graph))
-
+  (collection.graph/graph))
 
 (defn- ->int [id] (Integer/parseInt (name id)))
 
@@ -309,8 +311,8 @@
   [:as {body :body}]
   {body su/Map}
   (api/check-superuser)
-  (collection/update-graph! (dejsonify-graph body))
-  (collection/graph))
+  (collection.graph/update-graph! (dejsonify-graph body))
+  (collection.graph/graph))
 
 
 (api/define-routes)

--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -28,7 +28,6 @@
   (api/check-superuser)
   (perms/graph))
 
-
 (api/defendpoint PUT "/graph"
   "Do a batch update of Permissions by passing in a modified graph. This should return the same graph, in the same
   format, that you got from `GET /api/permissions/graph`, with any changes made in the wherever necessary. This

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -260,7 +260,9 @@
         collection-filter-clause (coll/visible-collection-ids->honeysql-filter-clause
                                   collection-id-column
                                   visible-collections)
-        honeysql-query           (h/merge-where honeysql-query collection-filter-clause)]
+        honeysql-query           (-> honeysql-query
+                                     (h/merge-where collection-filter-clause)
+                                     (h/merge-where [:= :collection.namespace nil]))]
     ;; add a JOIN against Collection *unless* the source table is already Collection
     (cond-> honeysql-query
       (not= collection-id-column :collection.id)

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -119,7 +119,7 @@
                                 (:database query))))))
     ;; make sure this Card doesn't have circular source query references
     (check-for-circular-source-query-references card)
-    (collection/check-collection-type card)))
+    (collection/check-collection-namespace card)))
 
 (defn- post-insert [card]
   ;; if this Card has any native template tag parameters we need to update FieldValues for any Fields that are
@@ -154,7 +154,7 @@
     ;; make sure this Card doesn't have circular source query references if we're updating the query
     (when (:dataset_query card)
       (check-for-circular-source-query-references card))
-    (collection/check-collection-type card)))
+    (collection/check-collection-namespace card)))
 
 ;; Cards don't normally get deleted (they get archived instead) so this mostly affects tests
 (defn- pre-delete [{:keys [id]}]
@@ -163,7 +163,6 @@
   (db/delete! 'DashboardCardSeries :card_id id)
   (db/delete! 'DashboardCard :card_id id)
   (db/delete! 'CardFavorite :card_id id))
-
 
 (u/strict-extend (class Card)
   models/IModel

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -179,7 +179,6 @@
          :name (tru "Our analytics")
          :id   "root"))
 
-
 (def ^:private CollectionWithLocationOrRoot
   (s/cond-pre
    RootCollection
@@ -496,7 +495,6 @@
                ===>
     D                D > B > C
 
-
   To move or archive B, you would need write permissions for A, B, C, and D:
 
   *  A, because we're moving something out of it
@@ -626,8 +624,8 @@
 
 (defn- copy-parent-permissions!
   "When creating a new Collection, we shall copy the Permissions entries for its parent. That way, Groups who can see
-  its parent can see it; and Groups who can 'curate' its parent can 'curate' it, as a default state. (Of course,
-  admins can change these permissions after the fact.)
+  its parent can see it; and Groups who can 'curate' (write) its parent can 'curate' it, as a default state. (Of
+  course, admins can change these permissions after the fact.)
 
   This does *not* apply to Collections that are created inside a Personal Collection or one of its descendants.
   Descendants of Personal Collections, like Personal Collections themselves, cannot have permissions entries in the

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -956,7 +956,3 @@
   "What types of Collection this model can go in. "
   {:arglists '([model])}
   (comp class db/resolve-model))
-
-(defmethod valid-collection-types :default
-  [_]
-  nil)

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -628,7 +628,7 @@
 
 (defn- pre-insert [{collection-name :name, color :color, :as collection}]
   (assert-valid-location collection)
-  (assert-valid-type collection)
+  (assert-valid-type (merge {:type nil} collection))
   (assert-valid-hex-color color)
   (assoc collection :slug (slugify collection-name)))
 

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -95,7 +95,6 @@
   "Schema for a directory-style 'path' to the location of a Collection."
   (s/pred valid-location-path?))
 
-
 (s/defn location-path :- LocationPath
   "Build a 'location path' from a sequence of `collections-or-ids`.
 

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -544,7 +544,7 @@
       (db/update-where! Collection {:id       [:in affected-collection-ids]
                                     :archived false}
         :archived true)
-      (doseq [model '[Card Dashboard Pulse]]
+      (doseq [model '[Card Dashboard NativeQuerySnippet Pulse]]
         (db/update-where! model {:collection_id [:in affected-collection-ids]
                                  :archived      false}
           :archived true)))))
@@ -558,7 +558,7 @@
       (db/update-where! Collection {:id       [:in affected-collection-ids]
                                     :archived true}
         :archived false)
-      (doseq [model '[Card Dashboard Pulse]]
+      (doseq [model '[Card Dashboard NativeQuerySnippet Pulse]]
         (db/update-where! model {:collection_id [:in affected-collection-ids]
                                  :archived      true}
           :archived false)))))

--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -88,7 +88,7 @@
   ([]
    (graph nil))
 
-  ([collection-namespace]
+  ([collection-namespace :- (s/maybe su/KeywordOrString)]
    (let [group-id->perms (group-id->permissions-set)
          collection-ids  (non-personal-collection-ids collection-namespace)]
      {:revision (collection-revision/latest-id)
@@ -140,7 +140,7 @@
   ([new-graph]
    (update-graph! nil new-graph))
 
-  ([collection-namespace :- (s/maybe s/Keyword), new-graph :- PermissionsGraph]
+  ([collection-namespace :- (s/maybe su/KeywordOrString), new-graph :- PermissionsGraph]
    (let [old-graph          (graph collection-namespace)
          ;; fetch the *entire* graph before making any updates. We'll record this in the perms revision.
          entire-graph       (graph ::all)

--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -144,14 +144,14 @@
    (let [old-graph          (graph collection-namespace)
          ;; fetch the *entire* graph before making any updates. We'll record this in the perms revision.
          entire-graph       (graph ::all)
-         old                (:groups old-graph)
-         new                (:groups new-graph)
+         old-perms          (:groups old-graph)
+         new-perms          (:groups new-graph)
          ;; filter out any groups not in the old graph
-         new                (select-keys new (keys old))
+         new-perms          (select-keys new-perms (keys old-perms))
          ;; filter out any collections not in the old graph
-         new                (into {} (for [[group-id collection-id->perms] new]
-                                  [group-id (select-keys collection-id->perms (keys (get old group-id)))]))
-         [diff-old changes] (data/diff old new)]
+         new-perms          (into {} (for [[group-id collection-id->perms] new-perms]
+                                       [group-id (select-keys collection-id->perms (keys (get old-perms group-id)))]))
+         [diff-old changes] (data/diff old-perms new-perms)]
      (perms/log-permissions-changes diff-old changes)
      (perms/check-revision-numbers old-graph new-graph)
      (when (seq changes)

--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -1,0 +1,133 @@
+(ns metabase.models.collection.graph
+  (:require [clojure.data :as data]
+            [metabase.api.common :as api :refer [*current-user-id*]]
+            [metabase.models
+             [collection :as collection :refer [Collection]]
+             [collection-revision :as collection-revision :refer [CollectionRevision]]
+             [permissions :as perms :refer [Permissions]]]
+            [metabase.util.schema :as su]
+            [schema.core :as s]
+            [toucan.db :as db]))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                               PERMISSIONS GRAPH                                                |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+;;; ---------------------------------------------------- Schemas -----------------------------------------------------
+
+(def ^:private CollectionPermissions
+  (s/enum :write :read :none))
+
+(def ^:private GroupPermissionsGraph
+  "collection-id -> status"
+  {(s/optional-key :root) CollectionPermissions   ; when doing a delta between old graph and new graph root won't always
+   su/IntGreaterThanZero  CollectionPermissions}) ; be present, which is why it's *optional*
+
+(def ^:private PermissionsGraph
+  {:revision s/Int
+   :groups   {su/IntGreaterThanZero GroupPermissionsGraph}})
+
+
+;;; -------------------------------------------------- Fetch Graph ---------------------------------------------------
+
+(defn- group-id->permissions-set []
+  (into {} (for [[group-id perms] (group-by :group_id (db/select 'Permissions))]
+             {group-id (set (map :object perms))})))
+
+(s/defn ^:private perms-type-for-collection :- CollectionPermissions
+  [permissions-set collection-or-id]
+  (cond
+    (perms/set-has-full-permissions? permissions-set (perms/collection-readwrite-path collection-or-id)) :write
+    (perms/set-has-full-permissions? permissions-set (perms/collection-read-path collection-or-id))      :read
+    :else                                                                                                :none))
+
+(s/defn ^:private group-permissions-graph :- GroupPermissionsGraph
+  "Return the permissions graph for a single group having `permissions-set`."
+  [permissions-set collection-ids]
+  (into
+   {:root (perms-type-for-collection permissions-set collection/root-collection)}
+   (for [collection-id collection-ids]
+     {collection-id (perms-type-for-collection permissions-set collection-id)})))
+
+(s/defn ^:private non-personal-collection-ids :- #{su/IntGreaterThanZero}
+  "Return a set of IDs of all Collections that are neither Personal Collections nor descendants of Personal
+  Collections (i.e., things that you can set Permissions for, and that should go in the graph.)"
+  []
+  (->> (db/query
+        (merge
+         {:select [[:id :id]]
+          :from   [Collection]}
+         (when-let [personal-collection-ids (seq (db/select-ids Collection :personal_owner_id [:not= nil]))]
+           {:where (apply
+                    vector
+                    :and
+                    [:not-in :id personal-collection-ids]
+                    (for [id personal-collection-ids]
+                      [:not [:like :location (format "/%d/%%" id)]]))})))
+       (map :id)
+       set))
+
+(s/defn graph :- PermissionsGraph
+  "Fetch a graph representing the current permissions status for every group and all permissioned collections. This
+  works just like the function of the same name in `metabase.models.permissions`; see also the documentation for that
+  function."
+  []
+  (let [group-id->perms (group-id->permissions-set)
+        collection-ids  (non-personal-collection-ids)]
+    {:revision (collection-revision/latest-id)
+     :groups   (into {} (for [group-id (db/select-ids 'PermissionsGroup)]
+                          {group-id (group-permissions-graph (group-id->perms group-id) collection-ids)}))}))
+
+
+;;; -------------------------------------------------- Update Graph --------------------------------------------------
+
+(s/defn ^:private update-collection-permissions!
+  [group-id             :- su/IntGreaterThanZero
+   collection-id        :- (s/cond-pre (s/eq :root) su/IntGreaterThanZero)
+   new-collection-perms :- CollectionPermissions]
+  (let [collection-id (if (= collection-id :root)
+                        collection/root-collection
+                        collection-id)]
+    ;; remove whatever entry is already there (if any) and add a new entry if applicable
+    (perms/revoke-collection-permissions! group-id collection-id)
+    (case new-collection-perms
+      :write (perms/grant-collection-readwrite-permissions! group-id collection-id)
+      :read  (perms/grant-collection-read-permissions! group-id collection-id)
+      :none  nil)))
+
+(s/defn ^:private update-group-permissions!
+  [group-id :- su/IntGreaterThanZero, new-group-perms :- GroupPermissionsGraph]
+  (doseq [[collection-id new-perms] new-group-perms]
+    (update-collection-permissions! group-id collection-id new-perms)))
+
+(defn- save-perms-revision!
+  "Save changes made to the collection permissions graph for logging/auditing purposes.
+   This doesn't do anything if `*current-user-id*` is unset (e.g. for testing or REPL usage)."
+  [current-revision old new]
+  (when *current-user-id*
+    ;; manually specify ID here so if one was somehow inserted in the meantime in the fraction of a second since we
+    ;; called `check-revision-numbers` the PK constraint will fail and the transaction will abort
+    (db/insert! CollectionRevision
+      :id     (inc current-revision)
+      :before  old
+      :after   new
+      :user_id *current-user-id*)))
+
+(s/defn update-graph!
+  "Update the collections permissions graph. This works just like the function of the same name in
+  `metabase.models.permissions`, but for `Collections`; refer to that function's extensive documentation to get a
+  sense for how this works."
+  ([new-graph :- PermissionsGraph]
+   (let [old-graph (graph)
+         [old new] (data/diff (:groups old-graph) (:groups new-graph))]
+     (perms/log-permissions-changes old new)
+     (perms/check-revision-numbers old-graph new-graph)
+     (when (seq new)
+       (db/transaction
+         (doseq [[group-id changes] new]
+           (update-group-permissions! group-id changes))
+         (save-perms-revision! (:revision old-graph) old new)))))
+  ;; The following arity is provided soley for convenience for tests/REPL usage
+  ([ks new-value]
+   {:pre [(sequential? ks)]}
+   (update-graph! (assoc-in (graph) (cons :groups ks) new-value))))

--- a/src/metabase/models/collection/root.clj
+++ b/src/metabase/models/collection/root.clj
@@ -1,0 +1,42 @@
+(ns metabase.models.collection.root
+  (:require [metabase.models
+             [interface :as i]
+             [permissions :as perms]]
+            [metabase.util :as u]
+            [potemkin.types :as p.types]
+            [toucan.models :as models]))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                   Root Collection Special Placeholder Object                                   |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+;; The Root Collection special placeholder object is used to represent the fact that we're working with the 'Root'
+;; Collection in many of the functions in this namespace. The Root Collection is not a true Collection, but instead
+;; represents things that have no collection_id, or are otherwise to be seen at the top-level by the current user.
+
+(p.types/defrecord+ RootCollection [])
+
+(u/strict-extend RootCollection
+  models/IModel
+  (merge
+   models/IModelDefaults
+   {:types {:type :keyword}})
+
+  i/IObjectPermissions
+  (merge
+   i/IObjectPermissionsDefaults
+   {:perms-objects-set (fn [this read-or-write]
+                         #{((case read-or-write
+                              :read  perms/collection-read-path
+                              :write perms/collection-readwrite-path) this)})
+    :can-read?         (partial i/current-user-has-full-permissions? :read)
+    :can-write?        (partial i/current-user-has-full-permissions? :write)}))
+
+(def ^RootCollection root-collection
+  "Special placeholder object representing the Root Collection, which isn't really a real Collection."
+  (map->RootCollection {::is-root? true}))
+
+(defn is-root-collection?
+  "Is `x` the special placeholder object representing the Root Collection?"
+  [x]
+  (instance? RootCollection x))

--- a/src/metabase/models/collection_revision.clj
+++ b/src/metabase/models/collection_revision.clj
@@ -23,5 +23,5 @@
   "Return the ID of the newest `CollectionRevision`, or zero if none have been made yet.
    (This is used by the collection graph update logic that checks for changes since the original graph was fetched)."
   []
-  (or (db/select-one-id CollectionRevision {:order-by [[:id :desc]]})
+  (or (:id (db/select-one [CollectionRevision [:%max.id :id]]))
       0))

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -55,9 +55,14 @@
   (db/delete! DashboardCard :dashboard_id (u/get-id dashboard)))
 
 (defn- pre-insert [dashboard]
-  (let [defaults {:parameters []}]
-    (merge defaults dashboard)))
+  (let [defaults  {:parameters []}
+        dashboard (merge defaults dashboard)]
+    (u/prog1 dashboard
+      (collection/check-collection-type (map->DashboardInstance dashboard)))))
 
+(defn- pre-update [dashboard]
+  (u/prog1 dashboard
+    (collection/check-collection-type dashboard)))
 
 (u/strict-extend (class Dashboard)
   models/IModel
@@ -66,6 +71,7 @@
           :types       (constantly {:parameters :json, :embedding_params :json})
           :pre-delete  pre-delete
           :pre-insert  pre-insert
+          :pre-update  pre-update
           :post-select public-settings/remove-public-uuid-if-public-sharing-is-disabled})
 
   ;; You can read/write a Dashboard if you can read/write its parent Collection

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -58,11 +58,11 @@
   (let [defaults  {:parameters []}
         dashboard (merge defaults dashboard)]
     (u/prog1 dashboard
-      (collection/check-collection-type (map->DashboardInstance dashboard)))))
+      (collection/check-collection-namespace (map->DashboardInstance dashboard)))))
 
 (defn- pre-update [dashboard]
   (u/prog1 dashboard
-    (collection/check-collection-type dashboard)))
+    (collection/check-collection-namespace dashboard)))
 
 (u/strict-extend (class Dashboard)
   models/IModel

--- a/src/metabase/models/native_query_snippet.clj
+++ b/src/metabase/models/native_query_snippet.clj
@@ -1,7 +1,9 @@
 (ns metabase.models.native-query-snippet
-  (:require [metabase.models.interface :as i]
+  (:require [metabase.models
+             [collection :refer [Collection]]
+             [interface :as i]]
             [metabase.util :as u]
-            [metabase.util.i18n :refer [tru]]
+            [metabase.util.i18n :refer [trs tru]]
             [schema.core :as s]
             [toucan
              [db :as db]
@@ -11,28 +13,59 @@
 
 (models/defmodel NativeQuerySnippet :native_query_snippet)
 
+(defn- assert-correct-collection-type [{collection-id :collection_id}]
+  (when collection-id
+    (let [collection-type (db/select-one-field :type Collection :id collection-id)]
+      (when-not (= (keyword collection-type) :snippet)
+        (let [msg (trs "NativeQuerySnippets can only go inside :snippet Collections.")]
+          (throw (ex-info msg {:status-code 400, :errors {:collection_id msg}})))))))
+
+(defn- pre-insert [snippet]
+  (u/prog1 snippet
+    (assert-correct-collection-type snippet)))
+
 (defn- pre-update [{:keys [creator_id id], :as updates}]
   (u/prog1 updates
     ;; throw an Exception if someone tries to update creator_id
     (when (contains? updates :creator_id)
       (when (not= creator_id (db/select-one-field :creator_id NativeQuerySnippet :id id))
-        (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a NativeQuerySnippet.")))))))
+        (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a NativeQuerySnippet.")))))
+    (assert-correct-collection-type updates)))
+
+(defn- can-read-parent-collection?
+  ([{collection-id :collection-id}]
+   (or (not collection-id)
+       (i/can-read? Collection collection-id)))
+
+  ([_ snippet-id]
+   (can-read-parent-collection? (db/select-one [NativeQuerySnippet :collection_id] :id (u/get-id snippet-id)))))
+
+(defn- can-write-parent-collection?
+  ([{collection-id :collection-id}]
+   (or (not collection-id)
+       (i/can-write? Collection collection-id)))
+
+  ([_ snippet-id]
+   (can-write-parent-collection? (db/select-one [NativeQuerySnippet :collection_id] :id (u/get-id snippet-id)))))
+
 
 (u/strict-extend (class NativeQuerySnippet)
   models/IModel
   (merge
    models/IModelDefaults
    {:properties (constantly {:timestamped? true})
+    :pre-insert pre-insert
     :pre-update pre-update})
 
   i/IObjectPermissions
   (merge
    i/IObjectPermissionsDefaults
-   {;; In Metabase CE, anyone can read/edit/create NativeQuerySnippets. In EE permissions are dictated by a 'folder'
-    ;; system similar to Collections (not yet implemented).
-    :can-read?   (constantly true)
-    :can-write?  (constantly true)
-    :can-create? (constantly true)}))
+   ;; Snippets can go in a `:snippet` Collection (called a "folder" in the UI) in Metabase EE. In Metabase CE,
+   ;; snippets cannot go in a Collection. If a Snippet is not in a Collection, anyone can read or write it. If a
+   ;; snippet *is* in a Collection, you need normal Collection permissions to read/write it.
+   {:can-read?   can-read-parent-collection?
+    :can-write?  can-write-parent-collection?
+    :can-create? can-write-parent-collection?}))
 
 
 ;;; ---------------------------------------------------- Schemas -----------------------------------------------------

--- a/src/metabase/models/native_query_snippet.clj
+++ b/src/metabase/models/native_query_snippet.clj
@@ -13,13 +13,13 @@
 
 (models/defmodel NativeQuerySnippet :native_query_snippet)
 
-(defmethod collection/allowed-collection-types (class NativeQuerySnippet)
+(defmethod collection/allowed-namespaces (class NativeQuerySnippet)
   [_]
-  #{:snippet})
+  #{:snippets})
 
 (defn- pre-insert [snippet]
   (u/prog1 snippet
-    (collection/check-collection-type snippet)))
+    (collection/check-collection-namespace snippet)))
 
 (defn- pre-update [{:keys [creator_id id], :as updates}]
   (u/prog1 updates
@@ -27,7 +27,7 @@
     (when (contains? updates :creator_id)
       (when (not= creator_id (db/select-one-field :creator_id NativeQuerySnippet :id id))
         (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a NativeQuerySnippet.")))))
-    (collection/check-collection-type updates)))
+    (collection/check-collection-namespace updates)))
 
 (defn- can-read-parent-collection?
   ([{collection-id :collection-id}]
@@ -57,9 +57,9 @@
   i/IObjectPermissions
   (merge
    i/IObjectPermissionsDefaults
-   ;; Snippets can go in a `:snippet` Collection (called a "folder" in the UI) in Metabase EE. In Metabase CE,
-   ;; snippets cannot go in a Collection. If a Snippet is not in a Collection, anyone can read or write it. If a
-   ;; snippet *is* in a Collection, you need normal Collection permissions to read/write it.
+   ;; Snippets can go in Collections in the `:snippets` namespace (these are called "folders" in the UI) in Metabase
+   ;; EE. In Metabase CE, snippets cannot go in a Collection. If a Snippet is not in a Collection, anyone can read or
+   ;; write it. If a snippet *is* in a Collection, you need normal Collection permissions to read/write it.
    {:can-read?   can-read-parent-collection?
     :can-write?  can-write-parent-collection?
     :can-create? can-write-parent-collection?}))

--- a/src/metabase/models/native_query_snippet/permissions.clj
+++ b/src/metabase/models/native_query_snippet/permissions.clj
@@ -1,0 +1,64 @@
+(ns metabase.models.native-query-snippet.permissions
+  "NativeQuerySnippets have different permissions implementations. In Metabase CE, anyone can read/edit/create all
+  NativeQuerySnippets. EE has a more advanced implementation.
+
+  The code in this namespace provides sort of a strategy pattern interface to the underlying permissions operations.
+  The default implementation is defined below and can be swapped out at runtime with the more advanced EE
+  implementation."
+  (:require [potemkin.types :as p.types]
+            [pretty.core :refer [PrettyPrintable]]))
+
+(p.types/defprotocol+ PermissionsImpl
+  "Protocol for implementing the permissions logic for NativeQuerySnippets."
+  (can-read?* [this snippet] [this model id]
+    "Can the current User read this `snippet`?")
+  (can-write?*  [this snippet] [this model id]
+    "Can the current User edit this `snippet`?")
+  (can-create?* [this snippet] [this model id]
+    "Can the current User save a new `snippet` with these values?"))
+
+(defonce ^:private impl (atom nil))
+
+(defn set-impl!
+  "Change the implementation used for NativeQuerySnippet permissions. `new-impl` must satisfy the `PermissionsImpl`
+  protocol defined above."
+  [new-impl]
+  (reset! impl new-impl))
+
+(def default-impl
+  "Default 'simple' permissions implementation for NativeQuerySnippets for Metabase CE."
+  (reify
+    PrettyPrintable
+    (pretty [_]
+      `default-impl)
+    PermissionsImpl
+    (can-read?* [_ _] true)
+    (can-read?* [_ _ _] true)
+    (can-write?* [_ _] true)
+    (can-write?* [_ _ _] true)
+    (can-create?* [_ _] true)
+    (can-create?* [_ _ _] true)))
+
+(when-not @impl
+  (set-impl! default-impl))
+
+(defn can-read?
+  "Can the current User read this `snippet`?"
+  ([snippet]
+   (can-read?* @impl snippet))
+  ([model id]
+   (can-read?* @impl model id)))
+
+(defn can-write?
+  "Can the current User edit this `snippet`?"
+  ([snippet]
+   (can-write?* @impl snippet))
+  ([model id]
+   (can-write?* @impl model id)))
+
+(defn can-create?
+  "Can the current User save a new `snippet` with these values?"
+  ([snippet]
+   (can-create?* @impl snippet))
+  ([model id]
+   (can-create?* @impl model id)))

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -148,7 +148,7 @@
   "Return the permissions path for *readwrite* access for a `collection-or-id`."
   [collection-or-id :- MapOrID]
   (str "/collection/"
-       (if (get collection-or-id :metabase.models.collection/is-root?)
+       (if (get collection-or-id :metabase.models.collection.root/is-root?)
          "root"
          (u/get-id collection-or-id))
        "/"))
@@ -245,7 +245,7 @@
     ;; now pass that function our collection_id if we have one, or if not, pass it an object representing the Root
     ;; Collection
     #{(path-fn (or (:collection_id this)
-                   {:metabase.models.collection/is-root? true}))}))
+                   {:metabase.models.collection.root/is-root? true}))}))
 
 (def IObjectPermissionsForParentCollection
   "Implementation of `IObjectPermissions` for objects that have a `collection_id`, and thus, a parent Collection.
@@ -500,7 +500,7 @@
   be given some sort of access."
   [collection-or-id :- MapOrID]
   ;; don't apply this check to the Root Collection, because it's never personal
-  (when-not (:metabase.models.collection/is-root? collection-or-id)
+  (when-not (:metabase.models.collection.root/is-root? collection-or-id)
     ;; ok, once we've confirmed this isn't the Root Collection, see if it's in the DB with a personal_owner_id
     (let [collection (if (map? collection-or-id)
                        collection-or-id

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -22,6 +22,7 @@
              [util :as u]]
             [metabase.models
              [card :refer [Card]]
+             [collection :as collection]
              [interface :as i]
              [permissions :as perms]
              [pulse-card :refer [PulseCard]]
@@ -43,6 +44,14 @@
 (defn- pre-delete [notification]
   (doseq [model [PulseCard PulseChannel]]
     (db/delete! model :pulse_id (u/get-id notification))))
+
+(defn- pre-insert [notification]
+  (u/prog1 notification
+    (collection/check-collection-type notification)))
+
+(defn- pre-update [updates]
+  (u/prog1 updates
+    (collection/check-collection-type updates)))
 
 (defn- alert->card
   "Return the Card associated with an Alert, fetching it if needed, for permissions-checking purposes."
@@ -73,7 +82,9 @@
    models/IModelDefaults
    {:hydration-keys (constantly [:pulse])
     :properties     (constantly {:timestamped? true})
-    :pre-delete     pre-delete})
+    :pre-delete     pre-delete
+    :pre-insert     pre-insert
+    :pre-update     pre-update})
   i/IObjectPermissions
   (merge
    i/IObjectPermissionsDefaults
@@ -413,7 +424,7 @@
 
 ;; TODO - why do we make sure to strictly validate everything when we create a PULSE but not when we create an ALERT?
 (defn update-alert!
-  "Updates the given `ALERT` and returns it"
+  "Updates the given `alert` and returns it"
   [alert]
   (update-notification! (alert->notification alert))
   ;; fetch the fully updated pulse and return it (and fire off an event)
@@ -439,5 +450,4 @@
                                                                 [:= :pcr.user_id user-id]]} "r"]]}]})]
     (when (zero? result)
       (log/warnf "Failed to remove user-id '%s' from alert-id '%s'" user-id alert-id))
-
     result))

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -47,11 +47,11 @@
 
 (defn- pre-insert [notification]
   (u/prog1 notification
-    (collection/check-collection-type notification)))
+    (collection/check-collection-namespace notification)))
 
 (defn- pre-update [updates]
   (u/prog1 updates
-    (collection/check-collection-type updates)))
+    (collection/check-collection-namespace updates)))
 
 (defn- alert->card
   "Return the Card associated with an Alert, fetching it if needed, for permissions-checking purposes."

--- a/test/expectations.clj
+++ b/test/expectations.clj
@@ -137,8 +137,8 @@
     ;; expecting it.
     (when-not (env/env :drivers)
       (t/testing "Don't write any new tests using expect!"
-        (t/is (<= total-expect-forms 1716))
-        (t/is (<= total-namespaces-using-expect 108))))))
+        (t/is (<= total-expect-forms 1602))
+        (t/is (<= total-namespaces-using-expect 107))))))
 
 (defmacro ^:deprecated expect
   "Simple macro that simulates converts an Expectations-style `expect` form into a `clojure.test` `deftest` form."

--- a/test/expectations.clj
+++ b/test/expectations.clj
@@ -137,8 +137,8 @@
     ;; expecting it.
     (when-not (env/env :drivers)
       (t/testing "Don't write any new tests using expect!"
-        (t/is (<= total-expect-forms 1601))
-        (t/is (<= total-namespaces-using-expect 107))))))
+        (t/is (<= total-expect-forms 1585))
+        (t/is (<= total-namespaces-using-expect 106))))))
 
 (defmacro ^:deprecated expect
   "Simple macro that simulates converts an Expectations-style `expect` form into a `clojure.test` `deftest` form."

--- a/test/expectations.clj
+++ b/test/expectations.clj
@@ -137,7 +137,7 @@
     ;; expecting it.
     (when-not (env/env :drivers)
       (t/testing "Don't write any new tests using expect!"
-        (t/is (<= total-expect-forms 1585))
+        (t/is (<= total-expect-forms 1555))
         (t/is (<= total-namespaces-using-expect 106))))))
 
 (defmacro ^:deprecated expect

--- a/test/expectations.clj
+++ b/test/expectations.clj
@@ -137,7 +137,7 @@
     ;; expecting it.
     (when-not (env/env :drivers)
       (t/testing "Don't write any new tests using expect!"
-        (t/is (<= total-expect-forms 1602))
+        (t/is (<= total-expect-forms 1601))
         (t/is (<= total-namespaces-using-expect 107))))))
 
 (defmacro ^:deprecated expect

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -55,7 +55,7 @@
                 "Rasta Toucan's Personal Collection"
                 "Trash Bird's Personal Collection"]
                (->> ((mt/user->client :crowberto) :get 200 "collection")
-                    (filter :personal_owner_id)
+                    (filter #((set (map mt/user->id [:crowberto :lucky :rasta :trashbird])) (:personal_owner_id %)))
                     (map :name)
                     sort)))))
 
@@ -83,25 +83,25 @@
         (is (= ["Archived Collection"]
                (map :name ((mt/user->client :rasta) :get 200 "collection" :archived :true))))))
 
-    (testing "?type= parameter"
+    (testing "?namespace= parameter"
       (mt/with-temp* [Collection [{normal-id :id} {:name "Normal Collection"}]
-                      Collection [{coins-id  :id} {:name "Coin Collection", :type "currency"}]]
+                      Collection [{coins-id  :id} {:name "Coin Collection", :namespace "currency"}]]
         (letfn [(collection-names [collections]
                   (->> collections
                        (filter #(#{normal-id coins-id} (:id %)))
                        (map :name)))]
-          (testing "shouldn't show Collections of a different `:type` by default"
+          (testing "shouldn't show Collections of a different `:namespace` by default"
             (is (= ["Normal Collection"]
                    (collection-names ((mt/user->client :rasta) :get 200 "collection")))))
 
-          (testing "By passing `:type` we should be able to see Collections of that `:type`"
-            (testing "?type=currency"
+          (testing "By passing `:namespace` we should be able to see Collections of that `:namespace`"
+            (testing "?namespace=currency"
               (is (= ["Coin Collection"]
-                     (collection-names ((mt/user->client :rasta) :get 200 "collection?type=currency")))))
+                     (collection-names ((mt/user->client :rasta) :get 200 "collection?namespace=currency")))))
 
-            (testing "?type=stamps"
+            (testing "?namespace=stamps"
               (is (= []
-                     (collection-names ((mt/user->client :rasta) :get 200 "collection?type=stamps")))))))))))
+                     (collection-names ((mt/user->client :rasta) :get 200 "collection?namespace=stamps")))))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -517,25 +517,25 @@
           (is (= [(collection-item "A")]
                  (api-get-root-collection-children :archived true))))))
 
-    (testing "?type= parameter"
+    (testing "?namespace= parameter"
       (mt/with-temp* [Collection [{normal-id :id} {:name "Normal Collection"}]
-                      Collection [{coins-id :id} {:name "Coin Collection", :type "currency"}]]
+                      Collection [{coins-id :id} {:name "Coin Collection", :namespace "currency"}]]
         (letfn [(collection-names [collections]
                   (->> collections
                        (filter #(= (:model %) "collection"))
                        (filter #(#{normal-id coins-id} (:id %)))
                        (map :name)))]
-          (testing "shouldn't show Collections of a different `:type` by default"
+          (testing "shouldn't show Collections of a different `:namespace` by default"
             (is (= ["Normal Collection"]
                    (collection-names ((mt/user->client :rasta) :get 200 "collection/root/items")))))
 
-          (testing "By passing `:type` we should be able to see Collections of that `:type`"
-            (testing "?type=currency"
+          (testing "By passing `:namespace` we should be able to see Collections of that `:namespace`"
+            (testing "?namespace=currency"
               (is (= ["Coin Collection"]
-                     (collection-names ((mt/user->client :rasta) :get 200 "collection/root/items?type=currency")))))
-            (testing "?type=stamps"
+                     (collection-names ((mt/user->client :rasta) :get 200 "collection/root/items?namespace=currency")))))
+            (testing "?namespace=stamps"
               (is (= []
-                     (collection-names ((mt/user->client :rasta) :get 200 "collection/root/items?type=stamps")))))))))))
+                     (collection-names ((mt/user->client :rasta) :get 200 "collection/root/items?namespace=stamps")))))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -217,7 +217,7 @@
     :can_write           true
     :name                "Lucky Pigeon's Personal Collection"
     :personal_owner_id   (mt/user->id :lucky)
-    :effective_ancestors [{:metabase.models.collection/is-root? true, :name "Our analytics", :id "root", :can_write true}]
+    :effective_ancestors [{:metabase.models.collection.root/is-root? true, :name "Our analytics", :id "root", :can_write true}]
     :effective_location  "/"
     :parent_id           nil
     :id                  (u/get-id (collection/user->personal-collection (mt/user->id :lucky)))
@@ -421,7 +421,7 @@
           (with-some-children-of-collection nil
             (mt/with-temp* [PermissionsGroup           [group]
                             PermissionsGroupMembership [_ {:user_id (mt/user->id :rasta), :group_id (u/get-id group)}]]
-              (perms/grant-permissions! group (perms/collection-read-path {:metabase.models.collection/is-root? true}))
+              (perms/grant-permissions! group (perms/collection-read-path {:metabase.models.collection.root/is-root? true}))
               (is (= [(default-item {:name "Birthday Card", :description nil, :favorite false, :model "card", :display "table"})
                       (default-item {:name "Dine & Dashboard", :description nil, :model "dashboard"})
                       (default-item {:name "Electro-Magnetic Pulse", :model "pulse"})

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -3,9 +3,8 @@
   (:require [clojure
              [string :as str]
              [test :refer :all]]
-            [expectations :refer [expect]]
             [metabase
-             [email-test :as et]
+             [test :as mt]
              [util :as u]]
             [metabase.models
              [card :refer [Card]]
@@ -19,12 +18,8 @@
              [pulse-card :refer [PulseCard]]
              [pulse-channel :refer [PulseChannel]]
              [pulse-channel-recipient :refer [PulseChannelRecipient]]]
-            [metabase.test
-             [fixtures :as fixtures]
-             [util :as tu]]
-            [metabase.test.data.users :refer [user->client user->id]]
-            [toucan.db :as db]
-            [toucan.util.test :as tt]))
+            [metabase.test.fixtures :as fixtures]
+            [toucan.db :as db]))
 
 (use-fixtures :once (fixtures/initialize :test-users-personal-collections))
 
@@ -36,7 +31,7 @@
   (testing "GET /api/collection"
     (testing "check that we can get a basic list of collections"
       ;; (for the purposes of test purposes remove the personal collections)
-      (tt/with-temp Collection [collection]
+      (mt/with-temp Collection [collection]
         (is (= [{:parent_id           nil
                  :effective_location  nil
                  :effective_ancestors []
@@ -44,98 +39,98 @@
                  :name                "Our analytics"
                  :id                  "root"}
                 (assoc (into {} collection) :can_write true)]
-               (for [collection ((user->client :crowberto) :get 200 "collection")
+               (for [collection ((mt/user->client :crowberto) :get 200 "collection")
                      :when      (not (:personal_owner_id collection))]
                  collection)))))
 
     (testing "We should only see our own Personal Collections!"
-      (is (= ["Our analytics"
-              "Lucky Pigeon's Personal Collection"]
-             (map :name ((user->client :lucky) :get 200 "collection"))))
+      (is (= ["Lucky Pigeon's Personal Collection"]
+             (->> ((mt/user->client :lucky) :get 200 "collection")
+                  (filter :personal_owner_id)
+                  (map :name))))
 
       (testing "...unless we are *admins*"
-        (is (= ["Our analytics"
-                "Crowberto Corv's Personal Collection"
+        (is (= ["Crowberto Corv's Personal Collection"
                 "Lucky Pigeon's Personal Collection"
                 "Rasta Toucan's Personal Collection"
                 "Trash Bird's Personal Collection"]
-               (map :name ((user->client :crowberto) :get 200 "collection"))))))
+               (->> ((mt/user->client :crowberto) :get 200 "collection")
+                    (filter :personal_owner_id)
+                    (map :name)
+                    sort)))))
 
     (testing "check that we don't see collections if we don't have permissions for them"
-      (tu/with-non-admin-groups-no-root-collection-perms
-        (tt/with-temp* [Collection [collection-1 {:name "Collection 1"}]
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp* [Collection [collection-1 {:name "Collection 1"}]
                         Collection [collection-2 {:name "Collection 2"}]]
           (perms/grant-collection-read-permissions! (group/all-users) collection-1)
           (is (= ["Our analytics"
                   "Collection 1"
                   "Rasta Toucan's Personal Collection"]
-                 (map :name ((user->client :rasta) :get 200 "collection")))))))
+                 (map :name ((mt/user->client :rasta) :get 200 "collection")))))))
 
     (testing "check that we don't see collections if they're archived"
-      (tt/with-temp* [Collection [collection-1 {:name "Archived Collection", :archived true}]
+      (mt/with-temp* [Collection [collection-1 {:name "Archived Collection", :archived true}]
                       Collection [collection-2 {:name "Regular Collection"}]]
-        (perms/grant-collection-read-permissions! (group/all-users) collection-1)
-        (perms/grant-collection-read-permissions! (group/all-users) collection-2)
         (is (= ["Our analytics"
                 "Rasta Toucan's Personal Collection"
                 "Regular Collection"]
-               (map :name ((user->client :rasta) :get 200 "collection"))))))
+               (map :name ((mt/user->client :rasta) :get 200 "collection"))))))
 
     (testing "Check that if we pass `?archived=true` we instead see archived Collections"
-      (tt/with-temp* [Collection [collection-1 {:name "Archived Collection", :archived true}]
+      (mt/with-temp* [Collection [collection-1 {:name "Archived Collection", :archived true}]
                       Collection [collection-2 {:name "Regular Collection"}]]
-        (perms/grant-collection-read-permissions! (group/all-users) collection-1)
-        (perms/grant-collection-read-permissions! (group/all-users) collection-2)
         (is (= ["Archived Collection"]
-               (map :name ((user->client :rasta) :get 200 "collection" :archived :true))))))))
+               (map :name ((mt/user->client :rasta) :get 200 "collection" :archived :true))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              GET /collection/:id                                               |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-;; check that we can see collection details (GET /api/collection/:id)
-(expect
-  "Coin Collection"
-  (tt/with-temp Collection [collection {:name "Coin Collection"}]
-    (perms/grant-collection-read-permissions! (group/all-users) collection)
-    (:name ((user->client :rasta) :get 200 (str "collection/" (u/get-id collection))))))
+(deftest fetch-collection-test
+  (testing "GET /api/collection/:id"
+    (testing "check that we can see collection details"
+      (mt/with-temp Collection [collection {:name "Coin Collection"}]
+        (perms/grant-collection-read-permissions! (group/all-users) collection)
+        (is (= "Coin Collection"
+               (:name ((mt/user->client :rasta) :get 200 (str "collection/" (u/get-id collection))))))))
 
-;; check that collections detail properly checks permissions
-(expect
-  "You don't have permissions to do that."
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp Collection [collection]
-      ((user->client :rasta) :get 403 (str "collection/" (u/get-id collection))))))
+    (testing "check that collections detail properly checks permissions"
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp Collection [collection]
+          (is (= "You don't have permissions to do that."
+                 ((mt/user->client :rasta) :get 403 (str "collection/" (u/get-id collection))))))))))
 
 
 ;;; ----------------------------------------- Cards, Dashboards, and Pulses ------------------------------------------
 
-;; check that cards are returned with the collection/items endpoint
-(tt/expect-with-temp [Collection [collection]
-                      Card       [card        {:collection_id (u/get-id collection)}]]
-  (tu/obj->json->obj
-    [{:id                  (u/get-id card)
-      :name                (:name card)
-      :collection_position nil
-      :display            "table"
-      :description         nil
-      :favorite            false
-      :model               "card"}])
-  (tu/obj->json->obj
-   ((user->client :crowberto) :get 200 (str "collection/" (u/get-id collection) "/items"))))
-
 (defn- do-with-some-children-of-collection [collection-or-id-or-nil f]
-  (tu/with-non-admin-groups-no-root-collection-perms
+  (mt/with-non-admin-groups-no-root-collection-perms
     (let [collection-id-or-nil (when collection-or-id-or-nil
                                  (u/get-id collection-or-id-or-nil))]
-      (tt/with-temp* [Card       [_ {:name "Birthday Card", :collection_id collection-id-or-nil}]
-                      Dashboard  [_ {:name "Dine & Dashboard", :collection_id collection-id-or-nil}]
-                      Pulse      [_ {:name "Electro-Magnetic Pulse", :collection_id collection-id-or-nil}]]
-        (f)))))
+      (mt/with-temp* [Card       [{card-id :id}      {:name "Birthday Card", :collection_id collection-id-or-nil}]
+                      Dashboard  [{dashboard-id :id} {:name "Dine & Dashboard", :collection_id collection-id-or-nil}]
+                      Pulse      [{pulse-id :id}     {:name "Electro-Magnetic Pulse", :collection_id collection-id-or-nil}]]
+        (f {:card-id card-id, :dashboard-id dashboard-id, :pulse-id pulse-id})))))
 
 (defmacro ^:private with-some-children-of-collection {:style/indent 1} [collection-or-id-or-nil & body]
-  `(do-with-some-children-of-collection ~collection-or-id-or-nil (fn [] ~@body)))
+  `(do-with-some-children-of-collection
+    ~collection-or-id-or-nil
+    (fn [~'&ids]
+      ~@body)))
+
+(defn- remove-non-test-items
+  "Remove Cards, Dashboards, and Pulses that aren't the 'Birthday Card'/'Dine & Dashboard'/'Electro-Magnetic Pulse'
+  created by `with-some-children-of-collection`."
+  [items {:keys [card-id dashboard-id pulse-id]}]
+  (filter (fn [{:keys [id model]}]
+            (case model
+              "card"      (= id card-id)
+              "dashboard" (= id dashboard-id)
+              "pulse"     (= id pulse-id)
+              true))
+          items))
 
 (defn- default-item [item-map]
   (merge {:id true, :collection_position nil} item-map))
@@ -148,95 +143,108 @@
           :name        collection-name}
          extra-keypairs))
 
-;; check that you get to see the children as appropriate
-(expect
-  (map default-item [{:name "Birthday Card", :description nil, :favorite false, :model "card", :display "table"}
-                     {:name "Dine & Dashboard", :description nil, :model "dashboard"}
-                     {:name "Electro-Magnetic Pulse", :model "pulse"}])
-  (tt/with-temp Collection [collection {:name "Debt Collection"}]
-    (perms/grant-collection-read-permissions! (group/all-users) collection)
-    (with-some-children-of-collection collection
-      (tu/boolean-ids-and-timestamps
-       ((user->client :rasta) :get 200 (str "collection/" (u/get-id collection) "/items"))))))
+(deftest collection-items-test
+  (testing "GET /api/collection/:id/items"
+    (testing "check that cards are returned with the collection/items endpoint"
+      (mt/with-temp* [Collection [collection]
+                      Card       [card        {:collection_id (u/get-id collection)}]]
+        (is (= (mt/obj->json->obj
+                 [{:id                  (u/get-id card)
+                   :name                (:name card)
+                   :collection_position nil
+                   :display             "table"
+                   :description         nil
+                   :favorite            false
+                   :model               "card"}])
+               (mt/obj->json->obj
+                 ((mt/user->client :crowberto) :get 200 (str "collection/" (u/get-id collection) "/items")))))))
 
-;; ...and that you can also filter so that you only see the children you want to see
-(expect
-  [(default-item {:name "Dine & Dashboard", :description nil, :model "dashboard"})]
-  (tt/with-temp Collection [collection {:name "Art Collection"}]
-    (perms/grant-collection-read-permissions! (group/all-users) collection)
-    (with-some-children-of-collection collection
-      (tu/boolean-ids-and-timestamps
-       ((user->client :rasta) :get 200 (str "collection/" (u/get-id collection) "/items?model=dashboard"))))))
+    (testing "check that you get to see the children as appropriate"
+      (mt/with-temp Collection [collection {:name "Debt Collection"}]
+        (perms/grant-collection-read-permissions! (group/all-users) collection)
+        (with-some-children-of-collection collection
+          (is (= (map default-item [{:name "Birthday Card", :description nil, :favorite false, :model "card", :display "table"}
+                                    {:name "Dine & Dashboard", :description nil, :model "dashboard"}
+                                    {:name "Electro-Magnetic Pulse", :model "pulse"}])
+                 (mt/boolean-ids-and-timestamps
+                  ((mt/user->client :rasta) :get 200 (str "collection/" (u/get-id collection) "/items")))))))
 
-;; Let's make sure the `archived` option works.
-(expect
-  [(default-item {:name "Dine & Dashboard", :description nil, :model "dashboard"})]
-  (tt/with-temp Collection [collection {:name "Art Collection"}]
-    (perms/grant-collection-read-permissions! (group/all-users) collection)
-    (with-some-children-of-collection collection
-      (db/update-where! Dashboard {:collection_id (u/get-id collection)} :archived true)
-      (tu/boolean-ids-and-timestamps
-       ((user->client :rasta) :get 200 (str "collection/" (u/get-id collection) "/items?archived=true"))))))
+      (testing "...and that you can also filter so that you only see the children you want to see"
+        (mt/with-temp Collection [collection {:name "Art Collection"}]
+          (perms/grant-collection-read-permissions! (group/all-users) collection)
+          (with-some-children-of-collection collection
+            (is (= [(default-item {:name "Dine & Dashboard", :description nil, :model "dashboard"})]
+                   (mt/boolean-ids-and-timestamps
+                    ((mt/user->client :rasta) :get 200 (str "collection/" (u/get-id collection) "/items?model=dashboard")))))))))
+
+    (testing "Let's make sure the `archived` option works."
+      (mt/with-temp Collection [collection {:name "Art Collection"}]
+        (perms/grant-collection-read-permissions! (group/all-users) collection)
+        (with-some-children-of-collection collection
+          (db/update-where! Dashboard {:collection_id (u/get-id collection)} :archived true)
+          (is (= [(default-item {:name "Dine & Dashboard", :description nil, :model "dashboard"})]
+                 (mt/boolean-ids-and-timestamps
+                  ((mt/user->client :rasta) :get 200 (str "collection/" (u/get-id collection) "/items?archived=true"))))))))))
+
 
 ;;; --------------------------------- Fetching Personal Collections (Ours & Others') ---------------------------------
 
 (defn- lucky-personal-collection []
-  {:description         nil
-   :archived            false
-   :slug                "lucky_pigeon_s_personal_collection"
-   :color               "#31698A"
-   :can_write           true
-   :name                "Lucky Pigeon's Personal Collection"
-   :personal_owner_id   (user->id :lucky)
-   :effective_ancestors [{:metabase.models.collection/is-root? true, :name "Our analytics", :id "root", :can_write true}]
-   :effective_location  "/"
-   :parent_id           nil
-   :id                  (u/get-id (collection/user->personal-collection (user->id :lucky)))
-   :location            "/"})
+  (merge
+   (mt/object-defaults Collection)
+   {:slug                "lucky_pigeon_s_personal_collection"
+    :color               "#31698A"
+    :can_write           true
+    :name                "Lucky Pigeon's Personal Collection"
+    :personal_owner_id   (mt/user->id :lucky)
+    :effective_ancestors [{:metabase.models.collection/is-root? true, :name "Our analytics", :id "root", :can_write true}]
+    :effective_location  "/"
+    :parent_id           nil
+    :id                  (u/get-id (collection/user->personal-collection (mt/user->id :lucky)))
+    :location            "/"}))
 
 (defn- lucky-personal-collection-id
   []
-  (u/get-id (collection/user->personal-collection (user->id :lucky))))
+  (u/get-id (collection/user->personal-collection (mt/user->id :lucky))))
 
 (defn- api-get-lucky-personal-collection [user-kw & {:keys [expected-status-code], :or {expected-status-code 200}}]
-  ((user->client user-kw) :get expected-status-code (str "collection/" (lucky-personal-collection-id))))
+  ((mt/user->client user-kw) :get expected-status-code (str "collection/" (lucky-personal-collection-id))))
 
 (defn- api-get-lucky-personal-collection-items [user-kw & {:keys [expected-status-code], :or {expected-status-code 200}}]
-  ((user->client user-kw) :get expected-status-code (str "collection/" (lucky-personal-collection-id) "/items")))
+  ((mt/user->client user-kw) :get expected-status-code (str "collection/" (lucky-personal-collection-id) "/items")))
 
-;; Can we use this endpoint to fetch our own Personal Collection?
-(expect
-  (lucky-personal-collection)
-  (api-get-lucky-personal-collection :lucky))
+(deftest fetch-personal-collection-test
+  (testing "GET /api/collection/:id"
+    (testing "Can we use this endpoint to fetch our own Personal Collection?"
+      (is (= (lucky-personal-collection)
+             (api-get-lucky-personal-collection :lucky))))
 
-;; Can and admin use this endpoint to fetch someone else's Personal Collection?
-(expect
-  (lucky-personal-collection)
-  (api-get-lucky-personal-collection :crowberto))
+    (testing "Can and admin use this endpoint to fetch someone else's Personal Collection?"
+      (is (= (lucky-personal-collection)
+             (api-get-lucky-personal-collection :crowberto))))
 
-;; Other, non-admin Users should not be allowed to fetch others' Personal Collections!
-(expect
-  "You don't have permissions to do that."
-  (api-get-lucky-personal-collection :rasta, :expected-status-code 403))
+    (testing "Other, non-admin Users should not be allowed to fetch others' Personal Collections!"
+      (is (= "You don't have permissions to do that."
+             (api-get-lucky-personal-collection :rasta, :expected-status-code 403))))))
 
 (def ^:private lucky-personal-subcollection-item
   [(collection-item "Lucky's Personal Sub-Collection" :can_write true)])
 
 (defn- api-get-lucky-personal-collection-with-subcollection [user-kw]
-  (tt/with-temp Collection [_ {:name     "Lucky's Personal Sub-Collection"
+  (mt/with-temp Collection [_ {:name     "Lucky's Personal Sub-Collection"
                                :location (collection/children-location
-                                          (collection/user->personal-collection (user->id :lucky)))}]
-    (tu/boolean-ids-and-timestamps (api-get-lucky-personal-collection-items user-kw))))
+                                          (collection/user->personal-collection (mt/user->id :lucky)))}]
+    (mt/boolean-ids-and-timestamps (api-get-lucky-personal-collection-items user-kw))))
 
-;; If we have a sub-Collection of our Personal Collection, that should show up
-(expect
-  lucky-personal-subcollection-item
-  (api-get-lucky-personal-collection-with-subcollection :lucky))
+(deftest fetch-personal-collection-items-test
+  (testing "GET /api/collection/:id/items"
+    (testing "If we have a sub-Collection of our Personal Collection, that should show up"
+      (is (= lucky-personal-subcollection-item
+             (api-get-lucky-personal-collection-with-subcollection :lucky))))
 
-;; sub-Collections of other's Personal Collections should show up for admins as well
-(expect
-  lucky-personal-subcollection-item
-  (api-get-lucky-personal-collection-with-subcollection :crowberto))
+    (testing "sub-Collections of other's Personal Collections should show up for admins as well"
+      (is (= lucky-personal-subcollection-item
+             (api-get-lucky-personal-collection-with-subcollection :crowberto))))))
 
 
 ;;; ------------------------------------ Effective Ancestors & Effective Children ------------------------------------
@@ -253,7 +261,7 @@
          `(perms/grant-collection-read-permissions! (group/all-users) ~collection-symb))
      ~@body))
 
-(defn- format-ancestors-and-children
+(defn- format-ancestors
   "Nicely format the `:effective_` results from an API call."
   [results]
   (-> results
@@ -261,420 +269,434 @@
       (update :effective_ancestors (partial map #(update % :id integer?)))
       (update :effective_location collection-test/location-path-ids->names)))
 
-(defn- api-get-collection-ancestors-and-children
+(defn- api-get-collection-ancestors
   "Call the API with Rasta to fetch `collection-or-id` and put the `:effective_` results in a nice format for the tests
   below."
   [collection-or-id & additional-get-params]
-  [(format-ancestors-and-children ((user->client :rasta) :get 200 (str "collection/" (u/get-id collection-or-id))))
-   (tu/boolean-ids-and-timestamps (apply (user->client :rasta) :get 200 (str "collection/" (u/get-id collection-or-id) "/items")
-                                         additional-get-params))])
+  (format-ancestors ((mt/user->client :rasta) :get 200 (str "collection/" (u/get-id collection-or-id)))))
 
-;; does a top-level Collection like A have the correct Children?
-(expect
-  [{:effective_ancestors []
-    :effective_location  "/"}
-   (map collection-item ["B" "C"])]
-  (with-collection-hierarchy [a b c d g]
-    (api-get-collection-ancestors-and-children a)))
+(defn- api-get-collection-children
+  [collection-or-id & additional-get-params]
+  (mt/boolean-ids-and-timestamps (apply (mt/user->client :rasta) :get 200 (str "collection/" (u/get-id collection-or-id) "/items")
+                                        additional-get-params)))
 
-;; ok, does a second-level Collection have its parent and its children?
-(expect
-  [{:effective_ancestors [{:name "A", :id true, :can_write false}]
-    :effective_location  "/A/"}
-   (map collection-item ["D" "G"])]
-  (with-collection-hierarchy [a b c d g]
-    (api-get-collection-ancestors-and-children c)))
+(deftest effective-ancestors-and-children-test
+  (testing "does a top-level Collection like A have the correct Children?"
+    (with-collection-hierarchy [a b c d g]
+      (testing "ancestors"
+        (is(= {:effective_ancestors []
+               :effective_location  "/"}
+              (api-get-collection-ancestors a))))
+      (testing "children"
+        (is (= (map collection-item ["B" "C"])
+               (api-get-collection-children a))))))
 
-;; what about a third-level Collection?
-(expect
-  [{:effective_ancestors [{:name "A", :id true, :can_write false}
-                          {:name "C", :id true, :can_write false}]
-    :effective_location  "/A/C/"}
-   []]
-  (with-collection-hierarchy [a b c d g]
-    (api-get-collection-ancestors-and-children d)))
+  (testing "ok, does a second-level Collection have its parent and its children?"
+    (with-collection-hierarchy [a b c d g]
+      (testing "ancestors"
+        (is (= {:effective_ancestors [{:name "A", :id true, :can_write false}]
+                :effective_location  "/A/"}
+               (api-get-collection-ancestors c))))
+      (testing "children"
+        (is (= (map collection-item ["D" "G"])
+               (api-get-collection-children c))))))
 
-;; for D: if we remove perms for C we should only have A as an ancestor; effective_location should lie and say we are
-;; a child of A
-(expect
-  [{:effective_ancestors [{:name "A", :id true, :can_write false}]
-    :effective_location  "/A/"}
-   []]
-  (with-collection-hierarchy [a b d g]
-    (api-get-collection-ancestors-and-children d)))
+  (testing "what about a third-level Collection?"
+    (with-collection-hierarchy [a b c d g]
+      (testing "ancestors"
+        (is (= {:effective_ancestors [{:name "A", :id true, :can_write false}
+                                      {:name "C", :id true, :can_write false}]
+                :effective_location  "/A/C/"}
+               (api-get-collection-ancestors d))))
+      (testing "children"
+        (is (= []
+               (api-get-collection-children d))))))
 
-;; for D: If, on the other hand, we remove A, we should see C as the only ancestor and as a root-level Collection.
-(expect
-  [{:effective_ancestors [{:name "C", :id true, :can_write false}]
-    :effective_location  "/C/"}
-   []]
-  (with-collection-hierarchy [b c d g]
-    (api-get-collection-ancestors-and-children d)))
+  (testing (str "for D: if we remove perms for C we should only have A as an ancestor; effective_location should lie "
+                "and say we are a child of A")
+    (with-collection-hierarchy [a b d g]
+      (testing "ancestors"
+        (is (= {:effective_ancestors [{:name "A", :id true, :can_write false}]
+                :effective_location  "/A/"}
+               (api-get-collection-ancestors d))))
+      (testing "children"
+        (is (= []
+               (api-get-collection-children d))))))
 
-;; for C: if we remove D we should get E and F as effective children
-(expect
-  [{:effective_ancestors [{:name "A", :id true, :can_write false}]
-    :effective_location  "/A/"}
-   (map collection-item ["E" "F"])]
-  (with-collection-hierarchy [a b c e f g]
-    (api-get-collection-ancestors-and-children c)))
+  (testing "for D: If, on the other hand, we remove A, we should see C as the only ancestor and as a root-level Collection."
+    (with-collection-hierarchy [b c d g]
+      (testing "ancestors"
+        (is (= {:effective_ancestors [{:name "C", :id true, :can_write false}]
+                :effective_location  "/C/"}
+               (api-get-collection-ancestors d))))
+      (testing "children"
+        (is (= []
+               (api-get-collection-children d)))))
 
-;; Make sure we can collapse multiple generations. For A: removing C and D should move up E and F
-(expect
-  [{:effective_ancestors []
-    :effective_location  "/"}
-   (map collection-item ["B" "E" "F"])]
-  (with-collection-hierarchy [a b e f g]
-    (api-get-collection-ancestors-and-children a)))
+    (testing "for C: if we remove D we should get E and F as effective children"
+      (with-collection-hierarchy [a b c e f g]
+        (testing "ancestors"
+          (is (= {:effective_ancestors [{:name "A", :id true, :can_write false}]
+                  :effective_location  "/A/"}
+                 (api-get-collection-ancestors c))))
+        (testing "children"
+          (is (= (map collection-item ["E" "F"])
+                 (api-get-collection-children c)))))))
 
-;; Let's make sure the 'archived` option works on Collections, nested or not
-(expect
-  [{:effective_ancestors []
-    :effective_location  "/"}
-   [(collection-item "B")]]
-  (with-collection-hierarchy [a b c]
-    (db/update! Collection (u/get-id b) :archived true)
-    (api-get-collection-ancestors-and-children a :archived true)))
+  (testing "Make sure we can collapse multiple generations. For A: removing C and D should move up E and F"
+    (with-collection-hierarchy [a b e f g]
+      (testing "ancestors"
+        (is (= {:effective_ancestors []
+                :effective_location  "/"}
+               (api-get-collection-ancestors a))))
+      (testing "children"
+        (is (= (map collection-item ["B" "E" "F"])
+               (api-get-collection-children a))))))
+
+  (testing "Let's make sure the 'archived` option works on Collections, nested or not"
+    (with-collection-hierarchy [a b c]
+      (db/update! Collection (u/get-id b) :archived true)
+      (testing "ancestors"
+        (is (= {:effective_ancestors []
+                :effective_location  "/"}
+               (api-get-collection-ancestors a :archived true))))
+      (testing "children"
+        (is (= [(collection-item "B")]
+               (api-get-collection-children a :archived true)))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              GET /collection/root                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-;; Check that we can see stuff that isn't in any Collection -- meaning they're in the so-called "Root" Collection
-(expect
-  {:name                "Our analytics"
-   :id                  "root"
-   :can_write           true
-   :effective_location  nil
-   :effective_ancestors []
-   :parent_id           nil}
-  (with-some-children-of-collection nil
-    ((user->client :crowberto) :get 200 "collection/root")))
+(deftest fetch-root-collection-test
+  (testing "GET /api/collection/root"
+    (testing "Check that we can see stuff that isn't in any Collection -- meaning they're in the so-called \"Root\" Collection"
+      (is (= {:name                "Our analytics"
+              :id                  "root"
+              :can_write           true
+              :effective_location  nil
+              :effective_ancestors []
+              :parent_id           nil}
+             (with-some-children-of-collection nil
+               ((mt/user->client :crowberto) :get 200 "collection/root")))))
 
-;; Make sure you can see everything for Users that can see everything
-(expect
-  [(default-item {:name "Birthday Card", :description nil, :favorite false, :model "card", :display "table"})
-   (collection-item "Crowberto Corv's Personal Collection")
-   (default-item {:name "Dine & Dashboard", :description nil, :model "dashboard"})
-   (default-item {:name "Electro-Magnetic Pulse", :model "pulse"})]
-  (with-some-children-of-collection nil
-    (tu/boolean-ids-and-timestamps ((user->client :crowberto) :get 200 "collection/root/items"))))
+    (testing "Make sure you can see everything for Users that can see everything"
+      (is (= [(default-item {:name "Birthday Card", :description nil, :favorite false, :model "card", :display "table"})
+              (collection-item "Crowberto Corv's Personal Collection")
+              (default-item {:name "Dine & Dashboard", :description nil, :model "dashboard"})
+              (default-item {:name "Electro-Magnetic Pulse", :model "pulse"})]
+             (with-some-children-of-collection nil
+               (-> ((mt/user->client :crowberto) :get 200 "collection/root/items")
+                   (remove-non-test-items &ids)
+                   mt/boolean-ids-and-timestamps))))
 
-;; ...but we don't let you see stuff you wouldn't otherwise be allowed to see
-(expect
-  [(collection-item "Rasta Toucan's Personal Collection")]
-  ;; if a User doesn't have perms for the Root Collection then they don't get to see things with no collection_id
-  (with-some-children-of-collection nil
-    (tu/boolean-ids-and-timestamps ((user->client :rasta) :get 200 "collection/root/items"))))
+      (testing "...but we don't let you see stuff you wouldn't otherwise be allowed to see"
+        (is (= [(collection-item "Rasta Toucan's Personal Collection")]
+               ;; if a User doesn't have perms for the Root Collection then they don't get to see things with no collection_id
+               (with-some-children-of-collection nil
+                 (mt/boolean-ids-and-timestamps ((mt/user->client :rasta) :get 200 "collection/root/items")))))
 
-;; ...but if they have read perms for the Root Collection they should get to see them
-(expect
-  [(default-item {:name "Birthday Card", :description nil, :favorite false, :model "card", :display "table"})
-   (default-item {:name "Dine & Dashboard", :description nil, :model "dashboard"})
-   (default-item {:name "Electro-Magnetic Pulse", :model "pulse"})
-   (collection-item "Rasta Toucan's Personal Collection")]
-  (with-some-children-of-collection nil
-    (tt/with-temp* [PermissionsGroup           [group]
-                    PermissionsGroupMembership [_ {:user_id (user->id :rasta), :group_id (u/get-id group)}]]
-      (perms/grant-permissions! group (perms/collection-read-path {:metabase.models.collection/is-root? true}))
-      (tu/boolean-ids-and-timestamps ((user->client :rasta) :get 200 "collection/root/items")))))
+        (testing "...but if they have read perms for the Root Collection they should get to see them"
+          (with-some-children-of-collection nil
+            (mt/with-temp* [PermissionsGroup           [group]
+                            PermissionsGroupMembership [_ {:user_id (mt/user->id :rasta), :group_id (u/get-id group)}]]
+              (perms/grant-permissions! group (perms/collection-read-path {:metabase.models.collection/is-root? true}))
+              (is (= [(default-item {:name "Birthday Card", :description nil, :favorite false, :model "card", :display "table"})
+                      (default-item {:name "Dine & Dashboard", :description nil, :model "dashboard"})
+                      (default-item {:name "Electro-Magnetic Pulse", :model "pulse"})
+                      (collection-item "Rasta Toucan's Personal Collection")]
+                     (-> ((mt/user->client :rasta) :get 200 "collection/root/items")
+                         (remove-non-test-items &ids)
+                         mt/boolean-ids-and-timestamps ))))))))
 
-;; So I suppose my Personal Collection should show up when I fetch the Root Collection, shouldn't it...
-(expect
-  [{:name        "Rasta Toucan's Personal Collection"
-    :id          (u/get-id (collection/user->personal-collection (user->id :rasta)))
-    :description nil
-    :model       "collection"
-    :can_write   true}]
-  ((user->client :rasta) :get 200 "collection/root/items"))
+    (testing "So I suppose my Personal Collection should show up when I fetch the Root Collection, shouldn't it..."
+      (is (= [{:name        "Rasta Toucan's Personal Collection"
+               :id          (u/get-id (collection/user->personal-collection (mt/user->id :rasta)))
+               :description nil
+               :model       "collection"
+               :can_write   true}]
+             (->> ((mt/user->client :rasta) :get 200 "collection/root/items")
+                  (filter #(str/includes? (:name %) "Personal Collection"))))))
 
-;; And for admins, only return our own Personal Collection (!)
-(expect
-  [{:name        "Crowberto Corv's Personal Collection"
-    :id          (u/get-id (collection/user->personal-collection (user->id :crowberto)))
-    :description nil
-    :model       "collection"
-    :can_write   true}]
-  ((user->client :crowberto) :get 200 "collection/root/items"))
+    (testing "For admins, only return our own Personal Collection (!)"
+      (is (= [{:name        "Crowberto Corv's Personal Collection"
+               :id          (u/get-id (collection/user->personal-collection (mt/user->id :crowberto)))
+               :description nil
+               :model       "collection"
+               :can_write   true}]
+             (->> ((mt/user->client :crowberto) :get 200 "collection/root/items")
+                  (filter #(str/includes? (:name %) "Personal Collection")))))
 
-;; That includes sub-collections of Personal Collections! I shouldn't see them!
-(expect
-  [{:name        "Crowberto Corv's Personal Collection"
-    :id          (u/get-id (collection/user->personal-collection (user->id :crowberto)))
-    :description nil
-    :model       "collection"
-    :can_write   true}]
-  (tt/with-temp Collection [_ {:name     "Lucky's Sub-Collection"
-                               :location (collection/children-location
-                                          (collection/user->personal-collection (user->id :lucky)))}]
-    ((user->client :crowberto) :get 200 "collection/root/items")))
+      (testing "That includes sub-collections of Personal Collections! I shouldn't see them!"
+        (mt/with-temp Collection [_ {:name     "Lucky's Sub-Collection"
+                                     :location (collection/children-location
+                                                (collection/user->personal-collection (mt/user->id :lucky)))}]
+          (is (= [{:name        "Crowberto Corv's Personal Collection"
+                   :id          (u/get-id (collection/user->personal-collection (mt/user->id :crowberto)))
+                   :description nil
+                   :model       "collection"
+                   :can_write   true}]
+                 (->> ((mt/user->client :crowberto) :get 200 "collection/root/items")
+                      (filter #(str/includes? (:name %) "Personal Collection"))))))))
 
-;; Can we look for `archived` stuff with this endpoint?
-(expect
-  [{:name                "Business Card"
-    :description         nil
-    :collection_position nil
-    :display             "table"
-    :favorite            false
-    :model               "card"}]
-  (tt/with-temp Card [card {:name "Business Card", :archived true}]
-    (for [item ((user->client :crowberto) :get 200 "collection/root/items?archived=true")]
-      (dissoc item :id))))
+    (testing "Can we look for `archived` stuff with this endpoint?"
+      (mt/with-temp Card [card {:name "Business Card", :archived true}]
+        (is (= [{:name                "Business Card"
+                 :description         nil
+                 :collection_position nil
+                 :display             "table"
+                 :favorite            false
+                 :model               "card"}]
+               (for [item ((mt/user->client :crowberto) :get 200 "collection/root/items?archived=true")]
+                 (dissoc item :id))))))))
 
 
 ;;; ----------------------------------- Effective Children, Ancestors, & Location ------------------------------------
 
-(defn- api-get-root-collection-ancestors-and-children
+(defn- api-get-root-collection-ancestors
   "Call the API with Rasta to fetch the 'Root' Collection and put the `:effective_` results in a nice format for the
   tests below."
   [& additional-get-params]
-  [(format-ancestors-and-children ((user->client :rasta) :get 200 "collection/root"))
-   (tu/boolean-ids-and-timestamps (apply (user->client :rasta) :get 200 "collection/root/items" additional-get-params))])
+  (format-ancestors ((mt/user->client :rasta) :get 200 "collection/root")))
 
-;; Do top-level collections show up as children of the Root Collection?
-(expect
-  [{:effective_ancestors []
-    :effective_location  nil}
-   (map collection-item ["A" "Rasta Toucan's Personal Collection"])]
-  (with-collection-hierarchy [a b c d e f g]
-    (api-get-root-collection-ancestors-and-children)))
+(defn- api-get-root-collection-children
+  [& additional-get-params]
+  (mt/boolean-ids-and-timestamps (apply (mt/user->client :rasta) :get 200 "collection/root/items" additional-get-params)))
 
-;; ...and collapsing children should work for the Root Collection as well
-(expect
-  [{:effective_ancestors []
-    :effective_location  nil}
-   (map collection-item ["B" "D" "F" "Rasta Toucan's Personal Collection"])]
-  (with-collection-hierarchy [b d e f g]
-    (api-get-root-collection-ancestors-and-children)))
+(deftest fetch-root-collection-items-test
+  (testing "GET /api/collection/root/items"
+    (testing "Do top-level collections show up as children of the Root Collection?"
+      (with-collection-hierarchy [a b c d e f g]
+        (testing "ancestors"
+          (is (= {:effective_ancestors []
+                  :effective_location  nil}
+                 (api-get-root-collection-ancestors))))
+        (testing "children"
+          (is (= (map collection-item ["A" "Rasta Toucan's Personal Collection"])
+                 (api-get-root-collection-children))))))
 
-;; does `archived` work on Collections as well?
-(expect
-  [{:effective_ancestors []
-    :effective_location  nil}
-   [(collection-item "A")]]
-  (with-collection-hierarchy [a b d e f g]
-    (db/update! Collection (u/get-id a) :archived true)
-    (api-get-root-collection-ancestors-and-children :archived true)))
+    (testing "...and collapsing children should work for the Root Collection as well"
+      (with-collection-hierarchy [b d e f g]
+        (testing "ancestors"
+          (is (= {:effective_ancestors []
+                  :effective_location  nil}
+                 (api-get-root-collection-ancestors))))
+        (testing "children"
+          (is (= (map collection-item ["B" "D" "F" "Rasta Toucan's Personal Collection"])
+                 (api-get-root-collection-children))))))
+
+    (testing "does `archived` work on Collections as well?"
+      (with-collection-hierarchy [a b d e f g]
+        (db/update! Collection (u/get-id a) :archived true)
+        (testing "ancestors"
+          (is (= {:effective_ancestors []
+                  :effective_location  nil}
+                 (api-get-root-collection-ancestors :archived true))))
+        (testing "children"
+          (is (= [(collection-item "A")]
+                 (api-get-root-collection-children :archived true))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              POST /api/collection                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-;; test that we can create a new collection (POST /api/collection)
-(expect
-  {:name              "Stamp Collection"
-   :slug              "stamp_collection"
-   :description       nil
-   :color             "#123456"
-   :archived          false
-   :location          "/"
-   :personal_owner_id nil}
-  (tu/with-model-cleanup [Collection]
-    (-> ((user->client :crowberto) :post 200 "collection"
-         {:name "Stamp Collection", :color "#123456"})
-        (dissoc :id))))
+(deftest create-collection-test
+  (testing "POST /api/collection"
+    (testing "test that we can create a new collection (POST /api/collection)"
+      (mt/with-model-cleanup [Collection]
+        (is (= (merge
+                (mt/object-defaults Collection)
+                {:name              "Stamp Collection"
+                 :slug              "stamp_collection"
+                 :color             "#123456"
+                 :archived          false
+                 :location          "/"
+                 :personal_owner_id nil})
+               (-> ((mt/user->client :crowberto) :post 200 "collection"
+                    {:name "Stamp Collection", :color "#123456"})
+                   (dissoc :id))))))
 
-;; test that non-admins aren't allowed to create a collection in the root collection
-(expect
-  "You don't have permissions to do that."
-  (tu/with-non-admin-groups-no-root-collection-perms
-    ((user->client :rasta) :post 403 "collection"
-     {:name "Stamp Collection", :color "#123456"})))
+    (testing "test that non-admins aren't allowed to create a collection in the root collection"
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (is (= "You don't have permissions to do that."
+               ((mt/user->client :rasta) :post 403 "collection"
+                {:name "Stamp Collection", :color "#123456"})))))
 
-;; Can a non-admin user with Root Collection perms add a new collection to the Root Collection? (#8949)
-(expect
-  {:name              "Stamp Collection"
-   :description       nil
-   :color             "#123456"
-   :archived          false
-   :location          "/"
-   :personal_owner_id nil
-   :slug              "stamp_collection"}
-  (tu/with-model-cleanup [Collection]
-    (tu/with-non-admin-groups-no-root-collection-perms
-      (-> (tt/with-temp* [PermissionsGroup           [group]
-                          PermissionsGroupMembership [_ {:user_id (user->id :rasta), :group_id (u/get-id group)}]]
+    (testing "Can a non-admin user with Root Collection perms add a new collection to the Root Collection? (#8949)"
+      (mt/with-model-cleanup [Collection]
+        (mt/with-non-admin-groups-no-root-collection-perms
+          (mt/with-temp* [PermissionsGroup           [group]
+                          PermissionsGroupMembership [_ {:user_id (mt/user->id :rasta), :group_id (u/get-id group)}]]
             (perms/grant-collection-readwrite-permissions! group collection/root-collection)
-            ((user->client :rasta) :post 200 "collection"
-             {:name "Stamp Collection", :color "#123456"}))
-          (dissoc :id)))))
+            (is (= (merge
+                    (mt/object-defaults Collection)
+                    {:name     "Stamp Collection"
+                     :color    "#123456"
+                     :location "/"
+                     :slug     "stamp_collection"})
+                   (dissoc ((mt/user->client :rasta) :post 200 "collection"
+                            {:name "Stamp Collection", :color "#123456"})
+                           :id)))))))
 
-;; Can I create a Collection as a child of an existing collection?
-(expect
-  {:id                true
-   :name              "Trading Card Collection"
-   :slug              "trading_card_collection"
-   :description       "Collection of basketball cards including limited-edition holographic Draymond Green"
-   :color             "#ABCDEF"
-   :archived          false
-   :location          "/A/C/D/"
-   :personal_owner_id nil}
-  (tu/with-model-cleanup [Collection]
-    (with-collection-hierarchy [a c d]
-      (-> ((user->client :crowberto) :post 200 "collection"
-           {:name        "Trading Card Collection"
-            :color       "#ABCDEF"
-            :description "Collection of basketball cards including limited-edition holographic Draymond Green"
-            :parent_id   (u/get-id d)})
-          (update :location collection-test/location-path-ids->names)
-          (update :id integer?)))))
-
+    (testing "Can I create a Collection as a child of an existing collection?"
+      (mt/with-model-cleanup [Collection]
+        (with-collection-hierarchy [a c d]
+          (is (= (merge
+                  (mt/object-defaults Collection)
+                  {:id          true
+                   :name        "Trading Card Collection"
+                   :slug        "trading_card_collection"
+                   :description "Collection of basketball cards including limited-edition holographic Draymond Green"
+                   :color       "#ABCDEF"
+                   :location    "/A/C/D/"})
+                 (-> ((mt/user->client :crowberto) :post 200 "collection"
+                      {:name        "Trading Card Collection"
+                       :color       "#ABCDEF"
+                       :description "Collection of basketball cards including limited-edition holographic Draymond Green"
+                       :parent_id   (u/get-id d)})
+                     (update :location collection-test/location-path-ids->names)
+                     (update :id integer?)))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                            PUT /api/collection/:id                                             |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-;; test that we can update a collection (PUT /api/collection/:id)
-(tt/expect-with-temp [Collection [collection]]
-  {:id                (u/get-id collection)
-   :name              "My Beautiful Collection"
-   :slug              "my_beautiful_collection"
-   :description       nil
-   :color             "#ABCDEF"
-   :archived          false
-   :location          "/"
-   :personal_owner_id nil}
-  ((user->client :crowberto) :put 200 (str "collection/" (u/get-id collection))
-   {:name "My Beautiful Collection", :color "#ABCDEF"}))
+(deftest update-collection-test
+  (testing "PUT /api/collection/:id"
+    (testing "test that we can update a collection"
+      (mt/with-temp Collection [collection]
+        (is (= (merge
+                (mt/object-defaults Collection)
+                {:id       (u/get-id collection)
+                 :name     "My Beautiful Collection"
+                 :slug     "my_beautiful_collection"
+                 :color    "#ABCDEF"
+                 :location "/"})
+               ((mt/user->client :crowberto) :put 200 (str "collection/" (u/get-id collection))
+                {:name "My Beautiful Collection", :color "#ABCDEF"})))))
 
-;; check that users without write perms aren't allowed to update a Collection
-(expect
-  "You don't have permissions to do that."
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp Collection [collection]
-      ((user->client :rasta) :put 403 (str "collection/" (u/get-id collection))
-       {:name "My Beautiful Collection", :color "#ABCDEF"}))))
+    (testing "check that users without write perms aren't allowed to update a Collection"
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp Collection [collection]
+          (is (= "You don't have permissions to do that."
+                 ((mt/user->client :rasta) :put 403 (str "collection/" (u/get-id collection))
+                  {:name "My Beautiful Collection", :color "#ABCDEF"}))))))))
 
-;; Archiving a collection should delete any alerts associated with questions in the collection
-(expect
-  {:emails (merge (et/email-to :crowberto {:subject "One of your alerts has stopped working",
-                                           :body    {"the question was archived by Crowberto Corv" true}})
-                  (et/email-to :rasta {:subject "One of your alerts has stopped working",
-                                       :body    {"the question was archived by Crowberto Corv" true}}))
-   :pulse  nil}
-  (tt/with-temp* [Collection            [{collection-id :id}]
-                  Card                  [{card-id :id :as card} {:collection_id collection-id}]
-                  Pulse                 [{pulse-id :id} {:alert_condition  "rows"
-                                                         :alert_first_only false
-                                                         :creator_id       (user->id :rasta)
-                                                         :name             "Original Alert Name"}]
+(deftest archive-collection-test
+  (testing "PUT /api/collection/:id"
+    (testing "Archiving a collection should delete any alerts associated with questions in the collection"
+      (mt/with-temp* [Collection            [{collection-id :id}]
+                      Card                  [{card-id :id :as card} {:collection_id collection-id}]
+                      Pulse                 [{pulse-id :id} {:alert_condition  "rows"
+                                                             :alert_first_only false
+                                                             :creator_id       (mt/user->id :rasta)
+                                                             :name             "Original Alert Name"}]
 
-                  PulseCard             [_              {:pulse_id pulse-id
-                                                         :card_id  card-id
-                                                         :position 0}]
-                  PulseChannel          [{pc-id :id}    {:pulse_id pulse-id}]
-                  PulseChannelRecipient [{pcr-id-1 :id} {:user_id          (user->id :crowberto)
-                                                         :pulse_channel_id pc-id}]
-                  PulseChannelRecipient [{pcr-id-2 :id} {:user_id          (user->id :rasta)
-                                                         :pulse_channel_id pc-id}]]
-    (et/with-fake-inbox
-      (et/with-expected-messages 2
-        ((user->client :crowberto) :put 200 (str "collection/" collection-id)
-         {:name "My Beautiful Collection", :color "#ABCDEF", :archived true}))
-      (array-map
-       :emails (et/regex-email-bodies #"the question was archived by Crowberto Corv")
-       :pulse  (Pulse pulse-id)))))
+                      PulseCard             [_              {:pulse_id pulse-id
+                                                             :card_id  card-id
+                                                             :position 0}]
+                      PulseChannel          [{pc-id :id}    {:pulse_id pulse-id}]
+                      PulseChannelRecipient [{pcr-id-1 :id} {:user_id          (mt/user->id :crowberto)
+                                                             :pulse_channel_id pc-id}]
+                      PulseChannelRecipient [{pcr-id-2 :id} {:user_id          (mt/user->id :rasta)
+                                                             :pulse_channel_id pc-id}]]
+        (mt/with-fake-inbox
+          (mt/with-expected-messages 2
+            ((mt/user->client :crowberto) :put 200 (str "collection/" collection-id)
+             {:name "My Beautiful Collection", :color "#ABCDEF", :archived true}))
+          (testing "emails"
+            (is (= (merge (mt/email-to :crowberto {:subject "One of your alerts has stopped working",
+                                                   :body    {"the question was archived by Crowberto Corv" true}})
+                          (mt/email-to :rasta {:subject "One of your alerts has stopped working",
+                                               :body    {"the question was archived by Crowberto Corv" true}}))
+                   (mt/regex-email-bodies #"the question was archived by Crowberto Corv"))))
+          (testing "Pulse"
+            (is (= nil
+                   (Pulse pulse-id)))))))
 
-;; I shouldn't be allowed to archive a Collection without proper perms
-(expect
-  "You don't have permissions to do that."
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp Collection [collection]
-      ((user->client :rasta) :put 403 (str "collection/" (u/get-id collection))
-       {:archived true}))))
+    (testing "I shouldn't be allowed to archive a Collection without proper perms"
+      (mt/with-non-admin-groups-no-root-collection-perms
+        (mt/with-temp Collection [collection]
+          (is (= "You don't have permissions to do that."
+                 ((mt/user->client :rasta) :put 403 (str "collection/" (u/get-id collection))
+                  {:archived true})))))
 
-;; Perms checking should be recursive as well...
-;;
-;; Create Collections A > B, and grant permissions for A. You should not be allowed to archive A because you would
-;; also need perms for B
-(expect
-  "You don't have permissions to do that."
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp* [Collection [collection-a]
-                    Collection [collection-b {:location (collection/children-location collection-a)}]]
-      (perms/grant-collection-readwrite-permissions! (group/all-users) collection-a)
-      ((user->client :rasta) :put 403 (str "collection/" (u/get-id collection-a))
-       {:archived true}))))
+      (testing "Perms checking should be recursive as well..."
+        ;; Create Collections A > B, and grant permissions for A. You should not be allowed to archive A because you
+        ;; would also need perms for B
+        (mt/with-non-admin-groups-no-root-collection-perms
+          (mt/with-temp* [Collection [collection-a]
+                          Collection [collection-b {:location (collection/children-location collection-a)}]]
+            (perms/grant-collection-readwrite-permissions! (group/all-users) collection-a)
+            (is (= "You don't have permissions to do that."
+                   ((mt/user->client :rasta) :put 403 (str "collection/" (u/get-id collection-a))
+                    {:archived true})))))))))
 
-;; Can I *change* the `location` of a Collection? (i.e. move it into a different parent Colleciton)
-(expect
-  {:id                true
-   :name              "E"
-   :slug              "e"
-   :description       nil
-   :color             "#ABCDEF"
-   :archived          false
-   :location          "/A/B/"
-   :personal_owner_id nil}
-  (with-collection-hierarchy [a b e]
-    (-> ((user->client :crowberto) :put 200 (str "collection/" (u/get-id e))
-         {:parent_id (u/get-id b)})
-        (update :location collection-test/location-path-ids->names)
-        (update :id integer?))))
+(deftest move-collection-test
+  (testing "PUT /api/collection/:id"
+    (testing "Can I *change* the `location` of a Collection? (i.e. move it into a different parent Collection)"
+      (with-collection-hierarchy [a b e]
+        (is (= (merge
+                (mt/object-defaults Collection)
+                {:id       true
+                 :name     "E"
+                 :slug     "e"
+                 :color    "#ABCDEF"
+                 :location "/A/B/"})
+               (-> ((mt/user->client :crowberto) :put 200 (str "collection/" (u/get-id e))
+                    {:parent_id (u/get-id b)})
+                   (update :location collection-test/location-path-ids->names)
+                   (update :id integer?))))))
 
-;; I shouldn't be allowed to move the Collection without proper perms.
-;; If I want to move A into B, I should need permissions for both A and B
-(expect
-  "You don't have permissions to do that."
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp* [Collection [collection-a]
-                    Collection [collection-b]]
-      (perms/grant-collection-readwrite-permissions! (group/all-users) collection-a)
-      ((user->client :rasta) :put 403 (str "collection/" (u/get-id collection-a))
-       {:parent_id (u/get-id collection-b)}))))
+    (testing "I shouldn't be allowed to move the Collection without proper perms."
+      (testing "If I want to move A into B, I should need permissions for both A and B"
+        (mt/with-non-admin-groups-no-root-collection-perms
+          (mt/with-temp* [Collection [collection-a]
+                          Collection [collection-b]]
+            (perms/grant-collection-readwrite-permissions! (group/all-users) collection-a)
+            (is (= "You don't have permissions to do that."
+                   ((mt/user->client :rasta) :put 403 (str "collection/" (u/get-id collection-a))
+                    {:parent_id (u/get-id collection-b)}))))))
 
-;; Perms checking should be recursive as well...
-;;
-;; Create A, B, and C; B is a child of A. Grant perms for A and B. Moving A into C should fail because we need perms
-;; for C:
-;; (collections with readwrite perms marked below with a `*`)
-;;
-;; A* -> B*  ==>  C -> A -> B
-;; C
-(expect
-  "You don't have permissions to do that."
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp* [Collection [collection-a]
-                    Collection [collection-b {:location (collection/children-location collection-a)}]
-                    Collection [collection-c]]
-      (doseq [collection [collection-a collection-b]]
-        (perms/grant-collection-readwrite-permissions! (group/all-users) collection))
-      ((user->client :rasta) :put 403 (str "collection/" (u/get-id collection-a))
-       {:parent_id (u/get-id collection-c)}))))
+      (testing "Perms checking should be recursive as well..."
+        (testing "Create A, B, and C; B is a child of A."
+          (testing "Grant perms for A and B. Moving A into C should fail because we need perms for C"
+            ;; (collections with readwrite perms marked below with a `*`)
+            ;; A* -> B* ==> C -> A -> B
+            (mt/with-non-admin-groups-no-root-collection-perms
+              (mt/with-temp* [Collection [collection-a]
+                              Collection [collection-b {:location (collection/children-location collection-a)}]
+                              Collection [collection-c]]
+                (doseq [collection [collection-a collection-b]]
+                  (perms/grant-collection-readwrite-permissions! (group/all-users) collection))
+                (is (= "You don't have permissions to do that."
+                       ((mt/user->client :rasta) :put 403 (str "collection/" (u/get-id collection-a))
+                        {:parent_id (u/get-id collection-c)}))))))
 
+          (testing "Grant perms for A and C. Moving A into C should fail because we need perms for B."
+            ;; A* -> B  ==>  C -> A -> B
+            ;; C*
+            (mt/with-non-admin-groups-no-root-collection-perms
+              (mt/with-temp* [Collection [collection-a]
+                              Collection [collection-b {:location (collection/children-location collection-a)}]
+                              Collection [collection-c]]
+                (doseq [collection [collection-a collection-c]]
+                  (perms/grant-collection-readwrite-permissions! (group/all-users) collection))
+                (is (= "You don't have permissions to do that."
+                       ((mt/user->client :rasta) :put 403 (str "collection/" (u/get-id collection-a))
+                        {:parent_id (u/get-id collection-c)}))))))
 
-;; Create A, B, and C; B is a child of A. Grant perms for A and C. Moving A into C should fail because we need perms
-;; for B:
-;; (collections with readwrite perms marked below with a `*`)
-;;
-;; A* -> B  ==>  C -> A -> B
-;; C*
-(expect
-  "You don't have permissions to do that."
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp* [Collection [collection-a]
-                    Collection [collection-b {:location (collection/children-location collection-a)}]
-                    Collection [collection-c]]
-      (doseq [collection [collection-a collection-c]]
-        (perms/grant-collection-readwrite-permissions! (group/all-users) collection))
-      ((user->client :rasta) :put 403 (str "collection/" (u/get-id collection-a))
-       {:parent_id (u/get-id collection-c)}))))
-
-;; Create A, B, and C; B is a child of A. Grant perms for B and C. Moving A into C should fail because we need perms
-;; for A:
-;; (collections with readwrite perms marked below with a `*`)
-;;
-;; A -> B*  ==>  C -> A -> B
-;; C*
-(expect
-  "You don't have permissions to do that."
-  (tu/with-non-admin-groups-no-root-collection-perms
-    (tt/with-temp* [Collection [collection-a]
-                    Collection [collection-b {:location (collection/children-location collection-a)}]
-                    Collection [collection-c]]
-      (doseq [collection [collection-b collection-c]]
-        (perms/grant-collection-readwrite-permissions! (group/all-users) collection))
-      ((user->client :rasta) :put 403 (str "collection/" (u/get-id collection-a))
-       {:parent_id (u/get-id collection-c)}))))
+          (testing "Grant perms for B and C. Moving A into C should fail because we need perms for A"
+            ;; A -> B*  ==>  C -> A -> B
+            ;; C*
+            (mt/with-non-admin-groups-no-root-collection-perms
+              (mt/with-temp* [Collection [collection-a]
+                              Collection [collection-b {:location (collection/children-location collection-a)}]
+                              Collection [collection-c]]
+                (doseq [collection [collection-b collection-c]]
+                  (perms/grant-collection-readwrite-permissions! (group/all-users) collection))
+                (is (= "You don't have permissions to do that."
+                       ((mt/user->client :rasta) :put 403 (str "collection/" (u/get-id collection-a))
+                        {:parent_id (u/get-id collection-c)})))))))))))

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -154,7 +154,7 @@
       (with-search-items-in-root-collection "test"
         (mt/with-temp* [PermissionsGroup           [group]
                         PermissionsGroupMembership [_ {:user_id (test-users/user->id :rasta), :group_id (u/get-id group)}]]
-          (perms/grant-permissions! group (perms/collection-read-path {:metabase.models.collection/is-root? true}))
+          (perms/grant-permissions! group (perms/collection-read-path {:metabase.models.collection.root/is-root? true}))
           (is (= (remove (comp #{"collection"} :model) (default-search-results))
                  (search-request :rasta :q "test")))))))
 
@@ -180,7 +180,7 @@
         (with-search-items-in-root-collection "test2"
           (mt/with-temp* [PermissionsGroup           [group]
                           PermissionsGroupMembership [_ {:user_id (test-users/user->id :rasta), :group_id (u/get-id group)}]]
-            (perms/grant-permissions! group (perms/collection-read-path {:metabase.models.collection/is-root? true}))
+            (perms/grant-permissions! group (perms/collection-read-path {:metabase.models.collection.root/is-root? true}))
             (perms/grant-collection-read-permissions! group collection)
             (is (= (sorted-results
                     (into

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -312,3 +312,13 @@
         (perms/revoke-permissions! (group/all-users) db-id)
         (is (= []
                (search-request :rasta :q (:name table))))))))
+
+(deftest collection-namespaces-test
+  (testing "Search should only return Collections in the 'default' namespace"
+    (mt/with-temp* [Collection [c1 {:name "Normal Collection"}]
+                    Collection [c2 {:name "Coin Collection", :namespace "currency"}]]
+      (is (= ["Normal Collection"]
+             (->> (search-request :crowberto :q "Collection")
+                  (filter #(and (= (:model %) "collection")
+                                (#{"Normal Collection" "Coin Collection"} (:name %))))
+                  (map :name)))))))

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -162,7 +162,7 @@
         (try
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"Cards can only go in normal Collections"
+               #"A Card can only go in Collections of type nil"
                (db/insert! Card (assoc (tt/with-temp-defaults Card) :collection_id collection-id, :name card-name))))
           (finally
             (db/delete! Card :name card-name)))))
@@ -171,5 +171,5 @@
       (mt/with-temp Card [{card-id :id}]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"Cards can only go in normal Collections"
+             #"A Card can only go in Collections of type nil"
              (db/update! Card card-id {:collection_id collection-id})))))))

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -1,103 +1,107 @@
 (ns metabase.models.card-test
   (:require [cheshire.core :as json]
-            [expectations :refer :all]
+            [clojure.test :refer :all]
+            [metabase
+             [test :as mt]
+             [util :as u]]
             [metabase.models
-             [card :as card :refer :all]
+             [card :as card :refer [Card]]
              [dashboard :refer [Dashboard]]
              [dashboard-card :refer [DashboardCard]]]
-            [metabase.test
-             [data :as data]
-             [util :as tu]]
-            [metabase.util :as u]
+            [metabase.test.util :as tu]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
 
-;; Check that the :dashboard_count delay returns the correct count of Dashboards a Card is in
-(expect
-  [0 1 2]
-  (tt/with-temp* [Card      [{card-id :id}]
-                  Dashboard [dash-1]
-                  Dashboard [dash-2]]
-    (let [add-card-to-dash!   (fn [dash] (db/insert! DashboardCard :card_id card-id, :dashboard_id (u/get-id dash)))
-          get-dashboard-count (fn [] (dashboard-count (Card card-id)))]
+(deftest dashboard-count-test
+  (testing "Check that the :dashboard_count delay returns the correct count of Dashboards a Card is in"
+    (tt/with-temp* [Card      [{card-id :id}]
+                    Dashboard [dash-1]
+                    Dashboard [dash-2]]
+      (letfn [(add-card-to-dash! [dash]
+                (db/insert! DashboardCard :card_id card-id, :dashboard_id (u/get-id dash)))
+              (get-dashboard-count []
+                (card/dashboard-count (Card card-id)))]
+        (is (= 0
+               (get-dashboard-count)))
+        (testing "add to a Dashboard"
+          (add-card-to-dash! dash-1)
+          (is (= 1
+                 (get-dashboard-count))))
+        (testing "add to a second Dashboard"
+          (add-card-to-dash! dash-2)
+          (is (= 2
+                 (get-dashboard-count))))))))
 
-      [(get-dashboard-count)
-       (do (add-card-to-dash! dash-1) (get-dashboard-count))
-       (do (add-card-to-dash! dash-2) (get-dashboard-count))])))
+(deftest card-dependencies-test
+  (testing "Segment dependencies"
+    (is (= {:Segment #{2 3}
+            :Metric  #{}}
+           (card/card-dependencies
+            {:dataset_query {:type  :query
+                             :query {:filter [:and
+                                              [:> [:field-id 4] "2014-10-19"]
+                                              [:= [:field-id 5] "yes"]
+                                              [:segment 2]
+                                              [:segment 3]]}}}))))
 
+  (testing "Segment and Metric dependencies"
+    (is (= {:Segment #{1}
+            :Metric  #{7}}
+           (card/card-dependencies
+            {:dataset_query {:type  :query
+                             :query {:aggregation [:metric 7]
+                                     :filter      [:and
+                                                   [:> [:field-id 4] "2014-10-19"]
+                                                   [:= [:field-id 5] "yes"]
+                                                   [:or [:segment 1] [:!= [:field-id 5] "5"]]]}}}))))
 
-;; card-dependencies
+  (testing "no dependencies"
+    (is (= {:Segment #{}
+            :Metric  #{}}
+           (card/card-dependencies
+            {:dataset_query {:type  :query
+                             :query {:aggregation nil
+                                     :filter      nil}}})))))
 
-(expect
-  {:Segment #{2 3}
-   :Metric  #{}}
-  (card-dependencies
-   {:dataset_query {:type  :query
-                    :query {:filter [:and
-                                     [:> [:field-id 4] "2014-10-19"]
-                                     [:= [:field-id 5] "yes"]
-                                     [:segment 2]
-                                     [:segment 3]]}}}))
+(deftest remove-from-dashboards-when-archiving-test
+  (testing "Test that when somebody archives a Card, it is removed from any Dashboards it belongs to"
+    (tt/with-temp* [Dashboard     [dashboard]
+                    Card          [card]
+                    DashboardCard [dashcard  {:dashboard_id (u/get-id dashboard), :card_id (u/get-id card)}]]
+      (db/update! Card (u/get-id card) :archived true)
+      (is (= 0
+             (db/count DashboardCard :dashboard_id (u/get-id dashboard)))))))
 
-(expect
-  {:Segment #{1}
-   :Metric  #{7}}
-  (card-dependencies
-   {:dataset_query {:type  :query
-                    :query {:aggregation [:metric 7]
-                            :filter      [:and
-                                          [:> [:field-id 4] "2014-10-19"]
-                                          [:= [:field-id 5] "yes"]
-                                          [:or [:segment 1] [:!= [:field-id 5] "5"]]]}}}))
+(deftest public-sharing-test
+  (testing "test that a Card's :public_uuid comes back if public sharing is enabled..."
+    (tu/with-temporary-setting-values [enable-public-sharing true]
+      (tt/with-temp Card [card {:public_uuid (str (java.util.UUID/randomUUID))}]
+        (is (schema= u/uuid-regex
+                     (:public_uuid card)))))
 
-(expect
-  {:Segment #{}
-   :Metric  #{}}
-  (card-dependencies
-   {:dataset_query {:type  :query
-                    :query {:aggregation nil
-                            :filter      nil}}}))
-
-
-;; Test that when somebody archives a Card, it is removed from any Dashboards it belongs to
-(expect
-  0
-  (tt/with-temp* [Dashboard     [dashboard]
-                  Card          [card]
-                  DashboardCard [dashcard  {:dashboard_id (u/get-id dashboard), :card_id (u/get-id card)}]]
-    (db/update! Card (u/get-id card) :archived true)
-    (db/count DashboardCard :dashboard_id (u/get-id dashboard))))
-
-
-;; test that a Card's :public_uuid comes back if public sharing is enabled...
-(expect
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (tt/with-temp Card [card {:public_uuid (str (java.util.UUID/randomUUID))}]
-      (boolean (:public_uuid card)))))
-
-;; ...but if public sharing is *disabled* it should come back as `nil`
-(expect
-  nil
-  (tu/with-temporary-setting-values [enable-public-sharing false]
-    (tt/with-temp Card [card {:public_uuid (str (java.util.UUID/randomUUID))}]
-      (:public_uuid card))))
+    (testing "...but if public sharing is *disabled* it should come back as `nil`"
+      (tu/with-temporary-setting-values [enable-public-sharing false]
+        (tt/with-temp Card [card {:public_uuid (str (java.util.UUID/randomUUID))}]
+          (is (= nil
+                 (:public_uuid card))))))))
 
 (defn- dummy-dataset-query [database-id]
-  {:database (data/id)
+  {:database (mt/id)
    :type     :native
    :native   {:query "SELECT count(*) FROM toucan_sightings;"}})
 
-(expect
-  [{:name "some name"    :database_id (data/id)}
-   {:name "another name" :database_id (data/id)}]
+(deftest database-id-test
   (tt/with-temp Card [{:keys [id] :as card} {:name          "some name"
-                                             :dataset_query (dummy-dataset-query (data/id))
-                                             :database_id   (data/id)}]
-    [(into {} (db/select-one [Card :name :database_id] :id id))
-     (do
-       (db/update! Card id {:name          "another name"
-                            :dataset_query (dummy-dataset-query (data/id))})
-       (into {} (db/select-one [Card :name :database_id] :id id)))]))
+                                             :dataset_query (dummy-dataset-query (mt/id))
+                                             :database_id   (mt/id)}]
+    (testing "before update"
+      (is (= {:name "some name", :database_id (mt/id)}
+             (into {} (db/select-one [Card :name :database_id] :id id)))))
+    (db/update! Card id {:name          "another name"
+                         :dataset_query (dummy-dataset-query (mt/id))})
+    (testing "after update"
+      (is (= {:name "another name" :database_id (mt/id)}
+             (into {} (db/select-one [Card :name :database_id] :id id)))))))
 
 
 ;;; ------------------------------------------ Circular Reference Detection ------------------------------------------
@@ -106,7 +110,7 @@
   "Generate values for a Card with `source-table` for use with `with-temp`."
   {:style/indent 1}
   [source-table & {:as kvs}]
-  (merge {:dataset_query {:database (data/id)
+  (merge {:dataset_query {:database (mt/id)
                           :type     :query
                           :query    {:source-table source-table}}}
          kvs))
@@ -119,39 +123,36 @@
                                ;; we have to manually JSON-encode since we're skipping normal pre-update stuff
                                (update :dataset_query json/generate-string))}))
 
-;; If a Card uses itself as a source, perms calculations should fallback to the 'only admins can see it' perms of
-;; #{"/db/0"} (DB 0 will never exist, so regular users will never get to see it, but because admins have root perms,
-;; they will still get to see it and perhaps fix it.)
-(expect
-  Exception
-  (tt/with-temp Card [card (card-with-source-table (data/id :venues))]
-    ;; now try to make the Card reference itself. Should throw Exception
-    (db/update! Card (u/get-id card)
-      (card-with-source-table (str "card__" (u/get-id card))))))
+(deftest circular-reference-test
+  (testing "Should throw an Exception if saving a Card that references itself"
+    (tt/with-temp Card [card (card-with-source-table (mt/id :venues))]
+      ;; now try to make the Card reference itself. Should throw Exception
+      (is (thrown?
+           Exception
+           (db/update! Card (u/get-id card)
+             (card-with-source-table (str "card__" (u/get-id card))))))))
 
-;; Do the same stuff with circular reference between two Cards... (A -> B -> A)
-(expect
-  Exception
-  (tt/with-temp* [Card [card-a (card-with-source-table (data/id :venues))]
-                  Card [card-b (card-with-source-table (str "card__" (u/get-id card-a)))]]
-    (db/update! Card (u/get-id card-a)
-      (card-with-source-table (str "card__" (u/get-id card-b))))))
+  (testing "Do the same stuff with circular reference between two Cards... (A -> B -> A)"
+    (tt/with-temp* [Card [card-a (card-with-source-table (mt/id :venues))]
+                    Card [card-b (card-with-source-table (str "card__" (u/get-id card-a)))]]
+      (is (thrown?
+           Exception
+           (db/update! Card (u/get-id card-a)
+             (card-with-source-table (str "card__" (u/get-id card-b))))))))
 
-;; ok now try it with A -> C -> B -> A
-(expect
-  Exception
-  (tt/with-temp* [Card [card-a (card-with-source-table (data/id :venues))]
-                  Card [card-b (card-with-source-table (str "card__" (u/get-id card-a)))]
-                  Card [card-c (card-with-source-table (str "card__" (u/get-id card-b)))]]
-    (db/update! Card (u/get-id card-a)
-                (card-with-source-table (str "card__" (u/get-id card-c))))))
+  (testing "ok now try it with A -> C -> B -> A"
+    (tt/with-temp* [Card [card-a (card-with-source-table (mt/id :venues))]
+                    Card [card-b (card-with-source-table (str "card__" (u/get-id card-a)))]
+                    Card [card-c (card-with-source-table (str "card__" (u/get-id card-b)))]]
+      (is (thrown?
+           Exception
+           (db/update! Card (u/get-id card-a)
+             (card-with-source-table (str "card__" (u/get-id card-c)))))))))
 
-(expect
-  #{1}
-  (#'card/extract-ids :segment {:query {:fields [[:segment 1]
-                                                 [:metric 2]]}}))
-
-(expect
-  #{2}
-  (#'card/extract-ids :metric {:query {:fields [[:segment 1]
-                                                [:metric 2]]}}))
+(deftest extract-ids-test
+  (doseq [[ids-type expected] {:segment #{1}
+                               :metric  #{2}}]
+    (testing (pr-str (list 'extract-ids ids-type 'card))
+      (is (= expected
+             (#'card/extract-ids ids-type {:query {:fields [[:segment 1]
+                                                            [:metric 2]]}}))))))

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -155,14 +155,14 @@
              (#'card/extract-ids ids-type {:query {:fields [[:segment 1]
                                                             [:metric 2]]}}))))))
 
-(deftest validate-collection-type-test
-  (mt/with-temp Collection [{collection-id :id} {:type "currency"}]
+(deftest validate-collection-namespace-test
+  (mt/with-temp Collection [{collection-id :id} {:namespace "currency"}]
     (testing "Shouldn't be able to create a Card in a non-normal Collection"
       (let [card-name (mt/random-name)]
         (try
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"A Card can only go in Collections of type nil"
+               #"A Card can only go in Collections in the \"default\" namespace"
                (db/insert! Card (assoc (tt/with-temp-defaults Card) :collection_id collection-id, :name card-name))))
           (finally
             (db/delete! Card :name card-name)))))
@@ -171,5 +171,5 @@
       (mt/with-temp Card [{card-id :id}]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"A Card can only go in Collections of type nil"
+             #"A Card can only go in Collections in the \"default\" namespace"
              (db/update! Card card-id {:collection_id collection-id})))))))

--- a/test/metabase/models/collection/graph_test.clj
+++ b/test/metabase/models/collection/graph_test.clj
@@ -7,11 +7,13 @@
             [metabase.api.common :refer [*current-user-id*]]
             [metabase.models
              [collection :as collection :refer [Collection]]
-             [collection-revision :refer [CollectionRevision]]
+             [collection-revision :as collection-revision :refer [CollectionRevision]]
              [permissions :as perms]
              [permissions-group :as group :refer [PermissionsGroup]]]
             [metabase.models.collection.graph :as graph]
             [metabase.test.fixtures :as fixtures]
+            [metabase.util.schema :as su]
+            [schema.core :as s]
             [toucan.db :as db]))
 
 (use-fixtures :once (fixtures/initialize :db :test-users :test-users-personal-collections))
@@ -22,19 +24,40 @@
 (defn- replace-collection-ids
   "In Collection perms `graph`, replace instances of the ID of `collection-or-id` with `:COLLECTION`, making it possible
   to write tests that don't need to know its actual numeric ID."
-  [collection-or-id graph]
-  (update graph :groups (partial m/map-vals (partial m/map-keys (fn [collection-id]
-                                                                  (if (= collection-id (u/get-id collection-or-id))
-                                                                    :COLLECTION
-                                                                    collection-id))))))
+  ([collection-or-id graph]
+   (replace-collection-ids collection-or-id graph :COLLECTION))
+
+  ([collection-or-id graph replacement-key]
+   (update graph :groups (partial m/map-vals (partial m/map-keys (fn [collection-id]
+                                                                   (if (= collection-id (u/get-id collection-or-id))
+                                                                     replacement-key
+                                                                     collection-id)))))))
 
 (defn- clear-graph-revisions! []
   (db/delete! CollectionRevision))
 
+(defn- only-groups
+  "Remove entries for non-'magic' groups from a fetched perms `graph`."
+  [graph groups-or-ids]
+  (update graph :groups select-keys (map u/get-id groups-or-ids)))
+
+(defn- only-collections
+  "Remove entries for Collections whose ID is not in `collection-ids` from a fetched perms `graph`."
+  [graph collections-or-ids]
+  (let [ids (for [collection-or-id collections-or-ids]
+              (if (= :root collection-or-id)
+                collection-or-id
+                (u/get-id collection-or-id)))]
+    (update graph :groups (fn [groups]
+                            (m/map-vals #(select-keys % ids) groups)))))
+
 (defn- graph
-  "Fetch collection graph. `:clear-revisions?` = delete any previously existing collection revision entries so we get
-  revision = 0."
-  [& {:keys [clear-revisions?]}]
+  "Fetch collection graph.
+
+  * `:clear-revisions?` = delete any previously existing collection revision entries so we get revision = 0
+  * `:collections`      = IDs of Collections to keep. `:root` is always kept.
+  * `:groups`           = IDs of Groups to keep. 'Magic' groups are always kept."
+  [& {:keys [clear-revisions? collections groups]}]
   (when clear-revisions?
     (clear-graph-revisions!))
   ;; force lazy creation of the three magic groups as needed
@@ -42,7 +65,9 @@
   (group/admin)
   (group/metabot)
   ;; now fetch the graph
-  (graph/graph))
+  (cond-> (-> (graph/graph)
+              (only-groups (concat [(group/all-users) (group/metabot) (group/admin)] groups))
+              (only-collections (cons :root collections)))))
 
 (deftest basic-test
   (testing "Check that the basic graph works"
@@ -61,7 +86,7 @@
                 :groups   {(u/get-id (group/all-users)) {:root :none,  :COLLECTION :none}
                            (u/get-id (group/metabot))   {:root :none,  :COLLECTION :none}
                            (u/get-id (group/admin))     {:root :write, :COLLECTION :write}}}
-               (replace-collection-ids collection (graph :clear-revisions? true))))))))
+               (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection]))))))))
 
 (deftest read-perms-test
   (testing "make sure read perms show up correctly"
@@ -72,7 +97,7 @@
                 :groups   {(u/get-id (group/all-users)) {:root :none,  :COLLECTION :read}
                            (u/get-id (group/metabot))   {:root :none,  :COLLECTION :none}
                            (u/get-id (group/admin))     {:root :write, :COLLECTION :write}}}
-               (replace-collection-ids collection (graph :clear-revisions? true))))))))
+               (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection]))))))))
 
 (deftest grant-write-perms-for-new-collections-test
   (testing "make sure we can grant write perms for new collections (!)"
@@ -83,7 +108,7 @@
                  :groups   {(u/get-id (group/all-users)) {:root :none,  :COLLECTION :write}
                             (u/get-id (group/metabot))   {:root :none,  :COLLECTION :none}
                             (u/get-id (group/admin))     {:root :write, :COLLECTION :write}}}
-                (replace-collection-ids collection (graph :clear-revisions? true))))))))
+                (replace-collection-ids collection (graph :clear-revisions? true, :collections [collection]))))))))
 
 (deftest non-magical-groups-test
   (testing "make sure a non-magical group will show up"
@@ -94,7 +119,7 @@
                              (u/get-id (group/metabot))   {:root :none}
                              (u/get-id (group/admin))     {:root :write}
                              (u/get-id new-group)         {:root :none}}}
-                 (graph :clear-revisions? true)))))))
+                 (graph :clear-revisions? true, :groups [new-group])))))))
 
 (deftest root-collection-read-perms-test
   (testing "How abut *read* permissions for the Root Collection?"
@@ -106,7 +131,7 @@
                            (u/get-id (group/metabot))   {:root :none}
                            (u/get-id (group/admin))     {:root :write}
                            (u/get-id new-group)         {:root :read}}}
-               (graph :clear-revisions? true)))))))
+               (graph :clear-revisions? true, :groups [new-group])))))))
 
 (deftest root-collection-write-perms-test
   (testing "How about granting *write* permissions for the Root Collection?"
@@ -118,7 +143,7 @@
                            (u/get-id (group/metabot))   {:root :none}
                            (u/get-id (group/admin))     {:root :write}
                            (u/get-id new-group)         {:root :write}}}
-               (graph :clear-revisions? true)))))))
+               (graph :clear-revisions? true, :groups [new-group])))))))
 
 (deftest no-op-test
   (testing "Can we do a no-op update?"
@@ -147,7 +172,7 @@
                   :groups   {(u/get-id (group/all-users)) {:root :none,  :COLLECTION :read}
                              (u/get-id (group/metabot))   {:root :none,  :COLLECTION :none}
                              (u/get-id (group/admin))     {:root :write, :COLLECTION :write}}}
-                 (replace-collection-ids collection (graph))))))))
+                 (replace-collection-ids collection (graph :collections [collection]))))))))
 
   (testing "can we give them *write* perms?"
     (mt/with-non-admin-groups-no-root-collection-perms
@@ -160,7 +185,7 @@
                   :groups   {(u/get-id (group/all-users)) {:root :none,  :COLLECTION :write}
                              (u/get-id (group/metabot))   {:root :none,  :COLLECTION :none}
                              (u/get-id (group/admin))     {:root :write, :COLLECTION :write}}}
-                 (replace-collection-ids collection (graph)))))))))
+                 (replace-collection-ids collection (graph :collections [collection])))))))))
 
 (deftest revoke-perms-test
   (testing "can we *revoke* perms?"
@@ -176,7 +201,7 @@
                   :groups   {(u/get-id (group/all-users)) {:root :none,  :COLLECTION :none}
                              (u/get-id (group/metabot))   {:root :none,  :COLLECTION :none}
                              (u/get-id (group/admin))     {:root :write, :COLLECTION :write}}}
-                 (replace-collection-ids collection (graph)))))))))
+                 (replace-collection-ids collection (graph :collections [collection])))))))))
 
 (deftest grant-root-permissions-test
   (testing "Can we grant *read* permissions for the Root Collection?"
@@ -192,7 +217,7 @@
                              (u/get-id (group/metabot))   {:root :none}
                              (u/get-id (group/admin))     {:root :write}
                              (u/get-id new-group)         {:root :read}}}
-                 (graph)))))))
+                 (graph :groups [new-group])))))))
 
   (testing "How about granting *write* permissions for the Root Collection?"
     (mt/with-temp PermissionsGroup [new-group]
@@ -207,7 +232,7 @@
                              (u/get-id (group/metabot))   {:root :none}
                              (u/get-id (group/admin))     {:root :write}
                              (u/get-id new-group)         {:root :write}}}
-                 (graph))))))))
+                 (graph :groups [new-group]))))))))
 
 (deftest revoke-root-permissions-test
   (testing "can we *revoke* RootCollection perms?"
@@ -224,7 +249,7 @@
                              (u/get-id (group/metabot))   {:root :none}
                              (u/get-id (group/admin))     {:root :write}
                              (u/get-id new-group)         {:root :none}}}
-                 (graph))))))))
+                 (graph :groups [new-group]))))))))
 
 (deftest personal-collections-should-not-appear-test
   (testing "Make sure that personal Collections *do not* appear in the Collections graph"
@@ -246,22 +271,23 @@
                (graph)))))))
 
 (deftest disallow-editing-personal-collections-test
-  (testing "Make sure that if we try to be sneaky and edit a Personal Collection via the graph, an Exception is thrown"
-    (clear-graph-revisions!)
+  (testing "Make sure that if we try to be sneaky and edit a Personal Collection via the graph, changes are ignored"
     (mt/with-non-admin-groups-no-root-collection-perms
-      (let [lucky-personal-collection-id (u/get-id (collection/user->personal-collection (mt/user->id :lucky)))]
-        (is (thrown?
-             Exception
-             (graph/update-graph! (assoc-in (graph :clear-revisions? true)
-                                            [:groups (u/get-id (group/all-users)) lucky-personal-collection-id]
-                                            :read))))
+      (let [lucky-personal-collection-id (u/get-id (collection/user->personal-collection (mt/user->id :lucky)))
+            path                         [:groups (u/get-id (group/all-users)) lucky-personal-collection-id]]
+        (mt/throw-if-called graph/update-group-permissions!
+          (graph/update-graph! (assoc-in (graph :clear-revisions? true) path :read)))
 
         (testing "double-check that the graph is unchanged"
           (is (= {:revision 0
                   :groups   {(u/get-id (group/all-users)) {:root :none}
                              (u/get-id (group/metabot))   {:root :none}
                              (u/get-id (group/admin))     {:root :write}}}
-                 (graph)))))))
+                 (graph))))
+
+        (testing "No revision should have been saved"
+          (is (= 0
+                 (collection-revision/latest-id)))))))
 
   (testing "Make sure you can't be sneaky and edit descendants of Personal Collections either."
     (mt/with-temp Collection [collection {:location (lucky-collection-children-location)}]
@@ -276,6 +302,83 @@
                                             :read))))))))
 
 (deftest collection-namespace-test
-  (testing "The permissions graph should be namespace-aware"
-    ;; TODO
-    ))
+  (testing "The permissions graph should be namespace-aware.\n"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp* [Collection [{default-a :id}   {:location "/"}]
+                      Collection [{default-ab :id}  {:location (format "/%d/" default-a)}]
+                      Collection [{currency-a :id}  {:namespace "currency", :location "/"}]
+                      Collection [{currency-ab :id} {:namespace "currency", :location (format "/%d/" currency-a)}]
+                      PermissionsGroup [{group-id :id}]]
+        (letfn [(nice-graph [graph]
+                  (let [id->alias {default-a   "Default A"
+                                   default-ab  "Default A -> B"
+                                   currency-a  "Currency A"
+                                   currency-ab "Currency A -> B"}]
+                    (transduce
+                     identity
+                     (fn
+                       ([graph]
+                        (-> (get-in graph [:groups group-id])
+                            (select-keys (vals id->alias))))
+                       ([graph [collection-id k]]
+                        (replace-collection-ids collection-id graph k)))
+                     graph
+                     id->alias)))]
+          (doseq [collection [default-a default-ab currency-a currency-ab]]
+            (perms/grant-collection-read-permissions! group-id collection))
+          (testing "Calling (graph) with no args should only show Collections in the default namespace"
+            (is (= {"Default A" :read, "Default A -> B" :read}
+                   (nice-graph (graph/graph))
+                   (nice-graph (graph/graph nil)))))
+
+          (testing "You should be able to pass an different namespace to (graph) to see Collections in that namespace"
+            (is (= {"Currency A" :read, "Currency A -> B" :read}
+                   (nice-graph (graph/graph :currency)))))
+
+          (testing "Should be able to pass `::graph/all` to get a combined graph of all namespaces (used for saving revisions)"
+            (is (= {"Default A" :read, "Default A -> B" :read "Currency A" :read, "Currency A -> B" :read}
+                   (nice-graph (graph/graph ::graph/all)))))
+
+          ;; bind a current user so CollectionRevisions get saved.
+          (mt/with-test-user :crowberto
+            (testing "Should be able to update the graph for the default namespace.\n"
+              (let [before (graph/graph ::graph/all)]
+                (graph/update-graph! (-> (graph/graph)
+                                         (assoc-in [:groups group-id default-ab] :write)
+                                         (assoc-in [:groups group-id currency-ab] :write)))
+                (is (= {"Default A" :read, "Default A -> B" :write}
+                       (nice-graph (graph/graph))))
+
+                (testing "Updates to Collections in other namespaces should be ignored"
+                  (is (= {"Currency A" :read, "Currency A -> B" :read}
+                         (nice-graph (graph/graph :currency)))))
+
+                (testing "A CollectionRevision recording the *changes* to the perms graph should be saved."
+                  (is (schema= {:id         su/IntGreaterThanZero
+                                :before     (s/eq (mt/obj->json->obj before))
+                                :after      (s/eq {(keyword (str group-id)) {(keyword (str default-ab)) "write"}})
+                                :user_id    (s/eq (mt/user->id :crowberto))
+                                :created_at java.time.temporal.Temporal
+                                s/Keyword   s/Any}
+                               (db/select-one CollectionRevision {:order-by [[:id :desc]]}))))))
+
+            (testing "Should be able to update the graph for a non-default namespace.\n"
+              (let [before (graph/graph ::graph/all)]
+                (graph/update-graph! :currency (-> (graph/graph)
+                                                   (assoc-in [:groups group-id default-a] :write)
+                                                   (assoc-in [:groups group-id currency-a] :write)))
+                (is (= {"Currency A" :write, "Currency A -> B" :read}
+                       (nice-graph (graph/graph :currency))))
+
+                (testing "Updates to Collections in other namespaces should be ignored"
+                  (is (= {"Default A" :read, "Default A -> B" :write}
+                         (nice-graph (graph/graph)))))
+
+                (testing "A CollectionRevision recording the *changes* to the perms graph should be saved."
+                  (is (schema= {:id         su/IntGreaterThanZero
+                                :before     (s/eq (mt/obj->json->obj before))
+                                :after      (s/eq {(keyword (str group-id)) {(keyword (str currency-a)) "write"}})
+                                :user_id    (s/eq (mt/user->id :crowberto))
+                                :created_at java.time.temporal.Temporal
+                                s/Keyword   s/Any}
+                               (db/select-one CollectionRevision {:order-by [[:id :desc]]}))))))))))))

--- a/test/metabase/models/collection/graph_test.clj
+++ b/test/metabase/models/collection/graph_test.clj
@@ -1,0 +1,279 @@
+(ns metabase.models.collection.graph-test
+  (:require [clojure.test :refer :all]
+            [medley.core :as m]
+            [metabase
+             [test :as mt]
+             [util :as u]]
+            [metabase.api.common :refer [*current-user-id*]]
+            [metabase.models
+             [collection :as collection :refer [Collection]]
+             [collection-revision :refer [CollectionRevision]]
+             [permissions :as perms]
+             [permissions-group :as group :refer [PermissionsGroup]]]
+            [metabase.models.collection.graph :as graph]
+            [metabase.test
+             [fixtures :as fixtures]
+             [util :as tu]]
+            [metabase.test.data.users :as test-users]
+            [toucan.db :as db]))
+
+(use-fixtures :once (fixtures/initialize :db :test-users :test-users-personal-collections))
+
+(defn- lucky-collection-children-location []
+  (collection/children-location (collection/user->personal-collection (test-users/user->id :lucky))))
+
+(defn- replace-collection-ids
+  "In Collection perms `graph`, replace instances of the ID of `collection-or-id` with `:COLLECTION`, making it possible
+  to write tests that don't need to know its actual numeric ID."
+  [collection-or-id graph]
+  (update graph :groups (partial m/map-vals (partial m/map-keys (fn [collection-id]
+                                                                  (if (= collection-id (u/get-id collection-or-id))
+                                                                    :COLLECTION
+                                                                    collection-id))))))
+
+(defn- clear-graph-revisions! []
+  (db/delete! CollectionRevision))
+
+(defn- graph
+  "Fetch collection graph. `:clear-revisions?` = delete any previously existing collection revision entries so we get
+  revision = 0."
+  [& {:keys [clear-revisions?]}]
+  (when clear-revisions?
+    (clear-graph-revisions!))
+  ;; force lazy creation of the three magic groups as needed
+  (group/all-users)
+  (group/admin)
+  (group/metabot)
+  ;; now fetch the graph
+  (graph/graph))
+
+(deftest basic-test
+  (testing "Check that the basic graph works"
+    (tu/with-non-admin-groups-no-root-collection-perms
+      (is (= {:revision 0
+              :groups   {(u/get-id (group/all-users)) {:root :none}
+                         (u/get-id (group/metabot))   {:root :none}
+                         (u/get-id (group/admin))     {:root :write}}}
+             (graph :clear-revisions? true))))))
+
+(deftest new-collection-perms-test
+  (testing "Creating a new Collection shouldn't give perms to anyone but admins"
+    (tu/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp Collection [collection]
+        (is (= {:revision 0
+                :groups   {(u/get-id (group/all-users)) {:root :none,  :COLLECTION :none}
+                           (u/get-id (group/metabot))   {:root :none,  :COLLECTION :none}
+                           (u/get-id (group/admin))     {:root :write, :COLLECTION :write}}}
+               (replace-collection-ids collection (graph :clear-revisions? true))))))))
+
+(deftest read-perms-test
+  (testing "make sure read perms show up correctly"
+    (tu/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp Collection [collection]
+        (perms/grant-collection-read-permissions! (group/all-users) collection)
+        (is (= {:revision 0
+                :groups   {(u/get-id (group/all-users)) {:root :none,  :COLLECTION :read}
+                           (u/get-id (group/metabot))   {:root :none,  :COLLECTION :none}
+                           (u/get-id (group/admin))     {:root :write, :COLLECTION :write}}}
+               (replace-collection-ids collection (graph :clear-revisions? true))))))))
+
+(deftest grant-write-perms-for-new-collections-test
+  (testing "make sure we can grant write perms for new collections (!)"
+    (tu/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp Collection [collection]
+        (perms/grant-collection-readwrite-permissions! (group/all-users) collection)
+        (is (=  {:revision 0
+                 :groups   {(u/get-id (group/all-users)) {:root :none,  :COLLECTION :write}
+                            (u/get-id (group/metabot))   {:root :none,  :COLLECTION :none}
+                            (u/get-id (group/admin))     {:root :write, :COLLECTION :write}}}
+                (replace-collection-ids collection (graph :clear-revisions? true))))))))
+
+(deftest non-magical-groups-test
+  (testing "make sure a non-magical group will show up"
+    (mt/with-temp PermissionsGroup [new-group]
+      (tu/with-non-admin-groups-no-root-collection-perms
+        (is (=   {:revision 0
+                  :groups   {(u/get-id (group/all-users)) {:root :none}
+                             (u/get-id (group/metabot))   {:root :none}
+                             (u/get-id (group/admin))     {:root :write}
+                             (u/get-id new-group)         {:root :none}}}
+                 (graph :clear-revisions? true)))))))
+
+(deftest root-collection-read-perms-test
+  (testing "How abut *read* permissions for the Root Collection?"
+    (mt/with-temp PermissionsGroup [new-group]
+      (tu/with-non-admin-groups-no-root-collection-perms
+        (perms/grant-collection-read-permissions! new-group collection/root-collection)
+        (is (= {:revision 0
+                :groups   {(u/get-id (group/all-users)) {:root :none}
+                           (u/get-id (group/metabot))   {:root :none}
+                           (u/get-id (group/admin))     {:root :write}
+                           (u/get-id new-group)         {:root :read}}}
+               (graph :clear-revisions? true)))))))
+
+(deftest root-collection-write-perms-test
+  (testing "How about granting *write* permissions for the Root Collection?"
+    (mt/with-temp PermissionsGroup [new-group]
+      (tu/with-non-admin-groups-no-root-collection-perms
+        (perms/grant-collection-readwrite-permissions! new-group collection/root-collection)
+        (is (= {:revision 0
+                :groups   {(u/get-id (group/all-users)) {:root :none}
+                           (u/get-id (group/metabot))   {:root :none}
+                           (u/get-id (group/admin))     {:root :write}
+                           (u/get-id new-group)         {:root :write}}}
+               (graph :clear-revisions? true)))))))
+
+(deftest no-op-test
+  (testing "Can we do a no-op update?"
+    ;; need to bind *current-user-id* or the Revision won't get updated
+    (clear-graph-revisions!)
+    (tu/with-non-admin-groups-no-root-collection-perms
+      (binding [*current-user-id* (test-users/user->id :crowberto)]
+        (graph/update-graph! (graph :clear-revisions? true))
+        (is (= {:revision 0
+                :groups   {(u/get-id (group/all-users)) {:root :none}
+                           (u/get-id (group/metabot))   {:root :none}
+                           (u/get-id (group/admin))     {:root :write}}}
+               (graph))
+            "revision should not have changed, because there was nothing to do...")))))
+
+(deftest grant-perms-test
+  (testing "Can we give someone read perms via the graph?"
+    (clear-graph-revisions!)
+    (tu/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp Collection [collection]
+        (binding [*current-user-id* (test-users/user->id :crowberto)]
+          (graph/update-graph! (assoc-in (graph :clear-revisions? true)
+                                         [:groups (u/get-id (group/all-users)) (u/get-id collection)]
+                                         :read))
+          (is (= {:revision 1
+                  :groups   {(u/get-id (group/all-users)) {:root :none,  :COLLECTION :read}
+                             (u/get-id (group/metabot))   {:root :none,  :COLLECTION :none}
+                             (u/get-id (group/admin))     {:root :write, :COLLECTION :write}}}
+                 (replace-collection-ids collection (graph))))))))
+
+  (testing "can we give them *write* perms?"
+    (tu/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp Collection [collection]
+        (binding [*current-user-id* (test-users/user->id :crowberto)]
+          (graph/update-graph! (assoc-in (graph :clear-revisions? true)
+                                         [:groups (u/get-id (group/all-users)) (u/get-id collection)]
+                                         :write))
+          (is (= {:revision 1
+                  :groups   {(u/get-id (group/all-users)) {:root :none,  :COLLECTION :write}
+                             (u/get-id (group/metabot))   {:root :none,  :COLLECTION :none}
+                             (u/get-id (group/admin))     {:root :write, :COLLECTION :write}}}
+                 (replace-collection-ids collection (graph)))))))))
+
+(deftest revoke-perms-test
+  (testing "can we *revoke* perms?"
+    (clear-graph-revisions!)
+    (tu/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp Collection [collection]
+        (binding [*current-user-id* (test-users/user->id :crowberto)]
+          (perms/grant-collection-read-permissions! (group/all-users) collection)
+          (graph/update-graph! (assoc-in (graph :clear-revisions? true)
+                                         [:groups (u/get-id (group/all-users)) (u/get-id collection)]
+                                         :none))
+          (is (= {:revision 1
+                  :groups   {(u/get-id (group/all-users)) {:root :none,  :COLLECTION :none}
+                             (u/get-id (group/metabot))   {:root :none,  :COLLECTION :none}
+                             (u/get-id (group/admin))     {:root :write, :COLLECTION :write}}}
+                 (replace-collection-ids collection (graph)))))))))
+
+(deftest grant-root-permissions-test
+  (testing "Can we grant *read* permissions for the Root Collection?"
+    (mt/with-temp PermissionsGroup [new-group]
+      (clear-graph-revisions!)
+      (tu/with-non-admin-groups-no-root-collection-perms
+        (binding [*current-user-id* (test-users/user->id :crowberto)]
+          (graph/update-graph! (assoc-in (graph :clear-revisions? true)
+                                         [:groups (u/get-id new-group) :root]
+                                         :read))
+          (is (= {:revision 1
+                  :groups   {(u/get-id (group/all-users)) {:root :none}
+                             (u/get-id (group/metabot))   {:root :none}
+                             (u/get-id (group/admin))     {:root :write}
+                             (u/get-id new-group)         {:root :read}}}
+                 (graph)))))))
+
+  (testing "How about granting *write* permissions for the Root Collection?"
+    (mt/with-temp PermissionsGroup [new-group]
+      (clear-graph-revisions!)
+      (tu/with-non-admin-groups-no-root-collection-perms
+        (binding [*current-user-id* (test-users/user->id :crowberto)]
+          (graph/update-graph! (assoc-in (graph :clear-revisions? true)
+                                         [:groups (u/get-id new-group) :root]
+                                         :write))
+          (is (= {:revision 1
+                  :groups   {(u/get-id (group/all-users)) {:root :none}
+                             (u/get-id (group/metabot))   {:root :none}
+                             (u/get-id (group/admin))     {:root :write}
+                             (u/get-id new-group)         {:root :write}}}
+                 (graph))))))))
+
+(deftest revoke-root-permissions-test
+  (testing "can we *revoke* RootCollection perms?"
+    (mt/with-temp PermissionsGroup [new-group]
+      (clear-graph-revisions!)
+      (tu/with-non-admin-groups-no-root-collection-perms
+        (binding [*current-user-id* (test-users/user->id :crowberto)]
+          (perms/grant-collection-readwrite-permissions! new-group collection/root-collection)
+          (graph/update-graph! (assoc-in (graph :clear-revisions? true)
+                                         [:groups (u/get-id new-group) :root]
+                                         :none))
+          (is (= {:revision 1
+                  :groups   {(u/get-id (group/all-users)) {:root :none}
+                             (u/get-id (group/metabot))   {:root :none}
+                             (u/get-id (group/admin))     {:root :write}
+                             (u/get-id new-group)         {:root :none}}}
+                 (graph))))))))
+
+(deftest personal-collections-should-not-appear-test
+  (testing "Make sure that personal Collections *do not* appear in the Collections graph"
+    (tu/with-non-admin-groups-no-root-collection-perms
+      (is (= {:revision 0
+              :groups   {(u/get-id (group/all-users)) {:root :none}
+                         (u/get-id (group/metabot))   {:root :none}
+                         (u/get-id (group/admin))     {:root :write}}}
+             (graph :clear-revisions? true)))))
+
+  (testing "Make sure descendants of Personal Collections do not come back as part of the graph either..."
+    (clear-graph-revisions!)
+    (tu/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp Collection [_ {:location (lucky-collection-children-location)}]
+        (is (= {:revision 0
+                :groups   {(u/get-id (group/all-users)) {:root :none}
+                           (u/get-id (group/metabot))   {:root :none}
+                           (u/get-id (group/admin))     {:root :write}}}
+               (graph)))))))
+
+(deftest disallow-editing-personal-collections-test
+  (testing "Make sure that if we try to be sneaky and edit a Personal Collection via the graph, an Exception is thrown"
+    (clear-graph-revisions!)
+    (tu/with-non-admin-groups-no-root-collection-perms
+      (let [lucky-personal-collection-id (u/get-id (collection/user->personal-collection (test-users/user->id :lucky)))]
+        (is (thrown?
+             Exception
+             (graph/update-graph! (assoc-in (graph :clear-revisions? true)
+                                            [:groups (u/get-id (group/all-users)) lucky-personal-collection-id]
+                                            :read))))
+
+        (testing "double-check that the graph is unchanged"
+          (is (= {:revision 0
+                  :groups   {(u/get-id (group/all-users)) {:root :none}
+                             (u/get-id (group/metabot))   {:root :none}
+                             (u/get-id (group/admin))     {:root :write}}}
+                 (graph)))))))
+
+  (testing "Make sure you can't be sneaky and edit descendants of Personal Collections either."
+    (mt/with-temp Collection [collection {:location (lucky-collection-children-location)}]
+      (let [lucky-personal-collection-id (u/get-id (collection/user->personal-collection (test-users/user->id :lucky)))]
+        (is (thrown?
+             Exception
+             (graph/update-graph! (assoc-in (graph :clear-revisions? true)
+                                            [:groups
+                                             (u/get-id (group/all-users))
+                                             lucky-personal-collection-id
+                                             (u/get-id collection)]
+                                            :read))))))))

--- a/test/metabase/models/collection/graph_test.clj
+++ b/test/metabase/models/collection/graph_test.clj
@@ -277,3 +277,8 @@
                                              lucky-personal-collection-id
                                              (u/get-id collection)]
                                             :read))))))))
+
+(deftest collection-type-test
+  (testing "The permissions graph should be type-aware"
+    ;; TODO
+    ))

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -42,14 +42,15 @@
 
 (deftest color-validation-test
   (testing "Collection colors should be validated when inserted into the DB"
-    (are [test-msg input] (is (thrown? Exception
-                                       (db/insert! Collection {:name "My Favorite Cards", :color input}))
-                              test-msg)
-      "Missing color"       nil
-      "Too short"           #"ABC"
-      "Invalid chars"       "#BCDEFG"
-      "Too long"            #"ABCDEFF"
-      "Missing hash prefix" "ABCDEF")))
+    (doseq [[input msg] {nil        "Missing color"
+                         "#ABC"     "Too short"
+                         "#BCDEFG"  "Invalid chars"
+                         "#ABCDEFF" "Too long"
+                         "ABCDEF"   "Missing hash prefix"}]
+      (testing msg
+        (is (thrown?
+             Exception
+             (db/insert! Collection {:name "My Favorite Cards", :color input})))))))
 
 ;; double-check that `with-temp-defaults` are working correctly for Collection
 (expect

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -244,14 +244,14 @@
           (is (= (db/count 'DashboardCard :dashboard_id (:id saved-dashboard))
                  (-> dashboard :ordered_cards count))))))))
 
-(deftest validate-collection-type-test
-  (mt/with-temp Collection [{collection-id :id} {:type "currency"}]
+(deftest validate-collection-namespace-test
+  (mt/with-temp Collection [{collection-id :id} {:namespace "currency"}]
     (testing "Shouldn't be able to create a Dashboard in a non-normal Collection"
       (let [dashboard-name (mt/random-name)]
         (try
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"A Dashboard can only go in Collections of type nil"
+               #"A Dashboard can only go in Collections in the \"default\" namespace"
                (db/insert! Dashboard (assoc (tt/with-temp-defaults Dashboard) :collection_id collection-id, :name dashboard-name))))
           (finally
             (db/delete! Dashboard :name dashboard-name)))))
@@ -260,5 +260,5 @@
       (mt/with-temp Dashboard [{card-id :id}]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"A Dashboard can only go in Collections of type nil"
+             #"A Dashboard can only go in Collections in the \"default\" namespace"
              (db/update! Dashboard card-id {:collection_id collection-id})))))))

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -1,5 +1,9 @@
 (ns metabase.models.dashboard-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
+            [expectations :refer [expect]]
+            [metabase
+             [test :as mt]
+             [util :as u]]
             [metabase.api.common :as api]
             [metabase.automagic-dashboards.core :as magic]
             [metabase.models
@@ -17,7 +21,6 @@
              [data :refer :all]
              [util :as tu]]
             [metabase.test.data.users :as users]
-            [metabase.util :as u]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
 
@@ -167,18 +170,18 @@
          (update (serialize-dashboard (Dashboard dashboard-id)) :cards check-ids)]))))
 
 
-;; test that a Dashboard's :public_uuid comes back if public sharing is enabled...
-(expect
-  (tu/with-temporary-setting-values [enable-public-sharing true]
-    (tt/with-temp Dashboard [dashboard {:public_uuid (str (java.util.UUID/randomUUID))}]
-      (boolean (:public_uuid dashboard)))))
+(deftest public-sharing-test
+  (testing "test that a Dashboard's :public_uuid comes back if public sharing is enabled..."
+    (tu/with-temporary-setting-values [enable-public-sharing true]
+      (tt/with-temp Dashboard [dashboard {:public_uuid (str (java.util.UUID/randomUUID))}]
+        (is (schema= u/uuid-regex
+                     (:public_uuid dashboard)))))
 
-;; ...but if public sharing is *disabled* it should come back as `nil`
-(expect
-  nil
-  (tu/with-temporary-setting-values [enable-public-sharing false]
-    (tt/with-temp Dashboard [dashboard {:public_uuid (str (java.util.UUID/randomUUID))}]
-      (:public_uuid dashboard))))
+    (testing "...but if public sharing is *disabled* it should come back as `nil`"
+      (tu/with-temporary-setting-values [enable-public-sharing false]
+        (tt/with-temp Dashboard [dashboard {:public_uuid (str (java.util.UUID/randomUUID))}]
+          (is (= nil
+                 (:public_uuid dashboard))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -226,23 +229,36 @@
     (binding [api/*current-user-permissions-set* (atom #{(perms/collection-readwrite-path collection)})]
       (mi/can-write? dash))))
 
+(deftest transient-dashboards-test
+  (testing "test that we save a transient dashboard"
+    (tu/with-model-cleanup ['Card 'Dashboard 'DashboardCard 'Collection]
+      (binding [api/*current-user-id*              (users/user->id :rasta)
+                api/*current-user-permissions-set* (-> :rasta
+                                                       users/user->id
+                                                       user/permissions-set
+                                                       atom)]
+        (let [dashboard                  (magic/automagic-analysis (Table (id :venues)) {})
+              rastas-personal-collection (db/select-one-field :id 'Collection
+                                           :personal_owner_id api/*current-user-id*)
+              saved-dashboard            (save-transient-dashboard! dashboard rastas-personal-collection)]
+          (is (= (db/count 'DashboardCard :dashboard_id (:id saved-dashboard))
+                 (-> dashboard :ordered_cards count))))))))
 
-;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                           Transient Dashboard Tests                                            |
-;;; +----------------------------------------------------------------------------------------------------------------+
+(deftest validate-collection-type-test
+  (mt/with-temp Collection [{collection-id :id} {:type "currency"}]
+    (testing "Shouldn't be able to create a Dashboard in a non-normal Collection"
+      (let [dashboard-name (mt/random-name)]
+        (try
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"A Dashboard can only go in Collections of type nil"
+               (db/insert! Dashboard (assoc (tt/with-temp-defaults Dashboard) :collection_id collection-id, :name dashboard-name))))
+          (finally
+            (db/delete! Dashboard :name dashboard-name)))))
 
-;; test that we save a transient dashboard
-(expect
-  (tu/with-model-cleanup ['Card 'Dashboard 'DashboardCard 'Collection]
-    (binding [api/*current-user-id*              (users/user->id :rasta)
-              api/*current-user-permissions-set* (-> :rasta
-                                                     users/user->id
-                                                     user/permissions-set
-                                                     atom)]
-      (let [dashboard                  (magic/automagic-analysis (Table (id :venues)) {})
-            rastas-personal-collection (db/select-one-field :id 'Collection
-                                         :personal_owner_id api/*current-user-id*)]
-        (->> (save-transient-dashboard! dashboard rastas-personal-collection)
-             :id
-             (db/count 'DashboardCard :dashboard_id)
-             (= (-> dashboard :ordered_cards count)))))))
+    (testing "Shouldn't be able to move a Dashboard to a non-normal Collection"
+      (mt/with-temp Dashboard [{card-id :id}]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"A Dashboard can only go in Collections of type nil"
+             (db/update! Dashboard card-id {:collection_id collection-id})))))))

--- a/test/metabase/models/native_query_snippet_test.clj
+++ b/test/metabase/models/native_query_snippet_test.clj
@@ -41,7 +41,7 @@
       (mt/with-temp Collection [{collection-id :id} {:type collection-type}]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"NativeQuerySnippets can only go inside :snippet Collections"
+             #"A NativeQuerySnippet can only go in Collections of type :snippet"
              (db/insert! NativeQuerySnippet
                {:name          (mt/random-name)
                 :content       "1 = 1"
@@ -54,5 +54,5 @@
                       Collection         [{dest-collection-id :id}   {:type collection-type}]]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"NativeQuerySnippets can only go inside :snippet Collections"
+             #"A NativeQuerySnippet can only go in Collections of type :snippet"
              (db/update! NativeQuerySnippet snippet-id :collection_id dest-collection-id)))))))

--- a/test/metabase/models/native_query_snippet_test.clj
+++ b/test/metabase/models/native_query_snippet_test.clj
@@ -16,43 +16,44 @@
              (db/select-one-field :creator_id NativeQuerySnippet :id snippet-id))))))
 
 (deftest snippet-collection-test
-  (testing "Should be allowed to create snippets in a :snippet Collection"
-    (mt/with-temp* [Collection         [{collection-id :id} {:type "snippet"}]
+  (testing "Should be allowed to create snippets in a Collection in the :snippets namespace"
+    (mt/with-temp* [Collection         [{collection-id :id} {:namespace "snippets"}]
                     NativeQuerySnippet [{snippet-id :id} {:collection_id collection-id}]]
       (is (= collection-id
              (db/select-one-field :collection_id NativeQuerySnippet :id snippet-id)))))
 
-  (doseq [[source dest] [[nil "snippet"]
-                         ["snippet" "snippet"]
-                         ["snippet" nil]]]
+  (doseq [[source dest] [[nil "snippets"]
+                         ["snippets" "snippets"]
+                         ["snippets" nil]]]
     (testing (format "Should be allowed to move snippets from %s to %s"
-                     (if source "a :snippet Collection" "no Collection")
-                     (if dest "a :snippet Collection" "no Collection"))
-      (mt/with-temp* [Collection         [{source-collection-id :id} {:type source}]
-                      Collection         [{dest-collection-id :id}   {:type dest}]
+                     (if source "a :snippets Collection" "no Collection")
+                     (if dest "a :snippets Collection" "no Collection"))
+      (mt/with-temp* [Collection         [{source-collection-id :id} {:namespace source}]
+                      Collection         [{dest-collection-id :id}   {:namespace dest}]
                       NativeQuerySnippet [{snippet-id :id} (when source
                                                              {:collection_id source-collection-id})]]
         (db/update! NativeQuerySnippet snippet-id :collection_id (when dest dest-collection-id))
         (is (= (when dest dest-collection-id)
                (db/select-one-field :collection_id NativeQuerySnippet :id snippet-id))))))
 
-  (doseq [collection-type [nil "x"]]
-    (testing (format "Should *not* be allowed to create snippets in a Collection of type %s" (pr-str collection-type))
-      (mt/with-temp Collection [{collection-id :id} {:type collection-type}]
+  (doseq [collection-namespace [nil "x"]]
+    (testing (format "Should *not* be allowed to create snippets in a Collection in the %s namespace"
+                     (pr-str collection-namespace))
+      (mt/with-temp Collection [{collection-id :id} {:namespace collection-namespace}]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"A NativeQuerySnippet can only go in Collections of type :snippet"
+             #"A NativeQuerySnippet can only go in Collections in the :snippets namespace"
              (db/insert! NativeQuerySnippet
                {:name          (mt/random-name)
                 :content       "1 = 1"
                 :creator_id    (mt/user->id :rasta)
                 :collection_id collection-id})))))
 
-    (testing (format "Should *not* be allowed to move snippets into a Collection of type %s" (pr-str collection-type))
-      (mt/with-temp* [Collection         [{source-collection-id :id} {:type "snippet"}]
+    (testing (format "Should *not* be allowed to move snippets into a Collection in the namespace %s" (pr-str collection-namespace))
+      (mt/with-temp* [Collection         [{source-collection-id :id} {:namespace "snippets"}]
                       NativeQuerySnippet [{snippet-id :id}           {:collection_id source-collection-id}]
-                      Collection         [{dest-collection-id :id}   {:type collection-type}]]
+                      Collection         [{dest-collection-id :id}   {:namespace collection-namespace}]]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"A NativeQuerySnippet can only go in Collections of type :snippet"
+             #"A NativeQuerySnippet can only go in Collections in the :snippets namespace"
              (db/update! NativeQuerySnippet snippet-id :collection_id dest-collection-id)))))))

--- a/test/metabase/models/native_query_snippet_test.clj
+++ b/test/metabase/models/native_query_snippet_test.clj
@@ -1,7 +1,8 @@
 (ns metabase.models.native-query-snippet-test
   (:require [clojure.test :refer :all]
-            [metabase.models.native-query-snippet :refer [NativeQuerySnippet]]
-            [metabase.test :as mt]
+            [metabase
+             [models :refer [Collection NativeQuerySnippet]]
+             [test :as mt]]
             [toucan.db :as db]))
 
 (deftest disallow-updating-creator-id-test
@@ -13,3 +14,45 @@
            (db/update! NativeQuerySnippet snippet-id :creator_id (mt/user->id :rasta))))
       (is (= (mt/user->id :lucky)
              (db/select-one-field :creator_id NativeQuerySnippet :id snippet-id))))))
+
+(deftest snippet-collection-test
+  (testing "Should be allowed to create snippets in a :snippet Collection"
+    (mt/with-temp* [Collection         [{collection-id :id} {:type "snippet"}]
+                    NativeQuerySnippet [{snippet-id :id} {:collection_id collection-id}]]
+      (is (= collection-id
+             (db/select-one-field :collection_id NativeQuerySnippet :id snippet-id)))))
+
+  (doseq [[source dest] [[nil "snippet"]
+                         ["snippet" "snippet"]
+                         ["snippet" nil]]]
+    (testing (format "Should be allowed to move snippets from %s to %s"
+                     (if source "a :snippet Collection" "no Collection")
+                     (if dest "a :snippet Collection" "no Collection"))
+      (mt/with-temp* [Collection         [{source-collection-id :id} {:type source}]
+                      Collection         [{dest-collection-id :id}   {:type dest}]
+                      NativeQuerySnippet [{snippet-id :id} (when source
+                                                             {:collection_id source-collection-id})]]
+        (db/update! NativeQuerySnippet snippet-id :collection_id (when dest dest-collection-id))
+        (is (= (when dest dest-collection-id)
+               (db/select-one-field :collection_id NativeQuerySnippet :id snippet-id))))))
+
+  (doseq [collection-type [nil "x"]]
+    (testing (format "Should *not* be allowed to create snippets in a Collection of type %s" (pr-str collection-type))
+      (mt/with-temp Collection [{collection-id :id} {:type collection-type}]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"NativeQuerySnippets can only go inside :snippet Collections"
+             (db/insert! NativeQuerySnippet
+               {:name          (mt/random-name)
+                :content       "1 = 1"
+                :creator_id    (mt/user->id :rasta)
+                :collection_id collection-id})))))
+
+    (testing (format "Should *not* be allowed to move snippets into a Collection of type %s" (pr-str collection-type))
+      (mt/with-temp* [Collection         [{source-collection-id :id} {:type "snippet"}]
+                      NativeQuerySnippet [{snippet-id :id}           {:collection_id source-collection-id}]
+                      Collection         [{dest-collection-id :id}   {:type collection-type}]]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"NativeQuerySnippets can only go inside :snippet Collections"
+             (db/update! NativeQuerySnippet snippet-id :collection_id dest-collection-id)))))))

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.models.pulse-test
   (:require [clojure.test :refer :all]
-            [expectations :refer :all]
+            [expectations :refer [expect]]
             [medley.core :as m]
             [metabase
              [test :as mt]
@@ -258,3 +258,22 @@
   (with-pulse-in-collection [db _ pulse]
     (binding [api/*current-user-permissions-set* (atom #{(perms/object-path (u/get-id db))})]
       (mi/can-read? pulse))))
+
+(deftest validate-collection-type-test
+  (mt/with-temp Collection [{collection-id :id} {:type "currency"}]
+    (testing "Shouldn't be able to create a Pulse in a non-normal Collection"
+      (let [pulse-name (mt/random-name)]
+        (try
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"A Pulse can only go in Collections of type nil"
+               (db/insert! Pulse (assoc (tt/with-temp-defaults Pulse) :collection_id collection-id, :name pulse-name))))
+          (finally
+            (db/delete! Pulse :name pulse-name)))))
+
+    (testing "Shouldn't be able to move a Pulse to a non-normal Collection"
+      (mt/with-temp Pulse [{card-id :id}]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"A Pulse can only go in Collections of type nil"
+             (db/update! Pulse card-id {:collection_id collection-id})))))))

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -128,10 +128,10 @@
                           (dissoc (user-details :rasta) :is_superuser :is_qbnewb)]})
   (mt/with-temp Pulse [{:keys [id]}]
     (update-notification-channels! {:id id} [{:enabled       true
-                                       :channel_type  :email
-                                       :schedule_type :daily
-                                       :schedule_hour 4
-                                       :recipients    [{:email "foo@bar.com"} {:id (user->id :rasta)}]}])
+                                              :channel_type  :email
+                                              :schedule_type :daily
+                                              :schedule_hour 4
+                                              :recipients    [{:email "foo@bar.com"} {:id (user->id :rasta)}]}])
     (-> (PulseChannel :pulse_id id)
         (hydrate :recipients)
         (dissoc :id :pulse_id :created_at :updated_at)
@@ -259,14 +259,14 @@
     (binding [api/*current-user-permissions-set* (atom #{(perms/object-path (u/get-id db))})]
       (mi/can-read? pulse))))
 
-(deftest validate-collection-type-test
-  (mt/with-temp Collection [{collection-id :id} {:type "currency"}]
+(deftest validate-collection-namespace-test
+  (mt/with-temp Collection [{collection-id :id} {:namespace "currency"}]
     (testing "Shouldn't be able to create a Pulse in a non-normal Collection"
       (let [pulse-name (mt/random-name)]
         (try
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"A Pulse can only go in Collections of type nil"
+               #"A Pulse can only go in Collections in the \"default\" namespace"
                (db/insert! Pulse (assoc (tt/with-temp-defaults Pulse) :collection_id collection-id, :name pulse-name))))
           (finally
             (db/delete! Pulse :name pulse-name)))))
@@ -275,5 +275,5 @@
       (mt/with-temp Pulse [{card-id :id}]
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"A Pulse can only go in Collections of type nil"
+             #"A Pulse can only go in Collections in the \"default\" namespace"
              (db/update! Pulse card-id {:collection_id collection-id})))))))

--- a/test/metabase/sync_database/analyze_test.clj
+++ b/test/metabase/sync_database/analyze_test.clj
@@ -17,9 +17,6 @@
 
 (defn- classified-special-type [values]
   (let [field (field/map->FieldInstance {:base_type :type/Text})]
-    (println "RESULT =" (classify-text-fingerprint/infer-special-type
-                         field
-                         (transduce identity (fingerprinters/fingerprinter field) values)))
     (:special_type (classify-text-fingerprint/infer-special-type
                     field
                     (transduce identity (fingerprinters/fingerprinter field) values)))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -577,7 +577,7 @@
 
 (defn do-with-model-cleanup [model-seq f]
   (try
-    (testing (str (pr-str (cons 'with-model-cleanup model-seq)) "\n")
+    (testing (str "\n" (pr-str (cons 'with-model-cleanup (map name model-seq))) "\n")
       (f))
     (finally
       (doseq [model model-seq]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -166,7 +166,9 @@
 
 (u/strict-extend (class NativeQuerySnippet)
   tt/WithTempDefaults
-  {:with-temp-defaults (fn [_] {:creator_id (user-id :crowberto)})})
+  {:with-temp-defaults (fn [_] {:creator_id (user-id :crowberto)
+                                :name       (random-name)
+                                :content    "1 = 1"})})
 
 (u/strict-extend (class PermissionsGroup)
   tt/WithTempDefaults


### PR DESCRIPTION
WIP impl of some preliminary work to support EE permissions for NativeQuerySnippets. The stuff in this PR isn't EE-specific and is stuff that should go in CE anyway; a separate EE PR will add EE-specific stuff. 

After trying a few different things I think this is the simplest approach to implementing the new perms system:

*  Add a notion of "namespace" to Collection. Normal Collections are in the default namespace, e.g. `:namespace = nil`. For now there is one other namespace, `:snippet`, which refers to "Snippet folders". Namespaces are completely independent and represent separate hierarchies
*  Snippets can optionally have a `collection_id` that points to a `:snippet` Collection ("folder"). If `collection_id` is set, Collection perms apply as usual
    *  Snippet `collection_id` can only be set if EE token is present
*  Various `/api/collection` endpoints will support a `?namespace=` parameter to work on non-default namespace Collections, e.g `:snippet` "folders". So to power the new Snippet "folder" perms UI we can use existing Collection endpoints with `?namespace=snippet`
    *  `/api/collection/` endpoints will only show "default" (`nil`) namespace Collections by default, so the "folders" will be invisible

TODO:

- [x] Add Snippet `collection_id`
    - [x] tests
- [x] Add Collection `namespace`
    - [x] tests
- [x] Validate Collection `namespace` is same as parent
    - [x] tests
- [x] Snippets can only go in `:snippet` Collections
    - [x] tests
- [x] Collection *list* API endpoints should accept `?namespace=` param and only show Collections of that namespace
    - [x] tests
- [x] `GET /api/collection/root/items?namespace=snippet` should *only* show Snippets
    - [x] tests
- [x] Collection `POST` API endpoint should allow creating a Collection with a `namespace` 
    - [ ] should we validate that the namespace is allowed? Define set of valid namespaces somewhere
    - [x] tests
- [x] Collection perms graph and related endpoints should be `:namespace` aware so you can edit different Collection "namespaces" separately
    - [x] tests 
- [x] Don't allow anything besides Snippets in `:snippet` Collections
    - [x] Cards
    - [x] Dashboards
    - [x] Pulses
    - [x] tests 
- [x] Tweak `CollectionRevision` so it is namespace-aware, or just save the entire combined graph (TBD)
- [x] (un)archiving a Collection should (un)archive its Snippets just like for Cards/Dashboards/Pulses
- [x] Make sure places that use `permissions-set->visible-collection-ids` and `visible-collection-ids->honeysql-filter-clause` properly handle Collection namespaces (search, MetaBot command, database `source-query-cards`)
- [x] Make sure Snippets come back for the Collection items endpoints for the `snippets` namespace

Stuff to go in follow-on EE PR:

- [ ] `PUT`/`POST` Snippet API endpoints should allow you to change Snippet Collection. 
    - [ ] permissions checks to do this
    - [ ] tests
- [x] Check Snippet collection for perms
    - [ ] tests
    - [ ] This should actually be EE-only