### PR TITLE
Merge EE migrations -> CE; convert FKs to ON DELETE CASCADE

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -4129,6 +4129,74 @@ databaseChangeLog:
               type: text
               remarks: 'JSON serialized map with attributes used for row level permissions'
   - changeSet:
+      id: 78
+      author: camsaul
+      comment: 'Added 0.30.0'
+      changes:
+        - createTable:
+            tableName: group_table_access_policy
+            remarks: 'Records that a given Card (Question) should automatically replace a given Table as query source for a given a Perms Group.'
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: group_id
+                  type: int
+                  remarks: 'ID of the Permissions Group this policy affects.'
+                  constraints:
+                    nullable: false
+                    references: permissions_group(id)
+                    foreignKeyName: fk_gtap_group_id
+                    deleteCascade: true
+              - column:
+                  name: table_id
+                  type: int
+                  remarks: 'ID of the Table that should get automatically replaced as query source for the Permissions Group.'
+                  constraints:
+                    nullable: false
+                    references: metabase_table(id)
+                    foreignKeyName: fk_gtap_table_id
+                    deleteCascade: true
+              - column:
+                  name: card_id
+                  type: int
+                  remarks: 'ID of the Card (Question) to be used to replace the Table.'
+                  constraints:
+                    nullable: false
+                    references: report_card(id)
+                    foreignKeyName: fk_gtap_card_id
+                    # This one is not ON DELETE CASCADE because we do not want people going around deleting Cards and
+                    # accidentally deleting their GTAPs that depend on them. However since Cards get archived instead
+                    # of deleted it shouldn't matter anyway
+              - column:
+                  name: attribute_remappings
+                  type: text
+                  remarks: 'JSON-encoded map of user attribute identifier to the param name used in the Card.'
+              # TODO - do we also want to include `created_at` and `updated_at` columns here? We can add them later if needed
+        # Add an index on table_id + group_id since that is what the Query Processor is going to be looking up 99% of
+        # the time in order to get the corresponding Card ID for query-rewriting purposes
+        #
+        # TODO - do we want indexes on any of the other FKs? Are we going to be looking up all the GTAPs for a given
+        # Table or for a given Group with enough regularity we would want to put indexes on those columns?
+        - createIndex:
+            indexName: idx_gtap_table_id_group_id
+            tableName: group_table_access_policy
+            columns:
+              - column:
+                  name: table_id
+              - column:
+                  name: group_id
+        # There should only ever be one GTAP entry for a give Group + Table combination.
+        - addUniqueConstraint:
+            tableName: group_table_access_policy
+            columnNames: table_id, group_id
+            constraintName: unique_gtap_table_id_group_id
+  - changeSet:
       id: 79
       author: camsaul
       comment: 'Added 0.30.0'
@@ -4221,6 +4289,16 @@ databaseChangeLog:
               remarks: 'When was this User last updated?'
         - sql:
             sql: update core_user set updated_at=date_joined
+# Remove the GTAP card_id constraint. When not included, will default to querying against the GTAP table_id.
+  - changeSet:
+      id: 83
+      author: senior
+      comment: 'Added 0.30.0'
+      changes:
+        - dropNotNullConstraint:
+            tableName: group_table_access_policy
+            columnName: card_id
+            columnDataType: int
 # Switch the logic for metric/segment archiving to be more consistent with other entities in the model.
 # Similarly, add the archived flag to pulses which doesn't have one.
   - changeSet:
@@ -4346,6 +4424,20 @@ databaseChangeLog:
             tableName: raw_column
         - dropTable:
             tableName: raw_table
+  - changeSet:
+      id: 88
+      author: senior
+      comment: 'Added 0.30.0'
+      changes:
+        - addColumn:
+            tableName: core_user
+            columns:
+              name: saml_auth
+              type: boolean
+              defaultValueBoolean: false
+              constraints:
+                nullable: false
+              remarks: 'Boolean to indicate if this user is authenticated via SAML'
 
 # The Quartz Task Scheduler can use a DB to 'cluster' tasks and make sure they are only ran by a single instance where
 # using a multi-instance Metabase setup.
@@ -5004,6 +5096,23 @@ databaseChangeLog:
               - column:
                   name: TRIGGER_GROUP
 
+  - changeSet:
+      id: 90
+      author: senior
+      comment: 'Added 0.30.0'
+      changes:
+        - addColumn:
+            tableName: core_user
+            columns:
+              name: sso_source
+              type: varchar(254)
+              remarks: 'String to indicate the SSO backend the user is from'
+        - sql:
+            sql: update core_user set sso_source='saml' where saml_auth=true
+        - dropColumn:
+            tableName: core_user
+            columnName: saml_auth
+
 # Forgot to get rid of the raw_table_id and raw_column_id columns when we dropped the tables they referenced in migration 87.
 
   - changeSet:
@@ -5301,13 +5410,27 @@ databaseChangeLog:
                 nullable: false
               defaultValueBoolean: true
 
+
+  # To fix EE full-app embedding without compromising security. Full-app embed sessions cannot have `SameSite` attributes in their cookies.
+  - changeSet:
+      id: 104
+      author: camsaul
+      comment: 'Added EE 1.1.6/CE 0.33.0'
+      changes:
+        - addColumn:
+            tableName: core_session
+            columns:
+              name: anti_csrf_token
+              type: text
+              remarks: 'Anti-CSRF token for full-app embed sessions.'
+
 #
 # Change `metabase_field.database_type` to `text` to accomodate more exotic field types (enums in Clickhouse, rows in Presto, ...)
 #
   - changeSet:
       id: 106
       author: sb
-      comment: 'Added 0.34.0'
+      comment: 'Added 0.33.5'
       changes:
         - modifyDataType:
             tableName: metabase_field
@@ -6411,7 +6534,7 @@ databaseChangeLog:
   - changeSet:
       id: 171
       author: camsaul
-      comment: Added 1.36.0
+      comment: Added 0.36.0
       changes:
         - addColumn:
             tableName: native_query_snippet
@@ -6435,7 +6558,7 @@ databaseChangeLog:
   - changeSet:
       id: 172
       author: camsaul
-      comment: Added 1.36.0
+      comment: Added 0.36.0
       changes:
         - addColumn:
             tableName: collection
@@ -6446,3 +6569,1087 @@ databaseChangeLog:
                   remarks: 'The namespace (hierachy) this Collection belongs to. NULL means the Collection is in the default namespace.'
                   constraints:
                     nullable: true
+
+# These migrations convert various FK constraints in the DB to ones with ON DELETE CASCADE so the DB can handle this
+# instead of relying on Toucan pre-delete methods to do it, which are subject to race conditions.
+
+  # activity.user_id -> core_user.id
+  - changeSet:
+      id: 173
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: activity
+            constraintName: fk_activity_ref_user_id
+
+  - changeSet:
+      id: 174
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: activity
+            baseColumnNames: user_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_activity_ref_user_id
+            onDelete: CASCADE
+
+  # card_label.card_id -> report_card.id
+  - changeSet:
+      id: 175
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: card_label
+            constraintName: fk_card_label_ref_card_id
+
+  - changeSet:
+      id: 176
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: card_label
+            baseColumnNames: card_id
+            referencedTableName: report_card
+            referencedColumnNames: id
+            constraintName: fk_card_label_ref_card_id
+            onDelete: CASCADE
+
+  # card_label.label_id -> label.id
+  - changeSet:
+      id: 177
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: card_label
+            constraintName: fk_card_label_ref_label_id
+
+  - changeSet:
+      id: 178
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: card_label
+            baseColumnNames: label_id
+            referencedTableName: label
+            referencedColumnNames: id
+            constraintName: fk_card_label_ref_label_id
+            onDelete: CASCADE
+
+  # collection.personal_owner_id -> core_user.id
+  - changeSet:
+      id: 179
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: collection
+            constraintName: fk_collection_personal_owner_id
+
+  - changeSet:
+      id: 180
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: collection
+            baseColumnNames: personal_owner_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_collection_personal_owner_id
+            onDelete: CASCADE
+
+  # collection_revision.user_id -> core_user.id
+  - changeSet:
+      id: 181
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: collection_revision
+            constraintName: fk_collection_revision_user_id
+
+  - changeSet:
+      id: 182
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: collection_revision
+            baseColumnNames: user_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_collection_revision_user_id
+            onDelete: CASCADE
+
+  # computation_job.creator_id -> core_user.id
+  - changeSet:
+      id: 183
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: computation_job
+            constraintName: fk_computation_job_ref_user_id
+
+  - changeSet:
+      id: 184
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: computation_job
+            baseColumnNames: creator_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_computation_job_ref_user_id
+            onDelete: CASCADE
+
+  # computation_job_result.job_id -> computation_job.id
+  - changeSet:
+      id: 185
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: computation_job_result
+            constraintName: fk_computation_result_ref_job_id
+
+  - changeSet:
+      id: 186
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: computation_job_result
+            baseColumnNames: job_id
+            referencedTableName: computation_job
+            referencedColumnNames: id
+            constraintName: fk_computation_result_ref_job_id
+            onDelete: CASCADE
+
+  # core_session.user_id -> core_user.id
+  - changeSet:
+      id: 187
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: core_session
+            constraintName: fk_session_ref_user_id
+
+  - changeSet:
+      id: 188
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: core_session
+            baseColumnNames: user_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_session_ref_user_id
+            onDelete: CASCADE
+
+  # dashboardcard_series.card_id -> report_card.id
+  - changeSet:
+      id: 189
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: dashboardcard_series
+            constraintName: fk_dashboardcard_series_ref_card_id
+
+  - changeSet:
+      id: 190
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: dashboardcard_series
+            baseColumnNames: card_id
+            referencedTableName: report_card
+            referencedColumnNames: id
+            constraintName: fk_dashboardcard_series_ref_card_id
+            onDelete: CASCADE
+
+  # dashboardcard_series.dashboardcard_id -> report_dashboardcard.id
+  - changeSet:
+      id: 191
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: dashboardcard_series
+            constraintName: fk_dashboardcard_series_ref_dashboardcard_id
+
+  - changeSet:
+      id: 192
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: dashboardcard_series
+            baseColumnNames: dashboardcard_id
+            referencedTableName: report_dashboardcard
+            referencedColumnNames: id
+            constraintName: fk_dashboardcard_series_ref_dashboardcard_id
+            onDelete: CASCADE
+
+  # group_table_access_policy.card_id -> report_card.id
+  - changeSet:
+      id: 193
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: group_table_access_policy
+            constraintName: fk_gtap_card_id
+
+  - changeSet:
+      id: 194
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: group_table_access_policy
+            baseColumnNames: card_id
+            referencedTableName: report_card
+            referencedColumnNames: id
+            constraintName: fk_gtap_card_id
+            onDelete: CASCADE
+
+  # metabase_field.parent_id -> metabase_field.id
+  - changeSet:
+      id: 195
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: metabase_field
+            constraintName: fk_field_parent_ref_field_id
+
+  - changeSet:
+      id: 196
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: metabase_field
+            baseColumnNames: parent_id
+            referencedTableName: metabase_field
+            referencedColumnNames: id
+            constraintName: fk_field_parent_ref_field_id
+            onDelete: CASCADE
+
+  # metabase_field.table_id -> metabase_table.id
+  - changeSet:
+      id: 197
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: metabase_field
+            constraintName: fk_field_ref_table_id
+
+  - changeSet:
+      id: 198
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: metabase_field
+            baseColumnNames: table_id
+            referencedTableName: metabase_table
+            referencedColumnNames: id
+            constraintName: fk_field_ref_table_id
+            onDelete: CASCADE
+
+  # metabase_fieldvalues.field_id -> metabase_field.id
+  - changeSet:
+      id: 199
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: metabase_fieldvalues
+            constraintName: fk_fieldvalues_ref_field_id
+
+  - changeSet:
+      id: 200
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: metabase_fieldvalues
+            baseColumnNames: field_id
+            referencedTableName: metabase_field
+            referencedColumnNames: id
+            constraintName: fk_fieldvalues_ref_field_id
+            onDelete: CASCADE
+
+  # metabase_table.db_id -> metabase_database.id
+  - changeSet:
+      id: 201
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: metabase_table
+            constraintName: fk_table_ref_database_id
+
+  - changeSet:
+      id: 202
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: metabase_table
+            baseColumnNames: db_id
+            referencedTableName: metabase_database
+            referencedColumnNames: id
+            constraintName: fk_table_ref_database_id
+            onDelete: CASCADE
+
+  # metric.creator_id -> core_user.id
+  - changeSet:
+      id: 203
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: metric
+            constraintName: fk_metric_ref_creator_id
+
+  - changeSet:
+      id: 204
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: metric
+            baseColumnNames: creator_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_metric_ref_creator_id
+            onDelete: CASCADE
+
+  # metric.table_id -> metabase_table.id
+  - changeSet:
+      id: 205
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: metric
+            constraintName: fk_metric_ref_table_id
+
+  - changeSet:
+      id: 206
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: metric
+            baseColumnNames: table_id
+            referencedTableName: metabase_table
+            referencedColumnNames: id
+            constraintName: fk_metric_ref_table_id
+            onDelete: CASCADE
+
+  # metric_important_field.field_id -> metabase_field.id
+  - changeSet:
+      id: 207
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: metric_important_field
+            constraintName: fk_metric_important_field_metabase_field_id
+
+  - changeSet:
+      id: 208
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: metric_important_field
+            baseColumnNames: field_id
+            referencedTableName: metabase_field
+            referencedColumnNames: id
+            constraintName: fk_metric_important_field_metabase_field_id
+            onDelete: CASCADE
+
+  # metric_important_field.metric_id -> metric.id
+  - changeSet:
+      id: 209
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: metric_important_field
+            constraintName: fk_metric_important_field_metric_id
+
+  - changeSet:
+      id: 210
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: metric_important_field
+            baseColumnNames: metric_id
+            referencedTableName: metric
+            referencedColumnNames: id
+            constraintName: fk_metric_important_field_metric_id
+            onDelete: CASCADE
+
+  # native_query_snippet.collection_id -> collection.id
+  - changeSet:
+      id: 211
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: native_query_snippet
+            constraintName: fk_snippet_collection_id
+
+  - changeSet:
+      id: 212
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: native_query_snippet
+            baseColumnNames: collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            constraintName: fk_snippet_collection_id
+            onDelete: SET NULL
+
+  # permissions.group_id -> permissions_group.id
+  - changeSet:
+      id: 213
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: permissions
+            constraintName: fk_permissions_group_id
+
+  - changeSet:
+      id: 214
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: permissions
+            baseColumnNames: group_id
+            referencedTableName: permissions_group
+            referencedColumnNames: id
+            constraintName: fk_permissions_group_id
+            onDelete: CASCADE
+
+  # permissions_group_membership.group_id -> permissions_group.id
+  - changeSet:
+      id: 215
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: permissions_group_membership
+            constraintName: fk_permissions_group_group_id
+
+  - changeSet:
+      id: 216
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: permissions_group_membership
+            baseColumnNames: group_id
+            referencedTableName: permissions_group
+            referencedColumnNames: id
+            constraintName: fk_permissions_group_group_id
+            onDelete: CASCADE
+
+  # permissions_group_membership.user_id -> core_user.id
+  - changeSet:
+      id: 217
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: permissions_group_membership
+            constraintName: fk_permissions_group_membership_user_id
+
+  - changeSet:
+      id: 218
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: permissions_group_membership
+            baseColumnNames: user_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_permissions_group_membership_user_id
+            onDelete: CASCADE
+
+  # permissions_revision.user_id -> core_user.id
+  - changeSet:
+      id: 219
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: permissions_revision
+            constraintName: fk_permissions_revision_user_id
+
+  - changeSet:
+      id: 220
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: permissions_revision
+            baseColumnNames: user_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_permissions_revision_user_id
+            onDelete: CASCADE
+
+  # pulse.collection_id -> collection.id
+  - changeSet:
+      id: 221
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: pulse
+            constraintName: fk_pulse_collection_id
+
+  - changeSet:
+      id: 222
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: pulse
+            baseColumnNames: collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            constraintName: fk_pulse_collection_id
+            onDelete: SET NULL
+
+  # pulse.creator_id -> core_user.id
+  - changeSet:
+      id: 223
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: pulse
+            constraintName: fk_pulse_ref_creator_id
+
+  - changeSet:
+      id: 224
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: pulse
+            baseColumnNames: creator_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_pulse_ref_creator_id
+            onDelete: CASCADE
+
+  # pulse_card.card_id -> report_card.id
+  - changeSet:
+      id: 225
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: pulse_card
+            constraintName: fk_pulse_card_ref_card_id
+
+  - changeSet:
+      id: 226
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: pulse_card
+            baseColumnNames: card_id
+            referencedTableName: report_card
+            referencedColumnNames: id
+            constraintName: fk_pulse_card_ref_card_id
+            onDelete: CASCADE
+
+  # pulse_card.pulse_id -> pulse.id
+  - changeSet:
+      id: 227
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: pulse_card
+            constraintName: fk_pulse_card_ref_pulse_id
+
+  - changeSet:
+      id: 228
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: pulse_card
+            baseColumnNames: pulse_id
+            referencedTableName: pulse
+            referencedColumnNames: id
+            constraintName: fk_pulse_card_ref_pulse_id
+            onDelete: CASCADE
+
+  # pulse_channel.pulse_id -> pulse.id
+  - changeSet:
+      id: 229
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: pulse_channel
+            constraintName: fk_pulse_channel_ref_pulse_id
+
+  - changeSet:
+      id: 230
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: pulse_channel
+            baseColumnNames: pulse_id
+            referencedTableName: pulse
+            referencedColumnNames: id
+            constraintName: fk_pulse_channel_ref_pulse_id
+            onDelete: CASCADE
+
+  # pulse_channel_recipient.pulse_channel_id -> pulse_channel.id
+  - changeSet:
+      id: 231
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: pulse_channel_recipient
+            constraintName: fk_pulse_channel_recipient_ref_pulse_channel_id
+
+  - changeSet:
+      id: 232
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: pulse_channel_recipient
+            baseColumnNames: pulse_channel_id
+            referencedTableName: pulse_channel
+            referencedColumnNames: id
+            constraintName: fk_pulse_channel_recipient_ref_pulse_channel_id
+            onDelete: CASCADE
+
+  # pulse_channel_recipient.user_id -> core_user.id
+  - changeSet:
+      id: 233
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: pulse_channel_recipient
+            constraintName: fk_pulse_channel_recipient_ref_user_id
+
+  - changeSet:
+      id: 234
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: pulse_channel_recipient
+            baseColumnNames: user_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_pulse_channel_recipient_ref_user_id
+            onDelete: CASCADE
+
+  # report_card.collection_id -> collection.id
+  - changeSet:
+      id: 235
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: report_card
+            constraintName: fk_card_collection_id
+
+  - changeSet:
+      id: 236
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_card
+            baseColumnNames: collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            constraintName: fk_card_collection_id
+            onDelete: SET NULL
+
+  # report_card.made_public_by_id -> core_user.id
+  - changeSet:
+      id: 237
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: report_card
+            constraintName: fk_card_made_public_by_id
+
+  - changeSet:
+      id: 238
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_card
+            baseColumnNames: made_public_by_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_card_made_public_by_id
+            onDelete: CASCADE
+
+  # report_card.creator_id -> core_user.id
+  - changeSet:
+      id: 239
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: report_card
+            constraintName: fk_card_ref_user_id
+
+  - changeSet:
+      id: 240
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_card
+            baseColumnNames: creator_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_card_ref_user_id
+            onDelete: CASCADE
+
+  # report_card.database_id -> metabase_database.id
+  - changeSet:
+      id: 241
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: report_card
+            constraintName: fk_report_card_ref_database_id
+
+  - changeSet:
+      id: 242
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_card
+            baseColumnNames: database_id
+            referencedTableName: metabase_database
+            referencedColumnNames: id
+            constraintName: fk_report_card_ref_database_id
+            onDelete: CASCADE
+
+  # report_card.table_id -> metabase_table.id
+  - changeSet:
+      id: 243
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: report_card
+            constraintName: fk_report_card_ref_table_id
+
+  - changeSet:
+      id: 244
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_card
+            baseColumnNames: table_id
+            referencedTableName: metabase_table
+            referencedColumnNames: id
+            constraintName: fk_report_card_ref_table_id
+            onDelete: CASCADE
+
+  # report_cardfavorite.card_id -> report_card.id
+  - changeSet:
+      id: 245
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: report_cardfavorite
+            constraintName: fk_cardfavorite_ref_card_id
+
+  - changeSet:
+      id: 246
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_cardfavorite
+            baseColumnNames: card_id
+            referencedTableName: report_card
+            referencedColumnNames: id
+            constraintName: fk_cardfavorite_ref_card_id
+            onDelete: CASCADE
+
+  # report_cardfavorite.owner_id -> core_user.id
+  - changeSet:
+      id: 247
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: report_cardfavorite
+            constraintName: fk_cardfavorite_ref_user_id
+
+  - changeSet:
+      id: 248
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_cardfavorite
+            baseColumnNames: owner_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_cardfavorite_ref_user_id
+            onDelete: CASCADE
+
+  # report_dashboard.collection_id -> collection.id
+  - changeSet:
+      id: 249
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: report_dashboard
+            constraintName: fk_dashboard_collection_id
+
+  - changeSet:
+      id: 250
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_dashboard
+            baseColumnNames: collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            constraintName: fk_dashboard_collection_id
+            onDelete: SET NULL
+
+  # report_dashboard.made_public_by_id -> core_user.id
+  - changeSet:
+      id: 251
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: report_dashboard
+            constraintName: fk_dashboard_made_public_by_id
+
+  - changeSet:
+      id: 252
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_dashboard
+            baseColumnNames: made_public_by_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_dashboard_made_public_by_id
+            onDelete: CASCADE
+
+  # report_dashboard.creator_id -> core_user.id
+  - changeSet:
+      id: 253
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: report_dashboard
+            constraintName: fk_dashboard_ref_user_id
+
+  - changeSet:
+      id: 254
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_dashboard
+            baseColumnNames: creator_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_dashboard_ref_user_id
+            onDelete: CASCADE
+
+  # report_dashboardcard.card_id -> report_card.id
+  - changeSet:
+      id: 255
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: report_dashboardcard
+            constraintName: fk_dashboardcard_ref_card_id
+
+  - changeSet:
+      id: 256
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_dashboardcard
+            baseColumnNames: card_id
+            referencedTableName: report_card
+            referencedColumnNames: id
+            constraintName: fk_dashboardcard_ref_card_id
+            onDelete: CASCADE
+
+  # report_dashboardcard.dashboard_id -> report_dashboard.id
+  - changeSet:
+      id: 257
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: report_dashboardcard
+            constraintName: fk_dashboardcard_ref_dashboard_id
+
+  - changeSet:
+      id: 258
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_dashboardcard
+            baseColumnNames: dashboard_id
+            referencedTableName: report_dashboard
+            referencedColumnNames: id
+            constraintName: fk_dashboardcard_ref_dashboard_id
+            onDelete: CASCADE
+
+  # revision.user_id -> core_user.id
+  - changeSet:
+      id: 259
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: revision
+            constraintName: fk_revision_ref_user_id
+
+  - changeSet:
+      id: 260
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: revision
+            baseColumnNames: user_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_revision_ref_user_id
+            onDelete: CASCADE
+
+  # segment.creator_id -> core_user.id
+  - changeSet:
+      id: 261
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: segment
+            constraintName: fk_segment_ref_creator_id
+
+  - changeSet:
+      id: 262
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: segment
+            baseColumnNames: creator_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_segment_ref_creator_id
+            onDelete: CASCADE
+
+  # segment.table_id -> metabase_table.id
+  - changeSet:
+      id: 263
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: segment
+            constraintName: fk_segment_ref_table_id
+
+  - changeSet:
+      id: 264
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: segment
+            baseColumnNames: table_id
+            referencedTableName: metabase_table
+            referencedColumnNames: id
+            constraintName: fk_segment_ref_table_id
+            onDelete: CASCADE
+
+  # view_log.user_id -> core_user.id
+  - changeSet:
+      id: 265
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: view_log
+            constraintName: fk_view_log_ref_user_id
+
+  - changeSet:
+      id: 266
+      author: camsaul
+      comment: Added 0.36.0
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: view_log
+            baseColumnNames: user_id
+            referencedTableName: core_user
+            referencedColumnNames: id
+            constraintName: fk_view_log_ref_user_id
+            onDelete: CASCADE

--- a/src/metabase/models/alert.clj
+++ b/src/metabase/models/alert.clj
@@ -1,1 +1,0 @@
-(ns metabase.models.alert)

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -158,11 +158,7 @@
 
 ;; Cards don't normally get deleted (they get archived instead) so this mostly affects tests
 (defn- pre-delete [{:keys [id]}]
-  (db/delete! 'PulseCard :card_id id)
-  (db/delete! 'Revision :model "Card", :model_id id)
-  (db/delete! 'DashboardCardSeries :card_id id)
-  (db/delete! 'DashboardCard :card_id id)
-  (db/delete! 'CardFavorite :card_id id))
+  (db/delete! 'Revision :model "Card", :model_id id))
 
 (u/strict-extend (class Card)
   models/IModel

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -791,12 +791,7 @@
   false)
 
 (defn- pre-delete [collection]
-  ;; unset the collection_id for Cards/Pulses in this collection. This is mostly for the sake of tests since IRL we
-  ;; shouldn't be deleting Collections, but rather archiving them instead
-  (doseq [model ['Card 'Pulse 'Dashboard]]
-    (db/update-where! model {:collection_id (u/get-id collection)}
-      :collection_id nil))
-  ;; Now delete all the Children of this Collection
+  ;; Delete all the Children of this Collection
   (db/delete! Collection :location (children-location collection))
   ;; You can't delete a Personal Collection! Unless we enable it because we are simultaneously deleting the User
   (when-not *allow-deleting-personal-collections*

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -51,8 +51,7 @@
 
 
 (defn- pre-delete [dashboard]
-  (db/delete! 'Revision :model "Dashboard" :model_id (u/get-id dashboard))
-  (db/delete! DashboardCard :dashboard_id (u/get-id dashboard)))
+  (db/delete! 'Revision :model "Dashboard" :model_id (u/get-id dashboard)))
 
 (defn- pre-insert [dashboard]
   (let [defaults  {:parameters []}

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -37,16 +37,12 @@
                   :visualization_settings {}}]
     (merge defaults dashcard)))
 
-(defn- pre-delete [{:keys [id]}]
-  (db/delete! 'DashboardCardSeries :dashboardcard_id id))
-
 (u/strict-extend (class DashboardCard)
   models/IModel
   (merge models/IModelDefaults
          {:properties  (constantly {:timestamped? true})
           :types       (constantly {:parameter_mappings :parameter-mappings, :visualization_settings :json})
           :pre-insert  pre-insert
-          :pre-delete  pre-delete
           :post-select (u/rpartial set/rename-keys {:sizex :sizeX, :sizey :sizeY})})
   i/IObjectPermissions
   (merge i/IObjectPermissionsDefaults

--- a/src/metabase/models/dashboard_card_series.clj
+++ b/src/metabase/models/dashboard_card_series.clj
@@ -1,5 +1,4 @@
 (ns metabase.models.dashboard-card-series
   (:require [toucan.models :as models]))
 
-
 (models/defmodel DashboardCardSeries :dashboardcard_series)

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -58,9 +58,7 @@
 
 (defn- pre-delete [{id :id, driver :engine, :as database}]
   (unschedule-tasks! database)
-  (db/delete! 'Card        :database_id id)
-  (db/delete! 'Permissions :object      [:like (str (perms/object-path id) "%")])
-  (db/delete! 'Table       :db_id       id)
+  (db/delete! 'Permissions :object [:like (str (perms/object-path id) "%")])
   (try
     (driver/notify-database-updated driver database)
     (catch Throwable e

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -77,12 +77,6 @@
   (u/prog1 field
     (check-valid-types field)))
 
-(defn- pre-delete [{:keys [id]}]
-  (db/delete! Field :parent_id id)
-  (db/delete! 'FieldValues :field_id id)
-  (db/delete! 'MetricImportantField :field_id id))
-
-
 ;;; Field permissions
 ;; There are several API endpoints where large instances can return many thousands of Fields. Normally Fields require
 ;; a DB call to fetch information about their Table, because a Field's permissions set is the same as its parent
@@ -149,8 +143,7 @@
                                        :settings         :json})
           :properties     (constantly {:timestamped? true})
           :pre-insert     pre-insert
-          :pre-update     pre-update
-          :pre-delete     pre-delete})
+          :pre-update     pre-update})
 
   i/IObjectPermissions
   (merge i/IObjectPermissionsDefaults

--- a/src/metabase/models/humanization.clj
+++ b/src/metabase/models/humanization.clj
@@ -25,7 +25,6 @@
     (str/upper-case word)
     (str/capitalize word)))
 
-
 (declare humanization-strategy)
 
 (defmulti ^String name->human-readable-name

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -27,9 +27,6 @@
       (when (not= creator_id (db/select-one-field :creator_id Metric :id id))
         (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a Metric.")))))))
 
-(defn- pre-delete [{:keys [id]}]
-  (db/delete! 'MetricImportantField :metric_id id))
-
 (defn- perms-objects-set [metric read-or-write]
   (let [table (or (:table metric)
                   (db/select-one ['Table :db_id :schema :id] :id (u/get-id (:table_id metric))))]
@@ -41,7 +38,6 @@
    models/IModelDefaults
    {:types      (constantly {:definition :metric-segment-definition})
     :properties (constantly {:timestamped? true})
-    :pre-delete pre-delete
     :pre-update pre-update})
   i/IObjectPermissions
   (merge

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -279,7 +279,6 @@
   (log/debug (u/format-color 'red "Revoking permissions for group %d: %s" (:group_id permissions) (:object permissions)))
   (assert-not-admin-group permissions))
 
-
 (u/strict-extend (class Permissions)
   models/IModel (merge models/IModelDefaults
                    {:pre-insert         pre-insert

--- a/src/metabase/models/permissions_group.clj
+++ b/src/metabase/models/permissions_group.clj
@@ -81,8 +81,6 @@
 
 (defn- pre-delete [{id :id, :as group}]
   (check-not-magic-group group)
-  (db/delete! 'Permissions                 :group_id id)
-  (db/delete! 'PermissionsGroupMembership  :group_id id)
   ;; Remove from LDAP mappings
   (classloader/require 'metabase.integrations.ldap)
   (setting/set-json! :ldap-group-mappings

--- a/src/metabase/models/permissions_revision.clj
+++ b/src/metabase/models/permissions_revision.clj
@@ -18,7 +18,6 @@
           :pre-insert pre-insert
           :pre-update (fn [& _] (throw (Exception. (tru "You cannot update a PermissionsRevision!"))))}))
 
-
 (defn latest-id
   "Return the ID of the newest `PermissionsRevision`, or zero if none have been made yet.
    (This is used by the permissions graph update logic that checks for changes since the original graph was fetched)."

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -41,10 +41,6 @@
 
 (models/defmodel Pulse :pulse)
 
-(defn- pre-delete [notification]
-  (doseq [model [PulseCard PulseChannel]]
-    (db/delete! model :pulse_id (u/get-id notification))))
-
 (defn- pre-insert [notification]
   (u/prog1 notification
     (collection/check-collection-namespace Pulse (:collection_id notification))))
@@ -82,7 +78,6 @@
    models/IModelDefaults
    {:hydration-keys (constantly [:pulse])
     :properties     (constantly {:timestamped? true})
-    :pre-delete     pre-delete
     :pre-insert     pre-insert
     :pre-update     pre-update})
   i/IObjectPermissions

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -128,17 +128,13 @@
                 :order-by [[:u.id :asc]]})]
      (user/add-common-name user))))
 
-(defn- pre-delete [{:keys [id]}]
-  (db/delete! PulseChannelRecipient :pulse_channel_id id))
-
 (u/strict-extend (class PulseChannel)
   models/IModel
   (merge
    models/IModelDefaults
    {:hydration-keys (constantly [:pulse_channel])
     :types          (constantly {:details :json, :channel_type :keyword, :schedule_type :keyword, :schedule_frame :keyword})
-    :properties     (constantly {:timestamped? true})
-    :pre-delete     pre-delete})
+    :properties     (constantly {:timestamped? true})})
 
   i/IObjectPermissions
   (merge

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -44,10 +44,6 @@
     (merge defaults table)))
 
 (defn- pre-delete [{:keys [db_id schema id]}]
-  (db/delete! Segment     :table_id id)
-  (db/delete! Metric      :table_id id)
-  (db/delete! Field       :table_id id)
-  (db/delete! 'Card       :table_id id)
   (db/delete! Permissions :object [:like (str (perms/object-path db_id schema id) "%")]))
 
 (defn- perms-objects-set [table read-or-write]

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -107,28 +107,6 @@
 (defn- post-select [user]
   (add-common-name user))
 
-;; `pre-delete` is more for the benefit of tests than anything else since these days we archive users instead of fully
-;; deleting them. In other words the following code is only ever called by tests
-(defn- pre-delete [{:keys [id]}]
-  (binding [perm-membership/*allow-changing-all-users-group-members* true
-            collection/*allow-deleting-personal-collections*         true]
-    (doseq [[model k] [['Activity                   :user_id]
-                       ['Card                       :creator_id]
-                       ['Card                       :made_public_by_id]
-                       ['Collection                 :personal_owner_id]
-                       ['Dashboard                  :creator_id]
-                       ['Dashboard                  :made_public_by_id]
-                       ['Metric                     :creator_id]
-                       ['Pulse                      :creator_id]
-                       ['QueryExecution             :executor_id]
-                       ['Revision                   :user_id]
-                       ['Segment                    :creator_id]
-                       ['Session                    :user_id]
-                       [PermissionsGroupMembership  :user_id]
-                       ['PermissionsRevision        :user_id]
-                       ['ViewLog                    :user_id]]]
-      (db/delete! model k id))))
-
 (def ^:private default-user-columns
   "Sequence of columns that are normally returned when fetching a User from the DB."
   [:id :email :date_joined :first_name :last_name :last_login :is_superuser :is_qbnewb])
@@ -154,7 +132,6 @@
           :post-insert    post-insert
           :pre-update     pre-update
           :post-select    post-select
-          :pre-delete     pre-delete
           :types          (constantly {:login_attributes :json-no-keywordization})}))
 
 (defn group-ids

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -1500,3 +1500,22 @@
              clojure.lang.ExceptionInfo
              #"Collection does not exist"
              (collection/check-collection-namespace Card Integer/MAX_VALUE)))))))
+
+(deftest delete-collection-set-children-collection-id-to-null-test
+  (testing "When deleting a Collection, should change collection_id of Children to nil instead of Cascading"
+    (mt/with-temp* [Collection [{coll-id :id}]
+                    Card       [{card-id :id}      {:collection_id coll-id}]
+                    Dashboard  [{dashboard-id :id} {:collection_id coll-id}]
+                    Pulse      [{pulse-id :id}     {:collection_id coll-id}]]
+      (db/delete! Collection :id coll-id)
+      (is (db/exists? Card :id card-id)
+          "Card")
+      (is (db/exists? Dashboard :id dashboard-id)
+          "Dashboard")
+      (is (db/exists? Pulse :id pulse-id)
+          "Pulse"))
+    (mt/with-temp* [Collection         [{coll-id :id}    {:namespace "snippets"}]
+                    NativeQuerySnippet [{snippet-id :id} {:collection_id coll-id}]]
+      (db/delete! Collection :id coll-id)
+      (is (db/exists? NativeQuerySnippet :id snippet-id)
+          "Snippet"))))


### PR DESCRIPTION
In many of the older tables in the application DB we performed the equivalent of "ON DELETE CASCADE" when deleting rows programatically using Toucan `pre-delete` method implementations. The main reason we did this IIRC is that the old Django database schema we started from didn't use `ON DELETE CASCADE` and I don't think we realized we could use it with Liquibase at first. Almost all of the newer models in the application DB use `ON DELETE CASCADE` or `ON DELETE SET NULL` for their FK constraints.

Having the application DB perform the cascading deletes rather that doing it programatically is desirable for a few reasons:
*  it is dramatically more performant, especially when deleting objects with lots of dependent objects (such as a Database which might have hundreds of Tables and tens of thousands of Fields)
*  it simplifies the model code a lot, and is more robust (not subject to bugs in the code)
*  performing cascading deletes programatically can be subject to race conditions if a background process such as sync is running. E.g. if sync is attempting to add new Fields at the same time we're deleting a Table (and `pre-delete` is trying to programatically delete Fields that might be referenced by newly added Fields). I have ran into this a few times in tests
*  Cascading deletes are atomic, while generally our toucan `pre-delete` programmatic equivalents are not ran inside transactions. This means it is possible for things to get in a weird state where we deleted some dependent rows but the delete as a whole fails and the original object is still there. Having the app DB do it is much more robust

I generated the migrations in this PR programatically using JDBC `DatabaseMetaData` to introspect our application DB and determine which FK constraints needed to be tweaked. 

I made each conversion a separate migration because it's a Liquibase best practice to do so, one change per migration. that way if the migration fails, it fails atomically, and your DB won't get in a state where some of the changes were made but others weren't.

As part of this PR I also merged in 3 migrations that were only present in the EE codebase. The actual code related to using them is still only present in EE, but having a unified set of migrations is one of the prereqs we were planning on tackling as part of the upcoming repo unification anyway; there are a few EE-specific tables whose FKs I wanted to convert to `ON DELETE CASCADE` 

Due to performance increases this Resolves #3569
