### PR TITLE
Uppercase certain identifiers for snowflake

### DIFF
--- a/modules/drivers/snowflake/resources/metabase-plugin.yaml
+++ b/modules/drivers/snowflake/resources/metabase-plugin.yaml
@@ -24,6 +24,7 @@ driver:
         - dbname
         - name: db
           required: true
+          display-name: Database name (case sensitive)
     - name: regionid
       display-name: Region ID
       placeholder: my_region

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -47,7 +47,7 @@
   (let [host (if regionid
                (str account "." regionid)
                account)
-        upcase-not-nil (fn [s] (when s (str/upper-case s)))]
+        upcase-not-nil (fn [s] (when s (u/upper-case-en s)))]
     ;; it appears to be the case that their JDBC driver ignores `db` -- see my bug report at
     ;; https://support.snowflake.net/s/question/0D50Z00008WTOMCSA5/
     (-> (merge {:classname                                  "net.snowflake.client.jdbc.SnowflakeDriver"

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -37,7 +37,8 @@
   [_ {:keys [account regionid], :as opts}]
   (let [host (if regionid
                (str account "." regionid)
-               account)]
+               account)
+        upcase-not-nil (fn [s] (when s (str/upper-case s)))]
     ;; it appears to be the case that their JDBC driver ignores `db` -- see my bug report at
     ;; https://support.snowflake.net/s/question/0D50Z00008WTOMCSA5/
     (-> (merge {:classname                                  "net.snowflake.client.jdbc.SnowflakeDriver"
@@ -59,9 +60,9 @@
                    ;; `db`. If we run across `dbname`, correct our behavior
                    (set/rename-keys {:dbname :db})
                    ;; see https://github.com/metabase/metabase/issues/9511
-                   (update :warehouse str/upper-case)
-                   (update :schema str/upper-case)
-                   (update :db str/upper-case)
+                   (update :warehouse upcase-not-nil)
+                   (update :schema upcase-not-nil)
+                   (update :db upcase-not-nil)
                    (dissoc :host :port :timezone)))
         (sql-jdbc.common/handle-additional-options opts))))
 

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -58,6 +58,10 @@
                    ;; original version of the Snowflake driver incorrectly used `dbname` in the details fields instead of
                    ;; `db`. If we run across `dbname`, correct our behavior
                    (set/rename-keys {:dbname :db})
+                   ;; see https://github.com/metabase/metabase/issues/9511
+                   (update :warehouse str/upper-case)
+                   (update :schema str/upper-case)
+                   (update :db str/upper-case)
                    (dissoc :host :port :timezone)))
         (sql-jdbc.common/handle-additional-options opts))))
 

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -286,7 +286,8 @@
   (and ((get-method driver/can-connect? :sql-jdbc) driver details)
        (let [spec (sql-jdbc.conn/details->connection-spec-for-testing-connection driver details)
              sql  (format "SHOW OBJECTS IN DATABASE \"%s\";" db)]
-         (jdbc/query spec sql))))
+         (jdbc/query spec sql)
+         true)))
 
 (defmethod unprepare/unprepare-value [:snowflake OffsetDateTime]
   [_ t]

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -98,10 +98,10 @@
       (is (= true
              (can-connect? (:details (mt/db))))
           "can-connect? should return true for normal Snowflake DB details")
-      (is (= false
-             (mt/suppress-output
-               (can-connect? (assoc (:details (mt/db)) :db (mt/random-name)))))
-          "can-connect? should return false for Snowflake databases that don't exist (#9041)"))))
+      (is (thrown? net.snowflake.client.jdbc.SnowflakeSQLException
+                   (mt/suppress-output
+                    (can-connect? (assoc (:details (mt/db)) :db (mt/random-name)))))
+          "can-connect? should throw for Snowflake databases that don't exist (#9511)"))))
 
 (deftest report-timezone-test
   (mt/test-driver :snowflake

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -47,13 +47,13 @@
     :password  (tx/db-test-env-var-or-throw :snowflake :password)
     ;; this lowercasing this value is part of testing the fix for
     ;; https://github.com/metabase/metabase/issues/9511
-    :warehouse (str/lower-case (tx/db-test-env-var-or-throw :snowflake :warehouse))
+    :warehouse (u/lower-case-en (tx/db-test-env-var-or-throw :snowflake :warehouse))
     ;; SESSION parameters
     :timezone "UTC"}
    ;; Snowflake JDBC driver ignores this, but we do use it in the `query-db-name` function in
    ;; `metabase.driver.snowflake`
    (when (= context :db)
-     {:db (qualified-db-name (str/lower-case database-name))})))
+     {:db (qualified-db-name (u/lower-case-en database-name))})))
 
 ;; Snowflake requires you identify an object with db-name.schema-name.table-name
 (defmethod sql.tx/qualified-name-components :snowflake
@@ -76,7 +76,7 @@
     (jdbc/with-db-metadata [metadata db-spec]
       ;; for whatever dumb reason the Snowflake JDBC driver always returns these as uppercase despite us making them
       ;; all lower-case
-      (set (map str/lower-case (sql-jdbc.sync/get-catalogs metadata))))))
+      (set (map u/lower-case-en (sql-jdbc.sync/get-catalogs metadata))))))
 
 (let [datasets (atom nil)]
   (defn- existing-datasets []

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -45,13 +45,15 @@
    {:account   (tx/db-test-env-var-or-throw :snowflake :account)
     :user      (tx/db-test-env-var-or-throw :snowflake :user)
     :password  (tx/db-test-env-var-or-throw :snowflake :password)
-    :warehouse (tx/db-test-env-var-or-throw :snowflake :warehouse)
+    ;; this lowercasing this value is part of testing the fix for
+    ;; https://github.com/metabase/metabase/issues/9511
+    :warehouse (str/lower-case (tx/db-test-env-var-or-throw :snowflake :warehouse))
     ;; SESSION parameters
     :timezone "UTC"}
    ;; Snowflake JDBC driver ignores this, but we do use it in the `query-db-name` function in
    ;; `metabase.driver.snowflake`
    (when (= context :db)
-     {:db (qualified-db-name database-name)})))
+     {:db (qualified-db-name (str/lower-case database-name))})))
 
 ;; Snowflake requires you identify an object with db-name.schema-name.table-name
 (defmethod sql.tx/qualified-name-components :snowflake

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -745,6 +745,14 @@
   [^CharSequence s]
   (.. s toString (toLowerCase (Locale/US))))
 
+(defn upper-case-en
+  "Locale-agnostic version of `clojure.string/upper-case`.
+  `clojure.string/upper-case` uses the default locale in conversions, turning
+  `ID` into `ıd`, in the Turkish locale. This function always uses the
+  `Locale/US` locale."
+  [^CharSequence s]
+  (.. s toString (toUpperCase (Locale/US))))
+
 (defn lower-case-map-keys
   "Changes the keys of a given map to lower case."
   [m]

--- a/src/metabase/util.clj
+++ b/src/metabase/util.clj
@@ -748,7 +748,7 @@
 (defn upper-case-en
   "Locale-agnostic version of `clojure.string/upper-case`.
   `clojure.string/upper-case` uses the default locale in conversions, turning
-  `ID` into `ıd`, in the Turkish locale. This function always uses the
+  `id` into `İD`, in the Turkish locale. This function always uses the
   `Locale/US` locale."
   [^CharSequence s]
   (.. s toString (toUpperCase (Locale/US))))

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -3,8 +3,9 @@
   (:require [clojure.test :refer :all]
             [clojure.tools.macro :as tools.macro]
             [flatland.ordered.map :refer [ordered-map]]
-            [metabase.util :as u])
-  (:import java.util.Locale))
+            [metabase
+             [test :as mt]
+             [util :as u]]))
 
 (defn- are+-message [expr arglist args]
   (pr-str
@@ -226,24 +227,14 @@
     nil nil))
 
 (deftest lower-case-en-test
-  (let [original-locale (Locale/getDefault)]
-    (try
-      (Locale/setDefault (Locale/forLanguageTag "tr"))
-      ;; `(str/lower-case "ID")` returns "ıd" in the Turkish locale
-      (is (= "id"
-             (u/lower-case-en "ID")))
-      (finally
-        (Locale/setDefault original-locale)))))
+  (mt/with-locale "tr"
+    (is (= "id"
+           (u/lower-case-en "ID")))))
 
 (deftest upper-case-en-test
-  (let [original-locale (Locale/getDefault)]
-    (try
-      (Locale/setDefault (Locale/forLanguageTag "tr"))
-      ;; `(str/upper-case "id")` returns "İD" in the Turkish locale
-      (is (= "ID"
-             (u/upper-case-en "id")))
-      (finally
-        (Locale/setDefault original-locale)))))
+  (mt/with-locale "tr"
+    (is (= "ID"
+           (u/upper-case-en "id")))))
 
 (deftest parse-currency-test
   (are+ [s expected] (= expected

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -3,7 +3,8 @@
   (:require [clojure.test :refer :all]
             [clojure.tools.macro :as tools.macro]
             [flatland.ordered.map :refer [ordered-map]]
-            [metabase.util :as u])
+            [metabase.util :as u]
+            [clojure.string :as str])
   (:import java.util.Locale))
 
 (defn- are+-message [expr arglist args]
@@ -232,6 +233,16 @@
       ;; `(str/lower-case "ID")` returns "ıd" in the Turkish locale
       (is (= "id"
              (u/lower-case-en "ID")))
+      (finally
+        (Locale/setDefault original-locale)))))
+
+(deftest upper-case-en-test
+  (let [original-locale (Locale/getDefault)]
+    (try
+      (Locale/setDefault (Locale/forLanguageTag "tr"))
+      ;; `(str/upper-case "id")` returns "İD" in the Turkish locale
+      (is (= "ID"
+             (u/upper-case-en "id")))
       (finally
         (Locale/setDefault original-locale)))))
 

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.util-test
   "Tests for functions in `metabase.util`."
-  (:require [clojure.tools.macro :as tools.macro]
+  (:require [clojure.test :refer :all]
+            [clojure.tools.macro :as tools.macro]
             [flatland.ordered.map :refer [ordered-map]]
             [metabase.util :as u])
   (:import java.util.Locale))

--- a/test/metabase/util_test.clj
+++ b/test/metabase/util_test.clj
@@ -1,10 +1,8 @@
 (ns metabase.util-test
   "Tests for functions in `metabase.util`."
-  (:require [clojure.test :refer :all]
-            [clojure.tools.macro :as tools.macro]
+  (:require [clojure.tools.macro :as tools.macro]
             [flatland.ordered.map :refer [ordered-map]]
-            [metabase.util :as u]
-            [clojure.string :as str])
+            [metabase.util :as u])
   (:import java.util.Locale))
 
 (defn- are+-message [expr arglist args]


### PR DESCRIPTION
Snowflake stores warehouse, database and schema names in uppper case.
When creating the connection details, uppercase them.

Resolves #9511

[ci snowflake]
