### PR TITLE
Infer native query col types even if first 100 values are nil

### DIFF
--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -15,6 +15,7 @@
              [error-type :as error-type]
              [reducible :as qp.reducible]
              [store :as qp.store]]
+            [metabase.sync.analyze.fingerprint.fingerprinters :as f]
             [metabase.util
              [i18n :refer [deferred-tru tru]]
              [schema :as su]]
@@ -59,53 +60,38 @@
 
 (defn- check-driver-native-columns
   "Double-check that the *driver* returned the correct number of `columns` for native query results."
-  [cols rows]
+  [cols first-row]
   {:pre [(sequential? cols) (every? map? cols)]}
-  (when (seq rows)
+  (when first-row
     (let [expected-count (count cols)
-          actual-count   (count (first rows))]
+          actual-count   (count first-row)]
       (when-not (= expected-count actual-count)
         (throw (ex-info (str (deferred-tru "Query processor error: number of columns returned by driver does not match results.")
                              "\n"
                              (deferred-tru "Expected {0} columns, but first row of resuls has {1} columns."
                                expected-count actual-count))
                  {:expected-columns (map :name cols)
-                  :first-row        (first rows)
+                  :first-row        first-row
                   :type             error-type/qp}))))))
 
-(defn- native-column-info-for-a-single-column
-  "Determine column metadata for a single column for native query results."
-  [unique-name-fn {col-name :name, driver-base-type :base_type, :as driver-col-metadata} values-sample]
-  ;; Native queries don't have the type information from the original `Field` objects used in the query.
-  ;;
-  ;; If the driver returned a base type more specific than :type/*, use that; otherwise look at the sample
-  ;; of rows and infer the base type based on the classes of the values
-  (let [col-name  (name col-name)
-        base-type (or (when-not (= driver-base-type :type/*)
-                        driver-base-type)
-                      (driver.common/values->base-type values-sample)
-                      :type/*)]
-    (merge
-     {:display_name (u/qualified-name col-name)
-      :base_type    base-type
-      :source       :native}
-     ;; It is perfectly legal for a driver to return a column with a blank name; for example, SQL Server does this
-     ;; for aggregations like `count(*)` if no alias is used. However, it is *not* legal to use blank names in MBQL
-     ;; `:field-literal` clauses, because `SELECT ""` doesn't make any sense. So if we can't return a valid
-     ;; `:field-literal`, omit the `:field_ref`.
-     (when (seq col-name)
-       {:field_ref [:field-literal (unique-name-fn col-name) base-type]})
-     driver-col-metadata
-     {:base_type base-type})))
-
 (defmethod column-info :native
-  [_ {:keys [cols rows]}]
-  (check-driver-native-columns cols rows)
-  (mapv (partial native-column-info-for-a-single-column (mbql.u/unique-name-generator))
-        cols
-        (for [i (range (count cols))]
-          (for [row rows]
-            (nth row i)))))
+  [_ {:keys [cols base-types first-row]}]
+  (check-driver-native-columns cols first-row)
+  (let [unique-name-fn (mbql.u/unique-name-generator)]
+    (vec (for [[{col-name :name,:as driver-col-metadata} base-type] (map vector cols base-types)]
+           (let [col-name (name col-name)]
+             (merge
+              {:display_name (u/qualified-name col-name)
+               :base_type    base-type
+               :source       :native}
+              ;; It is perfectly legal for a driver to return a column with a blank name; for example, SQL Server does this
+              ;; for aggregations like `count(*)` if no alias is used. However, it is *not* legal to use blank names in MBQL
+              ;; `:field-literal` clauses, because `SELECT ""` doesn't make any sense. So if we can't return a valid
+              ;; `:field-literal`, omit the `:field_ref`.
+              (when (seq col-name)
+                {:field_ref [:field-literal (unique-name-fn col-name) base-type]})
+              driver-col-metadata
+              {:base_type base-type}))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -559,18 +545,27 @@
   (deduplicate-cols-names
    (merge-cols-returned-by-driver (column-info query result) cols-returned-by-driver)))
 
-(def ^:private column-info-sample-size
-  "Number of result rows to sample when adding column info to results."
-  100)
+(defn- base-type-inferer
+  "Native queries don't have the type information from the original `Field` objects used in the query.
+  If the driver returned a base type more specific than :type/*, use that; otherwise look at the sample
+  of rows and infer the base type based on the classes of the values"
+  [{:keys [cols]}]
+  (apply f/col-wise (for [{driver-base-type :base_type} cols]
+                      (if-not (contains? #{nil :type/*} driver-base-type)
+                        (f/constant-fingerprinter driver-base-type)
+                        driver.common/values->base-type))))
 
 (defn- add-column-info-xform [{query-type :type, :as query} metadata rf]
   (qp.reducible/combine-additional-reducing-fns
    rf
-   [((take column-info-sample-size) conj)]
-   (fn combine [result sampled-rows]
+   [(base-type-inferer metadata)
+    ((take 1) conj)]
+   (fn combine [result base-types [first-row]]
      (rf (cond-> result
            (map? result)
-           (assoc-in [:data :cols] (merged-column-info query (assoc metadata :rows sampled-rows))))))))
+           (assoc-in [:data :cols] (merged-column-info query (assoc metadata
+                                                                    :base-types base-types
+                                                                    :first-row  first-row))))))))
 
 (defn add-column-info
   "Middleware for adding type information about the columns in the query results (the `:cols` key)."

--- a/test/metabase/driver/common_test.clj
+++ b/test/metabase/driver/common_test.clj
@@ -1,41 +1,26 @@
 (ns metabase.driver.common-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
             [metabase.driver.common :as driver.common]))
 
-(expect
-  :type/Text
-  (driver.common/values->base-type ["A" "B" "C"]))
-
-;; should ignore nils
-(expect
-  :type/Text
-  (driver.common/values->base-type [nil nil "C"]))
-
-;; should pick base-type of most common class
-(expect
-  :type/Text
-  (driver.common/values->base-type ["A" 100 "C"]))
-
-;; should fall back to :type/* if no better type is found
-(expect
-  :type/*
-  (driver.common/values->base-type [(Object.)]) )
-
-;; Should work with initial nils even if sequence is lazy
-(expect
-  [:type/Integer true]
-  (let [realized-lazy-seq? (atom false)]
-    [(driver.common/values->base-type (lazy-cat [nil nil nil]
-                                                (do (reset! realized-lazy-seq? true)
-                                                    [4 5 6])))
-     @realized-lazy-seq?]))
-
-;; but it should respect laziness and not keep scanning after it finds 100 values
-(expect
-  [:type/Integer false]
-  (let [realized-lazy-seq? (atom false)]
-    [(driver.common/values->base-type (lazy-cat [1 2 3]
-                                                (repeat 1000 nil)
-                                                (do (reset! realized-lazy-seq? true)
-                                                    [4 5 6])))
-     @realized-lazy-seq?]))
+(deftest base-type-inference-test
+  (is (= :type/Text
+         (transduce identity driver.common/values->base-type ["A" "B" "C"])))
+  (is (= :type/Text
+         (transduce identity driver.common/values->base-type ["A" 100 "C"])))
+  (is (= :type/*
+         (transduce identity driver.common/values->base-type [(Object.)])))
+  (testing "Base type inference should work with initial nils even if sequence is lazy"
+    (let [realized-lazy-seq? (atom false)]
+      (is (= [:type/Integer true]
+             [(transduce identity driver.common/values->base-type (lazy-cat [nil nil nil]
+                                                                            (do (reset! realized-lazy-seq? true)
+                                                                                [4 5 6])))
+              @realized-lazy-seq?]))))
+  (testing "Base type inference should respect laziness and not keep scanning after it finds 100 values"
+    (let [realized-lazy-seq? (atom false)]
+      (is (= [:type/Integer true]
+             [(transduce identity driver.common/values->base-type (lazy-cat [1 2 3]
+                                                                            (repeat 1000 nil)
+                                                                            (do (reset! realized-lazy-seq? true)
+                                                                                [4 5 6])))
+              @realized-lazy-seq?])))))

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -22,28 +22,21 @@
 
 (deftest native-column-info-test
   (testing "native column info"
-    (testing "should still infer types even if the initial value(s) are `nil` (#4256)"
-      (is (= [{:name "a", :display_name "a", :base_type :type/Integer, :source :native, :field_ref [:field-literal "a" :type/Integer]}
-              {:name "b", :display_name "b", :base_type :type/Integer, :source :native, :field_ref [:field-literal "b" :type/Integer]}]
-             (annotate/column-info
-              {:type :native}
-              {:cols [{:name "a"} {:name "b"}]
-               :rows [[1 nil] [2 nil] [3 nil] [4 5] [6 7]]}))))
+    (testing "should still infer types even if the initial value(s) are `nil` (#4256, #6924)"
+      (is (= [:type/Integer]
+             (transduce identity (#'annotate/base-type-inferer {:cols [{}]})
+                        (concat (repeat 1000 [nil]) [[1] [2]])))))
 
     (testing "should use default `base_type` of `type/*` if there are no non-nil values in the sample"
-      (is (= [{:name "a", :display_name "a", :base_type :type/*, :source :native, :field_ref [:field-literal "a" :type/*]}]
-             (annotate/column-info
-              {:type :native}
-              {:cols [{:name "a"}]
-               :rows [[nil]]}))))
+      (is (= [:type/*]
+             (transduce identity (#'annotate/base-type-inferer {:cols [{}]})
+                        [[nil]]))))
 
     (testing "should attempt to infer better base type if driver returns :type/* (#12150)"
       ;; `merged-column-info` handles merging info returned by driver & inferred by annotate
-      (is (= [{:name "a", :display_name "a", :base_type :type/Integer, :source :native, :field_ref [:field-literal "a" :type/Integer]}]
-             (annotate/merged-column-info
-              {:type :native}
-              {:cols [{:name "a", :base_type :type/*}]
-               :rows [[1] [2] [nil] [3]]}))))
+      (is (= [:type/Integer]
+             (transduce identity (#'annotate/base-type-inferer {:cols [{:base_type :type/*}]})
+                        [[1] [2] [nil] [3]]))))
 
     (testing "should disambiguate duplicate names"
       (is (= [{:name "a", :display_name "a", :base_type :type/Integer, :source :native, :field_ref [:field-literal "a" :type/Integer]}
@@ -51,7 +44,8 @@
              (annotate/column-info
               {:type :native}
               {:cols [{:name "a"} {:name "a"}]
-               :rows [[1 nil] [2 nil] [3 nil] [4 5] [6 7]]}))))))
+               :first-row [1 nil]
+               :base-types [:type/Integer :type/Integer]}))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Fixes #6924

Also reworks the sampling so that it's done as part of the query process transduce, rather than a separate O(number of cols * 100) loop.  