### PR TITLE
Support IPv6 for LDAP connections

### DIFF
--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -95,7 +95,12 @@
                                    (ldap-user-base)))))
 
 (defn- details->ldap-options [{:keys [host port bind-dn password security]}]
-  {:host      (str host ":" port)
+  ;; Connecting via IPv6 requires us to use this form for :host, otherwise
+  ;; clj-ldap will find the first : and treat it as an IPv4 and port number
+  {:host      {:address host
+               :port    (if (string? port)
+                          (Integer/parseInt port)
+                          port)}
    :bind-dn   bind-dn
    :password  password
    :ssl?      (= security "ssl")

--- a/test/metabase/integrations/ldap_test.clj
+++ b/test/metabase/integrations/ldap_test.clj
@@ -1,5 +1,5 @@
 (ns metabase.integrations.ldap-test
-  (:require [expectations :refer [expect]]
+  (:require [clojure.test :refer :all]
             [metabase.integrations.ldap :as ldap]
             [metabase.test.integrations.ldap :as ldap.test]
             [metabase.test.util :as tu]))
@@ -16,109 +16,100 @@
 ;; See test_resources/ldap.ldif for fixtures
 
 ;; The connection test should pass with valid settings
-(expect
-  {:status :SUCCESS}
-  (ldap.test/with-ldap-server
-    (ldap/test-ldap-connection (get-ldap-details))))
+(deftest connection-test
+  (testing "anonymous binds"
+   (testing "successfully connect to IPv4 host"
+     (is (= {:status :SUCCESS}
+            (ldap.test/with-ldap-server
+              (ldap/test-ldap-connection (get-ldap-details))))))
 
-;; The connection test should allow anonymous binds
-(expect
-  {:status :SUCCESS}
-  (ldap.test/with-ldap-server
-    (ldap/test-ldap-connection (dissoc (get-ldap-details) :bind-dn))))
+   (testing "successfully connect to IPv6 host"
+     (is (= {:status :SUCCESS}
+            (ldap.test/with-ldap-server
+              (ldap/test-ldap-connection (assoc (get-ldap-details)
+                                                :host "[::1]")))))))
+  (testing "invalid user search base"
+    (is (= :ERROR
+           (ldap.test/with-ldap-server
+             (:status (ldap/test-ldap-connection (assoc (get-ldap-details)
+                                                        :user-base "dc=example,dc=com")))))))
 
-;; The connection test should fail with an invalid user search base
-(expect
-  :ERROR
-  (ldap.test/with-ldap-server
-    (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :user-base "dc=example,dc=com")))))
+  (testing "invalid group search base"
+    (is (= :ERROR
+           (ldap.test/with-ldap-server
+             (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :group-base "dc=example,dc=com")))))))
 
-;; The connection test should fail with an invalid group search base
-(expect
-  :ERROR
-  (ldap.test/with-ldap-server
-    (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :group-base "dc=example,dc=com")))))
+  (testing "invalid bind DN"
+    (is (= :ERROR
+           (ldap.test/with-ldap-server
+             (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :bind-dn "cn=Not Directory Manager")))))))
 
-;; The connection test should fail with an invalid bind DN
-(expect
-  :ERROR
-  (ldap.test/with-ldap-server
-    (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :bind-dn "cn=Not Directory Manager")))))
+  (testing "invalid bind password"
+    (is (= :ERROR
+           (ldap.test/with-ldap-server
+             (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :password "wrong")))))))
 
-;; The connection test should fail with an invalid bind password
-(expect
-  :ERROR
-  (ldap.test/with-ldap-server
-    (:status (ldap/test-ldap-connection (assoc (get-ldap-details) :password "wrong")))))
+  (testing "basic get-connection works, will throw otherwise"
+    (is (= nil
+           (ldap.test/with-ldap-server
+             (.close (#'ldap/get-connection))))))
 
-;; Make sure the basic connection stuff works, this will throw otherwise
-(expect
-  nil
-  (ldap.test/with-ldap-server
-    (.close (#'ldap/get-connection))))
+  (testing "login should succeed"
+    (is (= true
+           (ldap.test/with-ldap-server
+             (ldap/verify-password "cn=Directory Manager" "password")))))
 
-;; Login with everything right should succeed
-(expect
-  (ldap.test/with-ldap-server
-    (ldap/verify-password "cn=Directory Manager" "password")))
+  (testing "wrong password"
+    (is (= false
+           (ldap.test/with-ldap-server
+             (ldap/verify-password "cn=Directory Manager" "wrongpassword")))))
 
-;; Login with wrong password should fail
-(expect
-  false
-  (ldap.test/with-ldap-server
-    (ldap/verify-password "cn=Directory Manager" "wrongpassword")))
+  (testing "invalid DN fails"
+    (is (= false
+           (ldap.test/with-ldap-server
+             (ldap/verify-password "cn=Nobody,ou=nowhere,dc=metabase,dc=com" "password")))))
 
-;; Login with invalid DN should fail
-(expect
-  false
-  (ldap.test/with-ldap-server
-    (ldap/verify-password "cn=Nobody,ou=nowhere,dc=metabase,dc=com" "password")))
+  (testing "regular user login"
+    (is (= true
+           (ldap.test/with-ldap-server
+             (ldap/verify-password "cn=Sally Brown,ou=People,dc=metabase,dc=com" "1234")))))
 
-;; Login for regular users should also work
-(expect
-  (ldap.test/with-ldap-server
-    (ldap/verify-password "cn=Sally Brown,ou=People,dc=metabase,dc=com" "1234")))
+  (testing "fail regular user login with bad password"
+    (is (= false
+           (ldap.test/with-ldap-server
+             (ldap/verify-password "cn=Sally Brown,ou=People,dc=metabase,dc=com" "password")))))
 
-;; Login for regular users should also fail for the wrong password
-(expect
-  false
-  (ldap.test/with-ldap-server
-    (ldap/verify-password "cn=Sally Brown,ou=People,dc=metabase,dc=com" "password")))
+  (testing "find by username"
+    (is (= {:dn         "cn=John Smith,ou=People,dc=metabase,dc=com"
+            :first-name "John"
+            :last-name  "Smith"
+            :email      "John.Smith@metabase.com"
+            :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com"]}
+           (ldap.test/with-ldap-server
+             (ldap/find-user "jsmith1")))))
 
-;; Find by username should work (given the default LDAP filter and test fixtures)
-(expect
-  {:dn         "cn=John Smith,ou=People,dc=metabase,dc=com"
-   :first-name "John"
-   :last-name  "Smith"
-   :email      "John.Smith@metabase.com"
-   :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com"]}
-  (ldap.test/with-ldap-server
-    (ldap/find-user "jsmith1")))
+  (testing "find by email"
+    (is (= {:dn         "cn=John Smith,ou=People,dc=metabase,dc=com"
+            :first-name "John"
+            :last-name  "Smith"
+            :email      "John.Smith@metabase.com"
+            :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com"]}
+           (ldap.test/with-ldap-server
+             (ldap/find-user "John.Smith@metabase.com")))))
 
-;; Find by email should also work (also given our default settings and fixtures)
-(expect
-  {:dn         "cn=John Smith,ou=People,dc=metabase,dc=com"
-   :first-name "John"
-   :last-name  "Smith"
-   :email      "John.Smith@metabase.com"
-   :groups     ["cn=Accounting,ou=Groups,dc=metabase,dc=com"]}
-  (ldap.test/with-ldap-server
-    (ldap/find-user "John.Smith@metabase.com")))
+  (testing "find by email, no groups"
+    (is (= {:dn         "cn=Fred Taylor,ou=People,dc=metabase,dc=com"
+            :first-name "Fred"
+            :last-name  "Taylor"
+            :email      "fred.taylor@metabase.com"
+            :groups     []}
+           (ldap.test/with-ldap-server
+             (ldap/find-user "fred.taylor@metabase.com")))))
 
-;; Find by email should also work (also given our default settings and fixtures)
-(expect
-  {:dn         "cn=Fred Taylor,ou=People,dc=metabase,dc=com"
-   :first-name "Fred"
-   :last-name  "Taylor"
-   :email      "fred.taylor@metabase.com"
-   :groups     []}
-  (ldap.test/with-ldap-server
-    (ldap/find-user "fred.taylor@metabase.com")))
-
-;; LDAP group matching should identify Metabase groups using DN equality rules
-(expect
-  #{1 2 3}
-  (tu/with-temporary-setting-values [ldap-group-mappings {"cn=accounting,ou=groups,dc=metabase,dc=com" [1 2]
-                                                          "cn=shipping,ou=groups,dc=metabase,dc=com" [2 3]}]
-    (#'ldap/ldap-groups->mb-group-ids ["CN=Accounting,OU=Groups,DC=metabase,DC=com"
-                                       "CN=Shipping,OU=Groups,DC=metabase,DC=com"])))
+  (testing "LDAP group matching should identify Metabase groups using DN equality rules"
+    (is (= #{1 2 3}
+           (tu/with-temporary-setting-values
+             [ldap-group-mappings {"cn=accounting,ou=groups,dc=metabase,dc=com" [1 2]
+                                   "cn=shipping,ou=groups,dc=metabase,dc=com" [2 3]}]
+             (#'ldap/ldap-groups->mb-group-ids ["CN=Accounting,OU=Groups,DC=metabase,DC=com"
+                                                "CN=Shipping,OU=Groups,DC=metabase,DC=com"]))))))


### PR DESCRIPTION
Adds support for IPv6 LDAP connections. The underlying clj-ldap library
requires a different format of the host parameter to support IPv6.

IPv6 addresses must be wrapped in [], like:
[2601:600:967f:88d4:b476:56a8:c364:94da]

Converted the LDAP expect tests to clojure.test also.

Resolves #12879
