### PR TITLE
Remove deprecated viewport meta tag `minimal-ui`

### DIFF
--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
     <meta name="robots" content="noindex" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- fixes #12896 
- Removes deprecated viewport meta tag `minimal-ui`

### How should this be manually tested?
- after compilation there should be no mention of `minimal-ui` in index.html (or anywhere in the project, for that matter)

### Screenshots
- provided as part of the original issue

### Notes/Questions:
N/A