### PR TITLE
Quote rows column, otherwise MySQL migration fails

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -6387,6 +6387,7 @@ databaseChangeLog:
       id: 169
       author: camsaul
       comment: Added 0.36.0
+      objectQuotingStrategy: ${quote_strategy}
       changes:
         - dropColumn:
             tableName: metabase_table


### PR DESCRIPTION
Cannot setup a new instance on MySQL, since migration 169 fails because `rows` is a reserved name.