### PR TITLE
Repro for #12899

### DIFF
--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, signInAsAdmin } from "__support__/cypress";
+import { restore, signInAsAdmin, popover } from "__support__/cypress";
 
 // test various entry points into the query builder
 
@@ -36,6 +36,13 @@ describe("scenarios > question > new", () => {
       cy.contains("Orders").click();
       cy.contains("Visualize").click();
       cy.contains("37.65");
+    });
+
+    it("should show `Custom Expression` in orders metrics", () => {
+      // go straight to "orders" in custom questions
+      cy.visit("/question/new?database=1&table=2&mode=notebook");
+      cy.findByText("Summarize").click();
+      popover().contains("Custom Expression");
     });
   });
 });

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -38,7 +38,7 @@ describe("scenarios > question > new", () => {
       cy.contains("37.65");
     });
 
-    it("should show `Custom Expression` in orders metrics", () => {
+    it.skip("should show `Custom Expression` in orders metrics (Issue #12899)", () => {
       // go straight to "orders" in custom questions
       cy.visit("/question/new?database=1&table=2&mode=notebook");
       cy.findByText("Summarize").click();


### PR DESCRIPTION
### What does this PR accomplish?
- reproduces the issue #12899 
- checks for the existence of section `Custom Expression` within Custom question > Orders Popover

### Where should the reviewer start?
1. `yarn test-cypress-open`
2. click on `/scenarios/question/new.cy.specs.js`

### How should this be manually tested?
- go to `/`
- Ask a question > Custom Question > Sample Dataset > Orders > Summarize > Pick the metric you want to see
- Popover should contain `Custom Expression` section

### Screenshots
N/A

### Notes/Questions
- I was using `cy.visit("/question/new?database=1&table=2&mode=notebook");` to go directly to orders, as per [this](https://github.com/metabase/metabase/wiki/E2E-Tests-with-Cypress#increase-viewport-size-to-avoid-scrolling) recommendation.
    - navigating like this opens the page with closed "Filter, Summarize, Join Data..."
- manual navigation to the same page, on the other hand, shows `Filter` and `Summarize` expanded by default
- my guess is that this is desired behaviour; documenting it just in case...
- test should pass when the underlying issue is solved