### PR TITLE
Fix z-index for all auth wrappers

### DIFF
--- a/frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx
+++ b/frontend/src/metabase/auth/containers/ForgotPasswordApp.jsx
@@ -29,7 +29,7 @@ export default class ForgotPasswordApp extends Component {
 
     return (
       <div className="full-height flex flex-column flex-full md-layout-centered">
-        <div className="Login-wrapper wrapper Grid Grid--full md-Grid--1of2">
+        <div className="Login-wrapper wrapper Grid Grid--full md-Grid--1of2 relative z2">
           <div className="Grid-cell flex layout-centered text-brand">
             <LogoIcon className="Logo my4 sm-my0" height={65} />
           </div>

--- a/frontend/src/metabase/auth/containers/PasswordResetApp.jsx
+++ b/frontend/src/metabase/auth/containers/PasswordResetApp.jsx
@@ -72,7 +72,7 @@ export default class PasswordResetApp extends Component {
         <div className="full-height">
           <div className="full-height flex flex-column flex-full md-layout-centered">
             <div className="wrapper">
-              <div className="Login-wrapper Grid  Grid--full md-Grid--1of2">
+              <div className="Login-wrapper Grid  Grid--full md-Grid--1of2 relative z2">
                 <div className="Grid-cell flex layout-centered text-brand">
                   <LogoIcon className="Logo my4 sm-my0" height={65} />
                 </div>
@@ -91,7 +91,7 @@ export default class PasswordResetApp extends Component {
     } else {
       return (
         <div className="full-height bg-white flex flex-column flex-full md-layout-centered">
-          <div className="Login-wrapper wrapper Grid  Grid--full md-Grid--1of2">
+          <div className="Login-wrapper wrapper Grid  Grid--full md-Grid--1of2 relative z2">
             <div className="Grid-cell flex layout-centered text-brand">
               <LogoIcon className="Logo my4 sm-my0" height={65} />
             </div>

--- a/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/auth/signin.cy.spec.js
@@ -1,5 +1,7 @@
 import { restore, signIn, signOut, USERS } from "__support__/cypress";
 
+const sizes = [[1280, 800], [640, 360]];
+
 describe("scenarios > auth > signin", () => {
   before(restore);
   beforeEach(signOut);
@@ -52,5 +54,22 @@ describe("scenarios > auth > signin", () => {
 
     // order table should load after login
     cy.contains("37.65");
+  });
+
+  sizes.forEach(size => {
+    it(`should redirect from /auth/forgot_password back to /auth/login (viewport: ${size})`, () => {
+      if (Cypress._.isArray(size)) {
+        cy.viewport(size[0], size[1]);
+      } else {
+        cy.viewport(size);
+      }
+
+      cy.visit("/");
+      cy.url().should("contain", "auth/login");
+      cy.findByText("I seem to have forgotten my password").click();
+      cy.url().should("contain", "auth/forgot_password");
+      cy.findByText("Back to login").click();
+      cy.url().should("contain", "auth/login");
+    });
   });
 });


### PR DESCRIPTION
###### From the original pull request template
### Tests
- [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
_(note: some tests are failing, but none for the files affected by this PR)_
- [ ] ~~If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`~~

- [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).

---
###### Additional info 
### Status
READY

### What does this PR accomplish?
- fixes #12658 
- replaces #12767 by providing additional Cypress test to the css fixes
- in general, this fix moves all auth wrappers up one level in the stacking context of their respective pages, which puts them above floating boat animation
- adds additional Cypress test to the `auth` tests suite

### Where should the reviewer start?
- by reviewing the affected files

### How should this be manually tested?
1. `yarn test-cypress-open`
2. click on `/scenarios/auth/signin.cy.specs.js`
3. all tests should pass
- alternatively, one could navigate to the project `/auth/forgot-password` and manually resize window. One should be able to return back to `/auth/login` regardless of the screen size

### Screenshots
- provided in the comments to the original commit messages

### Notes/Questions
- @flamber I couldn't cover the bug from #12658 with the cy test because it requires admin email setup completed. The token would be provided in the email sent to the user requesting password reset. Maybe there is a way to replicate this (from the store?), or provide some mock data to the `cypress.js`, but I am quite new to the code base and couldn't find my way around it. However, I'd be more than happy to help, with the small nudge in right direction from someone more familiar with the code.
- also, I wasn't sure about the possible best practices you use, so I tried to read other tests and code in general. Hopefully, introducing test for more than one screen size isn't bloating `signin.cy.specs.js` file?
- if needed, I can refactor it and write a simple test for small screen size **only** 
- this is my first contribution to Metabase :)