### PR TITLE
Fix startup issue in Turkish

### DIFF
--- a/src/metabase/util/date_2/common.clj
+++ b/src/metabase/util/date_2/common.clj
@@ -1,5 +1,6 @@
 (ns metabase.util.date-2.common
-  (:require [clojure.string :as str])
+  (:require [clojure.string :as str]
+            [metabase.util :as u])
   (:import [java.time.temporal ChronoField IsoFields TemporalField WeekFields]))
 
 ;; TODO - not sure this belongs here, it seems to be a bit more general than just `date-2`.
@@ -12,7 +13,7 @@
   ([^Class klass ^Class target-class]
    (into {} (for [^java.lang.reflect.Field f (.getFields klass)
                   :when                      (.isAssignableFrom target-class (.getType f))]
-              [(keyword (str/lower-case (str/replace (.getName f) #"_" "-")))
+              [(keyword (u/lower-case-en (str/replace (.getName f) #"_" "-")))
                (.get f nil)]))))
 
 (def ^TemporalField temporal-field

--- a/src/metabase/util/date_2/parse/builder.clj
+++ b/src/metabase/util/date_2/parse/builder.clj
@@ -9,7 +9,8 @@
 
   TODO - this is a prime library candidate."
   (:require [metabase.util.date-2.common :as common])
-  (:import [java.time.format DateTimeFormatter DateTimeFormatterBuilder SignStyle] java.time.temporal.TemporalField))
+  (:import [java.time.format DateTimeFormatter DateTimeFormatterBuilder SignStyle]
+           java.time.temporal.TemporalField))
 
 (defprotocol ^:private Section
   (^:private apply-section [this builder]))

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -162,6 +162,7 @@
   round-all-decimals
   scheduler-current-tasks
   throw-if-called
+  with-locale
   with-log-messages
   with-log-messages-for-level
   with-log-level

--- a/test/metabase/util/date_2_test.clj
+++ b/test/metabase/util/date_2_test.clj
@@ -3,8 +3,11 @@
              [string :as str]
              [test :refer :all]]
             [java-time :as t]
+            [metabase.test :as mt]
             [metabase.test.util.timezone :as tu.timezone]
-            [metabase.util.date-2 :as u.date]))
+            [metabase.util.date-2 :as u.date]
+            [metabase.util.date-2.common :as u.date.common])
+  (:import java.time.temporal.ChronoField))
 
 (deftest parse-test
   ;; system timezone should not affect the way strings are parsed
@@ -400,3 +403,8 @@
             (is (= false
                    (u.date/older-than? t (t/months 2)))
                 (format "%s did not happen before 2019-10-03" (pr-str t)))))))))
+
+(deftest static-instances-locale-test
+  (testing "in the Turkish locale, :minute-of-hour can be found"
+    (mt/with-locale "tr"
+      (is (some? (:minute-of-hour (u.date.common/static-instances ChronoField)))))))

--- a/test/metabase/util/honeysql_extensions_test.clj
+++ b/test/metabase/util/honeysql_extensions_test.clj
@@ -3,9 +3,9 @@
             [honeysql
              [core :as hsql]
              [format :as hformat]]
+            [metabase.test :as mt]
             [metabase.util.honeysql-extensions :as hx])
-  (:import java.util.Locale
-           metabase.util.honeysql_extensions.Identifier))
+  (:import metabase.util.honeysql_extensions.Identifier))
 
 (deftest format-test
   (testing "Basic format test not including a specific quoting option"
@@ -95,26 +95,13 @@
     (is (= (Identifier. :field ["keyword" "qualified/keyword"])
            (hx/identifier :field :keyword :qualified/keyword)))))
 
-(defn- call-with-locale
-  "Sets the default locale temporarily to `locale-tag`, then invokes `f` and reverts the locale change"
-  [locale-tag f]
-  (let [current-locale (Locale/getDefault)]
-    (try
-      (Locale/setDefault (Locale/forLanguageTag locale-tag))
-      (f)
-      (finally
-        (Locale/setDefault current-locale)))))
-
-(defmacro ^:private with-locale [locale-tag & body]
-  `(call-with-locale ~locale-tag (fn [] ~@body)))
-
 (deftest h2-quoting-test
   (testing (str "We provide our own quoting function for `:h2` databases. We quote and uppercase the identifier. Using "
                 "Java's toUpperCase method is surprisingly locale dependent. When uppercasing a string in a language "
                 "like Turkish, it can turn an i into an İ. This test converts a keyword with an `i` in it to verify "
                 "that we convert the identifier correctly using the english locale even when the user has changed the "
                 "locale to Turkish")
-    (with-locale "tr"
+    (mt/with-locale "tr"
       (is (= ["\"SETTING\""]
              (hformat/format :setting :quoting :h2))))))
 


### PR DESCRIPTION
During startup, we keywordize the name of the Java temporal classes, and
during that, we lower-case them. In Turkish, this means minute-of-hour
becomes mınute-of-hour (note the i is different) - which causes failures
downstream.

This moves a test helper into the common test code, and does the
lower-casing of the Temporal class names using Locale/US.

Resolves #12623

[ci all]
