### PR TITLE
Use base_type if there's no special_type for custom formatting

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -80,7 +80,7 @@ export function getGlobalSettingsForColumn(column: Column) {
   const customFormatting = MetabaseSettings.get("custom-formatting");
   // NOTE: the order of these doesn't matter as long as there's no overlap between settings
   for (const [type, globalSettings] of Object.entries(customFormatting || {})) {
-    if (isa(column.special_type, type)) {
+    if (isa(column.special_type || column.base_type, type)) {
       // $FlowFixMe
       Object.assign(settings, globalSettings);
     }


### PR DESCRIPTION
Yesterday two Cypress tests started failing. I _think_ they both broke in #12834

This PR fixes [one failure](https://dashboard.cypress.io/projects/a394u1/runs/777/test-results/265b83a5-e1a6-497c-b788-3f5ba5363ce6/screenshots). In that issue we were failing to associate global settings with datetime columns that didn't have a `special_type`. I think this probably changed for the sample dataset in our Cypress test for unrelated reasons, but I figured that we should fall back to `base_type` anyways.

The other issue (sorry for describing an issue in a PR) is due to missing `fingerprint` data in the `created_at` column response.