### PR TITLE
Skip flaky Cypress test

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/chart_drill.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/chart_drill.cy.spec.js
@@ -62,7 +62,8 @@ describe("scenarios > visualizations > chart drill", () => {
     });
   });
 
-  it("should drill through a nested query", () => {
+  // this test was very flaky
+  it.skip("should drill through a nested query", () => {
     // There's a slight hiccup in the UI with nested questions when we Summarize by City below.
     // Because there's only 5 rows, it automatically switches to the chart, but issues another
     // dataset request. So we wait for the dataset to load.


### PR DESCRIPTION
The hassle from rerunning tests due to this is worse than the reduction in coverage from skipping it. I'm leaving it in the codebase as a reminder if we want to fix it up.