### PR TITLE
Repro for #12651

### DIFF
--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -37,9 +37,10 @@ describe("scenarios > question > new", () => {
       openOrdersTable();
       cy.wait("@dataset");
       cy.url().should("include", "question#");
-      cy.get("[data-metabase-event$='Go to Notebook Mode']").click();
+      // Isolate icons within "QueryBuilder" scope because there is also `.Icon-sql` in top navigation
+      cy.get(".QueryBuilder .Icon-notebook").click();
       cy.url().should("include", "question/notebook#");
-      cy.get("[data-metabase-event$='Convert to SQL Click']").click();
+      cy.get(".QueryBuilder .Icon-sql").click();
       cy.findByText("Convert this question to SQL").click();
       cy.url().should("include", "question#");
     });

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -31,7 +31,7 @@ describe("scenarios > question > new", () => {
       cy.contains("37.65");
     });
 
-    it("should remove `/notebook` from URL when converting question to SQL/Native", () => {
+    it.skip("should remove `/notebook` from URL when converting question to SQL/Native (Issue #12651)", () => {
       cy.server();
       cy.route("POST", "/api/dataset").as("dataset");
       openOrdersTable();

--- a/frontend/test/metabase/scenarios/question/new.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/new.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, signInAsAdmin, popover } from "__support__/cypress";
+import {
+  restore,
+  signInAsAdmin,
+  popover,
+  openOrdersTable,
+} from "__support__/cypress";
 
 // test various entry points into the query builder
 
@@ -24,6 +29,19 @@ describe("scenarios > question > new", () => {
       cy.contains("Sample Dataset").click();
       cy.contains("Orders").click();
       cy.contains("37.65");
+    });
+
+    it("should remove `/notebook` from URL when converting question to SQL/Native", () => {
+      cy.server();
+      cy.route("POST", "/api/dataset").as("dataset");
+      openOrdersTable();
+      cy.wait("@dataset");
+      cy.url().should("include", "question#");
+      cy.get("[data-metabase-event$='Go to Notebook Mode']").click();
+      cy.url().should("include", "question/notebook#");
+      cy.get("[data-metabase-event$='Convert to SQL Click']").click();
+      cy.findByText("Convert this question to SQL").click();
+      cy.url().should("include", "question#");
     });
   });
 


### PR DESCRIPTION
### What does this PR accomplish?
- reproduces the issue #12651 
- checks for the link structure when converting a question to SQL/Native (it should remove `/notebook`)

### Where should the reviewer start?
1. `yarn test-cypress-open`
2. click on `/scenarios/question/new.cy.specs.js`

### How should this be manually tested?
- steps to reproduce from #12651 can be used for manual testing as well

### Screenshots
N/A

### Notes/Questions
Any other method to get to the open orders table other than
```javascript
    cy.server();
    cy.route("POST", "/api/dataset").as("dataset");
    openOrdersTable();
    cy.wait("@dataset");
```
was resulting in `(XHR) POST (aborted) /api/dataset`.
- test should pass after the underlying issue is solved