### PR TITLE
Fix URL in H2 database warning

### DIFF
--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -116,7 +116,7 @@
            (trs "If you decide to continue to use H2, please be sure to back up the database file regularly.")
            " "
            (trs "For more information, see")
-           "https://metabase.com/docs/latest/operations-guide/migrating-from-h2.html"))))
+           " https://metabase.com/docs/latest/operations-guide/migrating-from-h2.html"))))
    (or @connection-string-details
        (case (db-type)
          ;; TODO - we probably don't need to specifc `:type` here since we can just call (db-type)


### PR DESCRIPTION
Before:

```
07-02 09:03:27 WARN metabase.db :: WARNING: Using Metabase with an H2 application database is not recommended for production deployments. For production deployments, we highly recommend using Postgres, MySQL, or MariaDB instead. If you decide to continue to use H2, please be sure to back up the database file regularly. For more information, seehttps://metabase.com/docs/latest/operations-guide/migrating-from-h2.html
```

After:

```
07-02 09:07:32 WARN metabase.db :: WARNING: Using Metabase with an H2 application database is not recommended for production deployments. For production deployments, we highly recommend using Postgres, MySQL, or MariaDB instead. If you decide to continue to use H2, please be sure to back up the database file regularly. For more information, see https://metabase.com/docs/latest/operations-guide/migrating-from-h2.html
```