### PR TITLE
Sync views in Snowflake databases

### DIFF
--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -225,7 +225,7 @@
         excluded-schemas (set (sql-jdbc.sync/excluded-schemas driver))]
     {:tables (set (for [table (jdbc/query
                                (sql-jdbc.conn/db->pooled-connection-spec database)
-                               (format "SHOW TABLES IN DATABASE \"%s\"" db-name))
+                               (format "SHOW OBJECTS IN DATABASE \"%s\"" db-name))
                         :when (not (contains? excluded-schemas (:schema_name table)))]
                     {:name        (:name table)
                      :schema      (:schema_name table)

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.snowflake-test
-  (:require [clojure
+  (:require [clojure.java.jdbc :as jdbc]
+            [clojure
              [set :as set]
              [string :as str]
              [test :refer :all]]
@@ -7,11 +8,19 @@
              [driver :as driver]
              [models :refer [Table]]
              [query-processor :as qp]
-             [test :as mt]]
+             [sync :as sync]
+             [test :as mt]
+             [util :as u]]
+            [metabase.driver.sql-jdbc
+             [connection :as sql-jdbc.conn]
+             [execute :as sql-jdbc.execute]]
+            [metabase.models
+             [database :refer [Database]]]
             [metabase.test.data
              [dataset-definitions :as dataset-defs]
              [sql :as sql.tx]]
-            [metabase.test.data.sql.ddl :as ddl]))
+            [metabase.test.data.sql.ddl :as ddl]
+            [toucan.db :as db]))
 
 ;;
 (deftest ddl-statements-test
@@ -66,6 +75,28 @@
         (testing "should use the NAME FROM DETAILS instead of the DB DISPLAY NAME to fetch metadata (#8864)"
           (is (= expected
                  (driver/describe-database :snowflake (assoc (mt/db) :name "ABC")))))))))
+
+(deftest describe-database-views-test
+  (mt/test-driver :snowflake
+    (testing "describe-database views"
+      (let [details (mt/dbdef->connection-details :snowflake :db {:database-name "views_test"})
+            spec    (sql-jdbc.conn/connection-details->spec :snowflake details)]
+        ;; create the snowflake DB
+        (jdbc/execute! spec ["DROP DATABASE IF EXISTS \"views_test\";"]
+                       {:transaction? false})
+        (jdbc/execute! spec ["CREATE DATABASE \"views_test\";"]
+                       {:transaction? false})
+        ;; create the DB object
+        (mt/with-temp Database [database {:engine :snowflake, :details (assoc details :db "views_test")}]
+          (let [sync! #(sync/sync-database! database)]
+            ;; create a view
+            (jdbc/execute! spec ["CREATE VIEW \"views_test\".\"PUBLIC\".\"example_view\" AS SELECT 'hello world' AS \"name\";"])
+            ;; now sync the DB
+            (sync!)
+            ;; now take a look at the Tables in the database, there should be an entry for the view
+            (is (= [{:name "example_view"}]
+                   (map (partial into {})
+                        (db/select [Table :name] :db_id (u/get-id database)))))))))))
 
 (deftest describe-table-test
   (mt/test-driver :snowflake


### PR DESCRIPTION
The Snowflake driver currently uses the SQL query `SHOW TABLES IN DATABASE ...` in `describe-databases` to fetch the tables in the database.

Unfortunately, this excludes views from being visible to Metabase for sync, even though views work fine in the Metabase custom query editor. This might be a contributing factor to similar issues reported on Snowflake, it can be easy to confuse tables and views because they interchangeable much of the time:

- #8864 Metabase can't find Snowflake tables
- #9511 Snowflake Tables Don't Show
- [Issue with filter using Snowflake database](https://discourse.metabase.com/t/issue-with-filter-using-showflake-database/6142)

By changing to `SHOW OBJECTS IN DATABASE ...`, this will return views and tables, as mentioned in the [Snowflake docs](https://docs.snowflake.com/en/sql-reference/sql/show-objects.html) - and not any other types of objects.



###### Before submitting the PR, please make sure you do the following

- [x] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

 **NOTE: I ran the tests and there were a handful of failures, but these seem to occur on master branch and so I don't think I've introduced them here**

-  [x] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [x] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`  

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
