### PR TITLE
Test refactoring [ci drivers]

### DIFF
--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -84,14 +84,6 @@
   (-> (field-query field {:aggregation [[:count [:field-id (u/get-id field)]]]})
       first first int))
 
-(defn db-id
-  "Return the database ID of a given entity."
-  [x]
-  (or (:db_id x)
-      (:database_id x)
-      (db/select-one-field :db_id 'Table :id (:table_id x))))
-
-
 (def max-sample-rows
   "The maximum number of values we should return when using `table-rows-sample`. This many is probably fine for
   inferring special types and what-not; we don't want to scan millions of values at any rate."

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -520,7 +520,7 @@
 (deftest query-metadata-remappings-test
   (testing "GET /api/table/:id/query_metadata"
     (mt/with-temp-objects
-      (data/create-venue-category-remapping "Foo")
+      (data/create-venue-category-remapping! "Foo")
       (testing "Ensure internal remapped dimensions and human_readable_values are returned"
         (is (= [{:table_id   (mt/id :venues)
                  :id         (mt/id :venues :category_id)
@@ -552,7 +552,7 @@
                                  ((mt/user->client :rasta) :get 200 (format "table/%d/query_metadata" (mt/id :venues))))))))))
 
     (mt/with-temp-objects
-      (data/create-venue-category-fk-remapping "Foo")
+      (data/create-venue-category-fk-remapping! "Foo")
       (testing "Ensure FK remappings are returned"
         (is (= [{:table_id   (mt/id :venues)
                  :id         (mt/id :venues :category_id)

--- a/test/metabase/db/metadata_queries_test.clj
+++ b/test/metabase/db/metadata_queries_test.clj
@@ -1,61 +1,33 @@
 (ns metabase.db.metadata-queries-test
-  (:require [metabase.db.metadata-queries :refer :all]
-            [metabase.models
-             [card :refer [Card]]
-             [database :refer [Database]]
-             [field :refer [Field]]
-             [metric :refer [Metric]]
-             [segment :refer [Segment]]
-             [table :refer [Table]]]
-            [metabase.test :as mt]
-            [metabase.test.data :refer :all]
-            [metabase.test.data.datasets :as datasets]
-            [toucan.util.test :as tt]))
+  (:require [clojure.test :refer :all]
+            [metabase
+             [models :refer [Field Table]]
+             [test :as mt]]
+            [metabase.db.metadata-queries :as metadata-queries]))
 
 ;; Redshift tests are randomly failing -- see https://github.com/metabase/metabase/issues/2767
 (defn- metadata-queries-test-drivers []
   (mt/normal-drivers-except #{:redshift}))
 
-;; ### FIELD-DISTINCT-COUNT
-(datasets/expect-with-drivers (metadata-queries-test-drivers)
-  100
-  (field-distinct-count (Field (id :checkins :venue_id))))
+(deftest field-distinct-count-test
+  (mt/test-drivers (metadata-queries-test-drivers)
+    (is (= 100
+           (metadata-queries/field-distinct-count (Field (mt/id :checkins :venue_id)))))
 
-(datasets/expect-with-drivers (metadata-queries-test-drivers)
-  15
-  (field-distinct-count (Field (id :checkins :user_id))))
+    (is (= 15
+           (metadata-queries/field-distinct-count (Field (mt/id :checkins :user_id)))))))
 
+(deftest field-count-test
+  (mt/test-drivers (metadata-queries-test-drivers)
+    (is (= 1000
+           (metadata-queries/field-count (Field (mt/id :checkins :venue_id)))))))
 
-;; ### FIELD-COUNT
-(datasets/expect-with-drivers (metadata-queries-test-drivers)
-  1000
-  (field-count (Field (id :checkins :venue_id))))
+(deftest table-row-count-test
+  (mt/test-drivers (metadata-queries-test-drivers)
+    (is (= 1000
+           (metadata-queries/table-row-count (Table (mt/id :checkins)))))))
 
-
-;; ### TABLE-ROW-COUNT
-(datasets/expect-with-drivers (metadata-queries-test-drivers)
-  1000
-  (table-row-count (Table (id :checkins))))
-
-
-;; ### FIELD-DISTINCT-VALUES
-(datasets/expect-with-drivers (metadata-queries-test-drivers)
-  [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
-  (map int (field-distinct-values (Field (id :checkins :user_id)))))
-
-
-;; ### DB-ID
-(tt/expect-with-temp [Database [{database-id :id}]
-                      Table [{table-id :id} {:db_id database-id}]
-                      Metric [{metric-id :id} {:table_id table-id}]
-                      Segment [{segment-id :id} {:table_id table-id}]
-                      Field [{field-id :id} {:table_id table-id}]
-                      Card [{card-id :id}
-                            {:table_id table-id
-                             :database_id database-id}]]
-  [database-id database-id database-id database-id database-id]
-  (mapv db-id [(Table table-id)
-               (Metric metric-id)
-               (Segment segment-id)
-               (Card card-id)
-               (Field field-id)]))
+(deftest field-distinct-values-test
+  (mt/test-drivers (metadata-queries-test-drivers)
+    (is (= [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
+           (map int (metadata-queries/field-distinct-values (Field (mt/id :checkins :user_id))))))))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -14,7 +14,6 @@
             [metabase.models.field :refer [Field]]
             [metabase.test.data :as data]
             [metabase.test.data
-             [datasets :as datasets]
              [env :as tx.env]
              [interface :as tx]]
             [toucan.db :as db]))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -47,18 +47,6 @@
   [feature]
   (set/difference (normal-drivers) (normal-drivers-with-feature feature)))
 
-(defmacro ^:deprecated expect-with-non-timeseries-dbs
-  "DEPRECATED — Use `deftest` + `test-drivers` + `normal-drivers` instead.
-
-    (deftest my-test
-      (datasets/test-drivers (qp.test/normal-drivers)
-        (is (= ...))))"
-  {:style/indent 0}
-  [expected actual]
-  `(datasets/expect-with-drivers (normal-drivers)
-     ~expected
-     ~actual))
-
 (defn normal-drivers-except
   "Return the set of all drivers except Druid, Google Analytics, and those in `excluded-drivers`."
   [excluded-drivers]

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -73,7 +73,7 @@
 (deftest internal-remapping-test
   (mt/test-drivers (mt/normal-drivers)
     (mt/with-temp-objects
-      (data/create-venue-category-remapping "Foo")
+      (data/create-venue-category-remapping! "Foo")
       (let [{:keys [rows cols]} (qp.test/rows-and-cols
                                   (mt/format-rows-by [int int str]
                                     (mt/run-mbql-query venues

--- a/test/metabase/query_processor_test/constraints_test.clj
+++ b/test/metabase/query_processor_test/constraints_test.clj
@@ -1,70 +1,68 @@
 (ns metabase.query-processor-test.constraints-test
   "Test for MBQL `:constraints`"
-  (:require [metabase
+  (:require [clojure.test :refer :all]
+            [metabase
              [query-processor :as qp]
-             [query-processor-test :as qp.test]]
-            [metabase.test.data :as data]))
+             [test :as mt]]))
 
 (defn- mbql-query []
-  {:database (data/id)
-   :type     :query
-   :query    {:source-table (data/id :venues)
-              :fields       [[:field-id (data/id :venues :name)]]
-              :order-by     [[:asc [:field-id (data/id :venues :id)]]]}})
+  (mt/mbql-query venues
+    {:fields   [$name]
+     :order-by [[:asc $id]]}))
 
 (defn- native-query []
   (qp/query->native (mbql-query)))
 
-;; Do `:max-results` constraints affect the number of rows returned by native queries?
-(qp.test/expect-with-non-timeseries-dbs
-  [["Red Medicine"]
-   ["Stout Burgers & Beers"]
-   ["The Apple Pan"]
-   ["Wurstküche"]
-   ["Brite Spot Family Restaurant"]]
-  (qp.test/rows
-    (qp/process-query
-      {:database    (data/id)
-       :type        :native
-       :native      (native-query)
-       :constraints {:max-results 5}})))
+(deftest max-results-test
+  (mt/test-drivers (mt/normal-drivers)
+    (testing "Do `:max-results` constraints affect the number of rows returned by native queries?"
+      (is (= [["Red Medicine"]
+              ["Stout Burgers & Beers"]
+              ["The Apple Pan"]
+              ["Wurstküche"]
+              ["Brite Spot Family Restaurant"]]
+             (mt/rows
+               (qp/process-query
+                {:database    (mt/id)
+                 :type        :native
+                 :native      (native-query)
+                 :constraints {:max-results 5}})))))
 
-;; does it also work when running via `process-query-and-save-with-max-results-constraints!`, the function that powers
-;; endpoints like `POST /api/dataset`?
-(qp.test/expect-with-non-timeseries-dbs
-  [["Red Medicine"]
-   ["Stout Burgers & Beers"]
-   ["The Apple Pan"]
-   ["Wurstküche"]
-   ["Brite Spot Family Restaurant"]]
-  (qp.test/rows
-    (qp/process-query-and-save-with-max-results-constraints!
-        {:database    (data/id)
-         :type        :native
-         :native      (native-query)
-         :constraints {:max-results 5}}
-        {:context :question})))
+    (testing (str "does it also work when running via `process-query-and-save-with-max-results-constraints!`, the "
+                  "function that powers endpoints like `POST /api/dataset`?")
+      (is (= [["Red Medicine"]
+              ["Stout Burgers & Beers"]
+              ["The Apple Pan"]
+              ["Wurstküche"]
+              ["Brite Spot Family Restaurant"]]
+             (mt/rows
+               (qp/process-query-and-save-with-max-results-constraints!
+                {:database    (mt/id)
+                 :type        :native
+                 :native      (native-query)
+                 :constraints {:max-results 5}}
+                {:context :question})))))))
 
-;; constraints should override MBQL `:limit` if lower
-(qp.test/expect-with-non-timeseries-dbs
-  [["Red Medicine"]
-   ["Stout Burgers & Beers"]
-   ["The Apple Pan"]]
-  (qp.test/rows
-    (qp/process-query
-      (-> (mbql-query)
-          (assoc-in [:query :limit] 10)
-          (assoc :constraints {:max-results 3})))))
+(deftest override-limit-test
+  (mt/test-drivers (mt/normal-drivers)
+    (testing "constraints should override MBQL `:limit` if lower"
+      (is (= [["Red Medicine"]
+              ["Stout Burgers & Beers"]
+              ["The Apple Pan"]]
+             (mt/rows
+               (qp/process-query
+                (-> (mbql-query)
+                    (assoc-in [:query :limit] 10)
+                    (assoc :constraints {:max-results 3})))))))
 
-;; However if `:limit` is lower than `:constraints` we should not return more than the `:limit`
-(qp.test/expect-with-non-timeseries-dbs
-  [["Red Medicine"]
-   ["Stout Burgers & Beers"]
-   ["The Apple Pan"]
-   ["Wurstküche"]
-   ["Brite Spot Family Restaurant"]]
-  (qp.test/rows
-    (qp/process-query
-      (-> (mbql-query)
-          (assoc-in [:query :limit] 5)
-          (assoc :constraints {:max-results 10})))))
+    (testing "However if `:limit` is lower than `:constraints` we should not return more than the `:limit`"
+      (is (= [["Red Medicine"]
+              ["Stout Burgers & Beers"]
+              ["The Apple Pan"]
+              ["Wurstküche"]
+              ["Brite Spot Family Restaurant"]]
+             (mt/rows
+               (qp/process-query
+                (-> (mbql-query)
+                    (assoc-in [:query :limit] 5)
+                    (assoc :constraints {:max-results 10})))))))))

--- a/test/metabase/query_processor_test/fields_test.clj
+++ b/test/metabase/query_processor_test/fields_test.clj
@@ -1,26 +1,29 @@
 (ns metabase.query-processor-test.fields-test
   "Tests for the `:fields` clause."
-  (:require [metabase.query-processor-test :as qp.test]
-            [metabase.test.data :as data]))
+  (:require [clojure.test :refer :all]
+            [metabase
+             [query-processor-test :as qp.test]
+             [test :as mt]]))
 
-;; Test that we can restrict the Fields that get returned to the ones specified, and that results come back in the
-;; order of the IDs in the `fields` clause
-(qp.test/expect-with-non-timeseries-dbs
-  {:rows [["Red Medicine"                  1]
-          ["Stout Burgers & Beers"         2]
-          ["The Apple Pan"                 3]
-          ["Wurstküche"                    4]
-          ["Brite Spot Family Restaurant"  5]
-          ["The 101 Coffee Shop"           6]
-          ["Don Day Korean Restaurant"     7]
-          ["25°"                           8]
-          ["Krua Siri"                     9]
-          ["Fred 62"                      10]]
-   :cols [(qp.test/col :venues :name)
-          (qp.test/col :venues :id)]}
-  (qp.test/format-rows-by [str int]
-    (qp.test/rows-and-cols
-      (data/run-mbql-query venues
-        {:fields   [$name $id]
-         :limit    10
-         :order-by [[:asc $id]]}))))
+(deftest fields-clause-test
+  (mt/test-drivers (mt/normal-drivers)
+    (testing (str "Test that we can restrict the Fields that get returned to the ones specified, and that results come "
+                  "back in the order of the IDs in the `fields` clause")
+      (is (= {:rows [["Red Medicine"                  1]
+                     ["Stout Burgers & Beers"         2]
+                     ["The Apple Pan"                 3]
+                     ["Wurstküche"                    4]
+                     ["Brite Spot Family Restaurant"  5]
+                     ["The 101 Coffee Shop"           6]
+                     ["Don Day Korean Restaurant"     7]
+                     ["25°"                           8]
+                     ["Krua Siri"                     9]
+                     ["Fred 62"                      10]]
+              :cols [(mt/col :venues :name)
+                     (mt/col :venues :id)]}
+             (mt/format-rows-by [str int]
+               (qp.test/rows-and-cols
+                 (mt/run-mbql-query venues
+                   {:fields   [$name $id]
+                    :limit    10
+                    :order-by [[:asc $id]]}))))))))

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -290,7 +290,7 @@
   (delay (vec (dataset-field-values "categories" "name"))))
 
 ;; TODO - you should always call these functions with the `with-data` macro. We should enforce this
-(defn create-venue-category-remapping
+(defn create-venue-category-remapping!
   "Returns a thunk that adds an internal remapping for category_id in the venues table aliased as `remapping-name`.
   Can be used in a `with-data` invocation."
   [remapping-name]
@@ -302,7 +302,7 @@
                               :values                (json/generate-string (range 1 (inc (count @category-names))))
                               :human_readable_values (json/generate-string @category-names)})]))
 
-(defn create-venue-category-fk-remapping
+(defn create-venue-category-fk-remapping!
   "Returns a thunk that adds a FK remapping for category_id in the venues table aliased as `remapping-name`. Can be
   used in a `with-data` invocation."
   [remapping-name]


### PR DESCRIPTION
Rework some more tests to the new style. Remove the deprecated `expect-with-non-timeseries-dbs` macro