### PR TITLE
Fix FE unit test flake in generatePassword

### DIFF
--- a/frontend/test/metabase/lib/utils.unit.spec.js
+++ b/frontend/test/metabase/lib/utils.unit.spec.js
@@ -37,7 +37,7 @@ describe("utils", () => {
 
     it("can enforce uppercase requirements", () => {
       expect(
-        MetabaseUtils.generatePassword({ total: 14, uppercase: 2 }).match(
+        MetabaseUtils.generatePassword({ total: 14, upper: 2 }).match(
           /([A-Z])/g,
         ).length >= 2,
       ).toBe(true);


### PR DESCRIPTION
We had a typo in the option name. The test would pass just over 99% of the time by chance. That <1% was annoying on CI though.

Here's what the failure was:

```
Summary of all failing tests
 
 FAIL  frontend/test/********/lib/utils.unit.spec.js
 
  ● utils › generatePassword › can enforce uppercase requirements
 

 
    expect(received).toBe(expected)
 
    
 
    Expected value to be (using ===):
 
      true
 
    Received:
 
      false
 
      
 ```